### PR TITLE
Pin databind package versions in gh-release CI

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,15 +4,15 @@ on:
   pull_request:
     branches: [main]
     path:
-      - 'autogen/*'
-      - 'website/*'
-      - '.github/workflows/deploy-website.yml'
+      - "autogen/*"
+      - "website/*"
+      - ".github/workflows/deploy-website.yml"
   push:
     branches: [main]
     path:
-      - 'autogen/*'
-      - 'website/*'
-      - '.github/workflows/deploy-website.yml'
+      - "autogen/*"
+      - "website/*"
+      - ".github/workflows/deploy-website.yml"
   workflow_dispatch:
   merge_group:
     types: [checks_requested]
@@ -40,6 +40,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pydoc-markdown pyyaml termcolor
+          # Pin databind packages as version 4.5.0 is not compatible with pydoc-markdown.
+          pip install databind.core==4.4.2 databind.json==4.4.2
       - name: pydoc-markdown run
         run: |
           pydoc-markdown

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -87,6 +87,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pydoc-markdown pyyaml termcolor
+          # Pin databind packages as version 4.5.0 is not compatible with pydoc-markdown.
+          pip install databind.core==4.4.2 databind.json==4.4.2
       - name: pydoc-markdown run
         run: |
           pydoc-markdown


### PR DESCRIPTION
## Why are these changes needed?

Previous PR #2091  only fixed the doc build test, not the gh-release job. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
