### PR TITLE
Move executor diag print to conversable_agent

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1284,7 +1284,7 @@ class ConversableAgent(LLMAgent):
             else:
                 print(
                     colored(
-                        f"\n>>>>>>>> EXECUTING {num_code_blocks} CODE BLOCKS (inferred languages are [{", ".join([x.language for x in code_blocks])}])...",
+                        f"\n>>>>>>>> EXECUTING {num_code_blocks} CODE BLOCKS (inferred languages are [{', '.join([x.language for x in code_blocks])}])...",
                         "red",
                     ),
                     flush=True,

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1271,6 +1271,25 @@ class ConversableAgent(LLMAgent):
             code_blocks = self._code_executor.code_extractor.extract_code_blocks(message["content"])
             if len(code_blocks) == 0:
                 continue
+
+            num_code_blocks = len(code_blocks)
+            if num_code_blocks > 1:
+                print(
+                    colored(
+                        f"\n>>>>>>>> EXECUTING CODE BLOCK (inferred language is {code_blocks[0].language})...",
+                        "red",
+                    ),
+                    flush=True,
+                )
+            else:
+                print(
+                    colored(
+                        f"\n>>>>>>>> EXECUTING {num_code_blocks} CODE BLOCKS (inferred languages are [{", ".join([x.language for x in code_blocks])}])...",
+                        "red",
+                    ),
+                    flush=True,
+                )
+
             # found code blocks, execute code.
             code_result = self._code_executor.execute_code_blocks(code_blocks)
             exitcode2str = "execution succeeded" if code_result.exit_code == 0 else "execution failed"

--- a/autogen/coding/local_commandline_code_executor.py
+++ b/autogen/coding/local_commandline_code_executor.py
@@ -5,12 +5,10 @@ import warnings
 from typing import Any, ClassVar, List, Optional
 from pydantic import BaseModel, Field, field_validator
 
-from autogen.agentchat.conversable_agent import colored
 from ..agentchat.agent import LLMAgent
 from ..code_utils import execute_code
 from .base import CodeBlock, CodeExtractor, CodeResult
 from .markdown_code_extractor import MarkdownCodeExtractor
-
 
 __all__ = (
     "LocalCommandlineCodeExecutor",
@@ -139,14 +137,6 @@ If you want the user to save the code in a file before executing it, put # filen
             lang, code = code_block.language, code_block.code
 
             LocalCommandlineCodeExecutor.sanitize_command(lang, code)
-
-            print(
-                colored(
-                    f"\n>>>>>>>> EXECUTING CODE BLOCK {i} (inferred language is {lang})...",
-                    "red",
-                ),
-                flush=True,
-            )
             filename_uuid = uuid.uuid4().hex
             filename = None
             if lang in ["bash", "shell", "sh", "pwsh", "powershell", "ps1"]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Executors should not be printing to terminal. This moves handling of this to the conversable agent instead.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
