### PR TITLE
print exit feedback for user

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -747,6 +747,7 @@ class ConversableAgent(Agent):
         message = messages[-1]
         reply = ""
         no_human_input_msg = ""
+        exit_reason = "Terminated by human."  # the reason for conversation termination
         if self.human_input_mode == "ALWAYS":
             reply = self.get_human_input(
                 f"Provide feedback to {sender.name}. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: "
@@ -758,6 +759,7 @@ class ConversableAgent(Agent):
             if self._consecutive_auto_reply_counter[sender] >= self._max_consecutive_auto_reply_dict[sender]:
                 if self.human_input_mode == "NEVER":
                     reply = "exit"
+                    exit_reason = "Exceeded maximum auto-reply count."
                 else:
                     # self.human_input_mode == "TERMINATE":
                     terminate = self._is_termination_msg(message)
@@ -772,6 +774,7 @@ class ConversableAgent(Agent):
             elif self._is_termination_msg(message):
                 if self.human_input_mode == "NEVER":
                     reply = "exit"
+                    exit_reason = "Last message matched termination condition."
                 else:
                     # self.human_input_mode == "TERMINATE":
                     reply = self.get_human_input(
@@ -789,6 +792,8 @@ class ConversableAgent(Agent):
         if reply == "exit":
             # reset the consecutive_auto_reply_counter
             self._consecutive_auto_reply_counter[sender] = 0
+            # tell user if the termination check matched
+            print(colored(f"Termination check of {self.name} matched: {exit_reason}", "red"))
             return True, None
 
         # send the human reply
@@ -939,6 +944,14 @@ class ConversableAgent(Agent):
             if self._match_trigger(reply_func_tuple["trigger"], sender):
                 final, reply = reply_func(self, messages=messages, sender=sender, config=reply_func_tuple["config"])
                 if final:
+                    # inform user about conversation termination
+                    if reply is None:
+                        print(
+                            colored(
+                                f"{self.name} has chosen to end the conversation. Last speaker: {sender.name}", "red"
+                            ),
+                            "\n",
+                        )
                     return reply
         return self._default_auto_reply
 
@@ -993,6 +1006,14 @@ class ConversableAgent(Agent):
                 else:
                     final, reply = reply_func(self, messages=messages, sender=sender, config=reply_func_tuple["config"])
                 if final:
+                    # inform user about conversation termination
+                    if reply is None:
+                        print(
+                            colored(
+                                f"{self.name} has chosen to end the conversation. Last speaker: {sender.name}", "red"
+                            ),
+                            "\n",
+                        )
                     return reply
         return self._default_auto_reply
 

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -9,6 +9,14 @@ from ..code_utils import content_str
 from .agent import Agent
 from .conversable_agent import ConversableAgent
 
+try:
+    from termcolor import colored
+except ImportError:
+
+    def colored(x, *args, **kwargs):
+        return x
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -269,6 +277,7 @@ class GroupChatManager(ConversableAgent):
         message = messages[-1]
         speaker = sender
         groupchat = config
+        exit_reason = "Exceeded max rounds count"  # the reason for groupchat termination
         for i in range(groupchat.max_round):
             # set the name to speaker's name if the role is not function
             if message["role"] != "function":
@@ -301,10 +310,14 @@ class GroupChatManager(ConversableAgent):
                     # admin agent is not found in the participants
                     raise
             if reply is None:
+                exit_reason = f"Response of {speaker.name}"
                 break
             # The speaker sends the message without requesting a reply
             speaker.send(reply, self, request_reply=False)
             message = self.last_message(speaker)
+
+        # inform user about the groupchat termination
+        print(colored(f"{self.name} has chosen to end the groupchat. Reason: {exit_reason}", "red"), "\n")
         return True, None
 
     async def a_run_chat(
@@ -319,6 +332,7 @@ class GroupChatManager(ConversableAgent):
         message = messages[-1]
         speaker = sender
         groupchat = config
+        exit_reason = "Exceeded max rounds count"  # the reason for groupchat termination
         for i in range(groupchat.max_round):
             # set the name to speaker's name if the role is not function
             if message["role"] != "function":
@@ -352,8 +366,12 @@ class GroupChatManager(ConversableAgent):
                     # admin agent is not found in the participants
                     raise
             if reply is None:
+                exit_reason = f"Response of {speaker.name}"
                 break
             # The speaker sends the message without requesting a reply
             await speaker.a_send(reply, self, request_reply=False)
             message = self.last_message(speaker)
+
+        # inform user about the groupchat termination
+        print(colored(f"{self.name} has chosen to end the groupchat. Reason: {exit_reason}", "red"), "\n")
         return True, None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This would help inform the user when a conversation has ended and for what reason.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #706

## Termination scenarios
### One-to-one conversation - agent returns termination msg
![image](https://github.com/microsoft/autogen/assets/17806916/1c6ea67e-6375-4616-a3a9-42946865a295)

### One-to-one conversation - agent returns None
![image](https://github.com/microsoft/autogen/assets/17806916/b21e1bb4-03a0-498e-aecb-6a72f89e7b6b)

### One-to-one conversation - max consecutive auto-reply limit
![image](https://github.com/microsoft/autogen/assets/17806916/d0d200dd-990d-43e3-adf4-39c34400e2f4)

### One-to-one conversation - terminated by human
![image](https://github.com/microsoft/autogen/assets/17806916/6fe3bf71-668f-47b6-acd1-b396d4fd7d43)

### GroupChat conversation - agent returns termination msg
![image](https://github.com/microsoft/autogen/assets/17806916/d0d9a88b-4630-45e7-abc5-081684c1b203)

### GroupChat conversation - agent returns None
![image](https://github.com/microsoft/autogen/assets/17806916/8897f33d-f88f-4a90-9605-1684adb208c2)

### GroupChat conversation - max rounds limit
![image](https://github.com/microsoft/autogen/assets/17806916/9761786c-74d7-4a4b-be7a-b162c2b1f1a4)

### GroupChat conversation - terminated by human
![image](https://github.com/microsoft/autogen/assets/17806916/479b9b54-84d7-4e7d-8023-f523b4451b2b)

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
