### PR TITLE
[.Net] add mistral example

### DIFF
--- a/dotnet/eng/MetaInfo.props
+++ b/dotnet/eng/MetaInfo.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <VersionPrefix>0.0.11</VersionPrefix>
+        <VersionPrefix>0.0.12</VersionPrefix>
         <Authors>AutoGen</Authors>
         <PackageProjectUrl>https://microsoft.github.io/autogen-for-net/</PackageProjectUrl>
         <RepositoryUrl>https://github.com/microsoft/autogen</RepositoryUrl>

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs
@@ -4,9 +4,22 @@
 #region using_statement
 using AutoGen.Mistral;
 using AutoGen.Core;
+using AutoGen.Mistral.Extension;
+using FluentAssertions;
 #endregion using_statement
 
 namespace AutoGen.BasicSample.CodeSnippet;
+
+#region weather_function
+public partial class MistralAgentFunction
+{
+    [Function]
+    public async Task<string> GetWeather(string location)
+    {
+        return "The weather in " + location + " is sunny.";
+    }
+}
+#endregion weather_function
 
 internal class MistralAICodeSnippet
 {
@@ -18,9 +31,56 @@ internal class MistralAICodeSnippet
         var agent = new MistralClientAgent(
             client: client,
             name: "MistralAI",
-            model: MistralAIModelID.OPEN_MISTRAL_7B);
+            model: MistralAIModelID.OPEN_MISTRAL_7B)
+            .RegisterMessageConnector(); // support more AutoGen built-in message types.
 
         await agent.SendAsync("Hello, how are you?");
         #endregion create_mistral_agent
+
+        #region streaming_chat
+        var reply = await agent.GenerateStreamingReplyAsync(
+            messages: [new TextMessage(Role.User, "Hello, how are you?")]
+        );
+
+        await foreach (var message in reply)
+        {
+            if (message is TextMessageUpdate textMessageUpdate && textMessageUpdate.Content is string content)
+            {
+                Console.WriteLine(content);
+            }
+        }
+        #endregion streaming_chat
+    }
+
+    public async Task MistralAIChatAgentGetWeatherToolUsageAsync()
+    {
+        #region create_mistral_function_call_agent
+        var apiKey = Environment.GetEnvironmentVariable("MISTRAL_API_KEY") ?? throw new Exception("Missing MISTRAL_API_KEY environment variable");
+        var client = new MistralClient(apiKey: apiKey);
+        var agent = new MistralClientAgent(
+            client: client,
+            name: "MistralAI",
+            model: MistralAIModelID.MISTRAL_SMALL_LATEST)
+            .RegisterMessageConnector(); // support more AutoGen built-in message types like ToolCallMessage and ToolCallResultMessage
+        #endregion create_mistral_function_call_agent
+
+        #region create_get_weather_function_call_middleware
+        var mistralFunctions = new MistralAgentFunction();
+        var functionCallMiddleware = new FunctionCallMiddleware(
+            functions: [mistralFunctions.GetWeatherFunctionContract],
+            functionMap: new Dictionary<string, Func<string, Task<string>>> // with functionMap, the function will be automatically triggered if the tool name matches one of the keys.
+            {
+                { mistralFunctions.GetWeatherFunctionContract.Name, mistralFunctions.GetWeather }
+            });
+        #endregion create_get_weather_function_call_middleware
+
+        #region register_function_call_middleware
+        agent = agent.RegisterMiddleware(functionCallMiddleware);
+        #endregion register_function_call_middleware
+
+        #region send_message_with_function_call
+        var reply = await agent.SendAsync("What is the weather in Seattle?");
+        reply.GetContent().Should().Be("The weather in Seattle is sunny.");
+        #endregion send_message_with_function_call
     }
 }

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// MistralAICodeSnippet.cs
+
+#region using_statement
+using AutoGen.Mistral;
+using AutoGen.Core;
+#endregion using_statement
+
+namespace AutoGen.BasicSample.CodeSnippet;
+
+internal class MistralAICodeSnippet
+{
+    public async Task CreateMistralAIClientAsync()
+    {
+        #region create_mistral_agent
+        var apiKey = Environment.GetEnvironmentVariable("MISTRAL_API_KEY") ?? throw new Exception("Missing MISTRAL_API_KEY environment variable");
+        var client = new MistralClient(apiKey: apiKey);
+        var agent = new MistralClientAgent(
+            client: client,
+            name: "MistralAI",
+            model: MistralAIModelID.OPEN_MISTRAL_7B);
+
+        await agent.SendAsync("Hello, how are you?");
+        #endregion create_mistral_agent
+    }
+}

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs
@@ -16,9 +16,8 @@ internal class PrintMessageMiddlewareCodeSnippet
         var config = LLMConfiguration.GetAzureOpenAIGPT3_5_Turbo();
         var endpoint = new Uri(config.Endpoint);
         var openaiClient = new OpenAIClient(endpoint, new AzureKeyCredential(config.ApiKey));
-        var openaiMessageConnector = new OpenAIChatRequestMessageConnector();
         var agent = new OpenAIChatAgent(openaiClient, "assistant", config.DeploymentName)
-            .RegisterMiddleware(openaiMessageConnector);
+            .RegisterMessageConnector();
 
         #region PrintMessageMiddleware
         var agentWithPrintMessageMiddleware = agent

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs
@@ -3,6 +3,7 @@
 
 using AutoGen.Core;
 using AutoGen.OpenAI;
+using AutoGen.OpenAI.Extension;
 using Azure;
 using Azure.AI.OpenAI;
 
@@ -32,12 +33,10 @@ internal class PrintMessageMiddlewareCodeSnippet
         var config = LLMConfiguration.GetAzureOpenAIGPT3_5_Turbo();
         var endpoint = new Uri(config.Endpoint);
         var openaiClient = new OpenAIClient(endpoint, new AzureKeyCredential(config.ApiKey));
-        var openaiMessageConnector = new OpenAIChatRequestMessageConnector();
 
         #region print_message_streaming
         var streamingAgent = new OpenAIChatAgent(openaiClient, "assistant", config.DeploymentName)
-            .RegisterStreamingMiddleware(openaiMessageConnector)
-            .RegisterMiddleware(openaiMessageConnector)
+            .RegisterMessageConnector()
             .RegisterPrintMessage();
 
         await streamingAgent.SendAsync("write a long poem");

--- a/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/SemanticKernelCodeSnippet.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/CodeSnippet/SemanticKernelCodeSnippet.cs
@@ -3,6 +3,7 @@
 
 using AutoGen.Core;
 using AutoGen.SemanticKernel;
+using AutoGen.SemanticKernel.Extension;
 using FluentAssertions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -72,11 +73,10 @@ public class SemanticKernelCodeSnippet
             kernel: kernel,
             name: "assistant",
             systemMessage: "You are an assistant that help user to do some tasks.");
-        var connector = new SemanticKernelChatMessageContentConnector();
 
         // Register the connector middleware to the kernel agent
         var semanticKernelAgentWithConnector = semanticKernelAgent
