### PR TITLE
Add a warning message if docs_path not explicitly set

### DIFF
--- a/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
+++ b/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
@@ -175,7 +175,8 @@ class RetrieveUserProxyAgent(UserProxyAgent):
         if "docs_path" not in self._retrieve_config:
             logger.warning(
                 "docs_path is not provided in retrieve_config. "
-                f"Will raise ValueError if the collection `{self._collection_name}` doesn't exist."
+                f"Will raise ValueError if the collection `{self._collection_name}` doesn't exist. "
+                "Set docs_path to None to suppress this warning."
             )
         self._model = self._retrieve_config.get("model", "gpt-4")
         self._max_tokens = self.get_max_tokens(self._model)

--- a/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
+++ b/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
@@ -9,6 +9,7 @@ from autogen.agentchat import UserProxyAgent
 from autogen.retrieve_utils import create_vector_db_from_dir, query_vector_db, TEXT_FORMATS
 from autogen.token_count_utils import count_token
 from autogen.code_utils import extract_code
+from autogen import logger
 
 from typing import Callable, Dict, Optional, Union, List, Tuple, Any
 from IPython import get_ipython
@@ -171,6 +172,11 @@ class RetrieveUserProxyAgent(UserProxyAgent):
         self._client = self._retrieve_config.get("client", chromadb.Client())
         self._docs_path = self._retrieve_config.get("docs_path", None)
         self._collection_name = self._retrieve_config.get("collection_name", "autogen-docs")
+        if "docs_path" not in self._retrieve_config:
+            logger.warning(
+                "docs_path is not provided in retrieve_config. "
+                f"Will raise ValueError if the collection `{self._collection_name}` doesn't exist."
+            )
         self._model = self._retrieve_config.get("model", "gpt-4")
         self._max_tokens = self.get_max_tokens(self._model)
         self._chunk_token_size = int(self._retrieve_config.get("chunk_token_size", self._max_tokens * 0.4))

--- a/test/agentchat/contrib/test_retrievechat.py
+++ b/test/agentchat/contrib/test_retrievechat.py
@@ -27,7 +27,6 @@ except ImportError:
     reason="do not run on MacOS or windows or dependency is not installed",
 )
 def test_retrievechat():
-    conversations = {}
     # autogen.ChatCompletion.start_logging(conversations)  # deprecated in v0.2
 
     config_list = autogen.config_list_from_json(
@@ -65,8 +64,31 @@ def test_retrievechat():
     code_problem = "How can I use FLAML to perform a classification task, set use_spark=True, train 30 seconds and force cancel jobs if time limit is reached."
     ragproxyagent.initiate_chat(assistant, problem=code_problem, search_string="spark", silent=True)
 
-    print(conversations)
+
+def test_retrieve_config(caplog):
+    # test warning message when no docs_path is provided
+    ragproxyagent = RetrieveUserProxyAgent(
+        name="ragproxyagent",
+        human_input_mode="NEVER",
+        max_consecutive_auto_reply=2,
+        retrieve_config={
+            "chunk_token_size": 2000,
+            "get_or_create": True,
+        },
+    )
+
+    # Capture the printed content
+    captured_logs = caplog.records[0]
+    print(captured_logs)
+
+    # Assert on the printed content
+    assert (
+        f"docs_path is not provided in retrieve_config. Will raise ValueError if the collection `{ragproxyagent._collection_name}` doesn't exist."
+        in captured_logs.message
+    )
+    assert captured_logs.levelname == "WARNING"
 
 
 if __name__ == "__main__":
     test_retrievechat()
+    # test_retrieve_config()

--- a/test/agentchat/contrib/test_retrievechat.py
+++ b/test/agentchat/contrib/test_retrievechat.py
@@ -7,7 +7,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST  # noqa: E402
 
 try:
-    import openai
     from autogen.agentchat.contrib.retrieve_assistant_agent import (
         RetrieveAssistantAgent,
     )
@@ -16,6 +15,7 @@ try:
     )
     import chromadb
     from chromadb.utils import embedding_functions as ef
+    import openai
 
     skip_test = False
 except ImportError:

--- a/test/agentchat/contrib/test_retrievechat.py
+++ b/test/agentchat/contrib/test_retrievechat.py
@@ -27,6 +27,7 @@ except ImportError:
     reason="do not run on MacOS or windows or dependency is not installed",
 )
 def test_retrievechat():
+    conversations = {}
     # autogen.ChatCompletion.start_logging(conversations)  # deprecated in v0.2
 
     config_list = autogen.config_list_from_json(
@@ -63,6 +64,8 @@ def test_retrievechat():
 
     code_problem = "How can I use FLAML to perform a classification task, set use_spark=True, train 30 seconds and force cancel jobs if time limit is reached."
     ragproxyagent.initiate_chat(assistant, problem=code_problem, search_string="spark", silent=True)
+
+    print(conversations)
 
 
 def test_retrieve_config(caplog):

--- a/test/agentchat/contrib/test_retrievechat.py
+++ b/test/agentchat/contrib/test_retrievechat.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST  # noqa: E402
 
 try:
+    import openai
     from autogen.agentchat.contrib.retrieve_assistant_agent import (
         RetrieveAssistantAgent,
     )
@@ -15,7 +16,6 @@ try:
     )
     import chromadb
     from chromadb.utils import embedding_functions as ef
-    import openai
 
     skip_test = False
 except ImportError:
@@ -69,6 +69,10 @@ def test_retrievechat():
 
 
 def test_retrieve_config(caplog):
+    from autogen.agentchat.contrib.retrieve_user_proxy_agent import (
+        RetrieveUserProxyAgent,
+    )
+
     # test warning message when no docs_path is provided
     ragproxyagent = RetrieveUserProxyAgent(
         name="ragproxyagent",

--- a/test/agentchat/contrib/test_retrievechat.py
+++ b/test/agentchat/contrib/test_retrievechat.py
@@ -68,11 +68,11 @@ def test_retrievechat():
     print(conversations)
 
 
+@pytest.mark.skipif(
+    sys.platform in ["darwin", "win32"] or skip_test,
+    reason="do not run on MacOS or windows or dependency is not installed",
+)
 def test_retrieve_config(caplog):
-    from autogen.agentchat.contrib.retrieve_user_proxy_agent import (
-        RetrieveUserProxyAgent,
-    )
-
     # test warning message when no docs_path is provided
     ragproxyagent = RetrieveUserProxyAgent(
         name="ragproxyagent",
@@ -97,5 +97,5 @@ def test_retrieve_config(caplog):
 
 
 if __name__ == "__main__":
-    test_retrievechat()
-    # test_retrieve_config()
+    # test_retrievechat()
+    test_retrieve_config()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Address https://discord.com/channels/1153072414184452236/1153072414184452241/1179080685407973447

>  I wish "docs_path" :  False/None was mandatory when docs are not specified.. doesnt the zen of Python say something about explicity > implicity?  Turns out that if I have a typo in my retrieve_config the error that I get for not defining docs_path doenst help at all

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
