### PR TITLE
fix ModelClient create function signature error

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -83,7 +83,7 @@ class ModelClient(Protocol):
         choices: List[Choice]
         model: str
 
-    def create(self, **params: Any) -> ModelClientResponseProtocol:
+    def create(self, params: Dict[str, Any]) -> ModelClientResponseProtocol:
         ...  # pragma: no cover
 
     def message_retrieval(


### PR DESCRIPTION
CustomModelClient takes 1 positional argument but 2 were given if using **params


## Why are these changes needed?
If we define the parameters in `create` fuction of custom ModelClient class using `**params`, it would throw an error like below:
```
Traceback (most recent call last):
  File "/Users/truebit/Documents/dev/uiagents/agents/agents.py", line 30, in <module>
    user_proxy.initiate_chat(assistant, message="Write python code to print Hello World!")
  File "/Users/truebit/mambaforge/envs/uiagents/lib/python3.11/site-packages/autogen/agentchat/conversable_agent.py", line 913, in initiate_chat
    self.send(self.generate_init_message(**context), recipient, silent=silent)
  File "/Users/truebit/mambaforge/envs/uiagents/lib/python3.11/site-packages/autogen/agentchat/conversable_agent.py", line 605, in send
    recipient.receive(message, self, request_reply, silent)
  File "/Users/truebit/mambaforge/envs/uiagents/lib/python3.11/site-packages/autogen/agentchat/conversable_agent.py", line 767, in receive
    reply = self.generate_reply(messages=self.chat_messages[sender], sender=sender)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/truebit/mambaforge/envs/uiagents/lib/python3.11/site-packages/autogen/agentchat/conversable_agent.py", line 1740, in generate_reply
    final, reply = reply_func(self, messages=messages, sender=sender, config=reply_func_tuple["config"])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/truebit/mambaforge/envs/uiagents/lib/python3.11/site-packages/autogen/agentchat/conversable_agent.py", line 1156, in generate_oai_reply
    extracted_response = self._generate_oai_reply_from_client(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/truebit/mambaforge/envs/uiagents/lib/python3.11/site-packages/autogen/agentchat/conversable_agent.py", line 1175, in _generate_oai_reply_from_client
    response = llm_client.create(
               ^^^^^^^^^^^^^^^^^^
  File "/Users/truebit/mambaforge/envs/uiagents/lib/python3.11/site-packages/autogen/oai/client.py", line 624, in create
    response = client.create(params)
               ^^^^^^^^^^^^^^^^^^^^^
TypeError: CustomModelClient.create() takes 1 positional argument but 2 were given

## Related issue number

None

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