-            .RegisterMiddleware(connector); // middleware for non-streaming api
+            .RegisterMessageConnector();
 
         // now semanticKernelAgentWithConnector supports more message types
         IMessage[] messages = [

--- a/dotnet/sample/AutoGen.BasicSamples/Example10_SemanticKernel.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example10_SemanticKernel.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel;
 using AutoGen.Core;
-using AutoGen.SemanticKernel;
 using AutoGen.SemanticKernel.Extension;
 using FluentAssertions;
 using Microsoft.SemanticKernel;
@@ -62,11 +61,8 @@ public class Example10_SemanticKernel
         reply.Should().BeOfType<MessageEnvelope<ChatMessageContent>>();
         Console.WriteLine((reply as IMessage<ChatMessageContent>).Content.Items[0].As<TextContent>().Text);
 
-        // To support more AutoGen built-in IMessage, register skAgent with ChatMessageContentConnector
-        var connector = new SemanticKernelChatMessageContentConnector();
         var skAgentWithMiddleware = skAgent
-            .RegisterStreamingMiddleware(connector)
-            .RegisterMiddleware(connector)
+            .RegisterMessageConnector()
             .RegisterPrintMessage();
 
         // Now the skAgentWithMiddleware supports more IMessage types like TextMessage, ImageMessage or MultiModalMessage

--- a/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example11_Sequential_GroupChat_Example.cs
@@ -4,7 +4,9 @@
 #region using_statement
 using AutoGen.Core;
 using AutoGen.OpenAI;
+using AutoGen.OpenAI.Extension;
 using AutoGen.SemanticKernel;
+using AutoGen.SemanticKernel.Extension;
 using Azure.AI.OpenAI;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Plugins.Web;
@@ -27,7 +29,6 @@ public partial class Sequential_GroupChat_Example
         var webSearchPlugin = new WebSearchEnginePlugin(bingSearch);
         kernelBuilder.Plugins.AddFromObject(webSearchPlugin);
 
-        var kernelMessageConnector = new SemanticKernelChatMessageContentConnector();
         var kernel = kernelBuilder.Build();
         var kernelAgent = new SemanticKernelAgent(
             kernel: kernel,
@@ -41,8 +42,7 @@ public partial class Sequential_GroupChat_Example
             xxx
             ```
             """)
-            .RegisterStreamingMiddleware(kernelMessageConnector) // support TextMessageUpdate
-            .RegisterMiddleware(kernelMessageConnector) // support TextMessage
+            .RegisterMessageConnector()
             .RegisterPrintMessage(); // pretty print the message
 
         return kernelAgent;
@@ -63,11 +63,8 @@ public partial class Sequential_GroupChat_Example
             modelName: config.DeploymentName,
             systemMessage: "You summarize search result from bing in a short and concise manner");
 
-        var messageConnector = new OpenAIChatRequestMessageConnector();
-
         return openAIClientAgent
-            .RegisterStreamingMiddleware(messageConnector) // support TextMessageUpdate
-            .RegisterMiddleware(messageConnector) // support TextMessage
+            .RegisterMessageConnector()
             .RegisterPrintMessage(); // pretty print the message
         #endregion CreateSummarizerAgent
     }

--- a/dotnet/sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs
@@ -11,7 +11,7 @@ namespace AutoGen.BasicSample;
 
 public class Example14_MistralClientAgent_TokenCount
 {
-    #region mistral_ai_token_counter_middleware
+    #region token_counter_middleware
     public class MistralAITokenCounterMiddleware : IMiddleware
     {
         private readonly List<ChatCompletionResponse> responses = new List<ChatCompletionResponse>();
@@ -34,7 +34,7 @@ public class Example14_MistralClientAgent_TokenCount
             return responses.Sum(r => r.Usage.CompletionTokens);
         }
     }
-    #endregion mistral_ai_token_counter_middleware
+    #endregion token_counter_middleware
 
     public static async Task RunAsync()
     {
@@ -45,7 +45,7 @@ public class Example14_MistralClientAgent_TokenCount
             client: mistralClient,
             name: "assistant",
             model: MistralAIModelID.OPEN_MISTRAL_7B);
-        #region create_mistral_client_agent
+        #endregion create_mistral_client_agent
 
         #region register_middleware
         var tokenCounterMiddleware = new MistralAITokenCounterMiddleware();

--- a/dotnet/sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Example14_MistralClientAgent_TokenCount.cs
+
+#region using_statements
+using AutoGen.Core;
+using AutoGen.Mistral;
+#endregion using_statements
+using FluentAssertions;
+
+namespace AutoGen.BasicSample;
+
+public class Example14_MistralClientAgent_TokenCount
+{
+    #region mistral_ai_token_counter_middleware
+    public class MistralAITokenCounterMiddleware : IMiddleware
+    {
+        private readonly List<ChatCompletionResponse> responses = new List<ChatCompletionResponse>();
+        public string? Name => nameof(MistralAITokenCounterMiddleware);
+
+        public async Task<IMessage> InvokeAsync(MiddlewareContext context, IAgent agent, CancellationToken cancellationToken = default)
+        {
+            var reply = await agent.GenerateReplyAsync(context.Messages, context.Options, cancellationToken);
+
+            if (reply is IMessage<ChatCompletionResponse> message)
+            {
+                responses.Add(message.Content);
+            }
+
+            return reply;
+        }
+
+        public int GetCompletionTokenCount()
+        {
+            return responses.Sum(r => r.Usage.CompletionTokens);
+        }
+    }
+    #endregion mistral_ai_token_counter_middleware
+
+    public static async Task RunAsync()
+    {
+        #region create_mistral_client_agent
+        var apiKey = Environment.GetEnvironmentVariable("MISTRAL_API_KEY") ?? throw new Exception("Missing MISTRAL_API_KEY environment variable.");
+        var mistralClient = new MistralClient(apiKey);
+        var agent = new MistralClientAgent(
+            client: mistralClient,
+            name: "assistant",
+            model: MistralAIModelID.OPEN_MISTRAL_7B);
+        #region create_mistral_client_agent
+
+        #region register_middleware
+        var tokenCounterMiddleware = new MistralAITokenCounterMiddleware();
+        var mistralMessageConnector = new MistralChatMessageConnector();
+        var agentWithTokenCounter = agent
+            .RegisterMiddleware(tokenCounterMiddleware)
+            .RegisterMiddleware(mistralMessageConnector)
+            .RegisterPrintMessage();
+        #endregion register_middleware
+
+        #region chat_with_agent
+        await agentWithTokenCounter.SendAsync("write a long, tedious story");
+        Console.WriteLine($"Completion token count: {tokenCounterMiddleware.GetCompletionTokenCount()}");
+        tokenCounterMiddleware.GetCompletionTokenCount().Should().BeGreaterThan(0);
+        #endregion chat_with_agent
+    }
+}

--- a/dotnet/sample/AutoGen.BasicSamples/Program.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Program.cs
@@ -2,5 +2,4 @@
 // Program.cs
 
 using AutoGen.BasicSample;
-
-await Example13_OpenAIAgent_JsonMode.RunAsync();
+await Example14_MistralClientAgent_TokenCount.RunAsync();

--- a/dotnet/src/AutoGen.Core/Extension/StreamingMiddlewareExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/StreamingMiddlewareExtension.cs
@@ -21,6 +21,11 @@ public static class StreamingMiddlewareExtension
         var middlewareAgent = new MiddlewareStreamingAgent<TStreamingAgent>(agent);
         middlewareAgent.UseStreaming(middleware);
 
+        if (middleware is IMiddleware middlewareBase)
+        {
+            middlewareAgent.Use(middlewareBase);
+        }
+
         return middlewareAgent;
     }
 
@@ -34,6 +39,11 @@ public static class StreamingMiddlewareExtension
     {
         var copyAgent = new MiddlewareStreamingAgent<TAgent>(agent);
         copyAgent.UseStreaming(middleware);
+
+        if (middleware is IMiddleware middlewareBase)
+        {
+            copyAgent.Use(middlewareBase);
+        }
 
         return copyAgent;
     }

--- a/dotnet/src/AutoGen.Mistral/Agent/MistralClientAgent.cs
+++ b/dotnet/src/AutoGen.Mistral/Agent/MistralClientAgent.cs
@@ -11,6 +11,22 @@ using AutoGen.Mistral.Extension;
 
 namespace AutoGen.Mistral;
 
+/// <summary>
+/// Mistral client agent.
+/// 
+/// <para>This agent supports the following input message types:</para>
+/// <list type="bullet">
+/// <para><see cref="MessageEnvelope{T}"/> where T is <see cref="ChatMessage"/></para>
+/// </list>
+/// 
+/// <para>This agent returns the following message types:</para>
+/// <list type="bullet">
+/// <para><see cref="MessageEnvelope{T}"/> where T is <see cref="ChatCompletionResponse"/></para>
+/// </list>
+/// 
+/// You can register this agent with <see cref="MistralAgentExtension.RegisterMessageConnector(AutoGen.Mistral.MistralClientAgent, AutoGen.Mistral.MistralChatMessageConnector?)"/>
+/// to support more AutoGen message types.
+/// </summary>
 public class MistralClientAgent : IStreamingAgent
 {
     private readonly MistralClient _client;
@@ -19,6 +35,17 @@ public class MistralClientAgent : IStreamingAgent
     private readonly int? _randomSeed;
     private readonly bool _jsonOutput = false;
     private ToolChoiceEnum? _toolChoice;
+
+    /// <summary>
+    /// Create a new instance of <see cref="MistralClientAgent"/>.
+    /// </summary>
+    /// <param name="client"><see cref="MistralClient"/></param>
+    /// <param name="name">the name of this agent</param>
+    /// <param name="model">the mistral model id.</param>
+    /// <param name="systemMessage">system message.</param>
+    /// <param name="randomSeed">the seed to generate output.</param>
+    /// <param name="toolChoice">tool choice strategy.</param>
+    /// <param name="jsonOutput">use json output.</param>
     public MistralClientAgent(
         MistralClient client,
         string name,

--- a/dotnet/src/AutoGen.Mistral/Converters/JsonPropertyNameEnumConverter.cs
+++ b/dotnet/src/AutoGen.Mistral/Converters/JsonPropertyNameEnumConverter.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 
 namespace AutoGen.Mistral;
 
-public class JsonPropertyNameEnumConverter<T> : JsonConverter<T> where T : struct, Enum
+internal class JsonPropertyNameEnumConverter<T> : JsonConverter<T> where T : struct, Enum
 {
     public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {

--- a/dotnet/src/AutoGen.Mistral/Extension/MistralAgentExtension.cs
+++ b/dotnet/src/AutoGen.Mistral/Extension/MistralAgentExtension.cs
@@ -7,6 +7,9 @@ namespace AutoGen.Mistral.Extension;
 
 public static class MistralAgentExtension
 {
+    /// <summary>
+    /// Register a <see cref="MistralChatMessageConnector"/> to support more AutoGen message types.
+    /// </summary>
     public static MiddlewareStreamingAgent<MistralClientAgent> RegisterMessageConnector(
         this MistralClientAgent agent, MistralChatMessageConnector? connector = null)
     {
@@ -20,6 +23,9 @@ public static class MistralAgentExtension
 
     }
 
+    /// <summary>
+    /// Register a <see cref="MistralChatMessageConnector"/> to support more AutoGen message types.
+    /// </summary>
     public static MiddlewareStreamingAgent<MistralClientAgent> RegisterMessageConnector(
         this MiddlewareStreamingAgent<MistralClientAgent> agent, MistralChatMessageConnector? connector = null)
     {

--- a/dotnet/src/AutoGen.Mistral/MistralAIModelID.cs
+++ b/dotnet/src/AutoGen.Mistral/MistralAIModelID.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// MistralAIModelID.cs
+
+namespace AutoGen.Mistral;
+
+public class MistralAIModelID
+{
+    public const string OPEN_MISTRAL_7B = "open-mistral-7b";
+    public const string OPEN_MISTRAL_8X7B = "open-mixtral-8x7b";
+    public const string OPEN_MISTRAL_8X22B = "open-mixtral-8x22b";
+    public const string MISTRAL_SMALL_LATEST = "mistral-small-latest";
+    public const string MISTRAL_MEDIUM_LATEST = "mistral-medium-latest";
+    public const string MISTRAL_LARGE_LATEST = "mistral-large-latest";
+}

--- a/dotnet/src/AutoGen.OpenAI/Agent/GPTAgent.cs
+++ b/dotnet/src/AutoGen.OpenAI/Agent/GPTAgent.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using AutoGen.OpenAI.Extension;
 using Azure.AI.OpenAI;
 
 namespace AutoGen.OpenAI;
@@ -89,8 +90,8 @@ public class GPTAgent : IStreamingAgent
         GenerateReplyOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        var oaiConnectorMiddleware = new OpenAIChatRequestMessageConnector();
-        var agent = this._innerAgent.RegisterMiddleware(oaiConnectorMiddleware);
+        var agent = this._innerAgent
+            .RegisterMessageConnector();
         if (this.functionMap is not null)
         {
             var functionMapMiddleware = new FunctionCallMiddleware(functionMap: this.functionMap);
@@ -105,8 +106,8 @@ public class GPTAgent : IStreamingAgent
         GenerateReplyOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        var oaiConnectorMiddleware = new OpenAIChatRequestMessageConnector();
-        var agent = this._innerAgent.RegisterStreamingMiddleware(oaiConnectorMiddleware);
+        var agent = this._innerAgent
+            .RegisterMessageConnector();
         if (this.functionMap is not null)
         {
             var functionMapMiddleware = new FunctionCallMiddleware(functionMap: this.functionMap);

--- a/dotnet/src/AutoGen.OpenAI/Extension/OpenAIAgentExtension.cs
+++ b/dotnet/src/AutoGen.OpenAI/Extension/OpenAIAgentExtension.cs
@@ -17,8 +17,7 @@ public static class OpenAIAgentExtension
             connector = new OpenAIChatRequestMessageConnector();
         }
 
-        return agent.RegisterStreamingMiddleware(connector)
-                    .RegisterMiddleware(connector);
+        return agent.RegisterStreamingMiddleware(connector);
     }
 
     /// <summary>
@@ -33,7 +32,6 @@ public static class OpenAIAgentExtension
             connector = new OpenAIChatRequestMessageConnector();
         }
 
-        return agent.RegisterStreamingMiddleware(connector)
-                    .RegisterMiddleware(connector);
+        return agent.RegisterStreamingMiddleware(connector);
     }
 }

--- a/dotnet/src/AutoGen.OpenAI/Middleware/OpenAIChatRequestMessageConnector.cs
+++ b/dotnet/src/AutoGen.OpenAI/Middleware/OpenAIChatRequestMessageConnector.cs
@@ -81,7 +81,7 @@ public class OpenAIChatRequestMessageConnector : IMiddleware, IStreamingMiddlewa
             }
             else
             {
-                throw new InvalidOperationException("The type of streaming reply is not supported. Must be one of StreamingChatCompletionsUpdate");
+                yield return reply;
             }
         }
     }

--- a/dotnet/src/AutoGen.SemanticKernel/Extension/SemanticKernelAgentExtension.cs
+++ b/dotnet/src/AutoGen.SemanticKernel/Extension/SemanticKernelAgentExtension.cs
@@ -17,8 +17,7 @@ public static class SemanticKernelAgentExtension
             connector = new SemanticKernelChatMessageContentConnector();
         }
 
-        return agent.RegisterStreamingMiddleware(connector)
-                    .RegisterMiddleware(connector);
+        return agent.RegisterStreamingMiddleware(connector);
     }
 
     /// <summary>
@@ -33,7 +32,6 @@ public static class SemanticKernelAgentExtension
             connector = new SemanticKernelChatMessageContentConnector();
         }
 
-        return agent.RegisterStreamingMiddleware(connector)
-                    .RegisterMiddleware(connector);
+        return agent.RegisterStreamingMiddleware(connector);
     }
 }

--- a/dotnet/src/AutoGen.SemanticKernel/Middleware/SemanticKernelChatMessageContentConnector.cs
+++ b/dotnet/src/AutoGen.SemanticKernel/Middleware/SemanticKernelChatMessageContentConnector.cs
@@ -71,7 +71,7 @@ public class SemanticKernelChatMessageContentConnector : IMiddleware, IStreaming
         return input switch
         {
             IMessage<ChatMessageContent> messageEnvelope => PostProcessMessage(messageEnvelope),
-            _ => throw new System.NotImplementedException(),
+            _ => input,
         };
     }
 
@@ -81,7 +81,7 @@ public class SemanticKernelChatMessageContentConnector : IMiddleware, IStreaming
         {
             IStreamingMessage<StreamingChatMessageContent> streamingMessage => PostProcessMessage(streamingMessage),
             IMessage msg => PostProcessMessage(msg),
-            _ => throw new System.NotImplementedException(),
+            _ => input,
         };
     }
 

--- a/dotnet/src/AutoGen/AutoGen.csproj
+++ b/dotnet/src/AutoGen/AutoGen.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net.Generation" Version="$(JsonSchemaVersion)" />
     <ProjectReference Include="..\AutoGen.LMStudio\AutoGen.LMStudio.csproj" />
+    <ProjectReference Include="..\AutoGen.Mistral\AutoGen.Mistral.csproj" />
     <ProjectReference Include="..\AutoGen.SemanticKernel\AutoGen.SemanticKernel.csproj" />
     <ProjectReference Include="..\AutoGen.SourceGenerator\AutoGen.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 

--- a/dotnet/test/AutoGen.Tests/BasicSampleTest.cs
+++ b/dotnet/test/AutoGen.Tests/BasicSampleTest.cs
@@ -43,6 +43,12 @@ namespace AutoGen.Tests
             await Example13_OpenAIAgent_JsonMode.RunAsync();
         }
 
+        [ApiKeyFact("MISTRAL_API_KEY")]
+        public async Task MistralClientAgent_TokenCount()
+        {
+            await Example14_MistralClientAgent_TokenCount.RunAsync();
+        }
+
         [ApiKeyFact("OPENAI_API_KEY")]
         public async Task DynamicGroupChatGetMLNetPRTestAsync()
         {

--- a/dotnet/test/AutoGen.Tests/OpenAIChatAgentTest.cs
+++ b/dotnet/test/AutoGen.Tests/OpenAIChatAgentTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoGen.OpenAI;
+using AutoGen.OpenAI.Extension;
 using Azure.AI.OpenAI;
 using FluentAssertions;
 
@@ -65,10 +66,8 @@ public partial class OpenAIChatAgentTest
             name: "assistant",
             modelName: "gpt-35-turbo-16k");
 
-        var openAIChatMessageConnector = new OpenAIChatRequestMessageConnector();
         MiddlewareStreamingAgent<OpenAIChatAgent> assistant = openAIChatAgent
-            .RegisterStreamingMiddleware(openAIChatMessageConnector)
-            .RegisterMiddleware(openAIChatMessageConnector);
+            .RegisterMessageConnector();
 
         var messages = new IMessage[]
         {
@@ -114,16 +113,15 @@ public partial class OpenAIChatAgentTest
             name: "assistant",
             modelName: "gpt-35-turbo-16k");
 
-        var openAIChatMessageConnector = new OpenAIChatRequestMessageConnector();
         var functionCallMiddleware = new FunctionCallMiddleware(
             functions: [this.GetWeatherAsyncFunctionContract]);
         MiddlewareStreamingAgent<OpenAIChatAgent> assistant = openAIChatAgent
-            .RegisterStreamingMiddleware(openAIChatMessageConnector)
-            .RegisterMiddleware(openAIChatMessageConnector);
+            .RegisterMessageConnector();
 
+        assistant.Middlewares.Count().Should().Be(1);
+        assistant.StreamingMiddlewares.Count().Should().Be(1);
         var functionCallAgent = assistant
-            .RegisterMiddleware(functionCallMiddleware)
-            .RegisterStreamingMiddleware(functionCallMiddleware);
+            .RegisterMiddleware(functionCallMiddleware);
 
         var question = "What's the weather in Seattle";
         var messages = new IMessage[]
@@ -185,17 +183,14 @@ public partial class OpenAIChatAgentTest
             name: "assistant",
             modelName: "gpt-35-turbo-16k");
 
-        var openAIChatMessageConnector = new OpenAIChatRequestMessageConnector();
         var functionCallMiddleware = new FunctionCallMiddleware(
             functions: [this.GetWeatherAsyncFunctionContract],
             functionMap: new Dictionary<string, Func<string, Task<string>>> { { this.GetWeatherAsyncFunctionContract.Name!, this.GetWeatherAsyncWrapper } });
         MiddlewareStreamingAgent<OpenAIChatAgent> assistant = openAIChatAgent
-            .RegisterStreamingMiddleware(openAIChatMessageConnector)
-            .RegisterMiddleware(openAIChatMessageConnector);
+            .RegisterMessageConnector();
 
         var functionCallAgent = assistant
-            .RegisterMiddleware(functionCallMiddleware)
-            .RegisterStreamingMiddleware(functionCallMiddleware);
+            .RegisterMiddleware(functionCallMiddleware);
 
         var question = "What's the weather in Seattle";
         var messages = new IMessage[]

--- a/dotnet/test/AutoGen.Tests/SemanticKernelAgentTest.cs
+++ b/dotnet/test/AutoGen.Tests/SemanticKernelAgentTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoGen.SemanticKernel;
+using AutoGen.SemanticKernel.Extension;
 using FluentAssertions;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -118,10 +119,11 @@ public partial class SemanticKernelAgentTest
         builder.Plugins.AddFromFunctions("plugins", [function]);
         var kernel = builder.Build();
 
-        var connector = new SemanticKernelChatMessageContentConnector();
         var skAgent = new SemanticKernelAgent(kernel, "assistant")
-            .RegisterStreamingMiddleware(connector)
-            .RegisterMiddleware(connector);
+            .RegisterMessageConnector();
+
+        skAgent.Middlewares.Count().Should().Be(1);
+        skAgent.StreamingMiddlewares.Count().Should().Be(1);
 
         var question = "What is the weather in Seattle?";
         var reply = await skAgent.SendAsync(question);

--- a/dotnet/website/articles/AutoGen-Mistral-Overview.md
+++ b/dotnet/website/articles/AutoGen-Mistral-Overview.md
@@ -21,3 +21,6 @@ Import the required namespace
 
 Create a @AutoGen.Mistral.MistralClientAgent and start chatting!
 [!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=create_mistral_agent)]
+
+Use @AutoGen.Core.IStreamingAgent.GenerateStreamingReplyAsync* to stream the chat completion.
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=streaming_chat)]

--- a/dotnet/website/articles/AutoGen-Mistral-Overview.md
+++ b/dotnet/website/articles/AutoGen-Mistral-Overview.md
@@ -1,0 +1,23 @@
+## AutoGen.Mistral overview
+
+AutoGen.Mistral provides the following agent(s) to connect to [Mistral.AI](https://mistral.ai/) platform.
+- @AutoGen.Mistral.MistralClientAgent: A slim wrapper agent over @AutoGen.Mistral.MistralClient.
+
+### Get started with AutoGen.Mistral
+
+To get started with AutoGen.Mistral, follow the [installation guide](Installation.md) to make sure you add the AutoGen feed correctly. Then add the `AutoGen.Mistral` package to your project file.
+
+```bash
+dotnet add package AutoGen.Mistral
+```
+
+>[!NOTE]
+> You need to provide an api-key to use Mistral models which will bring additional cost while using. you can get the api key from [Mistral.AI](https://mistral.ai/).
+
+### Example
+
+Import the required namespace
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=using_statement)]
+
+Create a @AutoGen.Mistral.MistralClientAgent and start chatting!
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=create_mistral_agent)]

--- a/dotnet/website/articles/Installation.md
+++ b/dotnet/website/articles/Installation.md
@@ -7,6 +7,7 @@ AutoGen.Net provides the following packages, you can choose to install one or mo
 - `AutoGen`: The one-in-all package. This package has dependencies over `AutoGen.Core`, `AutoGen.OpenAI`, `AutoGen.LMStudio`, `AutoGen.SemanticKernel` and `AutoGen.SourceGenerator`.
 - `AutoGen.Core`: The core package, this package provides the abstraction for message type, agent and group chat.
 - `AutoGen.OpenAI`: This package provides the integration agents over openai models.
+- `AutoGen.Mistral`: This package provides the integration agents for Mistral.AI models.
 - `AutoGen.LMStudio`: This package provides the integration agents from LM Studio.
 - `AutoGen.SemanticKernel`: This package provides the integration agents over semantic kernel.
 - `AutoGen.SourceGenerator`: This package carries a source generator that adds support for type-safe function definition generation.

--- a/dotnet/website/articles/MistralChatAgent-count-token-usage.md
+++ b/dotnet/website/articles/MistralChatAgent-count-token-usage.md
@@ -1,0 +1,28 @@
+The following example shows how to create a `MistralAITokenCounterMiddleware` @AutoGen.Core.IMiddleware and count the token usage when chatting with @AutoGen.Mistral.MistralClientAgent.
+
+### Overview
+To collect the token usage for the entire chat session, one easy solution is simply collect all the responses from agent and sum up the token usage for each response. To collect all the agent responses, we can create a middleware which simply saves all responses to a list and register it with the agent. To get the token usage information for each response, because in the example we are using @AutoGen.Mistral.MistralClientAgent, we can simply get the token usage from the response object.
+
+> [!NOTE]
+> You can find the complete example in the [Example13_OpenAIAgent_JsonMode](https://github.com/microsoft/autogen/tree/dotnet/dotnet/sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs).
+
+- Step 1: Adding using statement
+[!code-csharp[](../../sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs?name=using_statements)]
+
+- Step 2: Create a `MistralAITokenCounterMiddleware` class which implements @AutoGen.Core.IMiddleware. This middleware will collect all the responses from the agent and sum up the token usage for each response.
+[!code-csharp[](../../sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs?name=token_counter_middleware)]
+
+- Step 3: Create a `MistralClientAgent`
+[!code-csharp[](../../sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs?name=create_mistral_client_agent)]
+
+- Step 4: Register the `MistralAITokenCounterMiddleware` with the `MistralClientAgent`. Note that the order of each middlewares matters. The token counter middleware needs to be registered before `mistralMessageConnector` because it collects response only when the responding message type is `IMessage<ChatCompletionResponse>` while the `mistralMessageConnector` will convert `IMessage<ChatCompletionResponse>` to one of @AutoGen.Core.TextMessage, @AutoGen.Core.ToolCallMessage or @AutoGen.Core.ToolCallResultMessage.
+[!code-csharp[](../../sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs?name=register_middleware)]
+
+- Step 5: Chat with the `MistralClientAgent` and get the token usage information from the response object.
+[!code-csharp[](../../sample/AutoGen.BasicSamples/Example14_MistralClientAgent_TokenCount.cs?name=chat_with_agent)]
+
+### Output
+When running the example, the completion token count will be printed to the console.
+```bash
+Completion token count: 1408 # might be different based on the response
+```

--- a/dotnet/website/articles/MistralChatAgent-use-function-call.md
+++ b/dotnet/website/articles/MistralChatAgent-use-function-call.md
@@ -1,0 +1,41 @@
+## Use tool in MistralChatAgent
+
+The following example shows how to enable tool support in @AutoGen.Mistral.MistralClientAgent by creating a `GetWeatherAsync` function and passing it to the agent.
+
+Firstly, you need to install the following packages:
+```bash
+dotnet add package AutoGen.Mistral
+dotnet add package AutoGen.SourceGenerator
+```
+
+> [!Note]
+> Tool support is only available in some mistral models. Please refer to the [link](https://docs.mistral.ai/capabilities/function_calling/#available-models) for tool call support in mistral models.
+
+> [!Note]
+> The `AutoGen.SourceGenerator` package carries a source generator that adds support for type-safe function definition generation. For more information, please check out [Create type-safe function](./Create-type-safe-function-call.md).
+
+> [!NOTE]
+> If you are using VSCode as your editor, you may need to restart the editor to see the generated code.
+
+Import the required namespace
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=using_statement)]
+
+Then define a public partial `MistralAgentFunction` class and `GetWeather` method. The `GetWeather` method is a simple function that returns the weather of a given location that marked with @AutoGen.Core.FunctionAttribute. Marking the class as `public partial` together with the @AutoGen.Core.FunctionAttribute attribute allows the source generator to generate the @AutoGen.Core.FunctionContract for the `GetWeather` method.
+
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=weather_function)]
+
+Then create an @AutoGen.Mistral.MistralClientAgent and register it with @AutoGen.Mistral.Extension.MistralAgentExtension.RegisterMessageConnector* so it can support @AutoGen.Core.ToolCallMessage and @AutoGen.Core.ToolCallResultMessage. These message types are necessary to use @AutoGen.Core.FunctionCallMiddleware, which provides support for processing and invoking function calls.
+
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=create_mistral_function_call_agent)]
+
+Then create an @AutoGen.Core.FunctionCallMiddleware with `GetWeather` function When creating the middleware, we also pass a `functionMap` object which means the function will be automatically invoked when the agent replies a `GetWeather` function call.
+
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=create_get_weather_function_call_middleware)]
+
+After the function call middleware is created, register it with the agent so the `GetWeather` function will be passed to agent during chat completion.
+
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=register_function_call_middleware)]
+
+Finally, you can chat with the @AutoGen.Mistral.MistralClientAgent about weather! The agent will automatically invoke the `GetWeather` function to "get" the weather information and return the result.
+
+[!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/MistralAICodeSnippet.cs?name=send_message_with_function_call)]

--- a/dotnet/website/articles/OpenAIChatAgent-use-function-call.md
+++ b/dotnet/website/articles/OpenAIChatAgent-use-function-call.md
@@ -17,7 +17,7 @@ Firstly, you need to install the following packages:
 Firstly, import the required namespaces:
 [!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
 
-Then, create a `GetWeather` function and pass it to @AutoGen.OpenAI.OpenAIChatAgent:
+Then, define a public partial class: `Function` with `GetWeather` method
 [!code-csharp[](../../sample/AutoGen.BasicSamples/CodeSnippet/OpenAICodeSnippet.cs?name=weather_function)]
 
 Then, create an @AutoGen.OpenAI.OpenAIChatAgent and register it with @AutoGen.OpenAI.OpenAIChatRequestMessageConnector so it can support @AutoGen.Core.ToolCallMessage and @AutoGen.Core.ToolCallResultMessage. These message types are necessary to use @AutoGen.Core.FunctionCallMiddleware, which provides support for processing and invoking function calls.

--- a/dotnet/website/articles/toc.yml
+++ b/dotnet/website/articles/toc.yml
@@ -79,12 +79,8 @@
       href: AutoGen-Mistral-Overview.md
     - name: Examples
       items:
-        - name: Simple chat and streaming chat
-          href: MistralChatAgent-simple-chat.md
         - name: Use function call in MistralChatAgent
           href: MistralChatAgent-use-function-call.md
-        - name: Use json mode in MistralChatAgent
-          href: MistralChatAgent-use-json-mode.md
         - name: Count token usage in MistralChatAgent
           href: MistralChatAgent-count-token-usage.md
 

--- a/dotnet/website/articles/toc.yml
+++ b/dotnet/website/articles/toc.yml
@@ -73,6 +73,20 @@
       href: SemanticKernelAgent-simple-chat.md
     - name: Use SemanticKernelChatMessageContentConnector to support more AutoGen built-in messages
       href: SemanticKernelAgent-support-more-messages.md
+- name: AutoGen.Mistral
+  items:
+    - name: Overview
+      href: AutoGen-Mistral-Overview.md
+    - name: Examples
+      items:
+        - name: Simple chat and streaming chat
+          href: MistralChatAgent-simple-chat.md
+        - name: Use function call in MistralChatAgent
+          href: MistralChatAgent-use-function-call.md
+        - name: Use json mode in MistralChatAgent
+          href: MistralChatAgent-use-json-mode.md
+        - name: Count token usage in MistralChatAgent
+          href: MistralChatAgent-count-token-usage.md
 
 - name: AutoGen.LMStudio
   items:

--- a/dotnet/website/update.md
+++ b/dotnet/website/update.md
@@ -1,3 +1,6 @@
+##### Update on 0.0.12 (2024-04-22)
+- Add AutoGen.Mistral package to support Mistral.AI models
+
 ##### Update on 0.0.11 (2024-04-10)
 - Add link to Discord channel in nuget's readme.md
 - Document improvements


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds some mistral examples plus documents to autogen dotnet website.

It also simplify the message connector configuration by providing `RegisterMessageConnector` for `OpenAIChatAgent` and `SemanticKernelAgent`

## Related issue number

#2302 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
