### PR TITLE
feat: add bind_dir arg to DockerCommandLineExecutor + docs update

### DIFF
--- a/autogen/coding/docker_commandline_code_executor.py
+++ b/autogen/coding/docker_commandline_code_executor.py
@@ -45,6 +45,7 @@ class DockerCommandLineCodeExecutor(CodeExecutor):
         container_name: Optional[str] = None,
         timeout: int = 60,
         work_dir: Union[Path, str] = Path("."),
+        bind_dir: Optional[Union[Path, str]] = None,
         auto_remove: bool = True,
         stop_container: bool = True,
     ):
@@ -67,6 +68,9 @@ class DockerCommandLineCodeExecutor(CodeExecutor):
             timeout (int, optional): The timeout for code execution. Defaults to 60.
             work_dir (Union[Path, str], optional): The working directory for the code
                 execution. Defaults to Path(".").
+            bind_dir (Union[Path, str], optional): The directory that will be bound
+            to the code executor container. Useful for cases where you want to spawn
+            the container from within a container. Defaults to work_dir.
             auto_remove (bool, optional): If true, will automatically remove the Docker
                 container when it is stopped. Defaults to True.
             stop_container (bool, optional): If true, will automatically stop the
@@ -84,6 +88,11 @@ class DockerCommandLineCodeExecutor(CodeExecutor):
             work_dir = Path(work_dir)
 
         work_dir.mkdir(exist_ok=True)
+
+        if bind_dir is None:
+            bind_dir = work_dir
+        elif isinstance(bind_dir, str):
+            bind_dir = Path(bind_dir)
 
         client = docker.from_env()
 
@@ -105,7 +114,7 @@ class DockerCommandLineCodeExecutor(CodeExecutor):
             entrypoint="/bin/sh",
             tty=True,
             auto_remove=auto_remove,
-            volumes={str(work_dir.resolve()): {"bind": "/workspace", "mode": "rw"}},
+            volumes={str(bind_dir.resolve()): {"bind": "/workspace", "mode": "rw"}},
             working_dir="/workspace",
         )
         self._container.start()
@@ -132,6 +141,7 @@ class DockerCommandLineCodeExecutor(CodeExecutor):
 
         self._timeout = timeout
         self._work_dir: Path = work_dir
+        self._bind_dir: Path = bind_dir
 
     @property
     def timeout(self) -> int:
@@ -142,6 +152,11 @@ class DockerCommandLineCodeExecutor(CodeExecutor):
     def work_dir(self) -> Path:
         """(Experimental) The working directory for the code execution."""
         return self._work_dir
+    
+    @property
+    def bind_dir(self) -> Path:
+        """(Experimental) The binding directory for the code execution container."""
+        return self._bind_dir
 
     @property
     def code_extractor(self) -> CodeExtractor:

--- a/autogen/coding/docker_commandline_code_executor.py
+++ b/autogen/coding/docker_commandline_code_executor.py
@@ -152,7 +152,7 @@ class DockerCommandLineCodeExecutor(CodeExecutor):
     def work_dir(self) -> Path:
         """(Experimental) The working directory for the code execution."""
         return self._work_dir
-    
+
     @property
     def bind_dir(self) -> Path:
         """(Experimental) The binding directory for the code execution container."""

--- a/website/docs/topics/code-execution/cli-code-executor.ipynb
+++ b/website/docs/topics/code-execution/cli-code-executor.ipynb
@@ -73,7 +73,9 @@
     "-v /var/run/docker.sock:/var/run/docker.sock\n",
     "```\n",
     "\n",
-    "This will allow the AutoGen container to spawn and control sibling containers on the host."
+    "This will allow the AutoGen container to spawn and control sibling containers on the host.\n",
+    "\n",
+    "If you need to bind a working directory to the AutoGen container but the directory belongs to your host machine, use the `bind_dir` parameter. This will allow the main AutoGen container to bind the *host* directory to the new spawned containers and allow it to access the files within the said directory. If the `bind_dir` is not specified, it will fallback to `work_dir`."
    ]
   },
   {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the user wants deploy an application to a scenario in which the main app runs in a docker container that executes code using the `DockerCommandLineExecutor`, only binding the `docker.sock` is not enough. If the spawned container needs file access from the host, the check that the constructor method of the DockerCommandLineExecutor cli does to work_dir prevents this from happening. Adding a new bind_dir argument solves this without breaking old code and allows for such behavior to be supported.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
