### PR TITLE
fix link that  returns 404

### DIFF
--- a/website/src/data/gallery.json
+++ b/website/src/data/gallery.json
@@ -112,7 +112,7 @@
   },
   {
     "title": "AutoGen + Flowise = Super AI Agents on No-Code Platform",
-    "link": "https://github.com/sugarforever/LangChain-Advanced/blob/main/Integrations/AutoGen/AutoGen_flowise_ai_agent.ipynb",
+    "link": "https://github.com/sugarforever/LangChain-Advanced/blob/main/Integrations/AutoGen/autogen_flowise_ai_agent.ipynb",
     "description": "Build super AI agents on a no-code platform using AutoGen and Flowise.",
     "image": "default.png",
     "tags": ["app"]


### PR DESCRIPTION

## Why are these changes needed?

Link to a demo `AutoGen + Flowise Use Case` returns 404, fixed link in the website.


## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
