### PR TITLE
Allow None for sender field in `CoversableAgent.generate_reply`

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1388,13 +1388,15 @@ class ConversableAgent(LLMAgent):
         if config is None:
             config = self
         if messages is None:
-            messages = self._oai_messages[sender]
+            messages = self._oai_messages[sender] if sender else []
         message = messages[-1]
         reply = ""
         no_human_input_msg = ""
+        sender_name = "the sender" if sender is None else sender.name
+        
         if self.human_input_mode == "ALWAYS":
             reply = self.get_human_input(
-                f"Provide feedback to {sender.name}. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: "
+                f"Provide feedback to {sender_name}. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: "
             )
             no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
             # if the human input is empty, and the message is a termination message, then we will terminate the conversation
@@ -1407,9 +1409,9 @@ class ConversableAgent(LLMAgent):
                     # self.human_input_mode == "TERMINATE":
                     terminate = self._is_termination_msg(message)
                     reply = self.get_human_input(
-                        f"Please give feedback to {sender.name}. Press enter or type 'exit' to stop the conversation: "
+                        f"Please give feedback to {sender_name}. Press enter or type 'exit' to stop the conversation: "
                         if terminate
-                        else f"Please give feedback to {sender.name}. Press enter to skip and use auto-reply, or type 'exit' to stop the conversation: "
+                        else f"Please give feedback to {sender_name}. Press enter to skip and use auto-reply, or type 'exit' to stop the conversation: "
                     )
                     no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
@@ -1420,7 +1422,7 @@ class ConversableAgent(LLMAgent):
                 else:
                     # self.human_input_mode == "TERMINATE":
                     reply = self.get_human_input(
-                        f"Please give feedback to {sender.name}. Press enter or type 'exit' to stop the conversation: "
+                        f"Please give feedback to {sender_name}. Press enter or type 'exit' to stop the conversation: "
                     )
                     no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
@@ -1471,7 +1473,7 @@ class ConversableAgent(LLMAgent):
             print(colored("\n>>>>>>>> USING AUTO REPLY...", "red"), flush=True)
 
         return False, None
-
+    
     async def a_check_termination_and_human_reply(
         self,
         messages: Optional[List[Dict]] = None,
@@ -1498,13 +1500,15 @@ class ConversableAgent(LLMAgent):
         if config is None:
             config = self
         if messages is None:
-            messages = self._oai_messages[sender]
-        message = messages[-1]
+            messages = self._oai_messages[sender] if sender else []
+        message = messages[-1] if messages else {}
         reply = ""
         no_human_input_msg = ""
+        sender_name = "the sender" if sender is None else sender.name
+        
         if self.human_input_mode == "ALWAYS":
             reply = await self.a_get_human_input(
-                f"Provide feedback to {sender.name}. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: "
+                f"Provide feedback to {sender_name}. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: "
             )
             no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
             # if the human input is empty, and the message is a termination message, then we will terminate the conversation
@@ -1517,9 +1521,9 @@ class ConversableAgent(LLMAgent):
                     # self.human_input_mode == "TERMINATE":
                     terminate = self._is_termination_msg(message)
                     reply = await self.a_get_human_input(
-                        f"Please give feedback to {sender.name}. Press enter or type 'exit' to stop the conversation: "
+                        f"Please give feedback to {sender_name}. Press enter or type 'exit' to stop the conversation: "
                         if terminate
-                        else f"Please give feedback to {sender.name}. Press enter to skip and use auto-reply, or type 'exit' to stop the conversation: "
+                        else f"Please give feedback to {sender_name}. Press enter to skip and use auto-reply, or type 'exit' to stop the conversation: "
                     )
                     no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation
@@ -1530,7 +1534,7 @@ class ConversableAgent(LLMAgent):
                 else:
                     # self.human_input_mode == "TERMINATE":
                     reply = await self.a_get_human_input(
-                        f"Please give feedback to {sender.name}. Press enter or type 'exit' to stop the conversation: "
+                        f"Please give feedback to {sender_name}. Press enter or type 'exit' to stop the conversation: "
                     )
                     no_human_input_msg = "NO HUMAN INPUT RECEIVED." if not reply else ""
                     # if the human input is empty, and the message is a termination message, then we will terminate the conversation

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1393,7 +1393,6 @@ class ConversableAgent(LLMAgent):
         reply = ""
         no_human_input_msg = ""
         sender_name = "the sender" if sender is None else sender.name
-        
         if self.human_input_mode == "ALWAYS":
             reply = self.get_human_input(
                 f"Provide feedback to {sender_name}. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: "
@@ -1473,7 +1472,7 @@ class ConversableAgent(LLMAgent):
             print(colored("\n>>>>>>>> USING AUTO REPLY...", "red"), flush=True)
 
         return False, None
-    
+
     async def a_check_termination_and_human_reply(
         self,
         messages: Optional[List[Dict]] = None,
@@ -1505,7 +1504,6 @@ class ConversableAgent(LLMAgent):
         reply = ""
         no_human_input_msg = ""
         sender_name = "the sender" if sender is None else sender.name
-        
         if self.human_input_mode == "ALWAYS":
             reply = await self.a_get_human_input(
                 f"Provide feedback to {sender_name}. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: "

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -472,6 +472,29 @@ async def test_a_generate_reply_raises_on_messages_and_sender_none(conversable_a
         await conversable_agent.a_generate_reply(messages=None, sender=None)
 
 
+def test_generate_reply_with_messages_and_sender_none(conversable_agent):
+    messages = [{"role": "user", "content": "hello"}]
+    try:
+        response = conversable_agent.generate_reply(messages=messages, sender=None)
+        assert response is not None, "Response should not be None"
+    except AssertionError as e:
+        pytest.fail(f"Unexpected AssertionError: {e}")
+    except Exception as e:
+        pytest.fail(f"Unexpected exception: {e}")
+
+
+@pytest.mark.asyncio
+async def test_a_generate_reply_with_messages_and_sender_none(conversable_agent):
+    messages = [{"role": "user", "content": "hello"}]
+    try:
+        response = await conversable_agent.a_generate_reply(messages=messages, sender=None)
+        assert response is not None, "Response should not be None"
+    except AssertionError as e:
+        pytest.fail(f"Unexpected AssertionError: {e}")
+    except Exception as e:
+        pytest.fail(f"Unexpected exception: {e}")
+
+
 def test_update_function_signature_and_register_functions() -> None:
     with pytest.MonkeyPatch.context() as mp:
         mp.setenv("OPENAI_API_KEY", MOCK_OPEN_AI_API_KEY)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, if we do:

```
agent = ConversableAgent("name", llm_config=False, human_input_mode="ALWAYS")
reply = agent.generate_reply(messages=[{"role": "user", "content": "hello"}])
```

We get

```
AttributeError: 'NoneType' object has no attribute 'name'
```

After fixing this bug it addresses potential issue with `sender` being `None` and using `sender_name` correctly throughout the method. This ensures that our method handles different scenarios robustly, including when sender might not be provided, and makes our method more resilient to various input conditions.

```
autogen@17295b29b93a:~/autogen$ python3
Python 3.11.8 (main, Feb 13 2024, 10:08:31) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from autogen.agentchat.conversable_agent import ConversableAgent
>>> agent = ConversableAgent("name", llm_config=False, human_input_mode="ALWAYS")
>>> reply = agent.generate_reply(messages=[{"role": "user", "content": "hello"}])
Provide feedback to the sender. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: hello
>>> print(reply)
{'role': 'user', 'content': 'hello'}
>>> reply = agent.generate_reply(messages=[{"role": "user", "content": "hello"}])
Provide feedback to the sender. Press enter to skip and use auto-reply, or type 'exit' to end the conversation: exit
>>> print(reply)
None
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #1708 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
