### PR TITLE
Fix permission block for deploy-website.yml

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,11 +17,7 @@ on:
   merge_group:
     types: [checks_requested]
 permissions:
-  pages: write
-    # actions: read
-  # checks: read
-  # contents: read
-  # deployments: read
+  contents: write
 jobs:
   checks:
     if: github.event_name != 'push'


### PR DESCRIPTION
Based on the instruction here: https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-first-deployment-with-github_token

Write permission is needed to publish GitHub page content to the gh-pages branch.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Org-wide policy change. Now permissions block is required. 

## Related issue number

#1264

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
