### PR TITLE
Debuged RestrictedPwershellExecution by Pypassing

### DIFF
--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -237,7 +237,7 @@ powershell_command = get_powershell_command()
 
 
 def check_and_update_powershell_execution_policy():
-    policy_check_command = ["powershell", "Get-ExecutionPolicy", "-Scope", "CurrentUser"]
+    policy_check_command = [powershell_command, "Get-ExecutionPolicy", "-Scope", "CurrentUser"]
     policy = subprocess.check_output(policy_check_command, text=True).strip()
 
     if policy == "Restricted":

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -237,6 +237,8 @@ powershell_command = get_powershell_command()
 
 
 def check_and_update_powershell_execution_policy():
+    import_security_prompt = ["Import-Module", "Microsoft.PowerShell.Security"]
+    subprocess.check_output(import_security_prompt, text=True).strip()
     policy_check_command = ["powershell", "Get-ExecutionPolicy", "-Scope", "CurrentUser"]
     policy = subprocess.check_output(policy_check_command, text=True).strip()
 

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -235,26 +235,31 @@ def get_powershell_command():
 
 powershell_command = get_powershell_command()
 
-def check_and_update_powershell_execution_policy():
 
+def check_and_update_powershell_execution_policy():
     policy_check_command = [powershell_command, "Get-ExecutionPolicy"]
     policy = subprocess.check_output(policy_check_command, text=True).strip()
 
     if policy == "Restricted":
         print("Application needs permission to execute scripts using PowerShell.")
-        user_input = input("Would you like to allow this application to execute PowerShell scripts? (proceed:any key, reject:n or no): ")
+        user_input = input(
+            "Would you like to allow this application to execute PowerShell scripts? (proceed:any key, reject:n or no): "
+        )
         if user_input.lower() in ["no", "n"]:
             print("Application attempted to perform an unauthorized operation and will now exit.")
             sys.exit()
         else:
             try:
