### PR TITLE
GroupChat handle is_termination_msg

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -257,6 +257,11 @@ class GroupChatManager(ConversableAgent):
             if message["role"] != "function":
                 message["name"] = speaker.name
             groupchat.messages.append(message)
+
+            if self._is_termination_msg(message):
+                # The conversation is over
+                break
+
             # broadcast the message to all agents except the speaker
             for agent in groupchat.agents:
                 if agent != speaker:
@@ -302,6 +307,11 @@ class GroupChatManager(ConversableAgent):
             if message["role"] != "function":
                 message["name"] = speaker.name
             groupchat.messages.append(message)
+
+            if self._is_termination_msg(message):
+                # The conversation is over
+                break
+
             # broadcast the message to all agents except the speaker
             for agent in groupchat.agents:
                 if agent != speaker:


### PR DESCRIPTION
## Why are these changes needed?

Setting the is_termination_msg function handler in the GroupChatManager has no effect. This is because the GroupChatManager simply forwards the message to the next agent, and it falls on those agents to stop the conversation. This is problematic as it wastes orchestration LLM calls when the conversation is over, and because it prevents the ability to use the GroupChatManager as a central place to control group chat termination.

This PR fixes the issue by checking the termination message before rebroadcasting.

## Related issue number

Closes #802 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
