### PR TITLE
[Core] Fix openai dependency error introduced when merging #1044

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, "autogen/version.py")) as fp:
 __version__ = version["__version__"]
 
 install_requires = [
-    "openai>=1.3,<1.5",
+    "openai>=1.3",
     "diskcache",
     "termcolor",
     "flaml",


### PR DESCRIPTION
## Why are these changes needed?

Fix dependency error introduced when merging #1044. The openai package version constraint should be >1.3. Removing the constraint <1.5 which was introduced by error. 

## Related issue number

#1044 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
