### PR TITLE
Add documentation and raise exception when registering async reply function in sync chat

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -638,10 +638,6 @@ class ConversableAgent(Agent):
 
             raise RuntimeError(msg)
 
-        if hasattr(self, "_groupchat"):
-            for agent in self._groupchat.agents:
-                agent._raise_exception_on_async_reply_functions()
-
     def initiate_chat(
         self,
         recipient: "ConversableAgent",

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -141,19 +141,21 @@ class ConversableAgent(Agent):
         )
         self._default_auto_reply = default_auto_reply
         self._reply_func_list = []
+        self._ignore_async_func_in_sync_chat_list = []
         self.reply_at_receive = defaultdict(bool)
         self.register_reply([Agent, None], ConversableAgent.generate_oai_reply)
-        self.register_reply([Agent, None], ConversableAgent.a_generate_oai_reply)
+        self.register_reply([Agent, None], ConversableAgent.a_generate_oai_reply, ignore_async_in_sync_chat=True)
         self.register_reply([Agent, None], ConversableAgent.generate_code_execution_reply)
         self.register_reply([Agent, None], ConversableAgent.generate_tool_calls_reply)
-        self.register_reply([Agent, None], ConversableAgent.a_generate_tool_calls_reply)
+        self.register_reply([Agent, None], ConversableAgent.a_generate_tool_calls_reply, ignore_async_in_sync_chat=True)
         self.register_reply([Agent, None], ConversableAgent.generate_function_call_reply)
-        self.register_reply([Agent, None], ConversableAgent.a_generate_function_call_reply)
+        self.register_reply(
+            [Agent, None], ConversableAgent.a_generate_function_call_reply, ignore_async_in_sync_chat=True
+        )
         self.register_reply([Agent, None], ConversableAgent.check_termination_and_human_reply)
-        self.register_reply([Agent, None], ConversableAgent.a_check_termination_and_human_reply)
-
-        # we will ignore async reply functions in sync chats for the initial reply functions and output warnings for user defined ones
-        self._initial_reply_functions = {f["reply_func"] for f in self._reply_func_list}
+        self.register_reply(
+            [Agent, None], ConversableAgent.a_check_termination_and_human_reply, ignore_async_in_sync_chat=True
+        )
 
         # Registered hooks are kept in lists, indexed by hookable method, to be called in their order of registration.
         # New hookable methods should be added to this list as required to support new agent capabilities.
@@ -166,6 +168,8 @@ class ConversableAgent(Agent):
         position: int = 0,
         config: Optional[Any] = None,
         reset_config: Optional[Callable] = None,
+        *,
+        ignore_async_in_sync_chat: bool = False,
     ):
         """Register a reply function.
 
@@ -173,9 +177,12 @@ class ConversableAgent(Agent):
         The function registered later will be checked earlier by default.
         To change the order, set the position to a positive integer.
 
-        Both sync and async reply functions caannn be registered. The sync reply function will be triggered
+        Both sync and async reply functions can be registered. The sync reply function will be triggered
         from both sync and async chats. However, an async reply function will only be triggered from async
-        chats (initiated with `ConversableAgent.a_initiate_chat`).
+        chats (initiated with `ConversableAgent.a_initiate_chat`). If an `async` reply function is registered
+        and a chat is initialized with a sync function, `ignore_async_in_sync_chat` determines the behaviour as follows:
+        - if `ignore_in_sync_chat` is set to `False` (default value), an exception will be raised, and
+        - if `ignore_in_sync_chat` is set to `True`, the reply function will be ignored.
 
         Args:
             trigger (Agent class, str, Agent instance, callable, or list): the trigger.
@@ -188,6 +195,12 @@ class ConversableAgent(Agent):
                 Note: Be sure to register `None` as a trigger if you would like to trigger an auto-reply function with non-empty messages and `sender=None`.
             reply_func (Callable): the reply function.
                 The function takes a recipient agent, a list of messages, a sender agent and a config as input and returns a reply message.
+            position: the position of the reply function in the reply function list.
+            config: the config to be passed to the reply function, see below.
+            reset_config: the function to reset the config, see below.
+            ignore_async_in_sync_chat: whether to ignore the reply function in sync chats. If `False`, an exception
+                will be raised if an async reply function is registered and a chat is initialized with a sync
+                function.
         ```python
         def reply_func(
             recipient: ConversableAgent,
@@ -216,6 +229,8 @@ class ConversableAgent(Agent):
                 "reset_config": reset_config,
             },
         )
+        if ignore_async_in_sync_chat and asyncio.coroutines.iscoroutinefunction(reply_func):
+            self._ignore_async_func_in_sync_chat_list.append(reply_func)
 
     @property
     def system_message(self) -> Union[str, List]:
@@ -610,7 +625,10 @@ class ConversableAgent(Agent):
         Raises:
             RuntimeError: if any async reply functions are registered.
         """
