### PR TITLE
reult length can be less then maximumOutputToKeep

### DIFF
--- a/dotnet/src/AutoGen.DotnetInteractive/Extension/AgentExtension.cs
+++ b/dotnet/src/AutoGen.DotnetInteractive/Extension/AgentExtension.cs
@@ -68,7 +68,10 @@ public static class AgentExtension
                     result.AppendLine("### End of executing result ###");
                 }
             }
-
+            if(result.Length <= maximumOutputToKeep)
+            {
+                maximumOutputToKeep=result.Length;
+            }
             return new Message(Role.Assistant, result.ToString().Substring(0, maximumOutputToKeep), from: agent.Name);
         });
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Minor issue in the samples where the execution in the agentextension has a maximumOutputToKeep but this can be longer then the message is itself resulting in an error

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
