### PR TITLE
Quick fix for 765

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -208,7 +208,7 @@ Then select the next role from {[agent.name for agent in agents]} to play. Only 
             regex = (
                 r"(?<=\W)" + re.escape(agent.name) + r"(?=\W)"
             )  # Finds agent mentions, taking word boundaries into account
-            count = len(re.findall(regex, " " + message_content + " "))  # Pad the message to help with matching
+            count = len(re.findall(regex, f" {message_content} "))  # Pad the message to help with matching
             if count > 0:
                 mentions[agent.name] = count
         return mentions


### PR DESCRIPTION

## Why are these changes needed?

For some reason select_speaker is getting a 'ChatCompletionMessage' rather than a str, and this wasn't being handled gracefully causing a crash.

This PR fixes the crash. 'ChatCompletionMessage' messages are now handled like any other response. However, it is unclear why some folks were seeing this behavior to begin with. This will require further investigation.

## Related issue number

Mitigates #765

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
