### PR TITLE
[.Net] Fix document comment from the most recent AutoGen.Net engineer sync

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -29,13 +29,13 @@ var assistantAgent = new AssistantAgent(
         Temperature = 0,
         ConfigList = [gpt35Config],
     })
-    .RegisterPrintFormatMessageHook(); // register a hook to print message nicely to console
+    .RegisterPrintMessage(); // register a hook to print message nicely to console
 
 // set human input mode to ALWAYS so that user always provide input
 var userProxyAgent = new UserProxyAgent(
     name: "user",
     humanInputMode: ConversableAgent.HumanInputMode.ALWAYS)
-    .RegisterPrintFormatMessageHook();
+    .RegisterPrintMessage();
 
 // start the conversation
 await userProxyAgent.InitiateChatAsync(

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/AgentCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/AgentCodeSnippet.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // AgentCodeSnippet.cs
+using AutoGen.Core;
 
 namespace AutoGen.BasicSample.CodeSnippet;
 

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/BuildInMessageCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/BuildInMessageCodeSnippet.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // BuildInMessageCodeSnippet.cs
 
+using AutoGen.Core;
 namespace AutoGen.BasicSample.CodeSnippet;
 
 internal class BuildInMessageCodeSnippet

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/CreateAnAgent.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/CreateAnAgent.cs
@@ -2,6 +2,7 @@
 // CreateAnAgent.cs
 
 using AutoGen;
+using AutoGen.Core;
 using AutoGen.OpenAI;
 using FluentAssertions;
 

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/FunctionCallCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/FunctionCallCodeSnippet.cs
@@ -2,6 +2,7 @@
 // FunctionCallCodeSnippet.cs
 
 using AutoGen;
+using AutoGen.Core;
 using AutoGen.OpenAI;
 using FluentAssertions;
 

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/GetStartCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/GetStartCodeSnippet.cs
@@ -3,6 +3,7 @@
 
 #region snippet_GetStartCodeSnippet
 using AutoGen;
+using AutoGen.Core;
 using AutoGen.OpenAI;
 #endregion snippet_GetStartCodeSnippet
 

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/GetStartCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/GetStartCodeSnippet.cs
@@ -23,13 +23,13 @@ public class GetStartCodeSnippet
                 Temperature = 0,
                 ConfigList = [gpt35Config],
             })
-            .RegisterPrintFormatMessageHook(); // register a hook to print message nicely to console
+            .RegisterPrintMessage(); // register a hook to print message nicely to console
 
         // set human input mode to ALWAYS so that user always provide input
         var userProxyAgent = new UserProxyAgent(
             name: "user",
             humanInputMode: HumanInputMode.ALWAYS)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // start the conversation
         await userProxyAgent.InitiateChatAsync(

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/MiddlewareAgentCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/MiddlewareAgentCodeSnippet.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // MiddlewareAgentCodeSnippet.cs
 
+using AutoGen.Core;
 using System.Text.Json;
 using AutoGen.OpenAI;
 using FluentAssertions;

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/OpenAICodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/OpenAICodeSnippet.cs
@@ -2,6 +2,7 @@
 // OpenAICodeSnippet.cs
 
 #region using_statement
+using AutoGen.Core;
 using AutoGen.OpenAI;
 using Azure.AI.OpenAI;
 #endregion using_statement
@@ -71,7 +72,6 @@ public partial class OpenAICodeSnippet
         // register openai chat message connector to support more message types
         var openAIChatMessageConnector = new OpenAIChatRequestMessageConnector();
         var agentWithConnector = openAIChatAgent
-            .RegisterStreamingMiddleware(openAIChatMessageConnector)
             .RegisterMiddleware(openAIChatMessageConnector);
 
         // now the agentWithConnector supports more message types
@@ -113,7 +113,6 @@ public partial class OpenAICodeSnippet
 
         var openAIChatMessageConnector = new OpenAIChatRequestMessageConnector();
         var agentWithMiddleware = openAIChatAgent
-            .RegisterStreamingMiddleware(openAIChatMessageConnector)
             .RegisterMiddleware(openAIChatMessageConnector);
         #endregion openai_chat_agent_get_weather_function_call
 

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs
@@ -21,7 +21,7 @@ internal class PrintMessageMiddlewareCodeSnippet
 
         #region PrintMessageMiddleware
         var agentWithPrintMessageMiddleware = agent
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         await agentWithPrintMessageMiddleware.SendAsync("write a long poem");
         #endregion PrintMessageMiddleware
@@ -38,7 +38,7 @@ internal class PrintMessageMiddlewareCodeSnippet
         var streamingAgent = new OpenAIChatAgent(openaiClient, "assistant", config.DeploymentName)
             .RegisterStreamingMiddleware(openaiMessageConnector)
             .RegisterMiddleware(openaiMessageConnector)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         await streamingAgent.SendAsync("write a long poem");
         #endregion print_message_streaming

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // PrintMessageMiddlewareCodeSnippet.cs
 
+using AutoGen.Core;
 using AutoGen.OpenAI;
 using Azure;
 using Azure.AI.OpenAI;

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/RunCodeSnippetCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/RunCodeSnippetCodeSnippet.cs
@@ -2,6 +2,7 @@
 // RunCodeSnippetCodeSnippet.cs
 
 #region code_snippet_0_1
+using AutoGen.Core;
 using AutoGen.DotnetInteractive;
 #endregion code_snippet_0_1
 

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/SemanticKernelCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/SemanticKernelCodeSnippet.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // SemanticKernelCodeSnippet.cs
 
+using AutoGen.Core;
 using AutoGen.SemanticKernel;
 using FluentAssertions;
 using Microsoft.SemanticKernel;
@@ -75,7 +76,6 @@ public class SemanticKernelCodeSnippet
 
         // Register the connector middleware to the kernel agent
         var semanticKernelAgentWithConnector = semanticKernelAgent
-            .RegisterStreamingMiddleware(connector) // middleware for streaming api
             .RegisterMiddleware(connector); // middleware for non-streaming api
 
         // now semanticKernelAgentWithConnector supports more message types

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs
@@ -4,6 +4,9 @@
 using System.Text.Json;
 using AutoGen.OpenAI.Extension;
 using Azure.AI.OpenAI;
+#region weather_report_using_statement
+using AutoGen.Core;
+#endregion weather_report_using_statement
 
 #region weather_report
 public partial class TypeSafeFunctionCall

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/UserProxyAgentCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/UserProxyAgentCodeSnippet.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // UserProxyAgentCodeSnippet.cs
+using AutoGen.Core;
 
 namespace AutoGen.BasicSample.CodeSnippet;
 

--- a/dotnet/sample/AutoGen.BasicSamples/Example01_AssistantAgent.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example01_AssistantAgent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Example01_AssistantAgent.cs
 
+using AutoGen.Core;
 using AutoGen;
 using AutoGen.BasicSample;
 using FluentAssertions;

--- a/dotnet/sample/AutoGen.BasicSamples/Example01_AssistantAgent.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example01_AssistantAgent.cs
@@ -25,7 +25,7 @@ public static class Example01_AssistantAgent
             name: "assistant",
             systemMessage: "You convert what user said to all uppercase.",
             llmConfig: config)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // talk to the assistant agent
         var reply = await assistantAgent.SendAsync("hello world");

--- a/dotnet/sample/AutoGen.BasicSamples/Example02_TwoAgent_MathChat.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example02_TwoAgent_MathChat.cs
@@ -34,7 +34,7 @@ public static class Example02_TwoAgent_MathChat
 
                 return reply;
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // create student agent
         // student agent will answer the math questions
@@ -46,7 +46,7 @@ public static class Example02_TwoAgent_MathChat
                 Temperature = 0,
                 ConfigList = [gpt35],
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // start the conversation
         var conversation = await student.InitiateChatAsync(

--- a/dotnet/sample/AutoGen.BasicSamples/Example02_TwoAgent_MathChat.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example02_TwoAgent_MathChat.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Example02_TwoAgent_MathChat.cs
 
+using AutoGen.Core;
 using AutoGen;
 using AutoGen.BasicSample;
 using FluentAssertions;

--- a/dotnet/sample/AutoGen.BasicSamples/Example03_Agent_FunctionCall.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example03_Agent_FunctionCall.cs
@@ -2,6 +2,7 @@
 // Example03_Agent_FunctionCall.cs
 
 using AutoGen;
+using AutoGen.Core;
 using AutoGen.BasicSample;
 using FluentAssertions;
 

--- a/dotnet/sample/AutoGen.BasicSamples/Example03_Agent_FunctionCall.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example03_Agent_FunctionCall.cs
@@ -72,7 +72,7 @@ public partial class Example03_Agent_FunctionCall
                 { nameof(UpperCase), instance.UpperCaseWrapper },
                 { nameof(CalculateTax), instance.CalculateTaxWrapper },
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // talk to the assistant agent
         var upperCase = await agent.SendAsync("convert to upper case: hello world");

--- a/dotnet/sample/AutoGen.BasicSamples/Example04_Dynamic_GroupChat_Coding_Task.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example04_Dynamic_GroupChat_Coding_Task.cs
@@ -43,7 +43,7 @@ public partial class Example04_Dynamic_GroupChat_Coding_Task
             config: gptConfig);
 
         var userProxy = new UserProxyAgent(name: "user", defaultReply: GroupChatExtension.TERMINATE, humanInputMode: HumanInputMode.NEVER)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // Create admin agent
         var admin = new AssistantAgent(
@@ -96,7 +96,7 @@ public partial class Example04_Dynamic_GroupChat_Coding_Task
                 Temperature = 0,
                 ConfigList = [gptConfig],
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // create coder agent
         // The coder agent is a composite agent that contains dotnet coder, code reviewer and nuget agent.
@@ -127,7 +127,7 @@ Here's some externel information
 ",
             config: gptConfig,
             temperature: 0.4f)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // code reviewer agent will review if code block from coder's reply satisfy the following conditions:
         // - There's only one code block
@@ -162,7 +162,7 @@ Here's some externel information
             """,
             config: gptConfig,
             temperature: 0f)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // create runner agent
         // The runner agent will run the code block from coder's reply.
@@ -177,7 +177,7 @@ Here's some externel information
                 var mostRecentCoderMessage = msgs.LastOrDefault(x => x.From == "coder") ?? throw new Exception("No coder message found");
                 return await agent.GenerateReplyAsync(new[] { mostRecentCoderMessage }, option, ct);
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         var adminToCoderTransition = Transition.Create(admin, coderAgent, async (from, to, messages) =>
         {

--- a/dotnet/sample/AutoGen.BasicSamples/Example04_Dynamic_GroupChat_Coding_Task.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example04_Dynamic_GroupChat_Coding_Task.cs
@@ -2,6 +2,7 @@
 // Example04_Dynamic_GroupChat_Coding_Task.cs
 
 using AutoGen;
+using AutoGen.Core;
 using AutoGen.BasicSample;
 using AutoGen.DotnetInteractive;
 using AutoGen.OpenAI;

--- a/dotnet/sample/AutoGen.BasicSamples/Example05_Dalle_And_GPT4V.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example05_Dalle_And_GPT4V.cs
@@ -2,6 +2,7 @@
 // Example05_Dalle_And_GPT4V.cs
 
 using AutoGen;
+using AutoGen.Core;
 using Azure.AI.OpenAI;
 using FluentAssertions;
 using autogen = AutoGen.LLMConfigAPI;

--- a/dotnet/sample/AutoGen.BasicSamples/Example05_Dalle_And_GPT4V.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example05_Dalle_And_GPT4V.cs
@@ -117,7 +117,7 @@ The image is generated from prompt {prompt}
                     return reply;
                 }
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         var gpt4VAgent = new AssistantAgent(
             name: "gpt4v",
@@ -135,7 +135,7 @@ The image should satisfy the following conditions:
                 Temperature = 0,
                 ConfigList = gpt4vConfig,
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         IEnumerable<IMessage> conversation = new List<IMessage>()
         {

--- a/dotnet/sample/AutoGen.BasicSamples/Example06_UserProxyAgent.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example06_UserProxyAgent.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Example06_UserProxyAgent.cs
+using AutoGen.Core;
 using AutoGen.OpenAI;
 
 namespace AutoGen.BasicSample;

--- a/dotnet/sample/AutoGen.BasicSamples/Example06_UserProxyAgent.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example06_UserProxyAgent.cs
@@ -15,13 +15,13 @@ public static class Example06_UserProxyAgent
             name: "assistant",
             systemMessage: "You are an assistant that help user to do some tasks.",
             config: gpt35)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // set human input mode to ALWAYS so that user always provide input
         var userProxyAgent = new UserProxyAgent(
             name: "user",
             humanInputMode: HumanInputMode.ALWAYS)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // start the conversation
         await userProxyAgent.InitiateChatAsync(

--- a/dotnet/sample/AutoGen.BasicSamples/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs
@@ -71,7 +71,7 @@ public partial class Example07_Dynamic_GroupChat_Calculate_Fibonacci
             If your code is incorrect, runner will tell you the error message. Fix the error and send the code again.",
             config: gpt3Config,
             temperature: 0.4f)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         return coder;
     }
@@ -107,7 +107,7 @@ public partial class Example07_Dynamic_GroupChat_Calculate_Fibonacci
                     return new[] { coderMsg };
                 }
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         return runner;
     }
@@ -222,7 +222,7 @@ public partial class Example07_Dynamic_GroupChat_Calculate_Fibonacci
 
                 throw new Exception("Failed to review code block");
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         return reviewer;
     }

--- a/dotnet/sample/AutoGen.BasicSamples/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using AutoGen;
 using AutoGen.BasicSample;
 using AutoGen.DotnetInteractive;
+using AutoGen.Core;
 using AutoGen.OpenAI;
 using FluentAssertions;
 

--- a/dotnet/sample/AutoGen.BasicSamples/Example08_LMStudio.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example08_LMStudio.cs
@@ -15,7 +15,7 @@ public class Example08_LMStudio
         #region lmstudio_example_1
         var config = new LMStudioConfig("localhost", 1234);
         var lmAgent = new LMStudioAgent("asssistant", config: config)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         await lmAgent.SendAsync("Can you write a piece of C# code to calculate 100th of fibonacci?");
 

--- a/dotnet/sample/AutoGen.BasicSamples/Example08_LMStudio.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example08_LMStudio.cs
@@ -2,6 +2,7 @@
 // Example08_LMStudio.cs
 
 #region lmstudio_using_statements
+using AutoGen.Core;
 using AutoGen.LMStudio;
 #endregion lmstudio_using_statements
 

--- a/dotnet/sample/AutoGen.BasicSamples/Example09_LMStudio_FunctionCall.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example09_LMStudio_FunctionCall.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using AutoGen.Core;
 using AutoGen.LMStudio;
 using Azure.AI.OpenAI;
 

--- a/dotnet/sample/AutoGen.BasicSamples/Example09_LMStudio_FunctionCall.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example09_LMStudio_FunctionCall.cs
@@ -121,7 +121,7 @@ You have access to the following functions. Use them if required:
 
                 return reply;
             })
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         var userProxyAgent = new UserProxyAgent(
             name: "user",

--- a/dotnet/sample/AutoGen.BasicSamples/Example10_SemanticKernel.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example10_SemanticKernel.cs
@@ -2,8 +2,9 @@
 // Example10_SemanticKernel.cs
 
 using System.ComponentModel;
-using AutoGen.SemanticKernel.Extension;
+using AutoGen.Core;
 using AutoGen.SemanticKernel;
+using AutoGen.SemanticKernel.Extension;
 using FluentAssertions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;

--- a/dotnet/sample/AutoGen.BasicSamples/Example10_SemanticKernel.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example10_SemanticKernel.cs
@@ -67,7 +67,7 @@ public class Example10_SemanticKernel
         var skAgentWithMiddleware = skAgent
             .RegisterStreamingMiddleware(connector)
             .RegisterMiddleware(connector)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         // Now the skAgentWithMiddleware supports more IMessage types like TextMessage, ImageMessage or MultiModalMessage
         // It also register a print format message hook to print the message in a human readable format to the console

--- a/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Example11_Sequential_GroupChat_Example.cs
 
+#region using_statement
+using AutoGen.Core;
 using AutoGen.OpenAI;
 using AutoGen.SemanticKernel;
 using Azure.AI.OpenAI;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Plugins.Web;
 using Microsoft.SemanticKernel.Plugins.Web.Bing;
+#endregion using_statement
 
 namespace AutoGen.BasicSample;
 

--- a/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs
@@ -43,7 +43,7 @@ public partial class Sequential_GroupChat_Example
             """)
             .RegisterStreamingMiddleware(kernelMessageConnector) // support TextMessageUpdate
             .RegisterMiddleware(kernelMessageConnector) // support TextMessage
-            .RegisterPrintFormatMessageHook(); // pretty print the message
+            .RegisterPrintMessage(); // pretty print the message
 
         return kernelAgent;
         #endregion CreateBingSearchAgent
@@ -68,7 +68,7 @@ public partial class Sequential_GroupChat_Example
         return openAIClientAgent
             .RegisterStreamingMiddleware(messageConnector) // support TextMessageUpdate
             .RegisterMiddleware(messageConnector) // support TextMessage
-            .RegisterPrintFormatMessageHook(); // pretty print the message
+            .RegisterPrintMessage(); // pretty print the message
         #endregion CreateSummarizerAgent
     }
 
@@ -78,7 +78,7 @@ public partial class Sequential_GroupChat_Example
         var userProxyAgent = new UserProxyAgent(
             name: "user",
             humanInputMode: HumanInputMode.ALWAYS)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         var bingSearchAgent = await CreateBingSearchAgentAsync();
         var summarizerAgent = await CreateSummarizerAgentAsync();

--- a/dotnet/sample/AutoGen.BasicSamples/Example12_TwoAgent_Fill_Application.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example12_TwoAgent_Fill_Application.cs
@@ -125,7 +125,7 @@ public partial class TwoAgent_Fill_Application
             systemMessage: """You create polite prompt to ask user provide missing information""")
             .RegisterStreamingMiddleware(openaiMessageConnector)
             .RegisterMiddleware(openaiMessageConnector)
