### PR TITLE
Introducing AutoGen Deploy

### DIFF
--- a/samples/autogen-deploy/README.md
+++ b/samples/autogen-deploy/README.md
@@ -1,0 +1,45 @@
+# AutoGen Deploy -- Running Your AutoGen Agents as a Service
+
+## Overview
+
+This sample shows how to run your AutoGen agents as a service and respond
+to client requests on demand.
+
+## Prerequisites
+
+We currently use RabbitMQ as the message broker. Using docker:
+
+```bash
+docker run -d --rm -p 5672:5672 --name autogen-deploy-broker rabbitmq:alpine
+```
+
+For other ways to install RabbitMQ, see [RabbitMQ Installation](https://www.rabbitmq.com/download.html).
+
+Other brokers will be supported in the future.
+
+## Install
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Sample
+
+First deploy two agents:
+
+```bash
+celery -A sample_service worker -l INFO
+```
+
+Then run a query:
+
+```python
+from sample_service import assistant, user_proxy
+
+user_proxy.initiate_chat(
+    assistant,
+    message="What is the change YTD of the S&P 500?",
+)
+```
+
+The agents are running as a service and will respond to the query.

--- a/samples/autogen-deploy/autogen_deploy.py
+++ b/samples/autogen-deploy/autogen_deploy.py
@@ -1,0 +1,41 @@
+from typing import Callable, Dict, List, Optional, Union
+from celery import Celery
+from autogen.agentchat import ConversableAgent, Agent
+
+
+def create_task(app: Celery, agent: ConversableAgent) -> Celery.Task:
+    @app.task(name=agent.name)
+    def _task(messages: List[Dict]):
+        # print(messages)
+        return agent.generate_reply(messages=messages)
+
+    return _task
+
+
+class CeleryAgent(ConversableAgent):
+    def __init__(self, app: Celery, agent: ConversableAgent) -> None:
+        super().__init__(name=agent.name)
+        self._app = app
+        self._agent = agent
+        self._task = create_task(app, agent)
+        # TODO: these states should be stored in external memory to be shared
+        # across instances of the agent.
+        self._oai_messages = agent._oai_messages
+        self.reply_at_receive = agent.reply_at_receive
+
+    def reset_consecutive_auto_reply_counter(self, sender: Agent | None = None):
+        return self._agent.reset_consecutive_auto_reply_counter(sender)
+
+    def clear_history(self, agent: Agent | None = None):
+        return self._agent.clear_history(agent)
+
+    def generate_init_message(self, **context) -> str | Dict:
+        return self._agent.generate_init_message(**context)
+
+    def generate_reply(
+        self,
+        messages: Optional[List[Dict]] = None,
+        sender: Optional[Agent] = None,
+        exclude: Optional[List[Callable]] = None,
+    ) -> Union[str, Dict, None]:
+        return self._task.delay(messages=messages).get()

--- a/samples/autogen-deploy/requirements.txt
+++ b/samples/autogen-deploy/requirements.txt
@@ -1,0 +1,2 @@
+pyautogen
+celery

--- a/samples/autogen-deploy/sample_query.py
+++ b/samples/autogen-deploy/sample_query.py
@@ -1,0 +1,6 @@
+from sample_service import assistant, user_proxy
+
+user_proxy.initiate_chat(
+    assistant,
+    message="What is the change YTD of the S&P 500?",
+)

--- a/samples/autogen-deploy/sample_service.py
+++ b/samples/autogen-deploy/sample_service.py
@@ -1,0 +1,26 @@
+from celery import Celery
+from autogen import AssistantAgent, UserProxyAgent, config_list_from_json
+from autogen_deploy import CeleryAgent
+
+config_list = config_list_from_json(
+    "OAI_CONFIG_LIST",
+    filter_dict={
+        "model": ["gpt-4", "gpt4", "gpt-4-32k", "gpt-4-32k-0314", "gpt-4-32k-v0314"],
+    },
+)
+
+assistant = AssistantAgent(
+    name="assistant",
+    llm_config={
+        "config_list": config_list,
+    },
+)
+user_proxy = UserProxyAgent(
+    "user_proxy",
+    code_execution_config={"work_dir": "coding", "use_docker": False},
+    human_input_mode="NEVER",
+)
+
+app = Celery("autogen_deploy", backend="rpc://", broker="pyamqp://guest@localhost//")
+assistant = CeleryAgent(app, assistant)
+user_proxy = CeleryAgent(app, user_proxy)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

**This is a work in progress.**  Comments and contributions welcome!

AutoGen's north star is to be THE multi-agent application development framework, so a robust and scalable serving solution is a must. Therefore, introducing AutoGen Deploy, a service framework to deploy your AutoGen agents as long-running, distributed workers handling messages on-demand. The agent workers talk to each other through a message broker. 

Example usage:

First convert your AutoGen agents to [Celery](https://github.com/celery/celery) workers:

sample_service.py
```python
assistant = AssistantAgent(
    name="assistant",
    llm_config={
        "config_list": config_list,
    },
)
user_proxy = UserProxyAgent(
    "user_proxy",
    code_execution_config={"work_dir": "coding", "use_docker": False},
    human_input_mode="NEVER",
)

app = Celery("autogen_deploy", backend="rpc://", broker="pyamqp://guest@localhost//")
assistant = CeleryAgent(app, assistant)
user_proxy = CeleryAgent(app, user_proxy)
```

To start a long-running service on localhost:
```
celery -A sample_service worker -l INFO
```

Query the service:
```python
from sample_service import assistant, user_proxy

user_proxy.initiate_chat(
    assistant,
    message="What is the change YTD of the S&P 500?",
)
```

It is important to note that because currently AutoGen agents do not store state in shared external memory (i.e., a database) the client is storing all agent state, while workers are stateless. Once we have finished the state serialization stuff, we can make the agent workers stateful by synchronizing using shared external memory. 

Also, because currently the human input handling is through console, it is not supported right now. So `human_input_mode` should be set to `NEVER`.

## Related issue number

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
