### PR TITLE
fix: forward kwargs to conversable agent + fix typing

### DIFF
--- a/autogen/agentchat/contrib/compressible_agent.py
+++ b/autogen/agentchat/contrib/compressible_agent.py
@@ -63,6 +63,8 @@ Reply "TERMINATE" in the end when everything is done.
         llm_config: Optional[Union[Dict, bool]] = None,
         default_auto_reply: Optional[Union[str, Dict, None]] = "",
         compress_config: Optional[Dict] = False,
+        description: Optional[str] = None,
+        **kwargs,
     ):
         """
         Args:
@@ -106,6 +108,8 @@ Reply "TERMINATE" in the end when everything is done.
             code_execution_config=code_execution_config,
             llm_config=llm_config,
             default_auto_reply=default_auto_reply,
+            description=description,
+            **kwargs,
         )
 
         self._set_compress_config(compress_config)

--- a/autogen/agentchat/contrib/compressible_agent.py
+++ b/autogen/agentchat/contrib/compressible_agent.py
@@ -95,6 +95,8 @@ Reply "TERMINATE" in the end when everything is done.
                 - "broadcast" (Optional, bool, default to True): whether to update the compressed message history to sender.
                 - "verbose" (Optional, bool, default to False): Whether to print the content before and after compression. Used when mode="COMPRESS".
                 - "leave_last_n" (Optional, int, default to 0): If provided, the last n messages will not be compressed. Used when mode="COMPRESS".
+            description (str): a short description of the agent. This description is used by other agents
+                (e.g. the GroupChatManager) to decide when to call upon this agent. (Default: system_message)
             **kwargs (dict): Please refer to other kwargs in
                 [ConversableAgent](../conversable_agent#__init__).
         """

--- a/test/agentchat/contrib/test_compressible_agent.py
+++ b/test/agentchat/contrib/test_compressible_agent.py
@@ -211,8 +211,19 @@ def test_mode_terminate():
     assert final, "Terminating the conversation at max token limit is not working."
 
 
+@pytest.mark.skipif(
+    sys.platform in ["darwin", "win32"] or skip,
+    reason="do not run on MacOS or windows OR dependency is not installed OR requested to skip",
+)
+def test_new_compressible_agent_description():
+    assistant = CompressibleAgent(name="assistant", description="this is a description")
+
+    assert assistant.description == "this is a description", "description is not set correctly"
+
+
 if __name__ == "__main__":
     test_mode_compress()
     test_mode_customized()
     test_compress_message()
     test_mode_terminate()
+    test_new_compressible_agent_description()


### PR DESCRIPTION
## Why are these changes needed?

Agent [descriptions](https://microsoft.github.io/autogen/blog/2023/12/29/AgentDescriptions) should be supported by `CompressibleAgent`.

This change makes `CompressibleAgent` behave as it's stated in its documentation, where it says that the kwargs of `ConversableAgent` are supported.

Also `new CompressibleAgent(description="some description")` gives a type error, because description is not an explicit argument of the constructor.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
