### PR TITLE
Makes select_speaker more robust by checking for mentions anywhere.

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -102,15 +102,8 @@ Then select the next role from {[agent.name for agent in agents]} to play. Only 
             # i = self._random.randint(0, len(self._agent_names) - 1)  # randomly pick an id
             return self.next_agent(last_speaker, agents)
 
-        # Find mentions of any agents
-        mentions = dict()
-        for agent in self.agents:
-            regex = r"\b" + re.escape(agent.name) + r"\b"  # Finds agent mentions, taking word boundaries into account
-            count = len(re.findall(regex, name))
-            if count > 0:
-                mentions[agent.name] = count
-
-        # If exactly one agent is found, use it. Otherwise, leave the OAI response unmodified
+        # If exactly one agent is mentioned, use it. Otherwise, leave the OAI response unmodified
+        mentions = _mentioned_agents(name, agents)
         if len(mentions) == 1:
             name = next(iter(mentions))
 
@@ -132,6 +125,20 @@ Then select the next role from {[agent.name for agent in agents]} to play. Only 
                 )
             roles.append(f"{agent.name}: {agent.system_message}")
         return "\n".join(roles)
+
+    def _mentioned_agents(self, message_content: str, agents: List[Agent]) -> Dict:
+        """
+        Finds and counts agent mentions in the string message_content, taking word boundaries into account.
+
+        Returns: A dictionary mapping agent names to mention counts (to be included, at least one mention must occur)
+        """
+        mentions = dict()
+        for agent in agents:
+            regex = r"(?<=\W)" + re.escape(agent.name) + r"(?=\W)"  # Finds agent mentions, taking word boundaries into account
+            count = len(re.findall(regex, " " + message_content + " ")) # Pad the message to help with matching
+            if count > 0:
+                mentions[agent.name] = count
+        return mentions
 
 
 class GroupChatManager(ConversableAgent):

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import sys
 from typing import Dict, List, Optional, Union
+import re
 from .agent import Agent
 from .conversable_agent import ConversableAgent
 import logging
@@ -100,6 +101,20 @@ Then select the next role from {[agent.name for agent in agents]} to play. Only 
         if not final:
             # i = self._random.randint(0, len(self._agent_names) - 1)  # randomly pick an id
             return self.next_agent(last_speaker, agents)
+
+        # Find mentions of any agents
+        mentions = dict()
+        for agent in self.agents:
+            regex = r"\b" + re.escape(agent.name) + r"\b"  # Finds agent mentions, taking word boundaries into account
+            count = len(re.findall(regex, name))
+            if count > 0:
+                mentions[agent.name] = count
+
+        # If exactly one agent is found, use it. Otherwise, leave the OAI response unmodified
+        if len(mentions) == 1:
+            name = next(iter(mentions))
+
+        # Return the result
         try:
             return self.agent_by_name(name)
         except ValueError:

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -112,6 +112,7 @@ def test_plugin():
     assert len(agent1.chat_messages[group_chat_manager]) == 2
     assert len(groupchat.messages) == 2
 
+
 def test_agent_mentions():
     agent1 = autogen.ConversableAgent(
         "alice",
@@ -135,19 +136,34 @@ def test_agent_mentions():
         default_auto_reply="This is sam speaking.",
     )
     groupchat = autogen.GroupChat(agents=[agent1, agent2, agent3], messages=[], max_round=2)
