### PR TITLE
Adding async support to get_human_input

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -732,6 +732,77 @@ class ConversableAgent(Agent):
 
         return False, None
 
+    async def a_check_termination_and_human_reply(
+        self,
+        messages: Optional[List[Dict]] = None,
+        sender: Optional[Agent] = None,
+        config: Optional[Any] = None,
+    ) -> Tuple[bool, Union[str, Dict, None]]:
+        """(async) Check if the conversation should be terminated, and if human reply is provided."""
+        if config is None:
+            config = self
+        if messages is None:
+            messages = self._oai_messages[sender]
+        message = messages[-1]
+        reply = ""
+        no_human_input_msg = ""
+        if self.human_input_mode == "ALWAYS":
+            reply = await self.a_get_human_input(
+                f"Provide feedback to {sender.name}. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: "
+            )
+            no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
+            # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+            reply = reply if reply or not self._is_termination_msg(message) else "exit"
+        else:
+            if self._consecutive_auto_reply_counter[sender] >= self._max_consecutive_auto_reply_dict[sender]:
+                if self.human_input_mode == "NEVER":
+                    reply = "exit"
+                else:
+                    # self.human_input_mode == "TERMINATE":
+                    terminate = self._is_termination_msg(message)
+                    reply = await self.a_get_human_input(
+                        f"Please give feedback to {sender.name}. Press enter or type 'exit' to stop the conversation: "
+                        if terminate
+                        else f"Please give feedback to {sender.name}. Press enter to skip and use auto-reply, or type 'exit' to stop the conversation: "
+                    )
+                    no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
+                    # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+                    reply = reply if reply or not terminate else "exit"
+            elif self._is_termination_msg(message):
+                if self.human_input_mode == "NEVER":
+                    reply = "exit"
+                else:
+                    # self.human_input_mode == "TERMINATE":
+                    reply = await self.a_get_human_input(
+                        f"Please give feedback to {sender.name}. Press enter or type 'exit' to stop the conversation: "
+                    )
+                    no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
+                    # if the human input is empty, and the message is a termination message, then we will terminate the conversation
+                    reply = reply or "exit"
+
+        # print the no_human_input_msg
+        if no_human_input_msg:
+            print(colored(f"\n>>>>>>>> {no_human_input_msg}", "red"), flush=True)
+
+        # stop the conversation
+        if reply == "exit":
+            # reset the consecutive_auto_reply_counter
+            self._consecutive_auto_reply_counter[sender] = 0
+            return True, None
+
+        # send the human reply
+        if reply or self._max_consecutive_auto_reply_dict[sender] == 0:
+            # reset the consecutive_auto_reply_counter
+            self._consecutive_auto_reply_counter[sender] = 0
+            return True, reply
+
+        # increment the consecutive_auto_reply_counter
+        self._consecutive_auto_reply_counter[sender] += 1
+        if self.human_input_mode != "NEVER":
+            print(colored("\n>>>>>>>> USING AUTO REPLY...", "red"), flush=True)
+
+        return False, None
+
     def generate_reply(
         self,
         messages: Optional[List[Dict]] = None,
@@ -856,6 +927,20 @@ class ConversableAgent(Agent):
 
     def get_human_input(self, prompt: str) -> str:
         """Get human input.
+
+        Override this method to customize the way to get human input.
+
+        Args:
+            prompt (str): prompt for the human input.
+
+        Returns:
+            str: human input.
+        """
+        reply = input(prompt)
+        return reply
+
+    async def a_get_human_input(self, prompt: str) -> str:
+        """(Async) Get human input.
 
         Override this method to customize the way to get human input.
 

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -27,8 +27,7 @@ async def test_async_get_human_input():
         name="user",
         human_input_mode="ALWAYS",
         max_consecutive_auto_reply=1,
-        code_execution_config=False,
-        default_auto_reply=None
+        code_execution_config=False
     )
 
     async def custom_a_get_human_input(prompt):

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -19,7 +19,9 @@ async def test_async_get_human_input():
         llm_config={"request_timeout": 600, "seed": 41, "config_list": config_list, "temperature": 0},
     )
 
-    user_proxy = autogen.UserProxyAgent(name="user", human_input_mode="ALWAYS", code_execution_config=False)
+    user_proxy = autogen.UserProxyAgent(
+        name="user", human_input_mode="ALWAYS", code_execution_config=False
+    )
 
     async def custom_a_get_human_input(prompt):
         return "This is a test"
@@ -32,4 +34,4 @@ async def test_async_get_human_input():
 
 
 if __name__ == "__main__":
-    test_async_get_human_input()
+    asyncio.run(test_async_get_human_input())

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -1,0 +1,43 @@
+import asyncio
+import autogen
+import pytest
+from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST
+
+async def test_stream():
+    try:
+        import openai
+    except ImportError:
+        return
+    config_list = autogen.config_list_from_json(OAI_CONFIG_LIST, KEY_LOC)
+
+    # create an AssistantAgent instance named "assistant"
+    assistant = autogen.AssistantAgent(
+        name="assistant",
+        llm_config={
+            "request_timeout": 600,
+            "seed": 41,
+            "config_list": config_list,
+            "temperature": 0,
+        }
+    )
+
+    user_proxy = autogen.UserProxyAgent(
+        name="user",
+        human_input_mode="ALWAYS",
+        max_consecutive_auto_reply=1,
+        code_execution_config=False,
+        default_auto_reply=None,
+    )
+    user_proxy._reply_func_list = []
+    user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_oai_reply)
+    user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_code_execution_reply)
+    user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_function_call_reply)
+    user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.a_check_termination_and_human_reply)
+
+    await user_proxy.a_initiate_chat(
+        assistant,
+        message="""Hello.""",
+    )
+
+if __name__ == "__main__":
+    asyncio.run(test_stream())

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -17,7 +17,7 @@ async def test_stream():
             "request_timeout": 600,
             "seed": 41,
             "config_list": config_list,
-            "temperature": 0,
+            "temperature": 0
         }
     )
 
@@ -26,7 +26,7 @@ async def test_stream():
         human_input_mode="ALWAYS",
         max_consecutive_auto_reply=1,
         code_execution_config=False,
-        default_auto_reply=None,
+        default_auto_reply=None
     )
     user_proxy._reply_func_list = []
     user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_oai_reply)
@@ -36,7 +36,7 @@ async def test_stream():
 
     await user_proxy.a_initiate_chat(
         assistant,
-        message="""Hello.""",
+        message="""Hello."""
     )
 
 if __name__ == "__main__":

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -3,7 +3,8 @@ import autogen
 import pytest
 from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST
 
-async def test_stream():
+@pytest.mark.asyncio
+async def test_async_get_human_input():
     try:
         import openai
     except ImportError:
@@ -13,6 +14,7 @@ async def test_stream():
     # create an AssistantAgent instance named "assistant"
     assistant = autogen.AssistantAgent(
         name="assistant",
+        max_consecutive_auto_reply=2,
         llm_config={
             "request_timeout": 600,
             "seed": 41,
@@ -28,6 +30,12 @@ async def test_stream():
         code_execution_config=False,
         default_auto_reply=None
     )
+
+    async def custom_a_get_human_input(prompt):
+        return "This is a test"
+
+    user_proxy.a_get_human_input = custom_a_get_human_input
+
     user_proxy._reply_func_list = []
     user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_oai_reply)
     user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_code_execution_reply)
@@ -36,8 +44,9 @@ async def test_stream():
 
     await user_proxy.a_initiate_chat(
         assistant,
+        clear_history=True,
         message="""Hello."""
     )
 
 if __name__ == "__main__":
-    asyncio.run(test_stream())
+    test_async_get_human_input()

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -19,9 +19,7 @@ async def test_async_get_human_input():
         llm_config={"request_timeout": 600, "seed": 41, "config_list": config_list, "temperature": 0},
     )
 
-    user_proxy = autogen.UserProxyAgent(
-        name="user", human_input_mode="ALWAYS", code_execution_config=False
-    )
+    user_proxy = autogen.UserProxyAgent(name="user", human_input_mode="ALWAYS", code_execution_config=False)
 
     async def custom_a_get_human_input(prompt):
         return "This is a test"
@@ -34,4 +32,4 @@ async def test_async_get_human_input():
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async_get_human_input())
+    test_async_get_human_input()

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -19,19 +19,13 @@ async def test_async_get_human_input():
         llm_config={"request_timeout": 600, "seed": 41, "config_list": config_list, "temperature": 0},
     )
 
-    user_proxy = autogen.UserProxyAgent(
-        name="user", human_input_mode="ALWAYS", max_consecutive_auto_reply=1, code_execution_config=False
-    )
+    user_proxy = autogen.UserProxyAgent(name="user", human_input_mode="ALWAYS", code_execution_config=False)
 
     async def custom_a_get_human_input(prompt):
         return "This is a test"
 
     user_proxy.a_get_human_input = custom_a_get_human_input
 
-    user_proxy._reply_func_list = []
-    user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_oai_reply)
-    user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_code_execution_reply)
-    user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_function_call_reply)
     user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.a_check_termination_and_human_reply)
 
     await user_proxy.a_initiate_chat(assistant, clear_history=True, message="Hello.")

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -3,6 +3,7 @@ import autogen
 import pytest
 from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST
 
+
 @pytest.mark.asyncio
 async def test_async_get_human_input():
     try:
@@ -15,19 +16,11 @@ async def test_async_get_human_input():
     assistant = autogen.AssistantAgent(
         name="assistant",
         max_consecutive_auto_reply=2,
-        llm_config={
-            "request_timeout": 600,
-            "seed": 41,
-            "config_list": config_list,
-            "temperature": 0
-        }
+        llm_config={"request_timeout": 600, "seed": 41, "config_list": config_list, "temperature": 0},
     )
 
     user_proxy = autogen.UserProxyAgent(
-        name="user",
-        human_input_mode="ALWAYS",
-        max_consecutive_auto_reply=1,
-        code_execution_config=False
+        name="user", human_input_mode="ALWAYS", max_consecutive_auto_reply=1, code_execution_config=False
     )
 
     async def custom_a_get_human_input(prompt):
@@ -41,11 +34,8 @@ async def test_async_get_human_input():
     user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.generate_function_call_reply)
     user_proxy.register_reply([autogen.Agent, None], autogen.ConversableAgent.a_check_termination_and_human_reply)
 
-    await user_proxy.a_initiate_chat(
-        assistant,
-        clear_history=True,
-        message="""Hello."""
-    )
+    await user_proxy.a_initiate_chat(assistant, clear_history=True, message="Hello.")
+
 
 if __name__ == "__main__":
     test_async_get_human_input()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/bonadio/autogenwebdemo

Hi I created this autogenwebdemo where I use FastApi as a backend and React as frontend. To be able to interact FastApi with Autogen I had to create an async version of the ConversableAgent get_human_input. I think it would be nice to have this feature on the original ConversableAgent

I create this PR to include two methods to the ConversableAgent. a_check_termination_and_human_reply which is a async version of check_termination_and_human_reply and a_get_human_input for get_human_input. 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x ] I've added tests (if relevant) corresponding to the changes introduced in this PR
- [ ] I've made sure all auto checks have passed.
  
