### PR TITLE
Addresses issue #199

### DIFF
--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -218,7 +218,7 @@ def execute_code(
     timeout: Optional[int] = None,
     filename: Optional[str] = None,
     work_dir: Optional[str] = None,
-    use_docker: Optional[Union[List[str], str, bool]] = True,
+    use_docker: Optional[Union[List[str], str, bool]] = None,
     lang: Optional[str] = "python",
 ) -> Tuple[int, str, str]:
     """Execute code in a docker container.
@@ -260,11 +260,15 @@ def execute_code(
     # Warn if docker was requested but cannot be provided. In this case
     # the current behavior is to fall back to run natively, but this behavior
     # is subject to change.
-    if use_docker and docker is None:
-        use_docker = False
-        logger.warning(
-            "execute_code was called with use_docker evaluating to True, but the python docker package is not available. Falling back to native code execution. Note: this fallback behavior is subject to change"
-        )
+    if use_docker is None:
+        if docker is None:
+            use_docker = False
+            logger.warning(
+                "execute_code was called without specifying a value for use_docker. Since the python docker package is not available, code will be run natively. Note: this fallback behavior is subject to change"
+            )
+        else:
+            # Default to true
+            use_docker = True
 
     timeout = timeout or DEFAULT_TIMEOUT
     original_filename = filename


### PR DESCRIPTION
## Why are these changes needed?

Behavior prior to pull request #172 would silently default to use_docker = False (i.e., it would run natively) when the docker package was not installed, but would throw an error if use_docker was set to True in the same condition.  

Pull request #172 changed this behavior to display a warning, but run natively in both cases.

This pull request keeps the warning from #172, but restores the prior behavior of throwing so that an error is thrown when use_docker is explicitly set to True, but the docker package is missing.

## Related issue number

#199
#172 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
