### PR TITLE
Warn if oai.Completion is provided with an empty config_list

### DIFF
--- a/autogen/oai/completion.py
+++ b/autogen/oai/completion.py
@@ -768,6 +768,13 @@ class Completion(openai_Completion):
         """
         if ERROR:
             raise ERROR
+
+        # Warn if a config list was provided but was empty
+        if type(config_list) is list and len(config_list) == 0:
+            logger.warning(
+                "Completion was provided with a config_list, but the list was empty. Adopting default OpenAI behavior, which reads from the 'model' parameter instead."
+            )
+
         if config_list:
             last = len(config_list) - 1
             cost = 0


### PR DESCRIPTION
## Why are these changes needed?

In various scenarios it is possible to provide the oai.Completion wrapper class with an empty config_list, in which case it will fall back to reading the model attribute (which often defaults to GPT-4). This can happen when explicitly provided with an empty config_list (e.g., when loading from a missing json file), or when filtering results in an empty list. 

This pull requests displays a warning in cases where an empty list was provided, as this is probably not the intention of the developer (if the list was simply omitted, then the parameter would be None)

## Related issue number

#125 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
