### PR TITLE
missing jupyter when import JupyterCodeExecutor

### DIFF
--- a/website/docs/topics/code-execution/jupyter-code-executor.ipynb
+++ b/website/docs/topics/code-execution/jupyter-code-executor.ipynb
@@ -188,7 +188,7 @@
     "The [`JupyterCodeExecutor`](/docs/reference/coding/jupyter/jupyter_code_executor) can also connect to a remote Jupyter server. This is done by passing connection information rather than an actual server object into the [`JupyterCodeExecutor`](/docs/reference/coding/jupyter/jupyter_code_executor) constructor.\n",
     "\n",
     "```python\n",
-    "from autogen.coding import JupyterCodeExecutor, JupyterConnectionInfo\n",
+    "from autogen.coding.jupyter import JupyterCodeExecutor, JupyterConnectionInfo\n",
     "\n",
     "executor = JupyterCodeExecutor(\n",
     "    jupyter_server=JupyterConnectionInfo(host='example.com', use_https=True, port=7893, token='mytoken')\n",


### PR DESCRIPTION
## Why are these changes needed?
It cannot correctly import JupyterCodeExecutor, JupyterConnectionInfo

## Checks

- [V] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [V] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [V] I've made sure all auto checks have passed.
