### PR TITLE
fix: be compatible with customizing model without all fields in the response

### DIFF
--- a/autogen/oai/completion.py
+++ b/autogen/oai/completion.py
@@ -1026,7 +1026,7 @@ class Completion(openai_Completion):
         Returns:
             The cost in USD. 0 if the model is not supported.
         """
-        model = response["model"]
+        model = response.get("model")
         if model not in cls.price1K:
             return 0
             # raise ValueError(f"Unknown model: {model}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I'm using customizing model by [one-api](https://github.com/songquanpeng/one-api), which does not implement all fields in the response of standard OpenAI/Azure OpenAI model. For example, the `model` field doesn't exist.

After this modification, even if `model` field is missing, it could continue running, it is more compitable.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
