### PR TITLE
Add support for HTML, CSS and Javascript in LocalCommandLineCodeExecutor

### DIFF
--- a/autogen/coding/local_commandline_code_executor.py
+++ b/autogen/coding/local_commandline_code_executor.py
@@ -28,7 +28,18 @@ A = ParamSpec("A")
 
 
 class LocalCommandLineCodeExecutor(CodeExecutor):
-    SUPPORTED_LANGUAGES: ClassVar[List[str]] = ["bash", "shell", "sh", "pwsh", "powershell", "ps1", "python"]
+    SUPPORTED_LANGUAGES: ClassVar[List[str]] = [
+        "bash",
+        "shell",
+        "sh",
+        "pwsh",
+        "powershell",
+        "ps1",
+        "python",
+        "javascript",
+        "html",
+        "css",
+    ]
     FUNCTION_PROMPT_TEMPLATE: ClassVar[
         str
     ] = """You have access to the following user defined functions. They can be accessed from the module called `$module_name` by their function names.
@@ -43,6 +54,7 @@ $functions"""
         work_dir: Union[Path, str] = Path("."),
         functions: List[Union[FunctionWithRequirements[Any, A], Callable[..., Any], FunctionWithRequirementsStr]] = [],
         functions_module: str = "functions",
+        save_code_only: bool = False,
     ):
         """(Experimental) A code executor class that executes code through a local command line
         environment.
@@ -55,10 +67,15 @@ $functions"""
         The code blocks are executed in the order they are received.
         Command line code is sanitized using regular expression match against a list of dangerous commands in order to prevent self-destructive
         commands from being executed which may potentially affect the users environment.
-        Currently the only supported languages is Python and shell scripts.
+        Currently the supported languages are Python, shell scripts, HTML, CSS and Javascript.
         For Python code, use the language "python" for the code block.
         For shell scripts, use the language "bash", "shell", or "sh" for the code
         block.
+        For HTML use the language "html".
+        For CSS use the language "css".
+        For JavaScript use the language "javascript".
+        Only Python and shell scripts are executed by default, other languages
+        are saved to file but not executed.
 
         Args:
             timeout (int): The timeout for code execution. Default is 60.
@@ -66,6 +83,7 @@ $functions"""
                 a default working directory will be used. The default working
                 directory is the current directory ".".
             functions (List[Union[FunctionWithRequirements[Any, A], Callable[..., Any]]]): A list of functions that are available to the code executor. Default is an empty list.
+            save_code_only (bool): If True, each code block will be saved to a file but not executed. Default is False.
         """
 
         if timeout < 1:
@@ -90,6 +108,8 @@ $functions"""
             self._setup_functions_complete = False
         else:
             self._setup_functions_complete = True
+
+        self._save_code_only = save_code_only
 
     def format_functions_for_prompt(self, prompt_template: str = FUNCTION_PROMPT_TEMPLATE) -> str:
         """(Experimental) Format the functions for a prompt.
