### PR TITLE
Made a configurable constant

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -241,7 +241,7 @@ Then select the next role from {[agent.name for agent in agents]} to play. Only 
         if agents is None:
             agents = self.agents
 
-        # USe the class attribute instead of a hardcoded string
+        # Use the class attribute instead of a hardcoded string
         intro_msg = self.DEFAULT_INTRO_MSG
         participant_roles = self._participant_roles(agents)
 

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -77,6 +77,11 @@ class GroupChat:
     _VALID_SPEAKER_SELECTION_METHODS = ["auto", "manual", "random", "round_robin"]
     _VALID_SPEAKER_TRANSITIONS_TYPE = ["allowed", "disallowed", None]
 
+    # Define a class attribute for the default introduction message
+    DEFAULT_INTRO_MSG = (
+        "Hello everyone. We have assembled a great team today to answer questions and solve tasks. In attendance are:"
+    )
+
     allowed_speaker_transitions_dict: Dict = field(init=False)
 
     def __post_init__(self):
@@ -236,10 +241,11 @@ Then select the next role from {[agent.name for agent in agents]} to play. Only 
         if agents is None:
             agents = self.agents
 
-        return f"""Hello everyone. We have assembled a great team today to answer questions and solve tasks. In attendance are:
+        # USe the class attribute instead of a hardcoded string
+        intro_msg = self.DEFAULT_INTRO_MSG
+        participant_roles = self._participant_roles(agents)
 
-{self._participant_roles(agents)}
-"""
+        return f"{intro_msg}\n\n{participant_roles}"
 
     def manual_select_speaker(self, agents: Optional[List[Agent]] = None) -> Union[Agent, None]:
         """Manually select the next speaker."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This modification ensure that the introduction message is easily configurable and can be changed without altering the method's logic directly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1690 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
