### PR TITLE
Show warning instead of error if env config file doesn't exist

### DIFF
--- a/samples/apps/autogen-studio/frontend/gatsby-config.ts
+++ b/samples/apps/autogen-studio/frontend/gatsby-config.ts
@@ -5,7 +5,7 @@ const envFile = `.env.${process.env.NODE_ENV}`;
 
 fs.access(envFile, fs.constants.F_OK, (err) => {
   if (err) {
-      throw(`File '${envFile}' is missing`);
+    console.warn(`File '${envFile}' is missing. Using default values.`);
   }
 });
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/autogen/pull/1475#issuecomment-1918114520