### PR TITLE
cleaner definition of tool_responses fixes #1174

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -855,24 +855,23 @@ class ConversableAgent(Agent):
         if messages is None:
             messages = self._oai_messages[sender]
         message = messages[-1]
-        if "tool_calls" in message and message["tool_calls"]:
-            tool_calls = message["tool_calls"]
-            tool_returns = []
-            for tool_call in tool_calls:
-                id = tool_call["id"]
-                function_call = tool_call.get("function", {})
-                func = self._function_map.get(function_call.get("name", None), None)
-                if asyncio.coroutines.iscoroutinefunction(func):
-                    continue
-                _, func_return = self.execute_function(function_call)
-                tool_returns.append(
-                    {
-                        "tool_call_id": id,
-                        "role": "tool",
-                        "name": func_return.get("name", ""),
-                        "content": func_return.get("content", ""),
-                    }
-                )
+        tool_returns = []
+        for tool_call in message.get("tool_calls", []):
+            id = tool_call["id"]
+            function_call = tool_call.get("function", {})
+            func = self._function_map.get(function_call.get("name", None), None)
+            if asyncio.coroutines.iscoroutinefunction(func):
+                continue
+            _, func_return = self.execute_function(function_call)
+            tool_returns.append(
+                {
+                    "tool_call_id": id,
+                    "role": "tool",
+                    "name": func_return.get("name", ""),
+                    "content": func_return.get("content", ""),
+                }
+            )
+        if len(tool_returns) > 0:
             return True, {
                 "role": "tool",
                 "tool_responses": tool_returns,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I couldn't replicate #1174, but I could imagine how this could have created an empty tool_responses.

I could also do a defensive dict key filter on generate_oai_reply, but feels really dirty. ideally there would be built out types and then it would work to just take the keys from the dict that are needed for the type. But that is a bigger thing.

## Related issue number

Closes #1174

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