-            .RegisterPrintFormatMessageHook()
+            .RegisterPrintMessage()
             .RegisterMiddleware(async (msgs, option, agent, ct) =>
             {
                 var lastReply = msgs.Last() ?? throw new Exception("No reply found.");
@@ -170,7 +170,7 @@ public partial class TwoAgent_Fill_Application
             """)
             .RegisterStreamingMiddleware(openaiMessageConnector)
             .RegisterMiddleware(openaiMessageConnector)
-            .RegisterPrintFormatMessageHook();
+            .RegisterPrintMessage();
 
         return chatAgent;
     }

--- a/dotnet/sample/AutoGen.BasicSamples/Example12_TwoAgent_Fill_Application.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example12_TwoAgent_Fill_Application.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using AutoGen.OpenAI;
+using AutoGen.Core;
 using Azure.AI.OpenAI;
 
 namespace AutoGen.BasicSample;

--- a/dotnet/sample/AutoGen.BasicSamples/GlobalUsing.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/GlobalUsing.cs
@@ -1,4 +1,3 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // GlobalUsing.cs
 
-global using AutoGen.Core;

--- a/dotnet/sample/AutoGen.BasicSamples/Program.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Program.cs
@@ -4,4 +4,4 @@
 using AutoGen.BasicSample;
 
 Console.ReadLine();
-await TwoAgent_Fill_Application.RunAsync();
+await Sequential_GroupChat_Example.RunAsync();

--- a/dotnet/src/AutoGen.Core/Agent/IMiddlewareAgent.cs
+++ b/dotnet/src/AutoGen.Core/Agent/IMiddlewareAgent.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// IMiddlewareAgent.cs
+
+using System.Collections.Generic;
+
+namespace AutoGen.Core;
+
+public interface IMiddlewareAgent : IAgent
+{
+    /// <summary>
+    /// Get the inner agent.
+    /// </summary>
+    IAgent Agent { get; }
+
+    /// <summary>
+    /// Get the middlewares.
+    /// </summary>
+    IEnumerable<IMiddleware> Middlewares { get; }
+
+    /// <summary>
+    /// Use middleware.
+    /// </summary>
+    void Use(IMiddleware middleware);
+}
+
+public interface IMiddlewareStreamAgent : IMiddlewareAgent, IStreamingAgent
+{
+    /// <summary>
+    /// Get the inner agent.
+    /// </summary>
+    IStreamingAgent StreamingAgent { get; }
+
+    IEnumerable<IStreamingMiddleware> StreamingMiddlewares { get; }
+
+    void UseStreaming(IStreamingMiddleware middleware);
+}
+
+public interface IMiddlewareAgent<out T> : IMiddlewareAgent
+    where T : IAgent
+{
+    /// <summary>
+    /// Get the typed inner agent.
+    /// </summary>
+    T TAgent { get; }
+}
+
+public interface IMiddlewareStreamAgent<out T> : IMiddlewareStreamAgent, IMiddlewareAgent<T>
+    where T : IStreamingAgent
+{
+}

--- a/dotnet/src/AutoGen.Core/Agent/MiddlewareAgent.cs
+++ b/dotnet/src/AutoGen.Core/Agent/MiddlewareAgent.cs
@@ -12,7 +12,7 @@ namespace AutoGen.Core;
 /// <summary>
 /// An agent that allows you to add middleware and modify the behavior of an existing agent.
 /// </summary>
-public class MiddlewareAgent : IAgent
+public class MiddlewareAgent : IMiddlewareAgent
 {
     private readonly IAgent _agent;
     private readonly List<IMiddleware> middlewares = new();
@@ -77,11 +77,6 @@ public class MiddlewareAgent : IAgent
         }));
     }
 
-    public void Use(Func<MiddlewareContext, IAgent, CancellationToken, Task<IMessage>> func, string? middlewareName = null)
-    {
-        this.middlewares.Add(new DelegateMiddleware(middlewareName, func));
-    }
-
     public void Use(IMiddleware middleware)
     {
         this.middlewares.Add(middleware);
@@ -119,7 +114,7 @@ public class MiddlewareAgent : IAgent
     }
 }
 
-public sealed class MiddlewareAgent<T> : MiddlewareAgent
+public sealed class MiddlewareAgent<T> : MiddlewareAgent, IMiddlewareAgent<T>
     where T : IAgent
 {
     public MiddlewareAgent(T innerAgent, string? name = null)

--- a/dotnet/src/AutoGen.Core/Extension/MiddlewareExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/MiddlewareExtension.cs
@@ -84,19 +84,13 @@ public static class MiddlewareExtension
         string? middlewareName = null)
         where TAgent : IAgent
     {
-        if (agent.Name == null)
+        var middleware = new DelegateMiddleware(middlewareName, async (context, agent, cancellationToken) =>
         {
-            throw new Exception("Agent name is null.");
-        }
+            return await func(context.Messages, context.Options, agent, cancellationToken);
+        });
 
-
-        var middlewareAgent = new MiddlewareAgent<TAgent>(agent);
-        middlewareAgent.Use(func, middlewareName);
-
-        return middlewareAgent;
+        return agent.RegisterMiddleware(middleware);
     }
-
-
 
     /// <summary>
     /// Register a middleware to an existing agent and return a new agent with the middleware.
@@ -106,15 +100,9 @@ public static class MiddlewareExtension
         IMiddleware middleware)
         where TAgent : IAgent
     {
-        if (agent.Name == null)
-        {
-            throw new Exception("Agent name is null.");
-        }
-
         var middlewareAgent = new MiddlewareAgent<TAgent>(agent);
-        middlewareAgent.Use(middleware);
 
-        return middlewareAgent;
+        return middlewareAgent.RegisterMiddleware(middleware);
     }
 
     /// <summary>
@@ -126,10 +114,12 @@ public static class MiddlewareExtension
         string? middlewareName = null)
         where TAgent : IAgent
     {
-        var copyAgent = new MiddlewareAgent<TAgent>(agent);
-        copyAgent.Use(func, middlewareName);
+        var delegateMiddleware = new DelegateMiddleware(middlewareName, async (context, agent, cancellationToken) =>
+        {
+            return await func(context.Messages, context.Options, agent, cancellationToken);
+        });
 
-        return copyAgent;
+        return agent.RegisterMiddleware(delegateMiddleware);
     }
 
     /// <summary>

--- a/dotnet/src/AutoGen.Core/Extension/MiddlewareExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/MiddlewareExtension.cs
@@ -42,7 +42,7 @@ public static class MiddlewareExtension
     /// Register a post process hook to an agent. The hook will be called before the agent return the reply and after the agent generate the reply.
     /// This is useful when you want to customize arbitrary behavior before the agent return the reply.
     /// 
-    /// One example is <see cref="PrintMessageMiddlewareExtension.RegisterPrintFormatMessageHook{TAgent}(TAgent)" />, which print the formatted message to console before the agent return the reply.
+    /// One example is <see cref="PrintMessageMiddlewareExtension.RegisterPrintMessage{TAgent}(TAgent)" />, which print the formatted message to console before the agent return the reply.
     /// </summary>
     /// <exception cref="Exception">throw when agent name is null.</exception>
     public static MiddlewareAgent<TAgent> RegisterPostProcess<TAgent>(

--- a/dotnet/src/AutoGen.Core/Extension/PrintMessageMiddlewareExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/PrintMessageMiddlewareExtension.cs
@@ -1,24 +1,37 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // PrintMessageMiddlewareExtension.cs
 
+using System;
+
 namespace AutoGen.Core;
 
 public static class PrintMessageMiddlewareExtension
 {
-    /// <summary>
-    /// Print formatted message to console.
-    /// </summary>
+    [Obsolete("This API will be removed in v0.1.0, Use RegisterPrintMessage instead.")]
     public static MiddlewareAgent<TAgent> RegisterPrintFormatMessageHook<TAgent>(this TAgent agent)
         where TAgent : IAgent
     {
-        var middleware = new PrintMessageMiddleware();
-        var middlewareAgent = new MiddlewareAgent<TAgent>(agent);
-        middlewareAgent.Use(middleware);
-
-        return middlewareAgent;
+        return RegisterPrintMessage(agent);
     }
 
+    [Obsolete("This API will be removed in v0.1.0, Use RegisterPrintMessage instead.")]
     public static MiddlewareAgent<TAgent> RegisterPrintFormatMessageHook<TAgent>(this MiddlewareAgent<TAgent> agent)
+        where TAgent : IAgent
+    {
+        return RegisterPrintMessage(agent);
+    }
+
+    [Obsolete("This API will be removed in v0.1.0, Use RegisterPrintMessage instead.")]
+    public static MiddlewareStreamingAgent<TAgent> RegisterPrintFormatMessageHook<TAgent>(this MiddlewareStreamingAgent<TAgent> agent)
+        where TAgent : IStreamingAgent
+    {
+        return RegisterPrintMessage(agent);
+    }
+
+    /// <summary>
+    /// Register a <see cref="PrintMessageMiddleware"/> to <paramref name="agent"/> which print formatted message to console.
+    /// </summary>
+    public static MiddlewareAgent<TAgent> RegisterPrintMessage<TAgent>(this TAgent agent)
         where TAgent : IAgent
     {
         var middleware = new PrintMessageMiddleware();
@@ -28,7 +41,23 @@ public static class PrintMessageMiddlewareExtension
         return middlewareAgent;
     }
 
-    public static MiddlewareStreamingAgent<TAgent> RegisterPrintFormatMessageHook<TAgent>(this MiddlewareStreamingAgent<TAgent> agent)
+    /// <summary>
+    /// Register a <see cref="PrintMessageMiddleware"/> to <paramref name="agent"/> which print formatted message to console.
+    /// </summary>
+    public static MiddlewareAgent<TAgent> RegisterPrintMessage<TAgent>(this MiddlewareAgent<TAgent> agent)
+        where TAgent : IAgent
+    {
+        var middleware = new PrintMessageMiddleware();
+        var middlewareAgent = new MiddlewareAgent<TAgent>(agent);
+        middlewareAgent.Use(middleware);
+
+        return middlewareAgent;
+    }
+
+    /// <summary>
+    /// Register a <see cref="PrintMessageMiddleware"/> to <paramref name="agent"/> which print formatted message to console.
+    /// </summary>
+    public static MiddlewareStreamingAgent<TAgent> RegisterPrintMessage<TAgent>(this MiddlewareStreamingAgent<TAgent> agent)
         where TAgent : IStreamingAgent
     {
         var middleware = new PrintMessageMiddleware();

--- a/dotnet/src/AutoGen.Core/Extension/StreamingMiddlewareExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/StreamingMiddlewareExtension.cs
@@ -48,10 +48,9 @@ public static class StreamingMiddlewareExtension
         string? middlewareName = null)
         where TAgent : IStreamingAgent
     {
-        var middlewareAgent = new MiddlewareStreamingAgent<TAgent>(agent);
-        middlewareAgent.UseStreaming(func, middlewareName);
+        var middleware = new DelegateStreamingMiddleware(middlewareName, new DelegateStreamingMiddleware.MiddlewareDelegate(func));
 
-        return middlewareAgent;
+        return agent.RegisterStreamingMiddleware(middleware);
     }
 
     /// <summary>
@@ -63,10 +62,9 @@ public static class StreamingMiddlewareExtension
         string? middlewareName = null)
         where TAgent : IStreamingAgent
     {
-        var copyAgent = new MiddlewareStreamingAgent<TAgent>(agent);
-        copyAgent.UseStreaming(func, middlewareName);
+        var middleware = new DelegateStreamingMiddleware(middlewareName, new DelegateStreamingMiddleware.MiddlewareDelegate(func));
 
-        return copyAgent;
+        return agent.RegisterStreamingMiddleware(middleware);
     }
 
     /// <summary>
@@ -78,10 +76,12 @@ public static class StreamingMiddlewareExtension
         string? middlewareName = null)
         where TStreamingAgent : IStreamingAgent
     {
-        var copyAgent = new MiddlewareStreamingAgent<TStreamingAgent>(streamingAgent);
-        copyAgent.Use(func, middlewareName);
+        var middleware = new DelegateMiddleware(middlewareName, async (context, agent, cancellationToken) =>
+        {
+            return await func(context.Messages, context.Options, agent, cancellationToken);
+        });
 
-        return copyAgent;
+        return streamingAgent.RegisterMiddleware(middleware);
     }
 
     /// <summary>

--- a/dotnet/src/AutoGen.LMStudio/README.md
+++ b/dotnet/src/AutoGen.LMStudio/README.md
@@ -21,7 +21,7 @@ var agent = new LMStudioAgent(
     name: "agent",
     systemMessage: "You are an agent that help user to do some tasks.",
     lmStudioConfig: lmStudioConfig)
-    .RegisterPrintFormatMessageHook(); // register a hook to print message nicely to console
+    .RegisterPrintMessage(); // register a hook to print message nicely to console
 
 await agent.SendAsync("Can you write a piece of C# code to calculate 100th of fibonacci?");
 ```

--- a/dotnet/website/articles/Create-type-safe-function-call.md
+++ b/dotnet/website/articles/Create-type-safe-function-call.md
@@ -2,11 +2,10 @@
 
 `AutoGen` provides a source generator to easness the trouble of manually craft function definition and function call wrapper from a function. To use this feature, simply add the `AutoGen.SourceGenerator` package to your project and decorate your function with @AutoGen.Core.FunctionAttribute.
 
-```xml
-<ItemGroup>
-    <PackageReference Include="AutoGen.SourceGenerator" Version="AUTOGEN_VERSION" />
-</ItemGroup>
+```bash
+dotnet add package AutoGen.SourceGenerator
 ```
+
 > [!NOTE]
 > It's recommended to enable structural xml document support by setting `GenerateDocumentationFile` property to true in your project file. This allows source generator to leverage the documentation of the function when generating the function definition.
 
@@ -24,9 +23,18 @@ Then, create a `public partial` class to host the methods you want to use in Aut
 > The method has to be a `public` instance method and its return type must be `Task<string>`.
 > Mark the method with @AutoGen.FunctionAttribute attribute.
 
+Firstly, import the required namespaces:
+
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report_using_statement)]
+
+Then, create a `WeatherReport` function and mark it with @AutoGen.Core.FunctionAttribute:
+
 [!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report)]
 
 The source generator will generate the @AutoGen.Core.FunctionContract and function call wrapper for `WeatherReport` in another partial class based on its signature and structural comments. The @AutoGen.Core.FunctionContract is introduced by [#1736](https://github.com/microsoft/autogen/pull/1736) and contains all the necessary metadata such as function name, parameters, and return type. It is LLM independent and can be used to generate openai function definition or semantic kernel function. The function call wrapper is a helper class that provides a type-safe way to call the function.
+
+> [!NOTE]
+> If you are using VSCode as your editor, you may need to restart the editor to see the generated code.
 
 The following code shows how to generate openai function definition from the @AutoGen.Core.FunctionContract and call the function using the function call wrapper.
 

--- a/dotnet/website/articles/Create-type-safe-function-call.md
+++ b/dotnet/website/articles/Create-type-safe-function-call.md
@@ -21,7 +21,7 @@ Then, create a `public partial` class to host the methods you want to use in Aut
 > [!NOTE]
 > A `public partial` class is required for the source generator to generate code.
 > The method has to be a `public` instance method and its return type must be `Task<string>`.
-> Mark the method with @AutoGen.FunctionAttribute attribute.
+> Mark the method with @AutoGen.Core.FunctionAttribute attribute.
 
 Firstly, import the required namespaces:
 

--- a/dotnet/website/articles/Installation.md
+++ b/dotnet/website/articles/Installation.md
@@ -1,14 +1,35 @@
-### Install AutoGen
+### Current version:
 
-#### Nuget build
 [![NuGet version](https://badge.fury.io/nu/AutoGen.Core.svg)](https://badge.fury.io/nu/AutoGen.Core)
 
-#### Nighly build
-- ![Static Badge](https://img.shields.io/badge/public-blue?style=flat) ![Static Badge](https://img.shields.io/badge/nightly-yellow?style=flat) ![Static Badge](https://img.shields.io/badge/github-grey?style=flat): https://nuget.pkg.github.com/microsoft/index.json
-- ![Static Badge](https://img.shields.io/badge/public-blue?style=flat) ![Static Badge](https://img.shields.io/badge/nightly-yellow?style=flat) ![Static Badge](https://img.shields.io/badge/myget-grey?style=flat): https://www.myget.org/F/agentchat/api/v3/index.json
-- ![Static Badge](https://img.shields.io/badge/internal-blue?style=flat) ![Static Badge](https://img.shields.io/badge/nightly-yellow?style=flat) ![Static Badge](https://img.shields.io/badge/azure_devops-grey?style=flat) : https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/AutoGen/nuget/v3/index.json
+AutoGen.Net provides the following packages, you can choose to install one or more of them based on your needs:
 
-Then, add the AutoGen feed to your project. You can do this by either adding a local `NuGet.config`(recommended) or adding the feed to your global `NuGet.config` file.
+- `AutoGen`: The one-in-all package. This package has dependencies over `AutoGen.Core`, `AutoGen.OpenAI`, `AutoGen.LMStudio`, `AutoGen.SemanticKernel` and `AutoGen.SourceGenerator`.
+- `AutoGen.Core`: The core package, this package provides the abstraction for message type, agent and group chat.
+- `AutoGen.OpenAI`: This package provides the integration agents over openai models.
+- `AutoGen.LMStudio`: This package provides the integration agents from LM Studio.
+- `AutoGen.SemanticKernel`: This package provides the integration agents over semantic kernel.
+- `AutoGen.SourceGenerator`: This package carries a source generator that adds support for type-safe function definition generation.
+- `AutoGen.DotnetInteractive`: This packages carries dotnet interactive support to execute dotnet code snippet.
+
+>[!Note]
+> Help me choose
+> - If you just want to install one package and enjoy the core features of AutoGen, choose `AutoGen`.
+> - If you want to leverage AutoGen's abstraction only and want to avoid introducing any other dependencies, like `Azure.AI.OpenAI` or `Semantic Kernel`, choose `AutoGen.Core`. You will need to implement your own agent, but you can still use AutoGen core features like group chat, built-in message type, workflow and middleware.
+>- If you want to use AutoGen with openai, choose `AutoGen.OpenAI`, similarly, choose `AutoGen.LMStudio` or `AutoGen.SemanticKernel` if you want to use agents from LM Studio or semantic kernel.
+>- If you just want the type-safe source generation for function call and don't want any other features, which even include the AutoGen's abstraction, choose `AutoGen.SourceGenerator`.
+
+Then, install the package using the following command:
+
+```bash
+dotnet add package AUTOGEN_PACKAGES
+```
+
+### Consume nightly build
+To consume nightly build, you can add one of the following feeds to your `NuGet.config` or global nuget config:
+- ![Static Badge](https://img.shields.io/badge/public-blue?style=flat) ![Static Badge](https://img.shields.io/badge/github-grey?style=flat): https://nuget.pkg.github.com/microsoft/index.json
+- ![Static Badge](https://img.shields.io/badge/public-blue?style=flat) ![Static Badge](https://img.shields.io/badge/myget-grey?style=flat): https://www.myget.org/F/agentchat/api/v3/index.json
+- ![Static Badge](https://img.shields.io/badge/internal-blue?style=flat) ![Static Badge](https://img.shields.io/badge/azure_devops-grey?style=flat) : https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/AutoGen/nuget/v3/index.json
 
 To add a local `NuGet.config`, create a file named `NuGet.config` in the root of your project and add the following content:
 ```xml
@@ -33,33 +54,9 @@ dotnet nuget add source FEED_URL --name AutoGen
 dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json --name dotnet-tools
 ```
 
-Once you finishing adding AutoGen feed, you can consume AutoGen packages in your project file by adding the following to your project file:
-```xml
-<ItemGroup>
-    <PackageReference Include="AutoGen" Version="AUTOGEN_VERSION" /> <!-- replace AUTOGEN_VERSION with the version you want to use -->
-
-    <!-- Optional: This package carries a source generator that adds support for type-safe function definition generation. -->
-    <!-- For more information, please check out AutoGen.SourceGenerator README -->
-    <PackageReference Include="AutoGen.SourceGenerator" Version="AUTOGEN_VERSION" />
-
-    <!-- Optional: This packages carries dotnet interactive support to execute dotnet code snippet -->
-    <PackageReference Include="AutoGen.DotnetInteractive" Version="AUTOGEN_VERSION" />
-</ItemGroup>
+Once you have added the feed, you can install the nightly-build package using the following command:
+```bash
+dotnet add package AUTOGEN_PACKAGES VERSION
 ```
 
-### Package overview
-AutoGen.Net provides the following packages, you can choose to install one or more of them based on your needs:
 
-- `AutoGen`: The one-in-all package, which includes all the core features of AutoGen like `AssistantAgent` and `AutoGen.SourceGenerator`, plus intergration over popular platforms like openai, semantic kernel and LM Studio.
-- `AutoGen.Core`: The core package, this package provides the abstraction for message type, agent and group chat.
-- `AutoGen.OpenAI`: This package provides the integration agents over openai models.
-- `AutoGen.LMStudio`: This package provides the integration agents from LM Studio.
-- `AutoGen.SemanticKernel`: This package provides the integration agents over semantic kernel.
-- `AutoGen.SourceGenerator`: This package carries a source generator that adds support for type-safe function definition generation.
-- `AutoGen.DotnetInteractive`: This packages carries dotnet interactive support to execute dotnet code snippet.
-
-#### Help me choose
-- If you just want to install one package and enjoy the core features of AutoGen, choose `AutoGen`.
-- If you want to leverage AutoGen's abstraction only and want to avoid introducing any other dependencies, like `Azure.AI.OpenAI` or `Semantic Kernel`, choose `AutoGen.Core`. You will need to implement your own agent, but you can still use AutoGen core features like group chat, built-in message type, workflow and middleware.
-- If you want to use AutoGen with openai, choose `AutoGen.OpenAI`, similarly, choose `AutoGen.LMStudio` or `AutoGen.SemanticKernel` if you want to use agents from LM Studio or semantic kernel.
-- If you just want the type-safe source generation for function call and don't want any other features, which even include the AutoGen's abstraction, choose `AutoGen.SourceGenerator`.

--- a/dotnet/website/articles/OpenAIChatAgent-support-more-messages.md
+++ b/dotnet/website/articles/OpenAIChatAgent-support-more-messages.md
@@ -1,3 +1,6 @@
 By default, @AutoGen.OpenAI.OpenAIChatAgent only supports the @AutoGen.Core.IMessage<T> type where `T` is original request or response message from `Azure.AI.OpenAI`. To support more AutoGen built-in message types like @AutoGen.Core.TextMessage, @AutoGen.Core.ImageMessage, @AutoGen.Core.MultiModalMessage and so on, you can register the agent with @AutoGen.OpenAI.OpenAIChatRequestMessageConnector. The @AutoGen.OpenAI.OpenAIChatRequestMessageConnector will convert the message from AutoGen built-in message types to `Azure.AI.OpenAI.ChatRequestMessage` and vice versa.
 
+import the required namespaces:
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
+
 [!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/OpenAICodeSnippet.cs?name=register_openai_chat_message_connector)]

--- a/dotnet/website/articles/OpenAIChatAgent-use-function-call.md
+++ b/dotnet/website/articles/OpenAIChatAgent-use-function-call.md
@@ -11,6 +11,12 @@ Firstly, you need to install the following packages:
 > [!Note]
 > The `AutoGen.SourceGenerator` package carries a source generator that adds support for type-safe function definition generation. For more information, please check out [Create type-safe function](./Create-type-safe-function-call.md).
 
+> [!NOTE]
+> If you are using VSCode as your editor, you may need to restart the editor to see the generated code.
+
+Firstly, import the required namespaces:
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
+
 Then, create a `GetWeather` function and pass it to @AutoGen.OpenAI.OpenAIChatAgent:
 [!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/OpenAICodeSnippet.cs?name=weather_function)]
 

--- a/dotnet/website/articles/Print-message-middleware.md
+++ b/dotnet/website/articles/Print-message-middleware.md
@@ -11,11 +11,11 @@
 > - (streaming) @AutoGen.Core.ToolCallMessageUpdate
 
 ## Use @AutoGen.Core.PrintMessageMiddleware in an agent
-You can use @AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintFormatMessageHook* to register the @AutoGen.Core.PrintMessageMiddleware to an agent.
+You can use @AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintMessage* to register the @AutoGen.Core.PrintMessageMiddleware to an agent.
 
 [!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs?name=PrintMessageMiddleware)]
 
-@AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintFormatMessageHook* will format the message and print it to console
+@AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintMessage* will format the message and print it to console
 ![image](../images/articles/PrintMessageMiddleware/printMessage.png)
 
 ## Streaming message support

--- a/dotnet/website/articles/Roundrobin-chat.md
+++ b/dotnet/website/articles/Roundrobin-chat.md
@@ -9,15 +9,22 @@ flowchart LR
     C -->|Summarize result| A[User]
 ```
 
-Step 1: Create a `bingSearch` agent using @AutoGen.SemanticKernel.SemanticKernelAgent
+> [!NOTE]
+> Complete code can be found in [Example11_Sequential_GroupChat_Example](https://github.com/microsoft/autogen/blob/dotnet/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs);
+
+Step 1: Add required using statements
+
+[!code-csharp[](../../sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs?name=using_statement)]
+
+Step 2: Create a `bingSearch` agent using @AutoGen.SemanticKernel.SemanticKernelAgent
 
 [!code-csharp[](../../sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs?name=CreateBingSearchAgent)]
 
-Step 2: Create a `summarization` agent using @AutoGen.SemanticKernel.SemanticKernelAgent
+Step 3: Create a `summarization` agent using @AutoGen.SemanticKernel.SemanticKernelAgent
 
 [!code-csharp[](../../sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs?name=CreateSummarizerAgent)]
 
-Step 3: Create a @AutoGen.Core.RoundRobinGroupChat and add `bingSearch` and `summarization` agents to it
+Step 4: Create a @AutoGen.Core.RoundRobinGroupChat and add `bingSearch` and `summarization` agents to it
 
 [!code-csharp[](../../sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs?name=Sequential_GroupChat_Example)]
 

--- a/dotnet/website/articles/Two-agent-chat.md
+++ b/dotnet/website/articles/Two-agent-chat.md
@@ -8,7 +8,7 @@ In `AutoGen`, you can start a conversation between two agents using @AutoGen.Cor
 The following example shows how to start a conversation between the teacher agent and student agent, where the student agent starts the conversation by asking teacher to create math questions.
 
 > [!TIP]
-> You can use @AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintFormatMessageHook* to pretty print the message replied by the agent.
+> You can use @AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintMessage* to pretty print the message replied by the agent.
 
 > [!NOTE]
 > The conversation is terminated when teacher agent sends a message containing the keyword: @AutoGen.Core.GroupChatExtension.TERMINATE.

--- a/dotnet/website/articles/getting-start.md
+++ b/dotnet/website/articles/getting-start.md
@@ -3,7 +3,14 @@
 [![Discord](https://img.shields.io/discord/1153072414184452236?logo=discord&style=flat)](https://discord.gg/pAbnFJrkgZ)
 [![NuGet version](https://badge.fury.io/nu/AutoGen.Core.svg)](https://badge.fury.io/nu/AutoGen.Core)
 
-Firstly, following the [installation guide](Installation.md) to install AutoGen packages.
+Firstly, add `AutoGen` package to your project.
+
+```bash
+dotnet add package AutoGen
+```
+
+> [!NOTE]
+> For more information about installing packages, please check out the [installation guide](Installation.md).
 
 Then you can start with the following code snippet to create a conversable agent and chat with it.
 

--- a/dotnet/website/articles/toc.yml
+++ b/dotnet/website/articles/toc.yml
@@ -12,8 +12,8 @@
           href: Create-a-user-proxy-agent.md
         - name: Chat with an agent using user proxy agent
           href: Two-agent-chat.md
-        - name: Create your own agent
-          href: Create-your-own-agent.md
+        # - name: Create your own agent
+        #   href: Create-your-own-agent.md
     - name: built-in messages
       href: Built-in-messages.md
     - name: function call
@@ -32,8 +32,8 @@
           items:
             - name: print message
               href: Print-message-middleware.md
-            - name: function call
-              href: Function-call-middleware.md
+            # - name: function call
+            #   href: Function-call-middleware.md
     - name: group chat
       items:
         - name: group chat overview

--- a/dotnet/website/update.md
+++ b/dotnet/website/update.md
@@ -1,6 +1,7 @@
 ##### Update on 0.0.11 (2024-03-26)
 - Add link to Discord channel in nuget's readme.md
 - Document improvements
+- [API Breaking Change] Rename `PrintMessageMiddlewareExtension.RegisterPrintFormatMessageHook' to `PrintMessageMiddlewareExtension.RegisterPrintMessage`.
 ##### Update on 0.0.10 (2024-03-12)
 - Rename `Workflow` to `Graph`
 - Rename `AddInitializeMessage` to `SendIntroduction`


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes the following comment/feedback from the most recent AutoGen.Net engineer sync
- Adding package installing command in getting-start page && fix missing using statement

![image](https://github.com/microsoft/autogen/assets/16876986/94c6851a-66f9-4721-ac59-2a07a778a683)

- In `installation` page, moving nightly build to sub-section to make it less obvious
![image](https://github.com/microsoft/autogen/assets/16876986/1c7adc37-c022-4a4d-bda8-f81279345392)

- reminder to restart VSCode when creating partial class
![image](https://github.com/microsoft/autogen/assets/16876986/b7c4a944-c690-4124-a61a-4d54dd21d782)

- adding missing using statement to all the rest of examples
- renaming `registerPrintFormatHook` to `RegisterPrintMessage`
![image](https://github.com/microsoft/autogen/assets/16876986/a9067bca-4739-438a-9557-410d5f85b18d)

- Include `Azure.AI.OpenAI` to openai examples
![image](https://github.com/microsoft/autogen/assets/16876986/0813db3c-4abb-4105-9408-e8c1b8dde7f9)

- Removing `RegisterStreaming` from documentation

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
