### PR TITLE
Add shebang functionality to tests

### DIFF
--- a/test/agentchat/contrib/capabilities/test_context_handling.py
+++ b/test/agentchat/contrib/capabilities/test_context_handling.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import os
 import sys

--- a/test/agentchat/contrib/chat_with_teachable_agent.py
+++ b/test/agentchat/contrib/chat_with_teachable_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 from autogen import UserProxyAgent, config_list_from_json
 from autogen.agentchat.contrib.capabilities.teachability import Teachability
 from autogen import ConversableAgent

--- a/test/agentchat/contrib/test_agent_builder.py
+++ b/test/agentchat/contrib/test_agent_builder.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import os
 import json

--- a/test/agentchat/contrib/test_compressible_agent.py
+++ b/test/agentchat/contrib/test_compressible_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import sys
 import autogen

--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 from unittest.mock import MagicMock
 import uuid
 import pytest

--- a/test/agentchat/contrib/test_img_utils.py
+++ b/test/agentchat/contrib/test_img_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import base64
 import os
 import unittest

--- a/test/agentchat/contrib/test_llava.py
+++ b/test/agentchat/contrib/test_llava.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/test/agentchat/contrib/test_lmm.py
+++ b/test/agentchat/contrib/test_lmm.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import unittest
 from unittest.mock import MagicMock
 

--- a/test/agentchat/contrib/test_qdrant_retrievechat.py
+++ b/test/agentchat/contrib/test_qdrant_retrievechat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import os
 import sys
 import pytest

--- a/test/agentchat/contrib/test_retrievechat.py
+++ b/test/agentchat/contrib/test_retrievechat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import os
 import sys

--- a/test/agentchat/contrib/test_society_of_mind_agent.py
+++ b/test/agentchat/contrib/test_society_of_mind_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import sys
 import autogen

--- a/test/agentchat/contrib/test_teachable_agent.py
+++ b/test/agentchat/contrib/test_teachable_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import os
 import sys

--- a/test/agentchat/contrib/test_web_surfer.py
+++ b/test/agentchat/contrib/test_web_surfer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import os
 import sys
 import re

--- a/test/agentchat/test_agent_usage.py
+++ b/test/agentchat/test_agent_usage.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 from autogen import gather_usage_summary
 from autogen import AssistantAgent, UserProxyAgent
 from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST

--- a/test/agentchat/test_assistant_agent.py
+++ b/test/agentchat/test_assistant_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import os
 import sys
 import pytest

--- a/test/agentchat/test_async.py
+++ b/test/agentchat/test_async.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import asyncio
 import autogen

--- a/test/agentchat/test_async_chats.py
+++ b/test/agentchat/test_async_chats.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 from autogen import AssistantAgent, UserProxyAgent
 from autogen import GroupChat, GroupChatManager
 import asyncio

--- a/test/agentchat/test_async_get_human_input.py
+++ b/test/agentchat/test_async_get_human_input.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import asyncio
 import os
 import sys

--- a/test/agentchat/test_chats.py
+++ b/test/agentchat/test_chats.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 from autogen import AssistantAgent, UserProxyAgent
 from autogen import GroupChat, GroupChatManager
 from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import asyncio
 import copy
 import sys

--- a/test/agentchat/test_function_call.py
+++ b/test/agentchat/test_function_call.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import asyncio
 import json

--- a/test/agentchat/test_function_call_groupchat.py
+++ b/test/agentchat/test_function_call_groupchat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import autogen
 import pytest
 import asyncio

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 from typing import Any, Dict, List, Optional, Type
 from autogen import AgentNameConflict
 import pytest

--- a/test/agentchat/test_human_input.py
+++ b/test/agentchat/test_human_input.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import autogen
 import pytest
 from unittest.mock import MagicMock

--- a/test/agentchat/test_math_user_proxy_agent.py
+++ b/test/agentchat/test_math_user_proxy_agent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import sys
 import os

--- a/test/agentchat/test_nested.py
+++ b/test/agentchat/test_nested.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import sys
 import os

--- a/test/agentchat/test_tool_calls.py
+++ b/test/agentchat/test_tool_calls.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import inspect
 import pytest
 import json

--- a/test/cache/test_cache.py
+++ b/test/cache/test_cache.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import unittest
 from unittest.mock import patch, MagicMock
 from autogen.cache.cache import Cache

--- a/test/cache/test_disk_cache.py
+++ b/test/cache/test_disk_cache.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import unittest
 from unittest.mock import patch, MagicMock
 from autogen.cache.disk_cache import DiskCache

--- a/test/cache/test_redis_cache.py
+++ b/test/cache/test_redis_cache.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import unittest
 import pickle
 from unittest.mock import patch, MagicMock

--- a/test/oai/_test_completion.py
+++ b/test/oai/_test_completion.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import datasets
 import sys
 import numpy as np

--- a/test/oai/test_client.py
+++ b/test/oai/test_client.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import shutil
 import time
 import pytest

--- a/test/oai/test_client_stream.py
+++ b/test/oai/test_client_stream.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import json
 from typing import Any, Dict, List, Literal, Optional, Union
 from unittest.mock import MagicMock

--- a/test/oai/test_utils.py
+++ b/test/oai/test_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import json
 import logging
 import os

--- a/test/test_browser_utils.py
+++ b/test/test_browser_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import pytest
 import os
 import sys

--- a/test/test_code_utils.py
+++ b/test/test_code_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import os
 import tempfile
 import unittest

--- a/test/test_notebook.py
+++ b/test/test_notebook.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 import sys
 import os
 import pytest

--- a/test/test_retrieve_utils.py
+++ b/test/test_retrieve_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 """
 Unit test for retrieve_utils.py
 """

--- a/test/test_token_count.py
+++ b/test/test_token_count.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3 -m pytest
+
 from autogen.token_count_utils import (
     count_token,
     num_tokens_from_functions,


### PR DESCRIPTION
Tests that contain `if __name__ == "__main__":` now have a shebang line and execute permission.

## Why are these changes needed?

The main reason for these changes is increased developer productivity and shortening the validation cycle. This functionality enables executing tests directly from the shell. We use the [shebang functionality](https://en.wikipedia.org/wiki/Shebang_(Unix)) and execute permissions. The end result looks like this:

```bash
$ ./test_cache.py
========================================== test session starts ==========================================
platform darwin -- Python 3.11.7, pytest-7.4.4, pluggy-1.4.0
....
collected 4 items

test_cache.py ....                                                                                [100%]

=========================================== 4 passed in 0.46s ===========================================
```

This is the blunt logic (there probably is a more elegant way to accomplish this ;-)) that I used to make the updates on macOS:

```bash
find . -name '*.py' | xargs grep -r __main__ -l | xargs sed -i.tmp '1 i\'$'\n''#!/usr/bin/env python3 -m pytest'$'\n'''
find . -name '*.py' | xargs grep -r __main__ -l | xargs sed -i.tmp '2 i\'$'\n'''$'\n'''
find . -name '*.py' | xargs grep -r __main__ -l | xargs chmod +x
find . -name '*.tmp' | xargs rm
```

Discussion points:

- Should all tests have the `if __name__ == "__main__":` part to make running them easier? Currently they don't, potential follow-up work here.
- If yes, should pre-commit hook check for it?

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ X] I've made sure all auto checks have passed.
