### PR TITLE
mypy in pre-commit fixed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
       language: python
       # use your preferred Python version
       # language_version: python3.8
-      additional_dependencies: [".[types]"]
+      additional_dependencies: []
       types: [python]
       # use require_serial so that script
       # is only called once per commit

--- a/scripts/pre-commit-mypy-run.sh
+++ b/scripts/pre-commit-mypy-run.sh
@@ -10,6 +10,6 @@ set -o errexit
 # Change directory to the project root directory.
 cd "$(dirname "$0")"/..
 
-pip install -e .[types]
+pip install -q -e .[types]
 
 mypy

--- a/scripts/pre-commit-mypy-run.sh
+++ b/scripts/pre-commit-mypy-run.sh
@@ -10,4 +10,6 @@ set -o errexit
 # Change directory to the project root directory.
 cd "$(dirname "$0")"/..
 
+pip install -e .[types]
+
 mypy


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It fixes the problem of importing optional targets to check typing with mypy in pre-commit.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
