### PR TITLE
Fix check_can_use_docker_or_throw

### DIFF
--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -280,14 +280,22 @@ def check_can_use_docker_or_throw(use_docker) -> None:
     if use_docker is not None:
         inside_docker = in_docker_container()
         docker_installed_and_running = is_docker_running()
-        if use_docker and not inside_docker and not docker_installed_and_running:
-            raise RuntimeError(
-                "Code execution is set to be run in docker (default behaviour) but docker is not running.\n"
-                "The options available are:\n"
-                "- Make sure docker is running (advised approach for code execution)\n"
-                '- Set "use_docker": False in code_execution_config\n'
-                '- Set AUTOGEN_USE_DOCKER to "0/False/no" in your environment variables'
-            )
+        if use_docker:
+            if inside_docker:
+                raise RuntimeError(
+                    "Code execution is set to be run in docker (default behaviour) but the code is already running in a docker container.\n"
+                    "The options available are:\n"
+                    '- Set "use_docker": False in code_execution_config\n'
+                    '- Set AUTOGEN_USE_DOCKER to "0/False/no" in your environment variables'
+                )
+            if not docker_installed_and_running:
+                raise RuntimeError(
+                    "Code execution is set to be run in docker (default behaviour) but docker is not running.\n"
+                    "The options available are:\n"
+                    "- Make sure docker is running (advised approach for code execution)\n"
+                    '- Set "use_docker": False in code_execution_config\n'
+                    '- Set AUTOGEN_USE_DOCKER to "0/False/no" in your environment variables'
+                )
 
 
 def _sanitize_filename_for_docker_tag(filename: str) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If the code is already running in a docker container, `check_can_use_docker_or_throw` should raise an exception.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1395 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
