### PR TITLE
In code_utils.py, handling NotADirectoryError as well in get_powershell_command

### DIFF
--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -219,7 +219,7 @@ def get_powershell_command():
         if result.returncode == 0:
             return "powershell"
 
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError):
         # This means that 'powershell' command is not found so now we try looking for 'pwsh'
         try:
             result = subprocess.run(
@@ -228,7 +228,7 @@ def get_powershell_command():
             if result.returncode == 0:
                 return "pwsh"
 
-        except FileNotFoundError:
+        except (FileNotFoundError, NotADirectoryError):
             if WIN32:
                 logging.warning("Neither powershell nor pwsh is installed but it is a Windows OS")
             return None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

On MacOS for example, the windows powershell directory does not even exist and the python subprocess looks for the powershell directory in the path and throws a NotADirectoryError. In windows, the powershell directory exists so that error is not thrown but the file name may be different (powershell.exe or pwsh.exe) so a FileNotFoundError is thrown.

We must be able to deal with both these scenarios, hence these changes are necessary.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #1947 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
