### PR TITLE
fix: properly setting last speaker in groupchat

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -374,7 +374,7 @@ class GroupChatManager(ConversableAgent):
                 break
             try:
                 # select the next speaker
-                speaker = groupchat.select_speaker(speaker, self)
+                speaker = groupchat.select_speaker(speaker, speaker)
                 # let the speaker speak
                 reply = speaker.generate_reply(sender=self)
             except KeyboardInterrupt:
@@ -431,7 +431,7 @@ class GroupChatManager(ConversableAgent):
                 break
             try:
                 # select the next speaker
-                speaker = await groupchat.a_select_speaker(speaker, self)
+                speaker = await groupchat.a_select_speaker(speaker, speaker)
                 # let the speaker speak
                 reply = await speaker.a_generate_reply(sender=self)
             except KeyboardInterrupt:


### PR DESCRIPTION
When selecting the the next speaker, and if the boolean argument of `allow_repeat_speaker` is `False`, then the previous speaker should not be a valid agent to choose from.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Right now, the argument `allow_repeat_speaker=False` doesn't work properly.  All it does it ensure that the group manager (`self`) doesn't get selected - but that couldn't get selected anyway because it's not in the agents list.

The argument `last_speaker` should be set to... well... the last speaker :) 

## Related issue number

No issue created.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
