### PR TITLE
Add test for async group chat

### DIFF
--- a/test/agentchat/test_async.py
+++ b/test/agentchat/test_async.py
@@ -4,7 +4,6 @@ import autogen
 from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST
 
 
-
 def get_market_news(ind, ind_upper):
     data = {
         "feed": [
@@ -45,23 +44,23 @@ def get_market_news(ind, ind_upper):
     )
     return feeds_summary
 
+
 @pytest.mark.asyncio
 async def test_async_groupchat():
-    
     try:
         import openai
     except ImportError:
         return
-    
+
     config_list = autogen.config_list_from_json(OAI_CONFIG_LIST, KEY_LOC)
-    
-    llm_config={
-            "timeout": 600,
-            "cache_seed": 41,
-            "config_list": config_list,
-            "temperature": 0,
-        }
-    
+
+    llm_config = {
+        "timeout": 600,
+        "cache_seed": 41,
+        "config_list": config_list,
+        "temperature": 0,
+    }
+
     # create an AssistantAgent instance named "assistant"
     assistant = autogen.AssistantAgent(
         name="assistant",
@@ -83,12 +82,14 @@ async def test_async_groupchat():
     )
 
     groupchat = autogen.GroupChat(agents=[user_proxy, assistant], messages=[], max_round=12)
-    manager = autogen.GroupChatManager(groupchat=groupchat, llm_config=llm_config,
-                                is_termination_msg=lambda x: "TERMINATE" in x.get("content", ""),
-                                )
-    await user_proxy.a_initiate_chat(manager,
-                                  message="""Have a short conversation with the assistant.""")
-    assert len(user_proxy.chat_messages)>0
+    manager = autogen.GroupChatManager(
+        groupchat=groupchat,
+        llm_config=llm_config,
+        is_termination_msg=lambda x: "TERMINATE" in x.get("content", ""),
+    )
+    await user_proxy.a_initiate_chat(manager, message="""Have a short conversation with the assistant.""")
+    assert len(user_proxy.chat_messages) > 0
+
 
 @pytest.mark.asyncio
 async def test_stream():


### PR DESCRIPTION
Issue #543 has been on hold  for 3 weeks, due to not having tests for groupchat.  I added a test for groupchat, so hopefully now we can use AutoGen to call OpenAI asynchronously.

- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
