### PR TITLE
Replace iostream warning message with info

### DIFF
--- a/autogen/io/base.py
+++ b/autogen/io/base.py
@@ -76,8 +76,10 @@ class IOStream(InputStream, OutputStream, Protocol):
         """
         iostream = IOStream._default_io_stream.get()
         if iostream is None:
-            logger.warning("No default IOStream has been set, defaulting to IOConsole.")
-            return IOStream.get_global_default()
+            logger.info("No default IOStream has been set, defaulting to IOConsole.")
+            iostream = IOStream.get_global_default()
+            # Set the default IOStream of the current context (thread/cooroutine)
+            IOStream.set_default(iostream)
         return iostream
 
     @staticmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`IOStream.get_default` function logs a warning when the default is not set for the thread/coroutine. This is changed to an info message as there is no danger of anything breaking.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Mentioned in #2204

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
