### PR TITLE
feat(tokenizer):add support for open source llm tokenizers

### DIFF
--- a/OAI_CONFIG_LIST_sample
+++ b/OAI_CONFIG_LIST_sample
@@ -20,5 +20,16 @@
         "base_url": "<your Azure OpenAI API base here>",
         "api_type": "azure",
         "api_version": "2024-02-15-preview"
+    },
+    {
+        "model": "<your open source LLM local path>",
+        "api_key": "<your key here>",
+        "base_url": "<your open source LLM url here>",
+        "api_type": "azure",
+        "api_version": "2024-02-15-preview",
+        "model_path_for_tokenizer": "<your open source LLM path i.e.(microsoft/Orca-2-13b)>",
+        "tokenizer_kwargs": {  
+            "use_fast": false
+        }
     }
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->
Hello everyone, I saw the Contribute guide but for some reason the tests would always fail on `_____________________________________ ERROR collecting test/test_function_utils.py _____________________________________
test/test_function_utils.py:288: in <module>
    class Currency(BaseModel):
pydantic/main.py:197: in pydantic.main.ModelMetaclass.__new__
    ???
pydantic/fields.py:497: in pydantic.fields.ModelField.infer
    ???
pydantic/fields.py:469: in pydantic.fields.ModelField._get_field_info
    ???
E   ValueError: `Field` default cannot be set in `Annotated` for 'amount'`

I tried but I'm very busy and I seem to not manage to make it work for now, I hope you can take a look and I'll try to run it again.

## Why are these changes needed?

This PR solves the following issue [https://github.com/microsoft/autogen/issues/1666](url)
Basically while serving open source llm models we were always tokenizing using cl100k_base, but now we support the native way of each model by specifying it in the OAI_CONFIG_LIST

## Related issue number

Closes #1666 

## Checks
Sadly I didn't manage to run checks because of the error mentioned above
