### PR TITLE
More async tool fixes

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -912,9 +912,7 @@ class ConversableAgent(Agent):
             return True, {
                 "role": "tool",
                 "tool_responses": tool_returns,
-                "content": "\n\n".join(
-                    [self._str_for_tool_response(tool_return["content"]) for tool_return in tool_returns]
-                ),
+                "content": "\n\n".join([self._str_for_tool_response(tool_return) for tool_return in tool_returns]),
             }
 
         return False, None
@@ -1128,7 +1126,10 @@ class ConversableAgent(Agent):
                     ]
                 )
 
-            response = {"role": "user", "content": reply, "tool_responses": tool_returns}
+            response = {"role": "user", "content": reply}
+            if tool_returns:
+                response["tool_responses"] = tool_returns
+
             return True, response
 
         # increment the consecutive_auto_reply_counter

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -871,7 +871,7 @@ class ConversableAgent(Agent):
                     "content": func_return.get("content", ""),
                 }
             )
-        if len(tool_returns) > 0:
+        if tool_returns:
             return True, {
                 "role": "tool",
                 "tool_responses": tool_returns,
@@ -907,7 +907,7 @@ class ConversableAgent(Agent):
             func = self._function_map.get(tool_call.get("function", {}).get("name", None), None)
             if func and asyncio.coroutines.iscoroutinefunction(func):
                 async_tool_calls.append(self._a_execute_tool_call(tool_call))
-        if len(async_tool_calls) > 0:
+        if async_tool_calls:
             tool_returns = await asyncio.gather(*async_tool_calls)
             return True, {
                 "role": "tool",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes for #1174, also includes the bug fix in #1201

Started thinking about test coverage, a little awkward to exercise correctly.

Also there is odd interplay between sync/async tool funcs and if that conversations is calling through the sync or async send/receive methods.

Current setup
* sync convo calls sync functions and tools
* async convo calls async functions and tools, if no async function or tools then it calls sync functions and tools

Previously
* sync convo calls sync functions
* async convo calls sync and async function

I see a similar thing happen with check_termination_and_human_reply when running in async, it gets called twice if a_human_reply returns None for no human input.

I think https://github.com/miguelgrinberg/promisio can resolve the issue by providing the same interface for both sync and async functions. But that is a much bigger change and likely not backward compatible.

## Related issue number

closes #1174

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
