### PR TITLE
openai base url default to None; read files when env vars exist; remove deprecated models

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -8,7 +8,7 @@ import inspect
 from flaml.automl.logger import logger_formatter
 from pydantic import ValidationError
 
-from autogen.oai.openai_utils import get_key, oai_price1k
+from autogen.oai.openai_utils import get_key, OAI_PRICE1K
 from autogen.token_count_utils import count_token
 
 TOOL_ENABLED = False
@@ -446,13 +446,13 @@ class OpenAIWrapper:
     def cost(self, response: Union[ChatCompletion, Completion]) -> float:
         """Calculate the cost of the response."""
         model = response.model
-        if model not in oai_price1k:
+        if model not in OAI_PRICE1K:
             # TODO: add logging to warn that the model is not found
             return 0
 
         n_input_tokens = response.usage.prompt_tokens
         n_output_tokens = response.usage.completion_tokens
-        tmp_price1K = oai_price1k[model]
+        tmp_price1K = OAI_PRICE1K[model]
         # First value is input token rate, second value is output token rate
         if isinstance(tmp_price1K, tuple):
             return (tmp_price1K[0] * n_input_tokens + tmp_price1K[1] * n_output_tokens) / 1000

--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -17,8 +17,8 @@ except ImportError:
     Assistant = object
 
 NON_CACHE_KEY = ["api_key", "base_url", "api_type", "api_version"]