-        reply_functions = {f["reply_func"] for f in self._reply_func_list}.difference(self._initial_reply_functions)
+        reply_functions = {f["reply_func"] for f in self._reply_func_list}.difference(
+            self._ignore_async_func_in_sync_chat_list
+        )
+
         async_reply_functions = [f for f in reply_functions if asyncio.coroutines.iscoroutinefunction(f)]
         if async_reply_functions != []:
             msg = (
@@ -645,7 +663,7 @@ class ConversableAgent(Agent):
                 "message" needs to be provided if the `generate_init_message` method is not overridden.
 
         Raises:
-            RuntimeError: if any async reply functions are registered.
+            RuntimeError: if any async reply functions are registered and not ignored in sync chat.
         """
         for agent in [self, recipient]:
             agent._raise_exception_on_async_reply_functions()

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -198,7 +198,7 @@ class ConversableAgent(Agent):
             position: the position of the reply function in the reply function list.
             config: the config to be passed to the reply function, see below.
             reset_config: the function to reset the config, see below.
-            ignore_async_in_sync_chat: whether to ignore the reply function in sync chats. If `False`, an exception
+            ignore_async_in_sync_chat: whether to ignore the async reply function in sync chats. If `False`, an exception
                 will be raised if an async reply function is registered and a chat is initialized with a sync
                 function.
         ```python

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -181,8 +181,8 @@ class ConversableAgent(Agent):
         from both sync and async chats. However, an async reply function will only be triggered from async
         chats (initiated with `ConversableAgent.a_initiate_chat`). If an `async` reply function is registered
         and a chat is initialized with a sync function, `ignore_async_in_sync_chat` determines the behaviour as follows:
-        - if `ignore_in_sync_chat` is set to `False` (default value), an exception will be raised, and
-        - if `ignore_in_sync_chat` is set to `True`, the reply function will be ignored.
+        - if `ignore_async_in_sync_chat` is set to `False` (default value), an exception will be raised, and
+        - if `ignore_async_in_sync_chat` is set to `True`, the reply function will be ignored.
 
         Args:
             trigger (Agent class, str, Agent instance, callable, or list): the trigger.

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -339,7 +339,13 @@ class GroupChatManager(ConversableAgent):
         # Allow sync chat if initiated using initiate_chat
         self.register_reply(Agent, GroupChatManager.run_chat, config=groupchat, reset_config=GroupChat.reset)
         # Allow async chat if initiated using a_initiate_chat
-        self.register_reply(Agent, GroupChatManager.a_run_chat, config=groupchat, reset_config=GroupChat.reset)
+        self.register_reply(
+            Agent,
+            GroupChatManager.a_run_chat,
+            config=groupchat,
+            reset_config=GroupChat.reset,
+            ignore_async_in_sync_chat=True,
+        )
 
     def run_chat(
         self,

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -447,3 +447,14 @@ class GroupChatManager(ConversableAgent):
             await speaker.a_send(reply, self, request_reply=False)
             message = self.last_message(speaker)
         return True, None
+
+    def _raise_exception_on_async_reply_functions(self) -> None:
+        """Raise an exception if any async reply functions are registered.
+
+        Raises:
+            RuntimeError: if any async reply functions are registered.
+        """
+        super()._raise_exception_on_async_reply_functions()
+
+        for agent in self._groupchat.agents:
+            agent._raise_exception_on_async_reply_functions()

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -332,6 +332,9 @@ class GroupChatManager(ConversableAgent):
             system_message=system_message,
             **kwargs,
         )
+        # Store groupchat
+        self._groupchat = groupchat
+
         # Order of register_reply is important.
         # Allow sync chat if initiated using initiate_chat
         self.register_reply(Agent, GroupChatManager.run_chat, config=groupchat, reset_config=GroupChat.reset)

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -144,20 +144,19 @@ def test_async_trigger_in_sync_chat():
     agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
     agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
 
-    a_reply_mock = unittest.mock.MagicMock()
-
     async def a_reply(recipient, messages, sender, config):
-        a_reply_mock()
         print("hello from a_reply")
         return (True, "hello from reply function")
 
     agent.register_reply(agent1, a_reply)
 
-    agent1.initiate_chat(agent, message="hi")
+    with pytest.raises(RuntimeError) as e:
+        agent1.initiate_chat(agent, message="hi")
 
-    a_reply_mock.assert_not_called()
-
-    assert agent1.last_message(agent)["content"] == "hi"
+    assert (
+        e.value.args[0] == "Async reply functions can only be used with ConversableAgent.a_initiate_chat(). "
+        "The following async reply functions are found: a_reply"
+    )
 
 
 @pytest.mark.asyncio

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -143,8 +143,12 @@ async def test_async_trigger():
 def test_async_trigger_in_sync_chat():
     agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
     agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
+    agent2 = ConversableAgent("a2", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
+
+    reply_mock = unittest.mock.MagicMock()
 
     async def a_reply(recipient, messages, sender, config):
+        reply_mock()
         print("hello from a_reply")
         return (True, "hello from reply function")
 
@@ -157,6 +161,9 @@ def test_async_trigger_in_sync_chat():
         e.value.args[0] == "Async reply functions can only be used with ConversableAgent.a_initiate_chat(). "
         "The following async reply functions are found: a_reply"
     )
+
+    agent2.register_reply(agent1, a_reply, ignore_async_in_sync_chat=True)
+    reply_mock.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Current state:

1. If you register a `sync` reply function and initiate an `async` chat, the reply function will be triggered.
2. If you register an `async` reply function and initiate a `sync` chat, the reply function will not be triggered.
3. and 4. if the reply function and chat initiation are either both `sync` or both `async`, then the reply function would be triggered.

Proposed change:

2. If you register an `async` reply function and initiate a `sync` chat, a `RunTime exception` will be raised unless we explicitly specify that the function should be ignored in sync chat.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1195

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
