### PR TITLE
Fixed #279

### DIFF
--- a/autogen/oai/completion.py
+++ b/autogen/oai/completion.py
@@ -229,7 +229,8 @@ class Completion(openai_Completion):
                 sleep(retry_wait_time)
             except APIError as err:
                 error_code = err and err.json_body and isinstance(err.json_body, dict) and err.json_body.get("error")
-                error_code = error_code and error_code.get("code")
+                if isinstance(error_code, dict):
+                    error_code = error_code.get("code")
                 if error_code == "content_filter":
                     raise
                 # transient error


### PR DESCRIPTION
## Why are these changes needed?

This is a popular issue, #279 which seems to be happening when an OpenAI-compatible API has a specific minor discrepancy from spec in the error response scenario.

Sometimes, when building an OpenAI-compatible API, the main inference scenario is built very well but the API's error response is not fully compliant.

I was building an OpenAI-compatible endpoint. In my case, my error response had an `error` object that was a string instead of an object.

This was my version, which was slightly off

```
    const errorObject = {
        "error":  "Authorization failed: there was a problem with the API key."
    }
```

This is what OpenAI would have returned

```
    const errorObject = {
        "error": {
          "message": "Authorization failed: there was a problem with the API key.",
          "type": "invalid_request_error",
          "param": null,
          "code": null
      }
    }
```

`error_code=error_data.get("code")` will throw because it is expecting `error_code` to be an object with a property `code` and in my case, `error` was a string.

## Related issue number

#279 

## Checks

- [x] (**_None needed)_** I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] **_(None needed)_** I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
