### PR TITLE
Update position of registered custom generate_reply functions for contrib/ agents per PR #794

### DIFF
--- a/autogen/agentchat/contrib/math_user_proxy_agent.py
+++ b/autogen/agentchat/contrib/math_user_proxy_agent.py
@@ -165,7 +165,7 @@ class MathUserProxyAgent(UserProxyAgent):
             default_auto_reply=default_auto_reply,
             **kwargs,
         )
-        self.register_reply([Agent, None], MathUserProxyAgent._generate_math_reply, 1)
+        self.register_reply([Agent, None], MathUserProxyAgent._generate_math_reply, position=2)
         # fixed var
         self._max_invalid_q_per_step = max_invalid_q_per_step
 

--- a/autogen/agentchat/contrib/teachable_agent.py
+++ b/autogen/agentchat/contrib/teachable_agent.py
@@ -63,7 +63,7 @@ class TeachableAgent(ConversableAgent):
             **kwargs,
         )
         # Register a custom reply function.
-        self.register_reply(Agent, TeachableAgent._generate_teachable_assistant_reply, 1)
+        self.register_reply(Agent, TeachableAgent._generate_teachable_assistant_reply, position=2)
 
         # Assemble the parameter settings.
         self._teach_config = {} if teach_config is None else teach_config

--- a/autogen/agentchat/contrib/text_analyzer_agent.py
+++ b/autogen/agentchat/contrib/text_analyzer_agent.py
@@ -46,7 +46,7 @@ class TextAnalyzerAgent(ConversableAgent):
             llm_config=llm_config,
             **kwargs,
         )
-        self.register_reply(Agent, TextAnalyzerAgent._analyze_in_reply, 1)
+        self.register_reply(Agent, TextAnalyzerAgent._analyze_in_reply, position=2)
 
     def _analyze_in_reply(
         self,


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

PR #794 added registration of async human input handler.  This bumped the position of the other default registered generate reply functions by 1. Two contrib/ agents were updated per this change (their generate_reply function was bumped by 1 to account for change), but three contrib/ agents were missed.  This completes the bump by 1 for those three agents.

## Related issue number

PR #794 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
