### PR TITLE
Function call errors when calling azure api using "gpt-35-turbo"

### DIFF
--- a/autogen/oai/completion.py
+++ b/autogen/oai/completion.py
@@ -53,6 +53,7 @@ class Completion(openai_Completion):
         "gpt-3.5-turbo-16k",
         "gpt-3.5-turbo-16k-0613",
         "gpt-35-turbo",
+        "gpt-35-turbo-0613",
         "gpt-35-turbo-16k",
         "gpt-4",
         "gpt-4-32k",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When making a function call in the Azure API, ensure including ‘gpt-35-turbo-0613’ in the Chat_models parameter. Otherwise will encounter an error with the message:`"openai.NotFoundError: Error code: 404 - {'error': {'message': 'Unrecognized request argument supplied: functions', 'type': 'invalid_request_error', 'param': None, 'code': None}}"  `


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/microsoft/autogen/issues/51

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
