### PR TITLE
Update OAI_CONFIG_LIST_sample

### DIFF
--- a/OAI_CONFIG_LIST_sample
+++ b/OAI_CONFIG_LIST_sample
@@ -5,14 +5,14 @@
         "api_key": "<your OpenAI API key here>"
     },
     {
-        "model": "gpt-4",
+        "model": "<your Azure OpenAI deployment name>",
         "api_key": "<your Azure OpenAI API key here>",
         "base_url": "<your Azure OpenAI API base here>",
         "api_type": "azure",
         "api_version": "2023-07-01-preview"
     },
     {
-        "model": "gpt-3.5-turbo",
+        "model": "<your Azure OpenAI deployment name>",
         "api_key": "<your Azure OpenAI API key here>",
         "base_url": "<your Azure OpenAI API base here>",
         "api_type": "azure",


### PR DESCRIPTION
## Why are these changes needed?

The previous sample file made it seem like the `model` fields should be hardcoded to whatever model you're using, even for the Azure examples, which is not the case. The `model` should in fact be the name of the Azure model deployment.

As [pointed out](https://github.com/microsoft/autogen/issues/601) by @sonichi 
>  "model" needs to be set to match the deployment_name while "deployment_name" can be removed.

## Related issue number

relates to https://github.com/microsoft/autogen/issues/601
