### PR TITLE
Handle 400 context length errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <img src="https://github.com/microsoft/autogen/blob/main/website/static/img/flaml.svg"  width=200>
     <br>
 </p> -->
-:fire: Nov 24: pyautogen [v0.2](releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://microsoft.github.io/autogen/docs/Installation#python).
+:fire: Nov 24: pyautogen [v0.2](https://github.com/microsoft/autogen/releases/tag/v0.2.0) is released with many updates and new features compared to v0.1.1. It switches to using openai-python v1. Please read the [migration guide](https://microsoft.github.io/autogen/docs/Installation#python).
 
 :fire: Nov 11: OpenAI's Assistants are available in AutoGen and interoperatable with other AutoGen agents! Checkout our [blogpost](https://microsoft.github.io/autogen/blog/2023/11/13/OAI-assistants) for details and examples.
 

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -621,7 +621,7 @@ class ConversableAgent(Agent):
                 if "content" in message:
                     try:
                         message["content"] = message["content"][:5000]
-                    except:
+                    except IndexError:
                         pass
                 short_messages.append(message)
             return short_messages

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -13,47 +13,87 @@ def conversable_agent():
     )
 
 
+def test_truncation():
+    long_string = "This is a really long string." * 10000
+    truncation_agent = ConversableAgent(
+        "truncation_tester",
+        max_consecutive_auto_reply=0,
+        llm_config=False,
+        human_input_mode="NEVER",
+    )
+    mock_messages = [{"content": long_string}, {"content": long_string}]
+    truncated_messages = truncation_agent.truncate_messages_if_over_context_len(
+        mock_messages, 5000
+    )
+    assert (
+        truncated_messages[0]["content"]
+        == ("This is a really long string." * 10000)[:5000]
+    )
+
+
 def test_trigger():
-    agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
-    agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
-    agent.register_reply(agent1, lambda recipient, messages, sender, config: (True, "hello"))
+    agent = ConversableAgent(
+        "a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
+    )
+    agent1 = ConversableAgent(
+        "a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
+    )
+    agent.register_reply(
+        agent1, lambda recipient, messages, sender, config: (True, "hello")
+    )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello"
-    agent.register_reply("a1", lambda recipient, messages, sender, config: (True, "hello a1"))
+    agent.register_reply(
+        "a1", lambda recipient, messages, sender, config: (True, "hello a1")
+    )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello a1"
     agent.register_reply(
-        ConversableAgent, lambda recipient, messages, sender, config: (True, "hello conversable agent")
+        ConversableAgent,
+        lambda recipient, messages, sender, config: (True, "hello conversable agent"),
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello conversable agent"
     agent.register_reply(
-        lambda sender: sender.name.startswith("a"), lambda recipient, messages, sender, config: (True, "hello a")
+        lambda sender: sender.name.startswith("a"),
+        lambda recipient, messages, sender, config: (True, "hello a"),
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello a"
     agent.register_reply(
-        lambda sender: sender.name.startswith("b"), lambda recipient, messages, sender, config: (True, "hello b")
+        lambda sender: sender.name.startswith("b"),
+        lambda recipient, messages, sender, config: (True, "hello b"),
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello a"
     agent.register_reply(
-        ["agent2", agent1], lambda recipient, messages, sender, config: (True, "hello agent2 or agent1")
+        ["agent2", agent1],
+        lambda recipient, messages, sender, config: (True, "hello agent2 or agent1"),
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello agent2 or agent1"
     agent.register_reply(
-        ["agent2", "agent3"], lambda recipient, messages, sender, config: (True, "hello agent2 or agent3")
+        ["agent2", "agent3"],
+        lambda recipient, messages, sender, config: (True, "hello agent2 or agent3"),
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello agent2 or agent1"
-    pytest.raises(ValueError, agent.register_reply, 1, lambda recipient, messages, sender, config: (True, "hi"))
+    pytest.raises(
+        ValueError,
+        agent.register_reply,
+        1,
+        lambda recipient, messages, sender, config: (True, "hi"),
+    )
     pytest.raises(ValueError, agent._match_trigger, 1, agent1)
 
 
 def test_context():
-    agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
-    agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
+    agent = ConversableAgent(
+        "a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
+    )
+    agent1 = ConversableAgent(
+        "a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
+    )
     agent1.send(
         {
             "content": "hello {name}",
@@ -89,7 +129,11 @@ def test_context():
 
 def test_generate_code_execution_reply():
     agent = ConversableAgent(
-        "a0", max_consecutive_auto_reply=10, code_execution_config=False, llm_config=False, human_input_mode="NEVER"
+        "a0",
+        max_consecutive_auto_reply=10,
+        code_execution_config=False,
+        llm_config=False,
+        human_input_mode="NEVER",
     )
 
     dummy_messages = [
@@ -109,13 +153,21 @@ def test_generate_code_execution_reply():
     }
 
     # scenario 1: if code_execution_config is not provided, the code execution should return false, none
-    assert agent.generate_code_execution_reply(dummy_messages, config=False) == (False, None)
+    assert agent.generate_code_execution_reply(dummy_messages, config=False) == (
+        False,
+        None,
+    )
 
     # scenario 2: if code_execution_config is provided, but no code block is found, the code execution should return false, none
-    assert agent.generate_code_execution_reply(dummy_messages, config={}) == (False, None)
+    assert agent.generate_code_execution_reply(dummy_messages, config={}) == (
+        False,
+        None,
+    )
 
     # scenario 3: if code_execution_config is provided, and code block is found, but it's not within the range of last_n_messages, the code execution should return false, none
-    assert agent.generate_code_execution_reply([code_message] + dummy_messages, config={"last_n_messages": 1}) == (
+    assert agent.generate_code_execution_reply(
+        [code_message] + dummy_messages, config={"last_n_messages": 1}
+    ) == (
         False,
         None,
     )
@@ -152,7 +204,9 @@ def test_generate_code_execution_reply():
 
         # With an assistant message present
         agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
-        assert agent.generate_code_execution_reply([assistant_message_for_auto] + dummy_messages_for_auto) == (
+        assert agent.generate_code_execution_reply(
+            [assistant_message_for_auto] + dummy_messages_for_auto
+        ) == (
             False,
             None,
         )
@@ -162,7 +216,9 @@ def test_generate_code_execution_reply():
     for i in range(4):
         # Without an assistant present
         agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
-        assert agent.generate_code_execution_reply([code_message] + dummy_messages_for_auto) == (
+        assert agent.generate_code_execution_reply(
+            [code_message] + dummy_messages_for_auto
+        ) == (
             True,
             "exitcode: 0 (execution succeeded)\nCode output: \nhello world\n",
         )
@@ -195,11 +251,23 @@ def test_generate_code_execution_reply():
 
 
 def test_max_consecutive_auto_reply():
-    agent = ConversableAgent("a0", max_consecutive_auto_reply=2, llm_config=False, human_input_mode="NEVER")
-    agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
-    assert agent.max_consecutive_auto_reply() == agent.max_consecutive_auto_reply(agent1) == 2
+    agent = ConversableAgent(
+        "a0", max_consecutive_auto_reply=2, llm_config=False, human_input_mode="NEVER"
+    )
+    agent1 = ConversableAgent(
+        "a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
+    )
+    assert (
+        agent.max_consecutive_auto_reply()
+        == agent.max_consecutive_auto_reply(agent1)
+        == 2
+    )
     agent.update_max_consecutive_auto_reply(1)
-    assert agent.max_consecutive_auto_reply() == agent.max_consecutive_auto_reply(agent1) == 1
+    assert (
+        agent.max_consecutive_auto_reply()
+        == agent.max_consecutive_auto_reply(agent1)
+        == 1
+    )
 
     agent1.initiate_chat(agent, message="hello")
     assert agent._consecutive_auto_reply_counter[agent1] == 1
@@ -220,12 +288,19 @@ def test_max_consecutive_auto_reply():
 
     assert agent1.reply_at_receive[agent] == agent.reply_at_receive[agent1] is True
     agent1.stop_reply_at_receive(agent)
-    assert agent1.reply_at_receive[agent] is False and agent.reply_at_receive[agent1] is True
+    assert (
+        agent1.reply_at_receive[agent] is False
+        and agent.reply_at_receive[agent1] is True
+    )
 
 
 def test_conversable_agent():
-    dummy_agent_1 = ConversableAgent(name="dummy_agent_1", llm_config=False, human_input_mode="ALWAYS")
-    dummy_agent_2 = ConversableAgent(name="dummy_agent_2", llm_config=False, human_input_mode="TERMINATE")
+    dummy_agent_1 = ConversableAgent(
+        name="dummy_agent_1", llm_config=False, human_input_mode="ALWAYS"
+    )
+    dummy_agent_2 = ConversableAgent(
+        name="dummy_agent_2", llm_config=False, human_input_mode="TERMINATE"
+    )
 
     # monkeypatch.setattr(sys, "stdin", StringIO("exit"))
     dummy_agent_1.receive("hello", dummy_agent_2)  # receive a str
@@ -271,7 +346,9 @@ def test_conversable_agent():
     dummy_agent_1.update_system_message("new system message")
     assert dummy_agent_1.system_message == "new system message"
 
-    dummy_agent_3 = ConversableAgent(name="dummy_agent_3", llm_config=False, human_input_mode="TERMINATE")
+    dummy_agent_3 = ConversableAgent(
+        name="dummy_agent_3", llm_config=False, human_input_mode="TERMINATE"
+    )
     with pytest.raises(KeyError):
         dummy_agent_1.last_message(dummy_agent_3)
 
@@ -282,9 +359,20 @@ def test_generate_reply():
         return num_to_be_added + given_num
 
     dummy_agent_2 = ConversableAgent(
-        name="user_proxy", llm_config=False, human_input_mode="TERMINATE", function_map={"add_num": add_num}
+        name="user_proxy",
+        llm_config=False,
+        human_input_mode="TERMINATE",
+        function_map={"add_num": add_num},
     )
-    messsages = [{"function_call": {"name": "add_num", "arguments": '{ "num_to_be_added": 5 }'}, "role": "assistant"}]
+    messsages = [
+        {
+            "function_call": {
+                "name": "add_num",
+                "arguments": '{ "num_to_be_added": 5 }',
+            },
+            "role": "assistant",
+        }
+    ]
 
     # when sender is None, messages is provided
     assert (
@@ -292,10 +380,13 @@ def test_generate_reply():
     ), "generate_reply not working when sender is None"
 
     # when sender is provided, messages is None
-    dummy_agent_1 = ConversableAgent(name="dummy_agent_1", llm_config=False, human_input_mode="ALWAYS")
+    dummy_agent_1 = ConversableAgent(
+        name="dummy_agent_1", llm_config=False, human_input_mode="ALWAYS"
+    )
     dummy_agent_2._oai_messages[dummy_agent_1] = messsages
     assert (
-        dummy_agent_2.generate_reply(messages=None, sender=dummy_agent_1)["content"] == "15"
+        dummy_agent_2.generate_reply(messages=None, sender=dummy_agent_1)["content"]
+        == "15"
     ), "generate_reply not working when messages is None"
 
 

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -22,78 +22,51 @@ def test_truncation():
         human_input_mode="NEVER",
     )
     mock_messages = [{"content": long_string}, {"content": long_string}]
-    truncated_messages = truncation_agent.truncate_messages_if_over_context_len(
-        mock_messages, 5000
-    )
-    assert (
-        truncated_messages[0]["content"]
-        == ("This is a really long string." * 10000)[:5000]
-    )
+    truncated_messages = truncation_agent.truncate_messages_if_over_context_len(mock_messages, 5000)
+    assert truncated_messages[0]["content"] == ("This is a really long string." * 10000)[:5000]
 
 
 def test_trigger():
-    agent = ConversableAgent(
-        "a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
-    )
-    agent1 = ConversableAgent(
-        "a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
-    )
-    agent.register_reply(
-        agent1, lambda recipient, messages, sender, config: (True, "hello")
-    )
+    agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
+    agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
+    agent.register_reply(agent1, lambda recipient, messages, sender, config: (True, "hello"))
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello"
-    agent.register_reply(
-        "a1", lambda recipient, messages, sender, config: (True, "hello a1")
-    )
+    agent.register_reply("a1", lambda recipient, messages, sender, config: (True, "hello a1"))
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello a1"
     agent.register_reply(
-        ConversableAgent,
-        lambda recipient, messages, sender, config: (True, "hello conversable agent"),
+        ConversableAgent, lambda recipient, messages, sender, config: (True, "hello conversable agent")
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello conversable agent"
     agent.register_reply(
-        lambda sender: sender.name.startswith("a"),
-        lambda recipient, messages, sender, config: (True, "hello a"),
+        lambda sender: sender.name.startswith("a"), lambda recipient, messages, sender, config: (True, "hello a")
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello a"
     agent.register_reply(
-        lambda sender: sender.name.startswith("b"),
-        lambda recipient, messages, sender, config: (True, "hello b"),
+        lambda sender: sender.name.startswith("b"), lambda recipient, messages, sender, config: (True, "hello b")
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello a"
     agent.register_reply(
-        ["agent2", agent1],
-        lambda recipient, messages, sender, config: (True, "hello agent2 or agent1"),
+        ["agent2", agent1], lambda recipient, messages, sender, config: (True, "hello agent2 or agent1")
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello agent2 or agent1"
     agent.register_reply(
-        ["agent2", "agent3"],
-        lambda recipient, messages, sender, config: (True, "hello agent2 or agent3"),
+        ["agent2", "agent3"], lambda recipient, messages, sender, config: (True, "hello agent2 or agent3")
     )
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello agent2 or agent1"
-    pytest.raises(
-        ValueError,
-        agent.register_reply,
-        1,
-        lambda recipient, messages, sender, config: (True, "hi"),
-    )
+    pytest.raises(ValueError, agent.register_reply, 1, lambda recipient, messages, sender, config: (True, "hi"))
     pytest.raises(ValueError, agent._match_trigger, 1, agent1)
 
 
 def test_context():
-    agent = ConversableAgent(
-        "a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
-    )
-    agent1 = ConversableAgent(
-        "a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
-    )
+    agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
+    agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
     agent1.send(
         {
             "content": "hello {name}",
@@ -129,11 +102,7 @@ def test_context():
 
 def test_generate_code_execution_reply():
     agent = ConversableAgent(
-        "a0",
-        max_consecutive_auto_reply=10,
-        code_execution_config=False,
-        llm_config=False,
-        human_input_mode="NEVER",
+        "a0", max_consecutive_auto_reply=10, code_execution_config=False, llm_config=False, human_input_mode="NEVER"
     )
 
     dummy_messages = [
@@ -153,21 +122,13 @@ def test_generate_code_execution_reply():
     }
 
     # scenario 1: if code_execution_config is not provided, the code execution should return false, none
-    assert agent.generate_code_execution_reply(dummy_messages, config=False) == (
-        False,
-        None,
-    )
+    assert agent.generate_code_execution_reply(dummy_messages, config=False) == (False, None)
 
     # scenario 2: if code_execution_config is provided, but no code block is found, the code execution should return false, none
-    assert agent.generate_code_execution_reply(dummy_messages, config={}) == (
-        False,
-        None,
-    )
+    assert agent.generate_code_execution_reply(dummy_messages, config={}) == (False, None)
 
     # scenario 3: if code_execution_config is provided, and code block is found, but it's not within the range of last_n_messages, the code execution should return false, none
-    assert agent.generate_code_execution_reply(
-        [code_message] + dummy_messages, config={"last_n_messages": 1}
-    ) == (
+    assert agent.generate_code_execution_reply([code_message] + dummy_messages, config={"last_n_messages": 1}) == (
         False,
         None,
     )
@@ -204,9 +165,7 @@ def test_generate_code_execution_reply():
 
         # With an assistant message present
         agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
-        assert agent.generate_code_execution_reply(
-            [assistant_message_for_auto] + dummy_messages_for_auto
-        ) == (
+        assert agent.generate_code_execution_reply([assistant_message_for_auto] + dummy_messages_for_auto) == (
             False,
             None,
         )
@@ -216,9 +175,7 @@ def test_generate_code_execution_reply():
     for i in range(4):
         # Without an assistant present
         agent._code_execution_config = {"last_n_messages": "auto", "use_docker": False}
-        assert agent.generate_code_execution_reply(
-            [code_message] + dummy_messages_for_auto
-        ) == (
+        assert agent.generate_code_execution_reply([code_message] + dummy_messages_for_auto) == (
             True,
             "exitcode: 0 (execution succeeded)\nCode output: \nhello world\n",
         )
@@ -251,23 +208,11 @@ def test_generate_code_execution_reply():
 
 
 def test_max_consecutive_auto_reply():
-    agent = ConversableAgent(
-        "a0", max_consecutive_auto_reply=2, llm_config=False, human_input_mode="NEVER"
-    )
-    agent1 = ConversableAgent(
-        "a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER"
-    )
-    assert (
-        agent.max_consecutive_auto_reply()
-        == agent.max_consecutive_auto_reply(agent1)
-        == 2
-    )
+    agent = ConversableAgent("a0", max_consecutive_auto_reply=2, llm_config=False, human_input_mode="NEVER")
+    agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
+    assert agent.max_consecutive_auto_reply() == agent.max_consecutive_auto_reply(agent1) == 2
     agent.update_max_consecutive_auto_reply(1)
-    assert (
-        agent.max_consecutive_auto_reply()
-        == agent.max_consecutive_auto_reply(agent1)
-        == 1
-    )
+    assert agent.max_consecutive_auto_reply() == agent.max_consecutive_auto_reply(agent1) == 1
 
     agent1.initiate_chat(agent, message="hello")
     assert agent._consecutive_auto_reply_counter[agent1] == 1
@@ -288,19 +233,12 @@ def test_max_consecutive_auto_reply():
 
     assert agent1.reply_at_receive[agent] == agent.reply_at_receive[agent1] is True
     agent1.stop_reply_at_receive(agent)
-    assert (
-        agent1.reply_at_receive[agent] is False
-        and agent.reply_at_receive[agent1] is True
-    )
+    assert agent1.reply_at_receive[agent] is False and agent.reply_at_receive[agent1] is True
 
 
 def test_conversable_agent():
-    dummy_agent_1 = ConversableAgent(
-        name="dummy_agent_1", llm_config=False, human_input_mode="ALWAYS"
-    )
-    dummy_agent_2 = ConversableAgent(
-        name="dummy_agent_2", llm_config=False, human_input_mode="TERMINATE"
-    )
+    dummy_agent_1 = ConversableAgent(name="dummy_agent_1", llm_config=False, human_input_mode="ALWAYS")
+    dummy_agent_2 = ConversableAgent(name="dummy_agent_2", llm_config=False, human_input_mode="TERMINATE")
 
     # monkeypatch.setattr(sys, "stdin", StringIO("exit"))
     dummy_agent_1.receive("hello", dummy_agent_2)  # receive a str
@@ -346,9 +284,7 @@ def test_conversable_agent():
     dummy_agent_1.update_system_message("new system message")
     assert dummy_agent_1.system_message == "new system message"
 
-    dummy_agent_3 = ConversableAgent(
-        name="dummy_agent_3", llm_config=False, human_input_mode="TERMINATE"
-    )
+    dummy_agent_3 = ConversableAgent(name="dummy_agent_3", llm_config=False, human_input_mode="TERMINATE")
     with pytest.raises(KeyError):
         dummy_agent_1.last_message(dummy_agent_3)
 
@@ -359,20 +295,9 @@ def test_generate_reply():
         return num_to_be_added + given_num
 
     dummy_agent_2 = ConversableAgent(
-        name="user_proxy",
-        llm_config=False,
-        human_input_mode="TERMINATE",
-        function_map={"add_num": add_num},
+        name="user_proxy", llm_config=False, human_input_mode="TERMINATE", function_map={"add_num": add_num}
     )
-    messsages = [
-        {
-            "function_call": {
-                "name": "add_num",
-                "arguments": '{ "num_to_be_added": 5 }',
-            },
-            "role": "assistant",
-        }
-    ]
+    messsages = [{"function_call": {"name": "add_num", "arguments": '{ "num_to_be_added": 5 }'}, "role": "assistant"}]
 
     # when sender is None, messages is provided
     assert (
@@ -380,13 +305,10 @@ def test_generate_reply():
     ), "generate_reply not working when sender is None"
 
     # when sender is provided, messages is None
-    dummy_agent_1 = ConversableAgent(
-        name="dummy_agent_1", llm_config=False, human_input_mode="ALWAYS"
-    )
+    dummy_agent_1 = ConversableAgent(name="dummy_agent_1", llm_config=False, human_input_mode="ALWAYS")
     dummy_agent_2._oai_messages[dummy_agent_1] = messsages
     assert (
-        dummy_agent_2.generate_reply(messages=None, sender=dummy_agent_1)["content"]
-        == "15"
+        dummy_agent_2.generate_reply(messages=None, sender=dummy_agent_1)["content"] == "15"
     ), "generate_reply not working when messages is None"
 
 


### PR DESCRIPTION
Handle 400 context length errors before they happen by checking length of messages sent to OpenAI.  If length of messages exceeds context length, this function will loop through all the messages and cut each one down to the first 5,000 characters.

## Why are these changes needed?

I saw a TODO in this file for handling errors that occur when the context length is too long. https://github.com/microsoft/autogen/blob/a107233e23a8a08924919bccf732e3509f31939d/autogen/agentchat/conversable_agent.py#L624

## Related issue number
#858 