### PR TITLE
fix: [autogenbench] writing to stdout encoding error in win-os

### DIFF
--- a/samples/tools/autogenbench/autogenbench/run_cmd.py
+++ b/samples/tools/autogenbench/autogenbench/run_cmd.py
@@ -500,6 +500,7 @@ echo RUN.SH COMPLETE !#!#
         chunk = chunk.decode("utf-8")
         log_file.write(chunk)
         log_file.flush()
+        sys.stdout.reconfigure(encoding="utf-8")
         sys.stdout.write(chunk)
         sys.stdout.flush()
 


### PR DESCRIPTION
Missed this part of the change in this other PR https://github.com/microsoft/autogen/pull/1957


<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