-                subprocess.check_call([powershell_command, "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True)
+                subprocess.check_call(
+                    [powershell_command, "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True
+                )
                 print("Execution policy updated successfully. The application will continue.")
             except subprocess.CalledProcessError as e:
                 print(f"Failed to update execution policy. Error: {e}")
                 sys.exit()
     else:
         return
+
 
 def _cmd(lang):
     if lang.startswith("python") or lang in ["bash", "sh", powershell_command]:

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -267,7 +267,7 @@ def _cmd(lang):
     if lang in ["shell"]:
         return ["sh"]
     if lang in ["ps1", "pwsh", powershell_command]:
-        if WIN32:
+        if WIN32 and powershell_command == "powershell" and not is_docker_running():
             check_and_update_powershell_execution_policy()
         return [powershell_command]
 

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -251,7 +251,7 @@ def check_and_update_powershell_execution_policy():
         else:
             try:
                 subprocess.check_call(
-                    ["powershell", "Set-ExecutionPolicy", "RemoteSigned", "-Scope", "CurrentUser"], text=True
+                    [powershell_command, "Set-ExecutionPolicy", "RemoteSigned", "-Scope", "CurrentUser"], text=True
                 )
                 print("Execution policy updated successfully. The application will continue.")
             except subprocess.CalledProcessError as e:

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -237,11 +237,11 @@ powershell_command = get_powershell_command()
 
 
 def check_and_update_powershell_execution_policy():
-    policy_check_command = ["powershell", "Get-ExecutionPolicy"]
+    policy_check_command = ["powershell", "Get-ExecutionPolicy", "-Scope", "CurrentUser"]
     policy = subprocess.check_output(policy_check_command, text=True).strip()
 
     if policy == "Restricted":
-        print("Application needs permission to execute scripts using PowerShell.")
+        print("Application needs permission to execute scripts using PowerShell. ")
         user_input = input(
             "Would you like to allow this application to execute PowerShell scripts? (proceed:any key, reject:n or no): "
         )
@@ -251,7 +251,7 @@ def check_and_update_powershell_execution_policy():
         else:
             try:
                 subprocess.check_call(
-                    ["powershell", "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True
+                    ["powershell", "Set-ExecutionPolicy", "RemoteSigned", "-Scope", "CurrentUser"], text=True
                 )
                 print("Execution policy updated successfully. The application will continue.")
             except subprocess.CalledProcessError as e:

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -237,7 +237,7 @@ powershell_command = get_powershell_command()
 
 
 def check_and_update_powershell_execution_policy():
-    policy_check_command = [powershell_command, "Get-ExecutionPolicy", "-Scope", "CurrentUser"]
+    policy_check_command = ["powershell", "Get-ExecutionPolicy", "-Scope", "CurrentUser"]
     policy = subprocess.check_output(policy_check_command, text=True).strip()
 
     if policy == "Restricted":
@@ -251,7 +251,7 @@ def check_and_update_powershell_execution_policy():
         else:
             try:
                 subprocess.check_call(
-                    [powershell_command, "Set-ExecutionPolicy", "RemoteSigned", "-Scope", "CurrentUser"], text=True
+                    ["powershell", "Set-ExecutionPolicy", "RemoteSigned", "-Scope", "CurrentUser"], text=True
                 )
                 print("Execution policy updated successfully. The application will continue.")
             except subprocess.CalledProcessError as e:

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -410,7 +410,6 @@ def execute_code(
             fout.write(code)
 
     if not use_docker or running_inside_docker:
-
         if lang.startswith("python"):
             cmd = [sys.executable]
         else:
@@ -476,8 +475,9 @@ def execute_code(
     # get a randomized str based on current time to wrap the exit code
     exit_code_str = f"exitcode{time.time()}"
     abs_path = pathlib.Path(work_dir).absolute()
-    cmd = ["sh", "-c"] \
-        + [f'{_cmd(lang)[0]} "{filename}"; exit_code=$?; echo -n {exit_code_str}; echo -n $exit_code; echo {exit_code_str}']
+    cmd = ["sh", "-c"] + [
+        f'{_cmd(lang)[0]} "{filename}"; exit_code=$?; echo -n {exit_code_str}; echo -n $exit_code; echo {exit_code_str}'
+    ]
 
     # create a docker container
     container = client.containers.run(

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -236,7 +236,8 @@ def get_powershell_command():
 powershell_command = get_powershell_command()
 
 def check_and_update_powershell_execution_policy():
-    policy_check_command = ["powershell", "Get-ExecutionPolicy"]
+
+    policy_check_command = [powershell_command, "Get-ExecutionPolicy"]
     policy = subprocess.check_output(policy_check_command, text=True).strip()
 
     if policy == "Restricted":
@@ -247,7 +248,7 @@ def check_and_update_powershell_execution_policy():
             sys.exit()
         else:
             try:
-                subprocess.check_call(["powershell", "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True)
+                subprocess.check_call([powershell_command, "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True)
                 print("Execution policy updated successfully. The application will continue.")
             except subprocess.CalledProcessError as e:
                 print(f"Failed to update execution policy. Error: {e}")
@@ -260,7 +261,7 @@ def _cmd(lang):
         return [lang]
     if lang in ["shell"]:
         return ["sh"]
-    if lang in ["ps1", "pwsh", "powershell"]:
+    if lang in ["ps1", "pwsh", powershell_command]:
         if WIN32:
             check_and_update_powershell_execution_policy()
         return [powershell_command]

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -237,8 +237,6 @@ powershell_command = get_powershell_command()
 
 
 def check_and_update_powershell_execution_policy():
-    import_security_prompt = ["Import-Module", "Microsoft.PowerShell.Security"]
-    subprocess.check_output(import_security_prompt, text=True).strip()
     policy_check_command = ["powershell", "Get-ExecutionPolicy", "-Scope", "CurrentUser"]
     policy = subprocess.check_output(policy_check_command, text=True).strip()
 
@@ -269,7 +267,7 @@ def _cmd(lang):
     if lang in ["shell"]:
         return ["sh"]
     if lang in ["ps1", "pwsh", powershell_command]:
-        if WIN32 and powershell_command == "powershell" and not is_docker_running():
+        if WIN32:
             check_and_update_powershell_execution_policy()
         return [powershell_command]
 

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -237,7 +237,7 @@ powershell_command = get_powershell_command()
 
 
 def check_and_update_powershell_execution_policy():
-    policy_check_command = [powershell_command, "Get-ExecutionPolicy"]
+    policy_check_command = ["powershell", "Get-ExecutionPolicy"]
     policy = subprocess.check_output(policy_check_command, text=True).strip()
 
     if policy == "Restricted":
@@ -251,7 +251,7 @@ def check_and_update_powershell_execution_policy():
         else:
             try:
                 subprocess.check_call(
-                    [powershell_command, "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True
+                    ["powershell", "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True
                 )
                 print("Execution policy updated successfully. The application will continue.")
             except subprocess.CalledProcessError as e:
@@ -267,7 +267,7 @@ def _cmd(lang):
     if lang in ["shell"]:
         return ["sh"]
     if lang in ["ps1", "pwsh", powershell_command]:
-        if WIN32:
+        if WIN32 and powershell_command == "powershell":
             check_and_update_powershell_execution_policy()
         return [powershell_command]
 

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -269,7 +269,7 @@ def _cmd(lang):
     if lang in ["shell"]:
         return ["sh"]
     if lang in ["ps1", "pwsh", powershell_command]:
-        if WIN32 and powershell_command == "powershell":
+        if WIN32 and powershell_command == "powershell" and not is_docker_running():
             check_and_update_powershell_execution_policy()
         return [powershell_command]
 

--- a/test/test_code_utils.py
+++ b/test/test_code_utils.py
@@ -431,9 +431,10 @@ def test_check_and_update_powershell_execution_policy():
             with patch("subprocess.check_call") as mocked_check_call:
                 check_and_update_powershell_execution_policy()
                 mocked_check_call.assert_called_once_with(
-                    ["powershell", "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True
+                    ["powershell", "Set-ExecutionPolicy", "RemoteSigned", "-Scope", "CurrentUser"], text=True
                 )
 
+    with patch("subprocess.check_output", return_value="Restricted"):
         with patch("builtins.input", return_value="no"):
             with pytest.raises(SystemExit):
                 check_and_update_powershell_execution_policy()

--- a/test/test_code_utils.py
+++ b/test/test_code_utils.py
@@ -423,7 +423,7 @@ def test_execute_code_raises_when_code_and_filename_are_both_none():
 
 @pytest.mark.skipif(
     skip_docker or not is_docker_running() and sys.platform != "win32",
-    reason="execution polict matters only without docker in window",
+    reason="execution policy matters only without docker in window",
 )
 def test_check_and_update_powershell_execution_policy():
     with patch("subprocess.check_output", return_value="Restricted"):

--- a/test/test_code_utils.py
+++ b/test/test_code_utils.py
@@ -434,7 +434,6 @@ def test_check_and_update_powershell_execution_policy():
                     ["powershell", "Set-ExecutionPolicy", "RemoteSigned", "-Scope", "CurrentUser"], text=True
                 )
 
-    with patch("subprocess.check_output", return_value="Restricted"):
         with patch("builtins.input", return_value="no"):
             with pytest.raises(SystemExit):
                 check_and_update_powershell_execution_policy()

--- a/test/test_code_utils.py
+++ b/test/test_code_utils.py
@@ -20,6 +20,7 @@ from autogen.code_utils import (
     in_docker_container,
     decide_use_docker,
     check_can_use_docker_or_throw,
+    check_and_update_powershell_execution_policy
 )
 from conftest import skip_docker
 
@@ -408,6 +409,20 @@ def test_execute_code_raises_when_code_and_filename_are_both_none():
 def test_execute_code_no_docker():
     test_execute_code(use_docker=False)
 
+@pytest.mark.skipif(
+    skip_docker or not is_docker_running() and sys.platform != "win32",
+    reason="execution polict matters only without docker in window",
+)
+def test_check_and_update_powershell_execution_policy():
+    with patch('subprocess.check_output', return_value="Restricted"):
+        with patch('builtins.input', return_value='yes'):
+            with patch('subprocess.check_call') as mocked_check_call:
+                check_and_update_powershell_execution_policy()
+                mocked_check_call.assert_called_once_with(["powershell", "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True)
+
+        with patch('builtins.input', return_value='no'):
+            with pytest.raises(SystemExit):
+                check_and_update_powershell_execution_policy()
 
 def test_execute_code_timeout_no_docker():
     exit_code, error, image = execute_code("import time; time.sleep(2)", timeout=1, use_docker=False)

--- a/test/test_code_utils.py
+++ b/test/test_code_utils.py
@@ -20,7 +20,7 @@ from autogen.code_utils import (
     in_docker_container,
     decide_use_docker,
     check_can_use_docker_or_throw,
-    check_and_update_powershell_execution_policy
+    check_and_update_powershell_execution_policy,
 )
 from conftest import skip_docker
 
@@ -337,7 +337,7 @@ def test_execute_code(use_docker=True):
         # execute code in a file using shell command directly
         if not use_docker:
             # with user input yes, ensure the powershell execution unrestricted
-            with patch('builtins.input', return_value='yes'):
+            with patch("builtins.input", return_value="yes"):
                 exit_code, msg, image = execute_code(
                     f"python {filename}",
                     lang="sh",
@@ -377,8 +377,10 @@ def test_execute_code(use_docker=True):
         if use_docker is True:
             assert isinstance(image, str)
 
+
 def test_execute_code_no_docker():
     test_execute_code(use_docker=False)
+
 
 @pytest.mark.skipif(
     skip_docker or not is_docker_running(),
@@ -424,15 +426,18 @@ def test_execute_code_raises_when_code_and_filename_are_both_none():
     reason="execution polict matters only without docker in window",
 )
 def test_check_and_update_powershell_execution_policy():
-    with patch('subprocess.check_output', return_value="Restricted"):
-        with patch('builtins.input', return_value='yes'):
-            with patch('subprocess.check_call') as mocked_check_call:
+    with patch("subprocess.check_output", return_value="Restricted"):
+        with patch("builtins.input", return_value="yes"):
+            with patch("subprocess.check_call") as mocked_check_call:
                 check_and_update_powershell_execution_policy()
-                mocked_check_call.assert_called_once_with(["powershell", "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True)
+                mocked_check_call.assert_called_once_with(
+                    ["powershell", "Set-ExecutionPolicy", "Unrestricted", "-Scope", "CurrentUser"], text=True
+                )
 
-        with patch('builtins.input', return_value='no'):
+        with patch("builtins.input", return_value="no"):
             with pytest.raises(SystemExit):
                 check_and_update_powershell_execution_policy()
+
 
 def test_execute_code_timeout_no_docker():
     exit_code, error, image = execute_code("import time; time.sleep(2)", timeout=1, use_docker=False)


### PR DESCRIPTION
## Why are these changes needed?

Win32 doesn't allow the direct execution of powershell without docker, and it causes an error .

- Additional
cmd line is passed as a list to subprocess.
_cmd function returned str, so we can't return more than one keyword.
To resolve the type conflict, I modified it to return a list.

## Extra
- Local model used, meaning no oai tests were checked.

## Related issue number
#1759

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

@microsoft-github-policy-service agree