### PR TITLE
Warn if use_docker evaluates to True but the python docker package is not available.

### DIFF
--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -218,7 +218,7 @@ def execute_code(
     timeout: Optional[int] = None,
     filename: Optional[str] = None,
     work_dir: Optional[str] = None,
-    use_docker: Optional[Union[List[str], str, bool]] = docker is not None,
+    use_docker: Optional[Union[List[str], str, bool]] = True,
     lang: Optional[str] = "python",
 ) -> Tuple[int, str, str]:
     """Execute code in a docker container.
@@ -256,6 +256,15 @@ def execute_code(
         error_msg = f"Either {code=} or {filename=} must be provided."
         logger.error(error_msg)
         raise AssertionError(error_msg)
+
+    # Warn if docker was requested but cannot be provided. In this case
+    # the current behavior is to fall back to run natively, but this behavior
+    # is subject to change.
+    if use_docker and docker is None:
+        use_docker = False
+        logger.warning(
+            "execute_code was called with use_docker evaluating to True, but the python docker package is not available. Falling back to native code execution. Note: this fallback behavior is subject to change"
+        )
 
     timeout = timeout or DEFAULT_TIMEOUT
     original_filename = filename


### PR DESCRIPTION
## Why are these changes needed?

By default autogen tries to execute code in a Docker container, but only if the **python** docker package is installed. Otherwise the default is to run in the native environment (even if Docker tools are otherwise installed). This can be confusing. This pull request logs a warning in this scenario, but does not change this default fallback behavior -- which is subject to change in the future. 

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
