### PR TITLE
fix markdown for long context user guide

### DIFF
--- a/website/docs/topics/long_contexts.md
+++ b/website/docs/topics/long_contexts.md
@@ -12,7 +12,6 @@ Why do we need to handle long contexts? The problem arises from several constrai
 
 The `TransformMessages` capability is designed to modify incoming messages before they are processed by the LLM agent. This can include limiting the number of messages, truncating messages to meet token limits, and more.
 
-````{=mdx}
 :::info Requirements
 Install `pyautogen`:
 ```bash
@@ -21,7 +20,6 @@ pip install pyautogen
 
 For more information, please refer to the [installation guide](/docs/installation/).
 :::
-````
 
 ### Exploring and Understanding Transformations
 
@@ -114,11 +112,9 @@ user_proxy = autogen.UserProxyAgent(
 )
 ```
 
-```{=mdx}
 :::tip
 Learn more about configuring LLMs for agents [here](/docs/topics/llm_configuration).
 :::
-```
 
 We first need to write the `test` function that creates a very long chat history by exchanging messages between an assistant and a user proxy agent, and then attempts to initiate a new chat without clearing the history, potentially triggering an error due to token limits.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes the markdown for the new user guide for long context handling, specifically the admonitions

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## Changes

### Before
![image](https://github.com/microsoft/autogen/assets/17806916/4f9c0b1e-fc4c-4606-a642-d9996fbdf8e4)
![image](https://github.com/microsoft/autogen/assets/17806916/82e21e17-7832-4e15-be84-33c9bb739b9a)

### After
![image](https://github.com/microsoft/autogen/assets/17806916/4e41266b-3dca-4106-968d-da471161aa79)
![image](https://github.com/microsoft/autogen/assets/17806916/5bf3dc66-018c-4951-b4c5-9b8d2a621be8)

