### PR TITLE
Add mypy to pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,6 +18,8 @@ jobs:
 
   pre-commit-check:
     runs-on: ubuntu-latest
+    env:
+      SKIP: "mypy"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -17,9 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-      - run: pip install ".[jupyter-executor]" mypy
-      # As more modules are type check clean, add them here
+      # All additional modules should be defined in setup.py
+      - run: pip install ".[types]"
+      # Any additional configuration should be defined in pyproject.toml
       - run: |
-          mypy --install-types --non-interactive \
-            autogen/logger \
-            autogen/exception_utils.py
+          mypy

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        version: ["3.8", "3.9", "3.10", "3.11"]
+        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -13,10 +13,16 @@ permissions: {}
 
 jobs:
   type-check:
+    strategy:
+      fail-fast: true
+      matrix:
+        version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+            python-version: ${{ matrix.version }}
       # All additional modules should be defined in setup.py
       - run: pip install ".[types]"
       # Any additional configuration should be defined in pyproject.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,22 @@ repos:
               website/docs/tutorial/code-executors.ipynb |
               notebook/.*
             )$
+  # See https://jaredkhan.com/blog/mypy-pre-commit
+  - repo: local
+    hooks:
+    - id: mypy
+      name: mypy
+      entry: "./scripts/pre-commit-mypy-run.sh"
+      language: python
+      # use your preferred Python version
+      # language_version: python3.8
+      additional_dependencies: [".[types]"]
+      types: [python]
+      # use require_serial so that script
+      # is only called once per commit
+      require_serial: true
+      # Print the number of files as a sanity-check
+      verbose: true
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.7.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,11 @@ max-complexity = 10
 
 [tool.mypy]
 
+files = [
+    "autogen/logger",
+    "autogen/exception_utils.py",
+]
+
 strict = true
 python_version = "3.8"
 ignore_missing_imports = true

--- a/scripts/pre-commit-mypy-run.sh
+++ b/scripts/pre-commit-mypy-run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# taken from: https://jaredkhan.com/blog/mypy-pre-commit
+
+# A script for running mypy,
+# with all its dependencies installed.
+
+set -o errexit
+
+# Change directory to the project root directory.
+cd "$(dirname "$0")"/..
+
+# Install the dependencies into the mypy env.
+# Note that this can take seconds to run.
+# In my case, I need to use a custom index URL.
+# Avoid pip spending time quietly retrying since
+# likely cause of failure is lack of VPN connection.
+# pip install --editable ".[types]"\
+#  --retries 1 \
+#  --no-input \
+#  --quiet
+
+mypy

--- a/scripts/pre-commit-mypy-run.sh
+++ b/scripts/pre-commit-mypy-run.sh
@@ -10,14 +10,4 @@ set -o errexit
 # Change directory to the project root directory.
 cd "$(dirname "$0")"/..
 
-# Install the dependencies into the mypy env.
-# Note that this can take seconds to run.
-# In my case, I need to use a custom index URL.
-# Avoid pip spending time quietly retrying since
-# likely cause of failure is lack of VPN connection.
-# pip install --editable ".[types]"\
-#  --retries 1 \
-#  --no-input \
-#  --quiet
-
 mypy

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,14 @@ install_requires = [
     "docker",
 ]
 
+jupyter_executor = [
+    "jupyter-kernel-gateway",
+    "websocket-client",
+    "requests",
+    "jupyter-client>=8.6.0",
+    "ipykernel>=6.29.0",
+]
+
 setuptools.setup(
     name="pyautogen",
     version=__version__,
@@ -57,17 +65,8 @@ setuptools.setup(
         "graph": ["networkx", "matplotlib"],
         "websurfer": ["beautifulsoup4", "markdownify", "pdfminer.six", "pathvalidate"],
         "redis": ["redis"],
-        "jupyter-executor": [
-            "jupyter-kernel-gateway",
-            "websocket-client",
-            "requests",
-            "jupyter-client>=8.6.0",
-            "ipykernel>=6.29.0",
-        ],
-        "types": [
-            "mypy==1.9.0",
-            ".[jupyter-executor]",
-        ],
+        "jupyter-executor": jupyter_executor,
+        "types": ["mypy==1.9.0"] + jupyter_executor,
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,10 @@ setuptools.setup(
             "jupyter-client>=8.6.0",
             "ipykernel>=6.29.0",
         ],
+        "types": [
+            "mypy==1.9.0",
+            ".[jupyter-executor]",
+        ],
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ideally, pre-commit hook should check types for files that will be checked by mypy in CI. This PR:
- adds to mypy configuration in pyproject.toml the list of files to be checked
- add optional dependency target [types] to setup.py including mypy and other packages that needs to be installed for type checking
- adds mypy check to pre-commit hook
- refactors the existing workflow in CI to use the same configuration as pre-commit

As a consequence, we can run mypy locally on a subset of files as specified in pyproject.toml by simply executing the following command:
```
$ mypy
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
