### PR TITLE
Async user hooks

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -570,7 +570,6 @@ class ConversableAgent(LLMAgent):
             message = await hook(sender=self, message=message, recipient=recipient, silent=silent)
         return message
 
-
     def send(
         self,
         message: Union[Dict, str],
@@ -1812,11 +1811,10 @@ class ConversableAgent(LLMAgent):
         # Call the hookable method that gives registered hooks a chance to process the last message.
         # Message modifications do not affect the incoming messages or self._oai_messages.
         messages = await self.a_process_last_received_message(messages)
-        
+
         # Call the hookable method that gives registered hooks a chance to process all messages.
         # Message modifications do not affect the incoming messages or self._oai_messages.
         messages = await self.a_process_all_messages_before_reply(messages)
-
 
         for reply_func_tuple in self._reply_func_list:
             reply_func = reply_func_tuple["reply_func"]
@@ -2469,7 +2467,7 @@ class ConversableAgent(LLMAgent):
                 continue
             processed_messages = hook(processed_messages)
         return processed_messages
-    
+
     async def a_process_all_messages_before_reply(self, messages: List[Dict]) -> List[Dict]:
         """
         Calls any registered capability hooks to process all messages, potentially modifying the messages.

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -230,6 +230,7 @@ class ConversableAgent(LLMAgent):
             "process_all_messages_before_reply": [],
             "a_process_all_messages_before_reply": [],
             "process_message_before_send": [],
+            "a_process_message_before_send": [],
         }
 
     @property

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1809,13 +1809,14 @@ class ConversableAgent(LLMAgent):
         if messages is None:
             messages = self._oai_messages[sender]
 
+        # Call the hookable method that gives registered hooks a chance to process the last message.
+        # Message modifications do not affect the incoming messages or self._oai_messages.
+        messages = await self.a_process_last_received_message(messages)
+        
         # Call the hookable method that gives registered hooks a chance to process all messages.
         # Message modifications do not affect the incoming messages or self._oai_messages.
         messages = await self.a_process_all_messages_before_reply(messages)
 
-        # Call the hookable method that gives registered hooks a chance to process the last message.
-        # Message modifications do not affect the incoming messages or self._oai_messages.
-        messages = await self.a_process_last_received_message(messages)
 
         for reply_func_tuple in self._reply_func_list:
             reply_func = reply_func_tuple["reply_func"]

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -1105,6 +1105,7 @@ def test_process_before_send():
     dummy_agent_1.send("silent hello", dummy_agent_2, silent=True)
     print_mock.assert_called_once_with(message="hello")
 
+
 @pytest.mark.asyncio
 async def test_process_before_send_async():
     print_mock = unittest.mock.MagicMock()
@@ -1113,13 +1114,12 @@ async def test_process_before_send_async():
     async def a_send_to_frontend(sender, message, recipient, silent):
         # Simulating an async operation with asyncio.sleep
         await asyncio.sleep(1)
-        
+
         assert sender.name == "dummy_agent_1", "Sender is not the expected agent"
         if not silent:
             print(f"Message sent from {sender.name} to {recipient.name}: {message}")
             print_mock(message=message)
         return message
-
 
     dummy_agent_1 = ConversableAgent(name="dummy_agent_1", llm_config=False, human_input_mode="NEVER")
     dummy_agent_2 = ConversableAgent(name="dummy_agent_2", llm_config=False, human_input_mode="NEVER")
@@ -1128,6 +1128,7 @@ async def test_process_before_send_async():
     print_mock.assert_called_once_with(message="hello")
     dummy_agent_1.send("silent hello", dummy_agent_2, silent=True)
     print_mock.assert_called_once_with(message="hello")
+
 
 if __name__ == "__main__":
     # test_trigger()

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -1105,6 +1105,29 @@ def test_process_before_send():
     dummy_agent_1.send("silent hello", dummy_agent_2, silent=True)
     print_mock.assert_called_once_with(message="hello")
 
+@pytest.mark.asyncio
+async def test_process_before_send_async():
+    print_mock = unittest.mock.MagicMock()
+
+    # Updated to include sender parameter
+    async def a_send_to_frontend(sender, message, recipient, silent):
+        # Simulating an async operation with asyncio.sleep
+        await asyncio.sleep(1)
+        
+        assert sender.name == "dummy_agent_1", "Sender is not the expected agent"
+        if not silent:
+            print(f"Message sent from {sender.name} to {recipient.name}: {message}")
+            print_mock(message=message)
+        return message
+
+
+    dummy_agent_1 = ConversableAgent(name="dummy_agent_1", llm_config=False, human_input_mode="NEVER")
+    dummy_agent_2 = ConversableAgent(name="dummy_agent_2", llm_config=False, human_input_mode="NEVER")
+    dummy_agent_1.register_hook("a_process_message_before_send", a_send_to_frontend)
+    await dummy_agent_1.a_send("hello", dummy_agent_2)
+    print_mock.assert_called_once_with(message="hello")
+    dummy_agent_1.send("silent hello", dummy_agent_2, silent=True)
+    print_mock.assert_called_once_with(message="hello")
 
 if __name__ == "__main__":
     # test_trigger()
@@ -1115,3 +1138,4 @@ if __name__ == "__main__":
     # test_no_llm_config()
     # test_max_turn()
     test_process_before_send()
+    asyncio.run(test_process_before_send_async())


### PR DESCRIPTION
## Why are these changes needed?

Async user hooks create an async version of hooks to work with the event loop through async calls, not to get them confused with sync calls. Any async chats will use async hooks inherently so the user hooks can do async actions.

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
