### PR TITLE
Make the port number optional in JupyterConnectionInfo()

### DIFF
--- a/autogen/coding/jupyter/base.py
+++ b/autogen/coding/jupyter/base.py
@@ -10,8 +10,8 @@ class JupyterConnectionInfo:
     """`str` - Host of the Jupyter gateway server"""
     use_https: bool
     """`bool` - Whether to use HTTPS"""
-    port: int
-    """`int` - Port of the Jupyter gateway server"""
+    port: Optional[int]
+    """`Optional[int]` - Port of the Jupyter gateway server. If None, the default port is used"""
     token: Optional[str]
     """`Optional[str]` - Token for authentication. If None, no token is used"""
 

--- a/autogen/coding/jupyter/base.py
+++ b/autogen/coding/jupyter/base.py
@@ -10,9 +10,9 @@ class JupyterConnectionInfo:
     """`str` - Host of the Jupyter gateway server"""
     use_https: bool
     """`bool` - Whether to use HTTPS"""
-    port: Optional[int]
+    port: Optional[int] = None
     """`Optional[int]` - Port of the Jupyter gateway server. If None, the default port is used"""
-    token: Optional[str]
+    token: Optional[str] = None
     """`Optional[str]` - Token for authentication. If None, no token is used"""
 
 

--- a/autogen/coding/jupyter/jupyter_client.py
+++ b/autogen/coding/jupyter/jupyter_client.py
@@ -41,10 +41,12 @@ class JupyterClient:
 
     def _get_api_base_url(self) -> str:
         protocol = "https" if self._connection_info.use_https else "http"
-        return f"{protocol}://{self._connection_info.host}:{self._connection_info.port}"
+        port = f":{self._connection_info.port}" if self._connection_info.port else ""
+        return f"{protocol}://{self._connection_info.host}{port}"
 
     def _get_ws_base_url(self) -> str:
-        return f"ws://{self._connection_info.host}:{self._connection_info.port}"
+        port = f":{self._connection_info.port}" if self._connection_info.port else ""
+        return f"ws://{self._connection_info.host}{port}"
 
     def list_kernel_specs(self) -> Dict[str, Dict[str, str]]:
         response = self._session.get(f"{self._get_api_base_url()}/api/kernelspecs", headers=self._get_headers())


### PR DESCRIPTION
## Why are these changes needed?

The changes are needed to make the port number optional in the `JupyterConnectionInfo()` class when using a remote Docker server with a Jupyter notebook. Currently, the code expects a port number even when using an HTTPS connection with a hostname. This update allows passing HTTPS-enabled hostnames without the need for a port number.

## Related issue number

Issue #2458

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

Please review the completed GitHub Pull请求变更文档 and make any necessary adjustments before opening the pull request.