### PR TITLE
Added an 'auto' mode to last_n_messages

### DIFF
--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -159,14 +159,7 @@ def test_generate_code_execution_reply():
 
     # scenario 6: if last_n_messages is set to 'auto' and code is found, then we execute it correctly
     dummy_messages_for_auto = []
-    for i in range(3):
-        dummy_messages_for_auto.append(
-            {
-                "content": "no code block",
-                "role": "user",
-            }
-        )
-
+    for i in range(4):
         # Without an assistant present
         agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
         assert agent.generate_code_execution_reply([code_message] + dummy_messages_for_auto) == (
@@ -181,6 +174,13 @@ def test_generate_code_execution_reply():
         ) == (
             True,
             "exitcode: 0 (execution succeeded)\nCode output: \nhello world\n",
+        )
+
+        dummy_messages_for_auto.append(
+            {
+                "content": "no code block",
+                "role": "user",
+            }
         )
 
     # scenario 7: if last_n_messages is set to 'auto' and code is present, but not before an assistant message, then nothing happens

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -128,6 +128,71 @@ def test_generate_code_execution_reply():
     )
     assert agent._code_execution_config["last_n_messages"] == 3
 
+    # scenario 5: if last_n_messages is set to 'auto' and no code is found, then nothing breaks both when an assistant message is and isn't present
+    assistant_message_for_auto = {
+        "content": "This is me! The assistant!",
+        "role": "assistant",
+    }
+
+    dummy_messages_for_auto = []
+    for i in range(3):
+        dummy_messages_for_auto.append(
+            {
+                "content": "no code block",
+                "role": "user",
+            }
+        )
+
+        # Without an assistant present
+        agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
+        assert agent.generate_code_execution_reply(dummy_messages_for_auto) == (
+            False,
+            None,
+        )
+
+        # With an assistant message present
+        agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
+        assert agent.generate_code_execution_reply([assistant_message_for_auto] + dummy_messages_for_auto) == (
+            False,
+            None,
+        )
+
+    # scenario 6: if last_n_messages is set to 'auto' and code is found, then we execute it correctly
+    dummy_messages_for_auto = []
+    for i in range(3):
+        dummy_messages_for_auto.append(
+            {
+                "content": "no code block",
+                "role": "user",
+            }
+        )
+
+        # Without an assistant present
+        agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
+        assert agent.generate_code_execution_reply([code_message] + dummy_messages_for_auto) == (
+            True,
+            "exitcode: 0 (execution succeeded)\nCode output: \nhello world\n",
+        )
+
+        # With an assistant message present
+        agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
+        assert agent.generate_code_execution_reply(
+            [assistant_message_for_auto] + [code_message] + dummy_messages_for_auto
+        ) == (
+            True,
+            "exitcode: 0 (execution succeeded)\nCode output: \nhello world\n",
+        )
+
+    # scenario 7: if last_n_messages is set to 'auto' and code is present, but not before an assistant message, then nothing happens
+    agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
+    assert agent.generate_code_execution_reply(
+        [code_message] + [assistant_message_for_auto] + dummy_messages_for_auto
+    ) == (
+        False,
+        None,
+    )
+    assert agent._code_execution_config["last_n_messages"] == "auto"
+
 
 def test_max_consecutive_auto_reply():
     agent = ConversableAgent("a0", max_consecutive_auto_reply=2, llm_config=False, human_input_mode="NEVER")
@@ -249,4 +314,5 @@ if __name__ == "__main__":
     # test_trigger()
     # test_context()
     # test_max_consecutive_auto_reply()
+    # test_generate_code_execution_reply()
     test_conversable_agent()


### PR DESCRIPTION
## Why are these changes needed?

At present, code execution will scan back n messages to find code to run. Here, n is fixed at the time the agent is created (and it defaults to 1). This code make this scanning dynamic, by searching through all the "new" messages that arrived since the agent last spoke (which is also typically when it last tried to execute code).

## Related issue number

This, together with #688, and #669, will likely address many issues related to user_proxy spam (issue: #624)

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
