### PR TITLE
oai wrapper path fix 

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
-from autogen import OpenAIWrapper
+from autogen.oai.client import OpenAIWrapper
 from autogen.code_utils import DEFAULT_MODEL, UNKNOWN, content_str, execute_code, extract_code, infer_lang
 
 from .agent import Agent

--- a/website/docs/Installation.md
+++ b/website/docs/Installation.md
@@ -58,7 +58,7 @@ Therefore, some changes are required for users of `pyautogen<0.2`.
 - MathChat is unsupported until it is tested in future release.
 - `autogen.Completion` and `autogen.ChatCompletion` are deprecated. The essential functionalities are moved to `autogen.OpenAIWrapper`:
 ```python
-from autogen import OpenAIWrapper
+from autogen.oai.client import OpenAIWrapper
 client = OpenAIWrapper(config_list=config_list)
 response = client.create(messages=[{"role": "user", "content": "2+2="}])
 print(client.extract_text_or_completion_object(response))

--- a/website/docs/Use-Cases/enhanced_inference.md
+++ b/website/docs/Use-Cases/enhanced_inference.md
@@ -113,7 +113,7 @@ When chat models are used and `prompt` is given as the input to `autogen.Complet
 `autogen.OpenAIWrapper.create()` can be used to create completions for both chat and non-chat models, and both OpenAI API and Azure OpenAI API.
 
 ```python
-from autogen import OpenAIWrapper
+from autogen.oai.client import OpenAIWrapper
 # OpenAI endpoint
 client = OpenAIWrapper()
 # ChatCompletion


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Corrected autogen oai path
from autogen import OpenAIWrapper

to

from autogen.oai.client import OpenAIWrapper

## Related issue number

 Closes issue #948

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
