### PR TITLE
[Core] Throw an error when the OAI_CONFIG_LIST is missing.

### DIFF
--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -257,7 +257,7 @@ def config_list_from_json(
     """Get a list of configs from a json parsed from an env variable or a file.
 
     Args:
-        env_or_file (str): The env variable name or file name.
+        env_or_file (str): The env variable name or file name. Env variables take presedence over files.
         file_location (str, optional): The file location.
         filter_dict (dict, optional): The filter dict with keys corresponding to a field in each config,
             and values corresponding to lists of acceptable values for each key.
@@ -271,6 +271,9 @@ def config_list_from_json(
 
     Returns:
         list: A list of configs for openai api calls.
+
+    Raises:
+        FileNotFoundError: if env_or_file is neither found as an environment variable nor a file
     """
     json_str = os.environ.get(env_or_file)
     if json_str:

--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -277,13 +277,9 @@ def config_list_from_json(
         config_list = json.loads(json_str)
     else:
         config_list_path = os.path.join(file_location, env_or_file)
-        try:
-            with open(config_list_path) as json_file:
-                config_list = json.load(json_file)
-        except FileNotFoundError:
-            logging.warning(f"The specified config_list file '{config_list_path}' does not exist.")
-            return []
-    return filter_config(config_list, filter_dict)
+        with open(config_list_path) as json_file:
+            config_list = json.load(json_file)
+            return filter_config(config_list, filter_dict)
 
 
 def get_config(

--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -282,7 +282,7 @@ def config_list_from_json(
         config_list_path = os.path.join(file_location, env_or_file)
         with open(config_list_path) as json_file:
             config_list = json.load(json_file)
-            return filter_config(config_list, filter_dict)
+    return filter_config(config_list, filter_dict)
 
 
 def get_config(

--- a/test/agentchat/contrib/test_compressible_agent.py
+++ b/test/agentchat/contrib/test_compressible_agent.py
@@ -6,8 +6,7 @@ from conftest import skip_openai
 from autogen.agentchat.contrib.compressible_agent import CompressibleAgent
 
 here = os.path.abspath(os.path.dirname(__file__))
-KEY_LOC = "notebook"
-OAI_CONFIG_LIST = "OAI_CONFIG_LIST"
+from test_assistant_agent import OAI_CONFIG_LIST, KEY_LOC  # noqa: E402
 
 try:
     import openai

--- a/test/agentchat/contrib/test_compressible_agent.py
+++ b/test/agentchat/contrib/test_compressible_agent.py
@@ -13,6 +13,12 @@ from test_assistant_agent import OAI_CONFIG_LIST, KEY_LOC  # noqa: E402
 try:
     import openai
 
+except ImportError:
+    skip = True
+else:
+    skip = False or skip_openai
+
+if not skip:
     config_list = autogen.config_list_from_json(
         OAI_CONFIG_LIST,
         file_location=KEY_LOC,
@@ -20,11 +26,6 @@ try:
             "model": ["gpt-3.5-turbo", "gpt-35-turbo", "gpt-3.5-turbo-16k", "gpt-35-turbo-16k"],
         },
     )
-
-except ImportError:
-    skip = True
-else:
-    skip = False or skip_openai
 
 
 @pytest.mark.skipif(

--- a/test/agentchat/contrib/test_compressible_agent.py
+++ b/test/agentchat/contrib/test_compressible_agent.py
@@ -8,19 +8,32 @@ here = os.path.abspath(os.path.dirname(__file__))
 KEY_LOC = "notebook"
 OAI_CONFIG_LIST = "OAI_CONFIG_LIST"
 
-
-config_list = autogen.config_list_from_json(
-    OAI_CONFIG_LIST,
-    file_location=KEY_LOC,
-    filter_dict={
-        "model": ["gpt-3.5-turbo", "gpt-35-turbo", "gpt-3.5-turbo-16k", "gpt-35-turbo-16k"],
+DUMMY_CONFIG_LIST = [
+    {
+        "model": "gpt-4",
+        "api_key": "sk-*******************************",
+        "organization": "org-*******************************",
     },
-)
+    {
+        "model": "gpt-4-1106-preview",
+        "api_key": "sk-*******************************",
+        "organization": "org-*******************************",
+    },
+]
 
 try:
     import openai
 
     OPENAI_INSTALLED = True
+
+    config_list = autogen.config_list_from_json(
+        OAI_CONFIG_LIST,
+        file_location=KEY_LOC,
+        filter_dict={
+            "model": ["gpt-3.5-turbo", "gpt-35-turbo", "gpt-3.5-turbo-16k", "gpt-35-turbo-16k"],
+        },
+    )
+
 except ImportError:
     OPENAI_INSTALLED = False
 
@@ -175,7 +188,7 @@ def test_mode_terminate():
         llm_config={
             "timeout": 600,
             "cache_seed": 43,
-            "config_list": config_list,
+            "config_list": DUMMY_CONFIG_LIST,
         },
         compress_config=True,
     )
@@ -200,7 +213,7 @@ def test_mode_terminate():
 
 
 if __name__ == "__main__":
-    test_mode_compress()
-    test_mode_customized()
-    test_compress_message()
+    # test_mode_compress()
+    # test_mode_customized()
+    # test_compress_message()
     test_mode_terminate()

--- a/test/agentchat/contrib/test_compressible_agent.py
+++ b/test/agentchat/contrib/test_compressible_agent.py
@@ -6,6 +6,8 @@ from conftest import skip_openai
 from autogen.agentchat.contrib.compressible_agent import CompressibleAgent
 
 here = os.path.abspath(os.path.dirname(__file__))
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from test_assistant_agent import OAI_CONFIG_LIST, KEY_LOC  # noqa: E402
 
 try:

--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -13,14 +13,15 @@ try:
     from autogen.agentchat.contrib.gpt_assistant_agent import GPTAssistantAgent
     from autogen.oai.openai_utils import retrieve_assistants_by_name
 
-    config_list = autogen.config_list_from_json(
-        OAI_CONFIG_LIST, file_location=KEY_LOC, filter_dict={"api_type": ["openai"]}
-    )
-
 except ImportError:
     skip = True
 else:
     skip = False or skip_openai
+
+if not skip:
+    config_list = autogen.config_list_from_json(
+        OAI_CONFIG_LIST, file_location=KEY_LOC, filter_dict={"api_type": ["openai"]}
+    )
 
 
 def ask_ossinsight(question):

--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -12,13 +12,13 @@ try:
     from autogen.agentchat.contrib.gpt_assistant_agent import GPTAssistantAgent
     from autogen.oai.openai_utils import retrieve_assistants_by_name
 
+    config_list = autogen.config_list_from_json(
+        OAI_CONFIG_LIST, file_location=KEY_LOC, filter_dict={"api_type": ["openai"]}
+    )
+
     skip_test = False
 except ImportError:
     skip_test = True
-
-config_list = autogen.config_list_from_json(
-    OAI_CONFIG_LIST, file_location=KEY_LOC, filter_dict={"api_type": ["openai"]}
-)
 
 
 def ask_ossinsight(question):

--- a/test/oai/test_utils.py
+++ b/test/oai/test_utils.py
@@ -69,6 +69,13 @@ def test_config_list_from_json():
     del os.environ["config_list_test"]
     os.remove(json_file)
 
+    # Test that an error is thrown when the config list is missing
+    try:
+        autogen.config_list_from_json("OAI_CONFIG_LIST.missing", file_location=KEY_LOC)
+        assert False  # We should not be able to get here, since the file should be missing
+    except FileNotFoundError:
+        pass
+
 
 def test_config_list_openai_aoai():
     # Testing the functionality for loading configurations for different API types

--- a/test/oai/test_utils.py
+++ b/test/oai/test_utils.py
@@ -38,6 +38,30 @@ FILTER_DICT = {
     }
 }
 
+# Example config list
+DUMMY_CONFIG_LIST = [
+    {
+        "model": "gpt-4",
+        "api_key": "sk-********************",
+    },
+    {
+        "model": "gpt-4-1106-preview",
+        "api_key": "sk-********************",
+    },
+    {
+        "model": "gpt-4-32k",
+        "api_key": "sk-********************",
+    },
+    {
+        "model": "gpt-3.5-turbo",
+        "api_key": "sk-********************",
+    },
+    {
+        "model": "gpt-3.5-turbo-16k",
+        "api_key": "sk-********************",
+    },
+]
+
 
 @pytest.fixture
 def mock_os_environ():
@@ -48,7 +72,7 @@ def mock_os_environ():
 def test_config_list_from_json():
     # Test the functionality for loading configurations from JSON file
     # and ensuring that the loaded configurations are as expected.
-    config_list = autogen.config_list_gpt4_gpt35(key_file_path=KEY_LOC)
+    config_list = DUMMY_CONFIG_LIST
     json_file = os.path.join(KEY_LOC, "config_list_test.json")
 
     with open(json_file, "w") as f:
@@ -62,9 +86,18 @@ def test_config_list_from_json():
     assert config_list == config_list_2
 
     config_list_3 = autogen.config_list_from_json(
-        OAI_CONFIG_LIST, file_location=KEY_LOC, filter_dict={"model": ["gpt4", "gpt-4-32k"]}
+        "config_list_test.json", file_location=KEY_LOC, filter_dict={"model": ["gpt-4", "gpt-4-32k"]}
     )
-    assert all(config.get("model") in ["gpt4", "gpt-4-32k"] for config in config_list_3)
+    assert config_list_3 == [
+        {
+            "model": "gpt-4",
+            "api_key": "sk-********************",
+        },
+        {
+            "model": "gpt-4-32k",
+            "api_key": "sk-********************",
+        },
+    ]
 
     del os.environ["config_list_test"]
     os.remove(json_file)

--- a/test/oai/test_utils.py
+++ b/test/oai/test_utils.py
@@ -70,11 +70,8 @@ def test_config_list_from_json():
     os.remove(json_file)
 
     # Test that an error is thrown when the config list is missing
-    try:
+    with pytest.raises(FileNotFoundError):
         autogen.config_list_from_json("OAI_CONFIG_LIST.missing", file_location=KEY_LOC)
-        assert False  # We should not be able to get here, since the file should be missing
-    except FileNotFoundError:
-        pass
 
 
 def test_config_list_openai_aoai():


### PR DESCRIPTION
## Why are these changes needed?
We silently return an empty list when someone explicitly asks for an OAI_CONFIG_LIST and it can't be found. Paired with other default behavior (e.g, #1077) this can lead to costly calls to GPT-4.

Tackling this was actually one of the very first commits I pushed to autogen in #174. At the time, I was advised that changing default behavior was unwise and that I should perhaps just output an warning message. 

Given #1077, and countless other issue since (maybe, #1025), I think it's about time that I go with my original instinct, and correct this unexpected and potentially dangerous behavior.

## Related issue number

#1077, #1076, #1025, #174, #178,  and so so many other. 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
