### PR TITLE
Replaced `asyncio.coroutines.iscoroutinefunction` with `inspect.iscoroutinefunction`

### DIFF
--- a/autogen/agentchat/contrib/compressible_agent.py
+++ b/autogen/agentchat/contrib/compressible_agent.py
@@ -4,6 +4,7 @@ from autogen import Agent, ConversableAgent
 import copy
 import asyncio
 import logging
+import inspect
 from autogen.token_count_utils import count_token, get_max_token_limit, num_tokens_from_functions
 
 try:
@@ -201,7 +202,7 @@ Reply "TERMINATE" in the end when everything is done.
             reply_func = reply_func_tuple["reply_func"]
             if exclude and reply_func in exclude:
                 continue
-            if asyncio.coroutines.iscoroutinefunction(reply_func):
+            if inspect.iscoroutinefunction(reply_func):
                 continue
             if self._match_trigger(reply_func_tuple["trigger"], sender):
                 final, reply = reply_func(self, messages=messages, sender=sender, config=reply_func_tuple["config"])

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -229,7 +229,7 @@ class ConversableAgent(Agent):
                 "reset_config": reset_config,
             },
         )
-        if ignore_async_in_sync_chat and asyncio.coroutines.iscoroutinefunction(reply_func):
+        if ignore_async_in_sync_chat and inspect.iscoroutinefunction(reply_func):
             self._ignore_async_func_in_sync_chat_list.append(reply_func)
 
     @property
@@ -629,7 +629,7 @@ class ConversableAgent(Agent):
             self._ignore_async_func_in_sync_chat_list
         )
 
-        async_reply_functions = [f for f in reply_functions if asyncio.coroutines.iscoroutinefunction(f)]
+        async_reply_functions = [f for f in reply_functions if inspect.iscoroutinefunction(f)]
         if async_reply_functions != []:
             msg = (
                 "Async reply functions can only be used with ConversableAgent.a_initiate_chat(). The following async reply functions are found: "
@@ -849,7 +849,7 @@ class ConversableAgent(Agent):
         if "function_call" in message and message["function_call"]:
             func_call = message["function_call"]
             func = self._function_map.get(func_call.get("name", None), None)
-            if asyncio.coroutines.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
                 return False, None
 
             _, func_return = self.execute_function(message["function_call"])
@@ -877,7 +877,7 @@ class ConversableAgent(Agent):
             func_call = message["function_call"]
             func_name = func_call.get("name", "")
             func = self._function_map.get(func_name, None)
-            if func and asyncio.coroutines.iscoroutinefunction(func):
+            if func and inspect.iscoroutinefunction(func):
                 _, func_return = await self.a_execute_function(func_call)
                 return True, func_return
 
@@ -906,7 +906,7 @@ class ConversableAgent(Agent):
             id = tool_call["id"]
             function_call = tool_call.get("function", {})
             func = self._function_map.get(function_call.get("name", None), None)
-            if asyncio.coroutines.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
                 continue
             _, func_return = self.execute_function(function_call)
             tool_returns.append(
@@ -1231,7 +1231,7 @@ class ConversableAgent(Agent):
             reply_func = reply_func_tuple["reply_func"]
             if exclude and reply_func in exclude:
                 continue
-            if asyncio.coroutines.iscoroutinefunction(reply_func):
+            if inspect.iscoroutinefunction(reply_func):
                 continue
             if self._match_trigger(reply_func_tuple["trigger"], sender):
                 final, reply = reply_func(self, messages=messages, sender=sender, config=reply_func_tuple["config"])
@@ -1288,7 +1288,7 @@ class ConversableAgent(Agent):
             if exclude and reply_func in exclude:
                 continue
             if self._match_trigger(reply_func_tuple["trigger"], sender):
-                if asyncio.coroutines.iscoroutinefunction(reply_func):
+                if inspect.iscoroutinefunction(reply_func):
                     final, reply = await reply_func(
                         self, messages=messages, sender=sender, config=reply_func_tuple["config"]
                     )
@@ -1537,7 +1537,7 @@ class ConversableAgent(Agent):
                     flush=True,
                 )
                 try:
-                    if asyncio.coroutines.iscoroutinefunction(func):
+                    if inspect.iscoroutinefunction(func):
                         content = await func(**arguments)
                     else:
                         # Fallback to sync function if the function is not async

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -4,6 +4,7 @@ import sys
 import time
 from typing import Any, Callable, Dict, Literal
 import unittest
+import inspect
 
 import pytest
 from unittest.mock import patch
@@ -559,7 +560,7 @@ def test__wrap_function_sync():
         == '{"currency":"EUR","amount":100.1}'
     )
 
-    assert not asyncio.coroutines.iscoroutinefunction(currency_calculator)
+    assert not inspect.iscoroutinefunction(currency_calculator)
 
 
 @pytest.mark.asyncio
@@ -597,7 +598,7 @@ async def test__wrap_function_async():
         == '{"currency":"EUR","amount":100.1}'
     )
 
-    assert asyncio.coroutines.iscoroutinefunction(currency_calculator)
+    assert inspect.iscoroutinefunction(currency_calculator)
 
 
 def get_origin(d: Dict[str, Callable[..., Any]]) -> Dict[str, Callable[..., Any]]:

--- a/test/test_function_utils.py
+++ b/test/test_function_utils.py
@@ -364,7 +364,7 @@ def test_load_basemodels_if_needed_sync() -> None:
     ) -> Tuple[Currency, CurrencySymbol]:
         return base, quote_currency
 
-    assert not asyncio.coroutines.iscoroutinefunction(f)
+    assert not inspect.iscoroutinefunction(f)
 
     actual = f(base={"currency": "USD", "amount": 123.45}, quote_currency="EUR")
     assert isinstance(actual[0], Currency)
@@ -382,7 +382,7 @@ async def test_load_basemodels_if_needed_async() -> None:
     ) -> Tuple[Currency, CurrencySymbol]:
         return base, quote_currency
 
-    assert asyncio.coroutines.iscoroutinefunction(f)
+    assert inspect.iscoroutinefunction(f)
 
     actual = await f(base={"currency": "USD", "amount": 123.45}, quote_currency="EUR")
     assert isinstance(actual[0], Currency)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In several places `asyncio.coroutines.iscoroutinefunction` was used instead of `inspect.iscoroutinefunction`.

Both `asyncio.coroutines.iscoroutinefunction` and `inspect.iscoroutinefunction` are used to check if a function is a coroutine function. However, they differ in the types of functions they consider to be coroutine functions.

- `inspect.iscoroutinefunction` considers a function to be a coroutine function if it is either:

   - A function decorated with `async def`
   - A function decorated with `@asyncio.coroutine`
   
- `asyncio.coroutines.iscoroutinefunction` only considers a function to be a coroutine function if it is decorated with `@asyncio.coroutine`. It does not consider functions decorated with `async def` to be coroutine functions.

See e.g. https://stackoverflow.com/questions/59343239/asyncio-iscoroutinefunction-returns-false-for-asynchronous-generator

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1260 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
