### PR TITLE
Ignore protobuf generated files in CAP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ exclude = [
      # This file needs to be either upgraded or removed and therefore should be
     # ignore from type checking for now
     "math_utils\\.py$",
+    "samples\\apps\\cap\\py\\autogencap\\proto\\.*\\.py",
 ]
 ignore-init-module-imports = true
 unfixable = ["F401"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Protobuf is an industry standard format for publishing and receiving messages. CAP uses these messages in the message bus.
protoc generates files that bind the message to python. These files are not meant to be fixed by hand.  

pre-commit ruff checks fails on these files.

## Related issue number

Closes #2190 

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
