### PR TITLE
Add a new devcontainer config with custom image for autogen

### DIFF
--- a/.devcontainer/default-hosted/devcontainer.json
+++ b/.devcontainer/default-hosted/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "customizations":  {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-toolsai.jupyter",
+                "visualstudioexptteam.vscodeintellicode",
+                "GitHub.copilot"
+            ],
+            "settings": {
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "/bin/bash"
+                    }
+                },
+                "terminal.integrated.defaultProfile.linux": "bash"
+            }
+        }
+    },
+    "image": "gagb/autogen-default:latest",
+    "updateContentCommand": "pip install -e . pre-commit && pre-commit install"
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Building a new codespace is very slow because `.devcontainer/Dockerfile` has a lot of RUN steps.
So, to speed this up I built and hosted a new image using `.devontainer/Dockerfile` and hosted it on Docker Hub as `gagb/autogen-default`.

```console
cd autogen/.devcontainer
docker build --platform linux/amd64 -t autogen-default -f Dockerfile .
docker tag autogen-default gagb/autogen-default
```

This PR adds a new devcontainer config called `default-hosted` which uses this image directly in its `devcontainer.json`.
DockerHub link of `gagb/autogen-default`: https://hub.docker.com/r/gagb/autogen-default


## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
