### PR TITLE
Fixed rounding bug in WebSurfer contrib tests.

### DIFF
--- a/notebook/agentchat_cost_token_tracking.ipynb
+++ b/notebook/agentchat_cost_token_tracking.ipynb
@@ -356,7 +356,6 @@
     }
    ],
    "source": [
-    "\n",
     "assistant = AssistantAgent(\n",
     "    \"assistant\",\n",
     "    system_message=\"You are a helpful assistant.\",\n",

--- a/notebook/agentchat_function_call_currency_calculator.ipynb
+++ b/notebook/agentchat_function_call_currency_calculator.ipynb
@@ -167,7 +167,7 @@
     "    quote_currency: Annotated[CurrencySymbol, \"Quote currency\"] = \"EUR\",\n",
     ") -> str:\n",
     "    quote_amount = exchange_rate(base_currency, quote_currency) * base_amount\n",
-    "    return f\"{quote_amount} {quote_currency}\"\n"
+    "    return f\"{quote_amount} {quote_currency}\""
    ]
   },
   {

--- a/notebook/agentchat_oai_assistant_retrieval.ipynb
+++ b/notebook/agentchat_oai_assistant_retrieval.ipynb
@@ -101,7 +101,7 @@
     "    \"config_list\": config_list,\n",
     "    \"assistant_id\": assistant_id,\n",
     "    \"tools\": [{\"type\": \"retrieval\"}],\n",
-    "    \"file_ids\": [\"file-CmlT0YKLB3ZCdHmslF9FOv69\"]\n",
+    "    \"file_ids\": [\"file-CmlT0YKLB3ZCdHmslF9FOv69\"],\n",
     "    # add id of an existing file in your openai account\n",
     "    # in this case I added the implementation of conversable_agent.py\n",
     "}\n",

--- a/samples/apps/autogen-studio/notebooks/tutorial.ipynb
+++ b/samples/apps/autogen-studio/notebooks/tutorial.ipynb
@@ -49,7 +49,6 @@
     }
    ],
    "source": [
-    "\n",
     "# load an agent specification in JSON\n",
     "agent_spec = json.load(open(\"agent_spec.json\"))\n",
     "\n",

--- a/test/test_browser_utils.py
+++ b/test/test_browser_utils.py
@@ -4,6 +4,7 @@ import sys
 import requests
 import hashlib
 import re
+import math
 
 from agentchat.test_assistant_agent import KEY_LOC  # noqa: E402
 
@@ -78,7 +79,7 @@ def test_simple_text_browser():
     assert BLOG_POST_STRING in browser.page_content
 
     # Check if page splitting works
-    approx_pages = int(len(browser.page_content) / viewport_size + 0.5)  # May be fewer, since it aligns to word breaks
+    approx_pages = math.ceil(len(browser.page_content) / viewport_size)  # May be fewer, since it aligns to word breaks
     assert len(browser.viewport_pages) <= approx_pages
     assert abs(len(browser.viewport_pages) - approx_pages) <= 1  # allow only a small deviation
     assert browser.viewport_pages[0][0] == 0


### PR DESCRIPTION
## Why are these changes needed?

Fixes a silly rounding bug that causes some websurfer contrib tests to fail.
The bug was previously unnoticed, but the length of the remote webpage used in the test has changed, causing the page breaks to fall in different locations.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
