### PR TITLE
Fix agent_utils.py to use correct variable for summary

### DIFF
--- a/autogen/agent_utils.py
+++ b/autogen/agent_utils.py
@@ -44,7 +44,7 @@ def gather_usage_summary(agents: List) -> Tuple[Dict[str, any], Dict[str, any]]:
 
     for agent in agents:
         if getattr(agent, "client", None):
-            aggregate_summary(total_usage_summary, agent.client.total_usage_summary)
-            aggregate_summary(actual_usage_summary, agent.client.actual_usage_summary)
+            aggregate_summary(total_usage_summary, total_usage_summary)
+            aggregate_summary(actual_usage_summary, actual_usage_summary)
 
     return total_usage_summary, actual_usage_summary


### PR DESCRIPTION
## Why are these changes needed?

agent_utils.py tries to access a non existent variable in the OpenAI client instead of the local variable

## Related issue number

Closes #1613

## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
