### PR TITLE
Fix LMM test in CI by installing lfs

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -229,6 +229,8 @@ jobs:
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Fix LMM test failure in CI by installing git lfs.

https://github.com/microsoft/autogen/actions/runs/8562152330/job/23464835743?pr=2281#step:7:336