### PR TITLE
Allow costs and window size limits to be specified in the config_list

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -93,7 +93,9 @@ class ModelClient(Protocol):
         """
         ...  # pragma: no cover
 
-    def cost(self, response: ModelClientResponseProtocol) -> float:
+    def cost(
+        self, response: ModelClientResponseProtocol, token_cost_1k: Optional[Union[float, Dict[str, float]]] = None
+    ) -> float:
         ...  # pragma: no cover
 
     @staticmethod
@@ -275,7 +277,11 @@ class OpenAIClient:
 
         return response
 
-    def cost(self, response: Union[ChatCompletion, Completion], token_cost_1k: Optional[Tuple[float]] = None) -> float:
+    def cost(
+        self,
+        response: Union[ChatCompletion, Completion],
+        token_cost_1k: Optional[Union[float, Dict[str, float]]] = None,
+    ) -> float:
         """Calculate the cost of the response."""
 
         # No cost specified. Use the default if possible

--- a/test/oai/test_custom_client.py
+++ b/test/oai/test_custom_client.py
@@ -49,7 +49,7 @@ def test_custom_model_client():
         def message_retrieval(self, response):
             return [response.choices[0].message.content]
 
-        def cost(self, response) -> float:
+        def cost(self, response, token_cost_1k=None) -> float:
             """Calculate the cost of the response."""
             response.cost = TEST_COST
             return TEST_COST
@@ -97,7 +97,7 @@ def test_registering_with_wrong_class_name_raises_error():
         def message_retrieval(self, response):
             return []
 
-        def cost(self, response) -> float:
+        def cost(self, response, token_cost_1k=None) -> float:
             return 0
 
         @staticmethod
@@ -127,7 +127,7 @@ def test_not_all_clients_registered_raises_error():
         def message_retrieval(self, response):
             return []
 
-        def cost(self, response) -> float:
+        def cost(self, response, token_cost_1k=None) -> float:
             return 0
 
         @staticmethod
@@ -179,7 +179,7 @@ def test_registering_with_extra_config_args():
         def message_retrieval(self, response):
             return []
 
-        def cost(self, response) -> float:
+        def cost(self, response, token_cost_1k=None) -> float:
             """Calculate the cost of the response."""
             return 0
 


### PR DESCRIPTION
## Why are these changes needed?

See issue #1680.

TL;DR: 
Token limits and costs are hardcoded in various files. Adding new models requires editing numerous files. Costs are keyed off model names, but those name may not be reliable. For example, "gpt-4" on Azure might point to an 8k, 32k, or 128k model. There is no requirement that these match with OpenAI names. Likewise, model names may not match at all (e.g., "my-gpt-4")
Adding new models or providers requires hand-editing core library files.

This PR allows costs and limits to be specified in the config. E.g., 

```
[
        "model": "gpt-4-turbo",
        "api_key": "blahblahblah",
        "base_url": "https://mymodel.openai.azure.com/",
        "api_type": "azure",
        "api_version": "2023-12-01-preview",
        "window_size":  { "input": 128000, "output":  4096 },
        "token_cost_1k":  { "input": 0.01, "output": 0.03 ) 
]
```

Limitations: Vision models are not fully-supported. We can compute the cost only after we get the tokens counts back after making the call.

## Related issue number

Closes #1680, #1270

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
