### PR TITLE
 Bug Fix: Icons centered on homepage

### DIFF
--- a/website/src/components/HomepageFeatures.module.css
+++ b/website/src/components/HomepageFeatures.module.css
@@ -8,6 +8,6 @@
 }
 
 .featureSvg {
-  height: 120px;
-  width: 200px;
+  height: 130px;
+  width: auto;
 }


### PR DESCRIPTION
## Why are these changes needed?

 Issue "[Bug]: Icons are off center on homepage #2053" was posted 3/18/24

## Related issue number

Closes #2053 

## Checks

