### PR TITLE
Fixed speak order

### DIFF
--- a/autogen/agentchat/assistant_agent.py
+++ b/autogen/agentchat/assistant_agent.py
@@ -1,5 +1,6 @@
 from .conversable_agent import ConversableAgent
-from typing import Callable, Dict, Optional, Union
+from .agent import Agent
+from typing import Callable, Dict, Optional, Union, Generator, List
 
 
 class AssistantAgent(ConversableAgent):
@@ -64,3 +65,18 @@ Reply "TERMINATE" in the end when everything is done.
             llm_config=llm_config,
             **kwargs,
         )
+
+    @property
+    def agent_chat_chain(self) -> None | Generator[Agent, None, None]:
+        if self._agent_chat_chain is None:
+            return None
+        for agent in self._agent_chat_chain:
+            yield agent
+
+    @agent_chat_chain.setter
+    def agent_chat_chain(self, agent_chat_chain: List[Agent]):
+        self._agent_chat_chain = agent_chat_chain
+
+    def reset(self):
+        self._agent_chat_chain = None
+        super().reset()

--- a/autogen/agentchat/assistant_agent.py
+++ b/autogen/agentchat/assistant_agent.py
@@ -1,6 +1,5 @@
 from .conversable_agent import ConversableAgent
-from .agent import Agent
-from typing import Callable, Dict, Optional, Union, Generator, List
+from typing import Callable, Dict, Optional, Union
 
 
 class AssistantAgent(ConversableAgent):
@@ -65,18 +64,3 @@ Reply "TERMINATE" in the end when everything is done.
             llm_config=llm_config,
             **kwargs,
         )
-
-    @property
-    def agent_chat_chain(self) -> None | Generator[Agent, None, None]:
-        if self._agent_chat_chain is None:
-            return None
-        for agent in self._agent_chat_chain:
-            yield agent
-
-    @agent_chat_chain.setter
-    def agent_chat_chain(self, agent_chat_chain: List[Agent]):
-        self._agent_chat_chain = agent_chat_chain
-
-    def reset(self):
-        self._agent_chat_chain = None
-        super().reset()

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -162,7 +162,7 @@ class GroupChatManager(ConversableAgent):
                 break
             try:
                 # select the next speaker
-                agent_chat_chain = getattr(speaker, "agent_chat_chain", None)
+                agent_chat_chain = speaker.agent_chat_chain if agent_chat_chain is None else agent_chat_chain
                 if agent_chat_chain is not None:
                     speaker = next(agent_chat_chain, None)
                     if speaker is None:

--- a/test/agentchat/test_agent_chat_chain.py
+++ b/test/agentchat/test_agent_chat_chain.py
@@ -1,0 +1,86 @@
+import autogen
+from autogen.agentchat import AssistantAgent
+
+OAI_CONFIG_LIST = "OAI_CONFIG_LIST"
+
+
+def test_agent_chat_chain():
+    conversations = {}
+    autogen.ChatCompletion.start_logging(conversations)
+    agent1 = AssistantAgent(
+        "alice",
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is alice sepaking.",
+    )
+    agent2 = AssistantAgent(
+        "bob",
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is bob sepaking.",
+    )
+    agent3 = AssistantAgent(
+        "carol",
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is carol sepaking.",
+    )
+    agent4 = AssistantAgent(
+        "john",
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is john sepaking.",
+    )
+    agent1.agent_chat_chain = [agent4, agent2, agent3]
+    groupchat = autogen.GroupChat(agents=[agent1, agent2, agent3, agent4], messages=[], max_round=4)
+    group_chat_manager = autogen.GroupChatManager(groupchat=groupchat, llm_config=False)
+    agent1.initiate_chat(group_chat_manager, message="This is alice sepaking.")
+    assert (
+        groupchat.messages[-1]["name"] == "carol"
+        and groupchat.messages[-2]["name"] == "bob"
+        and groupchat.messages[-3]["name"] == "john"
+        and groupchat.messages[-4]["name"] == "alice"
+    )
+
+
+def test_no_agent_chat_chain():
+    conversations = {}
+    autogen.ChatCompletion.start_logging(conversations)
+    agent1 = AssistantAgent(
+        "alice",
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is alice sepaking.",
+    )
+    agent2 = AssistantAgent(
+        "bob",
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is bob sepaking.",
+    )
+    agent3 = AssistantAgent(
+        "carol",
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is carol sepaking.",
+    )
+    agent4 = AssistantAgent(
+        "john",
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is john sepaking.",
+    )
+    groupchat = autogen.GroupChat(agents=[agent1, agent2, agent3, agent4], messages=[], max_round=4)
+    group_chat_manager = autogen.GroupChatManager(groupchat=groupchat, llm_config=False)
+    agent1.initiate_chat(group_chat_manager, message="This is alice sepaking.")
+    assert (
+        groupchat.messages[-1]["name"] == "john"
+        and groupchat.messages[-2]["name"] == "carol"
+        and groupchat.messages[-3]["name"] == "bob"
+        and groupchat.messages[-4]["name"] == "alice"
+    )
+
+
+if __name__ == "__main__":
+    test_agent_chat_chain()
+    test_no_agent_chat_chain()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Complex Group Chat may face the problem that Group Chat Manager cannot reasonably select the Next Speaker. At the same time, the order of agents in some automated processes is relatively fixed.

This PR adds `agent_chat_chain: List[Agent]` to the `ConversableAgent` class and enhances the `run_chat` method of the `GroupChatManager` class to ensure a fixed order of speakers in custom procedures.

## Related issue number

<!-- For example: "Closes #1234" -->

"Close #485"

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
