### PR TITLE
fix agentstudio when using non gpt

### DIFF
--- a/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
@@ -1,9 +1,11 @@
-from typing import List, Optional
 from dataclasses import asdict
-import autogen
-from .datamodel import AgentFlowSpec, AgentWorkFlowConfig, Message
-from .utils import get_skills_from_prompt, clear_folder
 from datetime import datetime
+from typing import List, Optional
+
+import autogen
+
+from .datamodel import AgentFlowSpec, AgentWorkFlowConfig, Message
+from .utils import clear_folder, get_skills_from_prompt
 
 
 class AutoGenWorkFlowManager:
@@ -102,7 +104,8 @@ class AutoGenWorkFlowManager:
         """
 
         agent_spec.config.is_termination_msg = agent_spec.config.is_termination_msg or (
-            lambda x: "TERMINATE" in x.get("content", "").rstrip()
+            lambda x: x.get("content", "")
+            and "TERMINATE" in x.get("content", "").rstrip()
         )
         skills_prompt = ""
         if agent_spec.skills:
@@ -139,10 +142,18 @@ class AutoGenWorkFlowManager:
         agent_spec = self.sanitize_agent_spec(agent_spec)
         if agent_spec.type == "assistant":
             agent = autogen.AssistantAgent(**asdict(agent_spec.config))
-            agent.register_reply([autogen.Agent, None], reply_func=self.process_reply, config={"callback": None})
+            agent.register_reply(
+                [autogen.Agent, None],
+                reply_func=self.process_reply,
+                config={"callback": None},
+            )
         elif agent_spec.type == "userproxy":
             agent = autogen.UserProxyAgent(**asdict(agent_spec.config))
-            agent.register_reply([autogen.Agent, None], reply_func=self.process_reply, config={"callback": None})
+            agent.register_reply(
+                [autogen.Agent, None],
+                reply_func=self.process_reply,
+                config={"callback": None},
+            )
         else:
             raise ValueError(f"Unknown agent type: {agent_spec.type}")
         return agent


### PR DESCRIPTION
## Why are these changes needed?

Currently when using non-openai models the autogenstudio produces an error when a model triggers a function call. Currently, I think there is no good support for function call hence the behaviour. This fixes it.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
