### PR TITLE
Remove info log for IOStream using default.

### DIFF
--- a/autogen/io/base.py
+++ b/autogen/io/base.py
@@ -76,7 +76,6 @@ class IOStream(InputStream, OutputStream, Protocol):
         """
         iostream = IOStream._default_io_stream.get()
         if iostream is None:
-            logger.info("No default IOStream has been set, defaulting to IOConsole.")
             iostream = IOStream.get_global_default()
             # Set the default IOStream of the current context (thread/cooroutine)
             IOStream.set_default(iostream)


### PR DESCRIPTION
The info log for using default IOStream is still too frequent and becomes noise when logging is set to info. 