### PR TITLE
ConversableAgent _prepare_chat should be called on each agent in initiate_chat

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -618,11 +618,9 @@ class ConversableAgent(Agent):
 
     def _prepare_chat(self, recipient, clear_history):
         self.reset_consecutive_auto_reply_counter(recipient)
-        recipient.reset_consecutive_auto_reply_counter(self)
-        self.reply_at_receive[recipient] = recipient.reply_at_receive[self] = True
+        self.reply_at_receive[recipient] = True
         if clear_history:
             self.clear_history(recipient)
-            recipient.clear_history(self)
 
     def _raise_exception_on_async_reply_functions(self) -> None:
         """Raise an exception if any async reply functions are registered.
@@ -669,6 +667,7 @@ class ConversableAgent(Agent):
         for agent in [self, recipient]:
             agent._raise_exception_on_async_reply_functions()
         self._prepare_chat(recipient, clear_history)
+        recipient._prepare_chat(self, clear_history)
         self.send(self.generate_init_message(**context), recipient, silent=silent)
 
     async def a_initiate_chat(

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -691,6 +691,7 @@ class ConversableAgent(Agent):
                 "message" needs to be provided if the `generate_init_message` method is not overridden.
         """
         self._prepare_chat(recipient, clear_history)
+        recipient._prepare_chat(self, clear_history)
         await self.a_send(self.generate_init_message(**context), recipient, silent=silent)
 
     def reset(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In `ConversableAgent`, `_prepare_chat` should be called on each agent in `initiate_chat`, rather than only on one agent. This code doesn't change functionality in any way except making the code more logical. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
