### PR TITLE
Dev/v0.2 - Enable streaming support for openai v1.0.0b3

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -247,19 +247,19 @@ class OpenAIWrapper:
                         # Cache the response
                         cache.set(key, response)
                     return response
-        
+
     def _completions_create(self, client, params):
         completions = client.chat.completions if "messages" in params else client.completions
         # If streaming is enabled, has messages, and does not have functions, then
         # iterate over the chunks of the response
-        if (params.get("stream", False) and "messages" in params and 'functions' not in params):
-            response_contents = [""] * params.get('n', 1)
-            finish_reasons = [""] * params.get('n', 1)            
+        if params.get("stream", False) and "messages" in params and "functions" not in params:
+            response_contents = [""] * params.get("n", 1)
+            finish_reasons = [""] * params.get("n", 1)
             completion_tokens = 0
-            
+
             # Set the terminal text color to green
-            print("\033[32m", end='')
-            
+            print("\033[32m", end="")
+
             # Send the chat completion request to OpenAI's API and process the response in chunks
             for chunk in completions.create(**params):
                 if chunk.choices:
@@ -268,29 +268,29 @@ class OpenAIWrapper:
                         finish_reasons[choice.index] = choice.finish_reason
                         # If content is present, print it to the terminal and update response variables
                         if content is not None:
-                            print(content, end='', flush=True)
+                            print(content, end="", flush=True)
                             response_contents[choice.index] += content
                             completion_tokens += 1
                         else:
                             print()
-                            
+
             # Reset the terminal text color
             print("\033[0m\n")
-            
+
             # Prepare the final ChatCompletion object based on the accumulated data
-            model = chunk.model.replace("gpt-35", "gpt-3.5") # hack for Azure API
+            model = chunk.model.replace("gpt-35", "gpt-3.5")  # hack for Azure API
             prompt_tokens = count_token(params["messages"], model)
             response = ChatCompletion(
                 id=chunk.id,
                 model=chunk.model,
                 created=chunk.created,
-                object='chat.completion',
+                object="chat.completion",
                 choices=[],
                 usage=CompletionUsage(
-                    prompt_tokens = prompt_tokens,
-                    completion_tokens = completion_tokens,
-                    total_tokens = prompt_tokens + completion_tokens
-                )
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=prompt_tokens + completion_tokens,
+                ),
             )
             for i in range(len(response_contents)):
                 response.choices.append(
@@ -298,16 +298,14 @@ class OpenAIWrapper:
                         index=i,
                         finish_reason=finish_reasons[i],
                         message=ChatCompletionMessage(
-                            role='assistant',
-                            content=response_contents[i],
-                            function_call=None
-                        )
+                            role="assistant", content=response_contents[i], function_call=None
+                        ),
                     )
                 )
         else:
             # If streaming is not enabled, send a regular chat completion request
             # Ensure streaming is disabled
-            params['stream'] = False
+            params["stream"] = False
             response = completions.create(**params)
         return response
 


### PR DESCRIPTION
## Why are these changes needed?
The OpenAI API, along with other LLM frameworks, offers streaming capabilities that enhance debugging workflows by eliminating the need to wait for complete responses, resulting in a more efficient and time-saving process.

This is a simple mechanism to support streaming.
Tested on openai v1.0.0b3.

To enable streaming just use this code:

```python
llm_config={
    "config_list": config_list,
    # Enable, disable streaming (defaults to False)
    "stream": True,
}

assistant = autogen.AssistantAgent(
    name="assistant",
    llm_config=llm_config,
)
```

## Related issue number
Related to #465, #217

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
