### PR TITLE
Code extraction fix

### DIFF
--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -26,7 +26,7 @@ FAST_MODEL = "gpt-3.5-turbo"
 #   The (.*?) matches the code itself (non-greedy).
 #   The \r?\n makes sure there is a linebreak before ```.
 #   The [ \t]* matches the potential spaces before closing ``` (the spec allows indentation).
-CODE_BLOCK_PATTERN = r"```[ \t]*(\w+)?[ \t]*\r?\n(.*?)\r?\n[ \t]*```"
+CODE_BLOCK_PATTERN = r"```[\t]*(\w+)?[\t]*\r?\n*(.*?)\r?\n*[\t]*```"
 WORKING_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extensions")
 UNKNOWN = "unknown"
 TIMEOUT_MSG = "Timeout"

--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -26,7 +26,7 @@ FAST_MODEL = "gpt-3.5-turbo"
 #   The (.*?) matches the code itself (non-greedy).
 #   The \r?\n makes sure there is a linebreak before ```.
 #   The [ \t]* matches the potential spaces before closing ``` (the spec allows indentation).
-CODE_BLOCK_PATTERN = r"```[\t]*(\w+)?[\t]*\r?\n*(.*?)\r?\n*[\t]*```"
+CODE_BLOCK_PATTERN = r"```[ \t]*(\w+)?[ \t]*\r?\n*(.*?)\r?\n*[ \t]*```"
 WORKING_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "extensions")
 UNKNOWN = "unknown"
 TIMEOUT_MSG = "Timeout"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Current Code Extractor is not able to extract single like codes given by agent.
It ideally should be able to extract any code given by the agent if it has a correct markdown format.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Current regex do not extract single line codes given by agent like below.

Please install required modules with \`\`\`sh pip3 install Flask flask_sqlalchemy flask_bcrypt flask_login ``` and execute the following Python code which uses Flask: