### PR TITLE
Output a warning if the OAI_CONFIG_LIST file is not found.

### DIFF
--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -237,10 +237,12 @@ def config_list_from_json(
     if json_str:
         config_list = json.loads(json_str)
     else:
+        config_list_path = os.path.join(file_location, env_or_file)
         try:
-            with open(os.path.join(file_location, env_or_file)) as json_file:
+            with open(config_list_path) as json_file:
                 config_list = json.load(json_file)
         except FileNotFoundError:
+            logging.warning(f"The specified config_list file '{config_list_path}' does not exist.")
             return []
     return filter_config(config_list, filter_dict)
 


### PR DESCRIPTION
## Why are these changes needed?
At present, if one calls config_list_from_json, autogen first checks the environment variables, then looks for a file on disk. If neither can be found, then an empty list is returned. This pull request changes no behavior, but logs a warning to help with debugging, since the location of this config_list file is confusing to some.

## Related issue number

Possibly #125 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
