### PR TITLE
Fixed skipping code execution in docker test if already running in a container

### DIFF
--- a/test/test_code.py
+++ b/test/test_code.py
@@ -359,7 +359,8 @@ def test_execute_code(use_docker=None):
 
 
 @pytest.mark.skipif(
-    sys.platform in ["win32"] or (not is_docker_running() and not in_docker_container()), reason="docker is not running"
+    sys.platform in ["win32"] or (not is_docker_running()) or in_docker_container(),
+    reason="docker is not running or in docker container already",
 )
 def test_execute_code_with_custom_filename_on_docker():
     exit_code, msg, image = execute_code("print('hello world')", filename="tmp/codetest.py", use_docker=True)
@@ -368,7 +369,8 @@ def test_execute_code_with_custom_filename_on_docker():
 
 
 @pytest.mark.skipif(
-    sys.platform in ["win32"] or (not is_docker_running() and not in_docker_container()), reason="docker is not running"
+    sys.platform in ["win32"] or (not is_docker_running()) or in_docker_container(),
+    reason="docker is not running or in docker container already",
 )
 def test_execute_code_with_misformed_filename_on_docker():
     exit_code, msg, image = execute_code(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixed skipping code execution in a test if already running in a container.


## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1382 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
