### PR TITLE
Update oai_openai_utils.ipynb

### DIFF
--- a/notebook/oai_openai_utils.ipynb
+++ b/notebook/oai_openai_utils.ipynb
@@ -454,7 +454,7 @@
       "text/plain": [
        "[{'api_key': 'sk-*********************', 'model': 'gpt-4'},\n",
        " {'api_key': '1234567890234567890',\n",
-       "  'base_url': 'https://api.someotherapi.com',\n",
+       "  'api_base': 'https://api.someotherapi.com',\n",
        "  'api_type': 'aoai',\n",
        "  'api_version': 'v2',\n",
        "  'model': 'gpt-3.5-turbo'}]"
@@ -474,7 +474,7 @@
     "            \"api_key_env_var\": \"ANOTHER_API_KEY\",\n",
     "            \"api_type\": \"aoai\",\n",
     "            \"api_version\": \"v2\",\n",
-    "            \"base_url\": \"https://api.someotherapi.com\"\n",
+    "            \"api_base\": \"https://api.someotherapi.com\"\n",
     "        }\n",
     "    },\n",
     "    filter_dict={\n",


### PR DESCRIPTION
## Why are these changes needed?

On latest, this parameter throws:
```
Traceback (most recent call last):
  File "C:\Users\anvolkma\Desktop\dev\MVN-MavenService\src\MVN\Experiments\Py\autogen_agent.py", line 6, in <module>
    config_list = config_list_from_dotenv(
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\anvolkma\AppData\Roaming\Python\Python311\site-packages\autogen\oai\openai_utils.py", line 351, in config_list_from_dotenv
    config_dict = get_config(api_key=api_key, **config_without_key_var)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: get_config() got an unexpected keyword argument 'base_url'
```

Changing it to `api_base`, which is supported.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