@@ -242,7 +262,22 @@ $functions"""
                 f.write(code)
             file_names.append(written_file)
 
-            program = sys.executable if lang.startswith("python") else _cmd(lang)
+            # Check if the code will be executed.
+            program = None
+            if lang.startswith("python"):
+                program = sys.executable
+            else:
+                try:
+                    program = _cmd(lang)
+                except NotImplementedError:
+                    pass
+
+            if program is None or self._save_code_only:
+                # Just return a message that the file is saved.
+                logs_all += f"Code saved to {str(written_file)}\n"
+                exitcode = 0
+                continue
+
             cmd = [program, str(written_file.absolute())]
 
             try:

--- a/test/coding/test_commandline_code_executor.py
+++ b/test/coding/test_commandline_code_executor.py
@@ -110,6 +110,83 @@ def _test_execute_code(executor: CodeExecutor) -> None:
             assert file_line.strip() == code_line.strip()
 
 
+def test_local_commandline_code_executor_save_files() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir)
+        _test_save_files(executor, save_file_only=False)
+
+
+def test_local_commandline_code_executor_save_files_only() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir, save_code_only=True)
+        _test_save_files(executor, save_file_only=True)
+
+
+def _test_save_files(executor: CodeExecutor, save_file_only: bool) -> None:
+
+    def _check_output(code_result: CodeBlock, expected_output: str) -> None:
+        if save_file_only:
+            return expected_output not in code_result.output
+        else:
+            return expected_output in code_result.output
+
+    # Test executable code block.
+
+    # Test saving to a given filename, Python.
+    code_blocks = [CodeBlock(code="# filename: test.py\nimport sys; print('hello world!')", language="python")]
+    code_result = executor.execute_code_blocks(code_blocks)
+    assert (
+        code_result.exit_code == 0 and _check_output(code_result, "hello world!") and code_result.code_file is not None
+    )
+    assert os.path.basename(code_result.code_file) == "test.py"
+
+    # Test saving to a given filename without "filename" prefix, Python.
+    code_blocks = [CodeBlock(code="# test.py\nimport sys; print('hello world!')", language="python")]
+    code_result = executor.execute_code_blocks(code_blocks)
+    assert (
+        code_result.exit_code == 0 and _check_output(code_result, "hello world!") and code_result.code_file is not None
+    )
+    assert os.path.basename(code_result.code_file) == "test.py"
+
+    # Test non-executable code block.
+
+    # Test saving to a given filename, Javascript.
+    code_blocks = [CodeBlock(code="// filename: test.js\nconsole.log('hello world!')", language="javascript")]
+    code_result = executor.execute_code_blocks(code_blocks)
+    assert code_result.exit_code == 0 and "hello world!" not in code_result.output and code_result.code_file is not None
+    assert os.path.basename(code_result.code_file) == "test.js"
+
+    # Test saving to a given filename without "filename" prefix, Javascript.
+    code_blocks = [CodeBlock(code="// test.js\nconsole.log('hello world!')", language="javascript")]
+    code_result = executor.execute_code_blocks(code_blocks)
+    assert code_result.exit_code == 0 and "hello world!" not in code_result.output and code_result.code_file is not None
+    assert os.path.basename(code_result.code_file) == "test.js"
+
+    # Test saving to a given filename, CSS.
+    code_blocks = [CodeBlock(code="/* filename: test.css */\nh1 { color: red; }", language="css")]
+    code_result = executor.execute_code_blocks(code_blocks)
+    assert code_result.exit_code == 0 and "hello world!" not in code_result.output and code_result.code_file is not None
+    assert os.path.basename(code_result.code_file) == "test.css"
+
+    # Test saving to a given filename without "filename" prefix, CSS.
+    code_blocks = [CodeBlock(code="/* test.css */\nh1 { color: red; }", language="css")]
+    code_result = executor.execute_code_blocks(code_blocks)
+    assert code_result.exit_code == 0 and "hello world!" not in code_result.output and code_result.code_file is not None
+    assert os.path.basename(code_result.code_file) == "test.css"
+
+    # Test saving to a given filename, HTML.
+    code_blocks = [CodeBlock(code="<!-- filename: test.html -->\n<h1>hello world!</h1>", language="html")]
+    code_result = executor.execute_code_blocks(code_blocks)
+    assert code_result.exit_code == 0 and "hello world!" not in code_result.output and code_result.code_file is not None
+    assert os.path.basename(code_result.code_file) == "test.html"
+
+    # Test saving to a given filename without "filename" prefix, HTML.
+    code_blocks = [CodeBlock(code="<!-- test.html -->\n<h1>hello world!</h1>", language="html")]
+    code_result = executor.execute_code_blocks(code_blocks)
+    assert code_result.exit_code == 0 and "hello world!" not in code_result.output and code_result.code_file is not None
+    assert os.path.basename(code_result.code_file) == "test.html"
+
+
 @pytest.mark.parametrize("cls", classes_to_test)
 def test_commandline_code_executor_timeout(cls) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Why are these changes needed?

Many web application development use cases require support for simply saving the static content like HTML, CSS and Javascript. 

This PR adds support for those languages in LocalCommandLineCodeExecutor. 

It also add option in LocalCommandLineCodeExecutor for only saving the code files not executing them. This is useful when the web application code starts a server and never exits. 

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #2379 #2383

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