- 
+
     # Basic counting
     assert json.dumps(groupchat._mentioned_agents("", [agent1, agent2, agent3]), sort_keys=True) == "{}"
     assert json.dumps(groupchat._mentioned_agents("alice", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 1}'
-    assert json.dumps(groupchat._mentioned_agents("alice bob alice", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 2, "bob": 1}'
-    assert json.dumps(groupchat._mentioned_agents("alice bob alice sam", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 2, "bob": 1, "sam": 1}'
-    assert json.dumps(groupchat._mentioned_agents("alice bob alice sam robert", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 2, "bob": 1, "sam": 1}'
+    assert (
+        json.dumps(groupchat._mentioned_agents("alice bob alice", [agent1, agent2, agent3]), sort_keys=True)
+        == '{"alice": 2, "bob": 1}'
+    )
+    assert (
+        json.dumps(groupchat._mentioned_agents("alice bob alice sam", [agent1, agent2, agent3]), sort_keys=True)
+        == '{"alice": 2, "bob": 1, "sam": 1}'
+    )
+    assert (
+        json.dumps(groupchat._mentioned_agents("alice bob alice sam robert", [agent1, agent2, agent3]), sort_keys=True)
+        == '{"alice": 2, "bob": 1, "sam": 1}'
+    )
 
     # Substring
-    assert json.dumps(groupchat._mentioned_agents("sam samantha basam asami", [agent1, agent2, agent3]), sort_keys=True) == '{"sam": 1}'
+    assert (
+        json.dumps(groupchat._mentioned_agents("sam samantha basam asami", [agent1, agent2, agent3]), sort_keys=True)
+        == '{"sam": 1}'
+    )
 
     # Word boundaries
-    assert json.dumps(groupchat._mentioned_agents("alice! .alice. .alice", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 3}'
+    assert (
+        json.dumps(groupchat._mentioned_agents("alice! .alice. .alice", [agent1, agent2, agent3]), sort_keys=True)
+        == '{"alice": 3}'
+    )
 
     # Special characters in agent names
     agent4 = autogen.ConversableAgent(
@@ -159,8 +175,13 @@ def test_agent_mentions():
     )
 
     groupchat = autogen.GroupChat(agents=[agent1, agent2, agent3, agent4], messages=[], max_round=2)
-    assert json.dumps(groupchat._mentioned_agents("alice bob alice sam robert .*", [agent1, agent2, agent3, agent4]), sort_keys=True) == '{".*": 1, "alice": 2, "bob": 1, "sam": 1}'
- 
+    assert (
+        json.dumps(
+            groupchat._mentioned_agents("alice bob alice sam robert .*", [agent1, agent2, agent3, agent4]),
+            sort_keys=True,
+        )
+        == '{".*": 1, "alice": 2, "bob": 1, "sam": 1}'
+    )
 
 
 if __name__ == "__main__":

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -1,5 +1,6 @@
 import pytest
 import autogen
+import json
 
 
 def test_func_call_groupchat():
@@ -111,9 +112,60 @@ def test_plugin():
     assert len(agent1.chat_messages[group_chat_manager]) == 2
     assert len(groupchat.messages) == 2
 
+def test_agent_mentions():
+    agent1 = autogen.ConversableAgent(
+        "alice",
+        max_consecutive_auto_reply=2,
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is alice sepaking.",
+    )
+    agent2 = autogen.ConversableAgent(
+        "bob",
+        max_consecutive_auto_reply=2,
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is bob speaking.",
+    )
+    agent3 = autogen.ConversableAgent(
+        "sam",
+        max_consecutive_auto_reply=2,
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="This is sam speaking.",
+    )
+    groupchat = autogen.GroupChat(agents=[agent1, agent2, agent3], messages=[], max_round=2)
+ 
+    # Basic counting
+    assert json.dumps(groupchat._mentioned_agents("", [agent1, agent2, agent3]), sort_keys=True) == "{}"
+    assert json.dumps(groupchat._mentioned_agents("alice", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 1}'
+    assert json.dumps(groupchat._mentioned_agents("alice bob alice", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 2, "bob": 1}'
+    assert json.dumps(groupchat._mentioned_agents("alice bob alice sam", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 2, "bob": 1, "sam": 1}'
+    assert json.dumps(groupchat._mentioned_agents("alice bob alice sam robert", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 2, "bob": 1, "sam": 1}'
+
+    # Substring
+    assert json.dumps(groupchat._mentioned_agents("sam samantha basam asami", [agent1, agent2, agent3]), sort_keys=True) == '{"sam": 1}'
+
+    # Word boundaries
+    assert json.dumps(groupchat._mentioned_agents("alice! .alice. .alice", [agent1, agent2, agent3]), sort_keys=True) == '{"alice": 3}'
+
+    # Special characters in agent names
+    agent4 = autogen.ConversableAgent(
+        ".*",
+        max_consecutive_auto_reply=2,
+        human_input_mode="NEVER",
+        llm_config=False,
+        default_auto_reply="Match everything.",
+    )
+
+    groupchat = autogen.GroupChat(agents=[agent1, agent2, agent3, agent4], messages=[], max_round=2)
+    assert json.dumps(groupchat._mentioned_agents("alice bob alice sam robert .*", [agent1, agent2, agent3, agent4]), sort_keys=True) == '{".*": 1, "alice": 2, "bob": 1, "sam": 1}'
+ 
+
 
 if __name__ == "__main__":
     test_func_call_groupchat()
     # test_broadcast()
     test_chat_manager()
     # test_plugin()
+    # test_agent_mentions()


### PR DESCRIPTION
Makes select_speaker more robust by checking for agent name mentions anywhere in the string returned by the LLM.

## Why are these changes needed?

Selecting the speaker fails when the LLM returns anything other than an exact agent name.

## Related issue number

Closes #663, and perhaps a few others.

Edit: I just saw #668, which is a different problem, but might be related?

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
