### PR TITLE
Improve docs/gallery card component

### DIFF
--- a/website/src/components/GalleryPage.js
+++ b/website/src/components/GalleryPage.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useState, useCallback } from "react";
 import galleryData from "../data/gallery.json";
-import { Card, List, Select } from "antd";
+import { Card, List, Select, Typography } from "antd";
 import { useLocation, useHistory } from "react-router-dom";
 
 const { Option } = Select;
+const { Paragraph, Title } = Typography;
 
 const GalleryPage = () => {
   const location = useLocation();
@@ -75,10 +76,10 @@ const GalleryPage = () => {
           gutter: 16,
           xs: 1,
           sm: 2,
-          md: 3,
-          lg: 3,
-          xl: 4,
-          xxl: 4,
+          md: 2,
+          lg: 2,
+          xl: 3,
+          xxl: 3,
         }}
         dataSource={filteredData}
         renderItem={(item) => (
@@ -91,7 +92,8 @@ const GalleryPage = () => {
             >
               <Card
                 hoverable
-                bordered
+                bordered={false}
+                style={{ height: 370, paddingTop: 15 }}
                 cover={
                   <img
                     alt={item.title}
@@ -102,29 +104,26 @@ const GalleryPage = () => {
                           : `/autogen/img/gallery/${item.image}`
                         : `/autogen/img/gallery/default.png`
                     }
+                    style={{
+                      height: 150,
+                      width: "fit-content",
+                      margin: "auto",
+                    }}
                   />
                 }
               >
-                <div>
-                  <span
-                    style={{
-                      fontSize: "1.2rem",
-                      fontWeight: "bold",
-                      color: "black",
-                    }}
-                  >
-                    {item.title}
-                  </span>
-                </div>
-                <div
+                <Title level={5} ellipsis={{ rows: 2 }}>
+                  {item.title}
+                </Title>
+                <Paragraph
+                  ellipsis={{ rows: 3 }}
                   style={{
-                    // fontSize: "0.8rem",
                     fontWeight: "normal",
                     color: "#727272",
                   }}
                 >
                   {item.description ? item.description : item.title}
-                </div>
+                </Paragraph>
                 <TagsView tags={item.tags} />
               </Card>
             </a>

--- a/website/src/components/GalleryPage.js
+++ b/website/src/components/GalleryPage.js
@@ -92,7 +92,7 @@ const GalleryPage = () => {
             >
               <Card
                 hoverable
-                bordered={false}
+                bordered
                 style={{ height: 370, paddingTop: 15 }}
                 cover={
                   <img
@@ -108,6 +108,7 @@ const GalleryPage = () => {
                       height: 150,
                       width: "fit-content",
                       margin: "auto",
+                      padding: 2,
                     }}
                   />
                 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The gallery features incredibly valuable community contributions, however it doesn't seem like the component in the current docs/gallery card is optimized:

<img width="1469" alt="image" src="https://github.com/microsoft/autogen/assets/82203888/57ce8c6a-faeb-40db-ba71-d776304a926a">


So updated the component to make it look better and more engaging:

<img width="1441" alt="image" src="https://github.com/microsoft/autogen/assets/82203888/dbf62155-3525-4f99-a786-b9b05ec670ff">

Let me know if any changes can be done to this to make it better.
I have continued the design approach by using the antd for typography.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