-
-oai_price1k = {
+DEFAULT_AZURE_API_VERSION = "2023-08-01-preview"
+OAI_PRICE1K = {
     "text-ada-001": 0.0004,
     "text-babbage-001": 0.0005,
     "text-curie-001": 0.002,
@@ -131,6 +131,9 @@ def config_list_openai_aoai(
 
     This function constructs configurations by reading API keys and base URLs from environment variables or text files.
     It supports configurations for both OpenAI and Azure OpenAI services, allowing for the exclusion of one or the other.
+    When text files are used, the environment variables will be overwritten.
+    To prevent text files from being used, set the corresponding file name to None.
+    Or set key_file_path to None to disallow reading from text files.
 
     Args:
         key_file_path (str, optional): The directory path where the API key files are located. Defaults to the current directory.
@@ -170,47 +173,53 @@ def config_list_openai_aoai(
         - The function checks for API keys and base URLs in the following environment variables: 'OPENAI_API_KEY', 'AZURE_OPENAI_API_KEY',
           'OPENAI_API_BASE' and 'AZURE_OPENAI_API_BASE'. If these are not found, it attempts to read from the specified files in the
           'key_file_path' directory.
-        - The API version for Azure configurations is set to '2023-08-01-preview' by default and can be changed as necessary.
+        - The API version for Azure configurations is set to DEFAULT_AZURE_API_VERSION by default.
         - If 'exclude' is set to 'openai', only Azure OpenAI configurations are returned, and vice versa.
         - The function assumes that the API keys and base URLs in the environment variables are separated by new lines if there are
           multiple entries.
     """
-    if "OPENAI_API_KEY" not in os.environ and exclude != "openai":
-        try:
-            with open(f"{key_file_path}/{openai_api_key_file}") as key_file:
-                os.environ["OPENAI_API_KEY"] = key_file.read().strip()
-        except FileNotFoundError:
-            logging.info(
-                "OPENAI_API_KEY is not found in os.environ "
-                "and key_openai.txt is not found in the specified path. You can specify the api_key in the config_list."
-            )
-    if "OPENAI_API_BASE" not in os.environ and exclude != "openai":
-        try:
-            with open(f"{key_file_path}/{openai_api_base_file}") as key_file:
-                os.environ["OPENAI_API_BASE"] = key_file.read().strip()
-        except FileNotFoundError:
-            logging.info(
-                "OPENAI_API_BASE is not found in os.environ "
-                "and base_openai.txt is not found in the specified path. You can specify the base_url in the config_list."
-            )
-    if "AZURE_OPENAI_API_KEY" not in os.environ and exclude != "aoai":
-        try:
-            with open(f"{key_file_path}/{aoai_api_key_file}") as key_file:
-                os.environ["AZURE_OPENAI_API_KEY"] = key_file.read().strip()
-        except FileNotFoundError:
-            logging.info(
-                "AZURE_OPENAI_API_KEY is not found in os.environ "
-                "and key_aoai.txt is not found in the specified path. You can specify the api_key in the config_list."
-            )
-    if "AZURE_OPENAI_API_BASE" not in os.environ and exclude != "aoai":
-        try:
-            with open(f"{key_file_path}/{aoai_api_base_file}") as key_file:
-                os.environ["AZURE_OPENAI_API_BASE"] = key_file.read().strip()
-        except FileNotFoundError:
-            logging.info(
-                "AZURE_OPENAI_API_BASE is not found in os.environ "
-                "and base_aoai.txt is not found in the specified path. You can specify the base_url in the config_list."
-            )
+    if exclude != "openai" and key_file_path is not None:
+        # skip if key_file_path is None
+        if openai_api_key_file is not None:
+            # skip if openai_api_key_file is None
+            try:
+                with open(f"{key_file_path}/{openai_api_key_file}") as key_file:
+                    os.environ["OPENAI_API_KEY"] = key_file.read().strip()
+            except FileNotFoundError:
+                logging.info(
+                    "OPENAI_API_KEY is not found in os.environ "
+                    "and key_openai.txt is not found in the specified path. You can specify the api_key in the config_list."
+                )
+        if openai_api_base_file is not None:
+            # skip if openai_api_base_file is None
+            try:
+                with open(f"{key_file_path}/{openai_api_base_file}") as key_file:
+                    os.environ["OPENAI_API_BASE"] = key_file.read().strip()
+            except FileNotFoundError:
+                logging.info(
+                    "OPENAI_API_BASE is not found in os.environ "
+                    "and base_openai.txt is not found in the specified path. You can specify the base_url in the config_list."
+                )
+    if exclude != "aoai" and key_file_path is not None:
+        # skip if key_file_path is None
+        if aoai_api_key_file is not None:
+            try:
+                with open(f"{key_file_path}/{aoai_api_key_file}") as key_file:
+                    os.environ["AZURE_OPENAI_API_KEY"] = key_file.read().strip()
+            except FileNotFoundError:
+                logging.info(
+                    "AZURE_OPENAI_API_KEY is not found in os.environ "
+                    "and key_aoai.txt is not found in the specified path. You can specify the api_key in the config_list."
+                )
+        if aoai_api_base_file is not None:
+            try:
+                with open(f"{key_file_path}/{aoai_api_base_file}") as key_file:
+                    os.environ["AZURE_OPENAI_API_BASE"] = key_file.read().strip()
+            except FileNotFoundError:
+                logging.info(
+                    "AZURE_OPENAI_API_BASE is not found in os.environ "
+                    "and base_aoai.txt is not found in the specified path. You can specify the base_url in the config_list."
+                )
     aoai_config = (
         get_config_list(
             # Assuming Azure OpenAI api keys in os.environ["AZURE_OPENAI_API_KEY"], in separated lines
@@ -218,7 +227,7 @@ def config_list_openai_aoai(
             # Assuming Azure OpenAI api bases in os.environ["AZURE_OPENAI_API_BASE"], in separated lines
             base_urls=os.environ.get("AZURE_OPENAI_API_BASE", "").split("\n"),
             api_type="azure",
-            api_version="2023-08-01-preview",  # change if necessary
+            api_version=DEFAULT_AZURE_API_VERSION,
         )
         if exclude != "aoai"
         else []

--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -94,8 +94,8 @@ def get_config_list(
     base_urls = ['https://api.service1.com', 'https://api.service2.com', 'https://api.service3.com']
 
     # Optionally, define the API type and version if they are common for all keys
-    api_type = 'openai'
-    api_version = 'v1'
+    api_type = 'azure'
+    api_version = '2023-08-01-preview'
 
     # Call the get_config_list function to get a list of configuration dictionaries
     config_list = get_config_list(api_keys, base_urls, api_type, api_version)
@@ -223,11 +223,14 @@ def config_list_openai_aoai(
         if exclude != "aoai"
         else []
     )
+    # process openai base urls
+    base_urls = os.environ.get("OPENAI_API_BASE", None)
+    base_urls = base_urls if base_urls is None else base_urls.split("\n")
     openai_config = (
         get_config_list(
             # Assuming OpenAI API_KEY in os.environ["OPENAI_API_KEY"]
             api_keys=os.environ.get("OPENAI_API_KEY", "").split("\n"),
-            base_urls=os.environ.get("OPENAI_API_BASE", "").split("\n"),
+            base_urls=base_urls,
             # "api_type": "open_ai",
         )
         if exclude != "openai"
@@ -274,7 +277,7 @@ def config_list_from_models(
         aoai_api_base_file = 'base_aoai.txt'
 
         # Define the list of models for which to create configurations
-        model_list = ['text-davinci-003', 'gpt-3.5-turbo']
+        model_list = ['gpt-4', 'gpt-3.5-turbo']
 
         # Call the function to get a list of configuration dictionaries
         config_list = config_list_from_models(
@@ -287,7 +290,7 @@ def config_list_from_models(
 
         # The `config_list` will contain configurations for the specified models, for example:
         # [
-        #     {'api_key': '...', 'base_url': 'https://api.openai.com', 'model': 'text-davinci-003'},
+        #     {'api_key': '...', 'base_url': 'https://api.openai.com', 'model': 'gpt-4'},
         #     {'api_key': '...', 'base_url': 'https://api.openai.com', 'model': 'gpt-3.5-turbo'}
         # ]
     ```

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -99,7 +99,6 @@ def test_completion():
     [
         (None, "gpt-3.5-turbo-instruct"),
         (42, "gpt-3.5-turbo-instruct"),
-        (None, "text-ada-001"),
     ],
 )
 def test_cost(cache_seed, model):
@@ -144,5 +143,5 @@ if __name__ == "__main__":
     test_oai_tool_calling_extraction()
     test_chat_completion()
     test_completion()
-    test_cost()
+    # test_cost()
     test_usage_summary()

--- a/test/oai/test_utils.py
+++ b/test/oai/test_utils.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 import pytest
 import logging
@@ -7,8 +6,7 @@ import tempfile
 from unittest import mock
 from unittest.mock import patch
 import autogen  # noqa: E402
-
-sys.path.append("../../autogen")
+from autogen.oai.openai_utils import DEFAULT_AZURE_API_VERSION
 
 # Example environment variables
 ENV_VARS = {
@@ -127,7 +125,7 @@ def test_config_list_openai_aoai():
                 "api_key": "sk-testkeyaoai456",
                 "base_url": "https://api.azure.com/v1",
                 "api_type": "azure",
-                "api_version": "2023-08-01-preview",
+                "api_version": DEFAULT_AZURE_API_VERSION,
             },
         ]
         assert config_list == expected_config_list
@@ -144,14 +142,14 @@ def test_config_list_openai_aoai():
 )
 def test_config_list_openai_aoai_env_vars():
     # Test the config_list_openai_aoai function with environment variables set
-    configs = autogen.oai.openai_utils.config_list_openai_aoai()
+    configs = autogen.oai.openai_utils.config_list_openai_aoai(key_file_path=None)
     assert len(configs) == 2
     assert {"api_key": "test_openai_key", "base_url": "https://api.openai.com"} in configs
     assert {
         "api_key": "test_aoai_key",
         "base_url": "https://api.azure.com",
         "api_type": "azure",
-        "api_version": "2023-08-01-preview",
+        "api_version": DEFAULT_AZURE_API_VERSION,
     } in configs
 
 
@@ -174,13 +172,13 @@ def test_config_list_openai_aoai_env_vars_multi():
         "api_key": "test_aoai_key",
         "base_url": "https://api.azure.com",
         "api_type": "azure",
-        "api_version": "2023-08-01-preview",
+        "api_version": DEFAULT_AZURE_API_VERSION,
     } in configs
     assert {
         "api_key": "test_aoai_key2",
         "base_url": "https://api.azure.com/v2",
         "api_type": "azure",
-        "api_version": "2023-08-01-preview",
+        "api_version": DEFAULT_AZURE_API_VERSION,
     } in configs
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. #1046 introduces a bug of defaulting openai base url to "". It causes test failures in https://github.com/microsoft/autogen/actions/runs/7366572506/job/20050787096?pr=1026
This PR changes the default to None.
1. #1046 introduces a test which fails with the current utils when env vars already exist: https://github.com/microsoft/autogen/actions/runs/7371478796/job/20058910737?pr=1110
This PR changes the utility such that it tries to read from files even when the env vars exist, unless the file path or file names are explicitly set to None.
1. This PR also removes models from the test which are going to be deprecated from Jan 4.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
