### PR TITLE
[Fix] Handle Missing Contents in `MessageTokenLimiter`

### DIFF
--- a/autogen/agentchat/contrib/capabilities/transforms.py
+++ b/autogen/agentchat/contrib/capabilities/transforms.py
@@ -126,9 +126,16 @@ class MessageTokenLimiter:
         processed_messages_tokens = 0
 
         # calculate tokens for all messages
-        total_tokens = sum(_count_tokens(msg["content"]) for msg in temp_messages)
+        total_tokens = sum(
+            _count_tokens(msg["content"]) for msg in temp_messages if isinstance(msg.get("content"), (str, list))
+        )
 
         for msg in reversed(temp_messages):
+            # Some messages may not have content.
+            if not isinstance(msg.get("content"), (str, list)):
+                processed_messages.insert(0, msg)
+                continue
+
             expected_tokens_remained = self._max_tokens - processed_messages_tokens - self._max_tokens_per_message
 
             # If adding this message would exceed the token limit, truncate the last message to meet the total token

--- a/test/agentchat/contrib/capabilities/test_transform_messages.py
+++ b/test/agentchat/contrib/capabilities/test_transform_messages.py
@@ -76,6 +76,29 @@ def test_limit_token_transform():
     assert len(transformed_messages) <= len(messages)
 
 
+def test_limit_token_transform_without_content():
+    """Test the TokenLimitTransform with messages that don't have content."""
+
+    messages = [{"role": "user", "function_call": "example"}, {"role": "assistant", "content": None}]
+
+    # check if token limit per message works nicely with total token limit.
+    token_limit_transform = MessageTokenLimiter(max_tokens=10, max_tokens_per_message=5)
+
+    transformed_messages = token_limit_transform.apply_transform(copy.deepcopy(messages))
+
+    assert len(transformed_messages) == len(messages)
+
+
+def test_limit_token_transform_total_token_count():
+    """Tests if the TokenLimitTransform truncates without dropping messages."""
+    messages = [{"role": "very very very very very"}]
+
+    token_limit_transform = MessageTokenLimiter(max_tokens=1)
+    transformed_messages = token_limit_transform.apply_transform(copy.deepcopy(messages))
+
+    assert len(transformed_messages) == 1
+
+
 def test_max_message_history_length_transform():
     """
     Test the MessageHistoryLimiter capability to limit the number of messages.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes a bug for cases when contents are missing from a message. Added two tests:
1. Tests the behavior of the transform when the content type is unexpected. 
2. Check if the transform always returns a message

## Related issue number

Closes #2340 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
