### PR TITLE
Warn if GroupChat is underpopulatd.

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -3,6 +3,9 @@ import sys
 from typing import Dict, List, Optional, Union
 from .agent import Agent
 from .conversable_agent import ConversableAgent
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -42,6 +45,14 @@ Then select the next role from {self.agent_names} to play. Only return the role.
     def select_speaker(self, last_speaker: Agent, selector: ConversableAgent):
         """Select the next speaker."""
         selector.update_system_message(self.select_speaker_msg())
+
+        # Warn if GroupChat is underpopulated, without established changing behavior
+        n_agents = len(self.agent_names)
+        if n_agents < 3:
+            logger.warning(
+                f"GroupChat is underpopulated with {n_agents} agents. Direct communication would be more efficient."
+            )
+
         final, name = selector.generate_oai_reply(
             self.messages
             + [


### PR DESCRIPTION
## Why are these changes needed?

When using GroupChat, every turn requires that the Manager make a call to the LLM to decide who goes next. However, this is wasteful if there are fewer than 3 agents in the chat. In this scenario a warning is now presented to the developer to hint that direct communication would be more efficient.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
