### PR TITLE
Optimize group chat speaker selection system message

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -267,8 +267,9 @@ class GroupChat:
                 agents = last_agent_transitions
 
         roles = self._participant_roles(agents)
+        agentlist = f"{[agent.name for agent in agents]}"
 
-        return_msg = self.select_speaker_message_template.format(roles=roles, agentlist=agents)
+        return_msg = self.select_speaker_message_template.format(roles=roles, agentlist=agentlist)
         return return_msg
 
     def select_speaker_prompt(self, agents: Optional[List[Agent]] = None) -> str:

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -259,10 +259,17 @@ class GroupChat:
         if agents is None:
             agents = self.agents
 
-        roles = self._participant_roles(agents)
-        agentlist = f"{[agent.name for agent in agents]}"
+        last_agent_name = self.messages[-1].get("name") if self.messages else None
 
-        return_msg = self.select_speaker_message_template.format(roles=roles, agentlist=agentlist)
+        if self.speaker_transitions_type == "allowed" and last_agent_name:
+            last_agent_transitions = self.allowed_speaker_transitions_dict.get(last_agent_name, [])
+            if last_agent_transitions:
+                agents = last_agent_transitions
+
+        roles = self._participant_roles(agents)
+        agent_names = [agent.name for agent in agents]
+
+        return_msg = self.select_speaker_message_template.format(roles=roles, agentlist=agent_names)
         return return_msg
 
     def select_speaker_prompt(self, agents: Optional[List[Agent]] = None) -> str:

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -267,9 +267,8 @@ class GroupChat:
                 agents = last_agent_transitions
 
         roles = self._participant_roles(agents)
-        agent_names = [agent.name for agent in agents]
 
-        return_msg = self.select_speaker_message_template.format(roles=roles, agentlist=agent_names)
+        return_msg = self.select_speaker_message_template.format(roles=roles, agentlist=agents)
         return return_msg
 
     def select_speaker_prompt(self, agents: Optional[List[Agent]] = None) -> str:


### PR DESCRIPTION
## Why are these changes needed?

The group chat system message currently always includes the agent descriptions of all agents even when setting speaker_transitions_type = "allowed" meaning only certain agents may follow one another. This means that the system message is longer than it needs to be, increasing cost and reducing performance slightly as well as allowing for the LLM to possibly select a role that it not an allowed transition.

## Related issue number

#2456

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
