### PR TITLE
Update all tests to check for non-empty config_lists.

### DIFF
--- a/test/agentchat/contrib/chat_with_teachable_agent.py
+++ b/test/agentchat/contrib/chat_with_teachable_agent.py
@@ -33,6 +33,8 @@ def create_teachable_agent(reset_db=False):
     # See https://microsoft.github.io/autogen/docs/FAQ#set-your-api-endpoints
     # and OAI_CONFIG_LIST_sample
     config_list = config_list_from_json(env_or_file=OAI_CONFIG_LIST, filter_dict=filter_dict, file_location=KEY_LOC)
+    assert len(config_list) > 0
+
     teachable_agent = TeachableAgent(
         name="teachableagent",
         llm_config={"config_list": config_list, "timeout": 120, "cache_seed": cache_seed},

--- a/test/agentchat/contrib/test_compressible_agent.py
+++ b/test/agentchat/contrib/test_compressible_agent.py
@@ -25,6 +25,11 @@ except ImportError:
     OPENAI_INSTALLED = False
 
 
+def test_non_empty_config_list():
+    # Check that the config_list is non-empty, as we expect
+    assert len(config_list) > 0
+
+
 @pytest.mark.skipif(
     sys.platform in ["darwin", "win32"] or not OPENAI_INSTALLED,
     reason="do not run on MacOS or windows or dependency is not installed",
@@ -200,6 +205,7 @@ def test_mode_terminate():
 
 
 if __name__ == "__main__":
+    test_non_empty_config_list()
     test_mode_compress()
     test_mode_customized()
     test_compress_message()

--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -19,6 +19,7 @@ except ImportError:
 config_list = autogen.config_list_from_json(
     OAI_CONFIG_LIST, file_location=KEY_LOC, filter_dict={"api_type": ["openai"]}
 )
+assert len(config_list) > 0
 
 
 def ask_ossinsight(question):

--- a/test/agentchat/contrib/test_qdrant_retrievechat.py
+++ b/test/agentchat/contrib/test_qdrant_retrievechat.py
@@ -42,6 +42,7 @@ def test_retrievechat():
         OAI_CONFIG_LIST,
         file_location=KEY_LOC,
     )
+    assert len(config_list) > 0
 
     assistant = RetrieveAssistantAgent(
         name="assistant",

--- a/test/agentchat/contrib/test_retrievechat.py
+++ b/test/agentchat/contrib/test_retrievechat.py
@@ -34,6 +34,7 @@ def test_retrievechat():
         OAI_CONFIG_LIST,
         file_location=KEY_LOC,
     )
+    assert len(config_list) > 0
 
     assistant = RetrieveAssistantAgent(
         name="assistant",

--- a/test/agentchat/contrib/test_teachable_agent.py
+++ b/test/agentchat/contrib/test_teachable_agent.py
@@ -43,6 +43,8 @@ def create_teachable_agent(reset_db=False, verbosity=0):
     # See https://microsoft.github.io/autogen/docs/FAQ#set-your-api-endpoints
     # and OAI_CONFIG_LIST_sample
     config_list = config_list_from_json(env_or_file=OAI_CONFIG_LIST, filter_dict=filter_dict, file_location=KEY_LOC)
+    assert len(config_list) > 0
+
     teachable_agent = TeachableAgent(
         name="teachableagent",
         llm_config={"config_list": config_list, "timeout": 120, "cache_seed": cache_seed},


### PR DESCRIPTION
## Why are these changes needed?
Almost all the tests load a config_list without checking if it actually loaded anything. I noticed this with test_compressible_agent #1072 and #1073, but the problem is pervasive.

If the list is empty, it will silently default to GPT-4, and that's definitely not what we want. As seen here, it masks costly misconfigurations!

## Related issue number

#1072 and #1073

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
