### PR TITLE
Fix exception cause in agent_builder.py

### DIFF
--- a/autogen/agentchat/contrib/agent_builder.py
+++ b/autogen/agentchat/contrib/agent_builder.py
@@ -446,7 +446,7 @@ class AgentBuilder:
             try:
                 with open(filepath) as f:
                     cached_configs = json.load(f)
-            except FileNotFoundError:
-                raise FileNotFoundError(f"{filepath} does not exist.")
+            except FileNotFoundError as e:
+                raise FileNotFoundError(f"{filepath} does not exist.") from e
             _config_check(cached_configs)
             return self.build(cached_configs=cached_configs, **kwargs)


### PR DESCRIPTION
## Why are these changes needed?

Fix exception cause in `agent_builder.py`. More context: https://blog.ram.rachum.com/post/621791438475296768/improving-python-exception-chaining-with


## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
