### PR TITLE
Check for missing dependencies before building the website

### DIFF
--- a/website/build_website.sh
+++ b/website/build_website.sh
@@ -1,8 +1,29 @@
+#!/bin/bash
 #
 # This script generates documentation using pydoc-markdown and renders the website using Quarto.
 #
-# Usage: bash build_website.sh
+
+missing_deps=false
+
 #
+# Check for missing dependencies, report them, and exit when building the
+# website is likely to fail.
+#
+for dependency in node pydoc-markdown quarto python yarn npm
+do
+    if ! command -v "$dependency" &> /dev/null
+    then
+        echo "Command '$dependency' not found."
+        missing_deps=true
+    fi
+done
+
+if [ "$missing_deps" = true ]
+then
+    echo -e "\nSome of the dependencies are missing."
+    echo "Please install them to build the website."
+    exit 1
+fi
 
 # Generate documentation using pydoc-markdown
 pydoc-markdown


### PR DESCRIPTION
**Summary**:
 
- Add an executable permission to the file.
 - Check for the dependencies before the website build starts.
 - Output a list of missing dependencies.
 - Note: `command -v` is POSIX compatible.

**Sample output**:

```bash
$ ./build_website.sh
Command 'pydoc-markdown' not found.
Command 'python' not found.

Some of the dependencies are missing.
Please install them to build the website.
```

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

TL;DR: make the life of anyone who wants to contribute to the documentation (and doesn't necessary run all the steps described in `README.md` ;-)) _easier_. My workflow consisted of 5-6 retries till I got all the dependencies right. This set of changes reduces the frustration and performs the dependency checks beforehand.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ X] I've made sure all auto checks have passed.
