### PR TITLE
Fix formatting in sequential chat notebook

### DIFF
--- a/notebook/agentchats_sequential_chats.ipynb
+++ b/notebook/agentchats_sequential_chats.ipynb
@@ -78,6 +78,7 @@
     "### Solve tasks with a series of chats\n",
     "\n",
     "The `autogen.initiate_chats` interface can take a list of dictionaries as inputs. Each dictionary preserves the following fields: \n",
+    "\n",
     "- `sender`: a conversable agent as the sender;\n",
     "- `recipient`: a conversable agent as the recipient;\n",
     "- `message`: is a string of text (typically a message containing the task);\n",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes the formatting of a list.

Existing:
<img width="1023" alt="image" src="https://github.com/microsoft/autogen/assets/7558482/32c89aaf-93a2-43c5-8952-23068f7493ec">

Fixed:
<img width="989" alt="image" src="https://github.com/microsoft/autogen/assets/7558482/1ed56709-61e1-4c05-864d-9307587fa075">


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
