### PR TITLE
Fix iostream on new thread

### DIFF
--- a/autogen/io/__init__.py
+++ b/autogen/io/__init__.py
@@ -3,6 +3,7 @@ from .console import IOConsole
 from .websockets import IOWebsockets
 
 # Set the default input/output stream to the console
-IOStream._default_io_stream.set(IOConsole())
+IOStream.set_global_default(IOConsole())
+IOStream.set_default(IOConsole())
 
 __all__ = ("IOConsole", "IOStream", "InputStream", "OutputStream", "IOWebsockets")

--- a/test/io/test_base.py
+++ b/test/io/test_base.py
@@ -1,4 +1,5 @@
-from typing import Any
+from threading import Thread
+from typing import Any, List
 
 from autogen.io import IOConsole, IOStream, IOWebsockets
 
@@ -26,3 +27,24 @@ class TestIOStream:
             assert isinstance(IOStream.get_default(), MyIOStream)
 
         assert isinstance(IOStream.get_default(), IOConsole)
+
+    def test_get_default_on_new_thread(self) -> None:
+        exceptions: List[Exception] = []
+
+        def on_new_thread(exceptions: List[Exception] = exceptions) -> None:
+            try:
+                assert isinstance(IOStream.get_default(), IOConsole)
+                raise RuntimeError("This should not be raised.")
+            except Exception as e:
+                exceptions.append(e)
+
+        # create a new thread and run the function
+        thread = Thread(target=on_new_thread)
+
+        thread.start()
+
+        # get exception from the thread
+        thread.join()
+
+        if exceptions:
+            raise exceptions[0]

--- a/test/io/test_base.py
+++ b/test/io/test_base.py
@@ -34,7 +34,6 @@ class TestIOStream:
         def on_new_thread(exceptions: List[Exception] = exceptions) -> None:
             try:
                 assert isinstance(IOStream.get_default(), IOConsole)
-                raise RuntimeError("This should not be raised.")
             except Exception as e:
                 exceptions.append(e)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

On newly created threads, a thread-specific `IOStream` is not automatically set. This causes an exception to be raised when `iostream.get_default` function is called. This PR introduces a new global `IOStream` defaulting to `IOConsole` to be returned when `iostream.get_default` function is called in a new thread.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #2179

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
