### PR TITLE
Fix: limit version of pytest to under 8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
             "nbformat",
             "pre-commit",
             "pytest-asyncio",
-            "pytest>=6.1.1",
+            "pytest>=6.1.1,<8",
         ],
         "blendsearch": ["flaml[blendsearch]"],
         "mathchat": ["sympy", "pydantic==1.10.9", "wolframalpha"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Running pytest with the latest version 8.0.0 released an hour ago is not working.

<!-- Please give a short summary of the change and the problem this solves. -->

### Steps to reproduce

Install the latest version of pytest manually or (re)run CI:
```
pip install pytest==8.0.0
```
and then run the tests:
```
coverage run -a -m pytest test --ignore=test/agentchat/contrib --skip-openai
=============== test session starts ===============
platform linux -- Python 3.10.13, pytest-8.0.0, pluggy-1.4.0
rootdir: /workspaces/autogen
configfile: pyproject.toml
plugins: asyncio-0.23.3, anyio-4.2.0
asyncio: mode=strict
collected 0 items                                 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/main.py", line 272, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/main.py", line 325, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_hooks.py", line 501, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 138, in _multicall
INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
INTERNALERROR>     teardown.throw(exception)  # type: ignore[union-attr]
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/logging.py", line 783, in pytest_collection
INTERNALERROR>     return (yield)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
INTERNALERROR>     teardown.throw(exception)  # type: ignore[union-attr]
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/warnings.py", line 118, in pytest_collection
INTERNALERROR>     return (yield)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
INTERNALERROR>     teardown.throw(exception)  # type: ignore[union-attr]
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1365, in pytest_collection
INTERNALERROR>     return (yield)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/main.py", line 336, in pytest_collection
INTERNALERROR>     session.perform_collect()
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/main.py", line 799, in perform_collect
INTERNALERROR>     self.items.extend(self.genitems(node))
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/main.py", line 942, in genitems
INTERNALERROR>     yield from self.genitems(subnode)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/main.py", line 942, in genitems
INTERNALERROR>     yield from self.genitems(subnode)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/main.py", line 937, in genitems
INTERNALERROR>     rep, duplicate = self._collect_one_node(node, handle_dupes)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/main.py", line 825, in _collect_one_node
INTERNALERROR>     rep = collect_one_node(node)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/_pytest/runner.py", line 566, in collect_one_node
INTERNALERROR>     ihook.pytest_collectstart(collector=collector)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_hooks.py", line 501, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 138, in _multicall
INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/vscode/.local/lib/python3.10/site-packages/pytest_asyncio/plugin.py", line 626, in pytest_collectstart
INTERNALERROR>     pyobject = collector.obj
INTERNALERROR> AttributeError: 'Package' object has no attribute 'obj'
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1436

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
