### PR TITLE
Import `oai.client` directly in `ConversableAgent`

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union
 import warnings
 
-from .. import OpenAIWrapper, ModelClient
+from ..oai.client import OpenAIWrapper, ModelClient
 from ..cache.cache import Cache
 from ..code_utils import (
     DEFAULT_MODEL,


### PR DESCRIPTION
### Bug fixed
Incorrect import statement was present in conversible_agent.py.
It has been corrected.

## Why are these changes needed ?

Full description provided in #1526 

## Related issue number
closes #1526  #1498 

Reviewer
@ekzhu 