### PR TITLE
fix assistant creating without file

### DIFF
--- a/autogen/agentchat/contrib/gpt_assistant_agent.py
+++ b/autogen/agentchat/contrib/gpt_assistant_agent.py
@@ -64,6 +64,7 @@ class GPTAssistantAgent(ConversableAgent):
                 instructions=instructions,
                 tools=llm_config.get("tools", []),
                 model=llm_config.get("model", "gpt-4-1106-preview"),
+                file_ids=llm_config.get("file_ids", []),
             )
         else:
             # retrieve an existing assistant

--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import sys
 import autogen
+from autogen import OpenAIWrapper
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST  # noqa: E402
@@ -168,6 +169,38 @@ def test_gpt_assistant_existing_no_instructions():
     assistant.delete_assistant()
     assert instruction_match is True
 
+
+@pytest.mark.skipif(
+    sys.platform in ["darwin", "win32"] or skip_test,
+    reason="do not run on MacOS or windows or dependency is not installed",
+)
+def test_get_assistant_files():
+    """
+    Test function to create a new GPTAssistantAgent, set its instructions, retrieve the instructions,
+    and assert that the retrieved instructions match the set instructions.
+    """
+    current_file_path = os.path.abspath(__file__)
+    openai_client = OpenAIWrapper(config_list=config_list)._clients[0]
+    file = openai_client.files.create(file=open(current_file_path, "rb"), purpose="assistants")
+
+    assistant = GPTAssistantAgent(
+        "assistant",
+        instructions="This is a test",
+        llm_config={
+            "config_list": config_list,
+            "tools": [{"type": "retrieval"}],
+            "file_ids": [file.id],
+        },
+    )
+
+    files = assistant.openai_client.beta.assistants.files.list(assistant_id=assistant.assistant_id)
+    retrived_file_ids = [fild.id for fild in files]
+    expected_file_id = file.id
+
+    assistant.delete_assistant()
+    openai_client.files.delete(file.id)
+
+    assert expected_file_id in retrived_file_ids
 
 if __name__ == "__main__":
     test_gpt_assistant_chat()

--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -202,8 +202,10 @@ def test_get_assistant_files():
 
     assert expected_file_id in retrived_file_ids
 
+
 if __name__ == "__main__":
     test_gpt_assistant_chat()
     test_get_assistant_instructions()
     test_gpt_assistant_instructions_overwrite()
     test_gpt_assistant_existing_no_instructions()
+    test_get_assistant_files()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Creating an assistant with file ids, otherwise the retrieval function cannot be used.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
