### PR TITLE
Add extra_body field to LLMConfig dataclass for Azure AI Search support on Autogen studio

### DIFF
--- a/samples/apps/autogen-studio/autogenstudio/datamodel.py
+++ b/samples/apps/autogen-studio/autogenstudio/datamodel.py
@@ -93,6 +93,7 @@ class LLMConfig:
     cache_seed: Optional[Union[int, None]] = None
     timeout: Optional[int] = None
     max_tokens: Optional[int] = None
+    extra_body: Optional[dict] = None
 
     def dict(self):
         result = asdict(self)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Adding extra_body field to llm configuration for autogen studio allows to use Azure AI Search indexes like shown in [Bring your own data](https://learn.microsoft.com/en-us/azure/ai-services/openai/references/on-your-data?tabs=python)
