### PR TITLE
Update Orchestrator MMSurfer settings to match those used in TwoAgents

### DIFF
--- a/samples/tools/autogenbench/scenarios/WebArena/Templates/Orchestrator/scenario.py
+++ b/samples/tools/autogenbench/scenarios/WebArena/Templates/Orchestrator/scenario.py
@@ -78,15 +78,15 @@ web_surfer = MultimodalWebSurferAgent(
     headless=True,
     browser_channel="chromium",
     browser_data_dir=None,
-    start_page="https://bing.com",
-    debug_dir=os.path.join(os.path.dirname(__file__), "debug"),
+    start_page=HOMEPAGE,
+    debug_dir=os.getenv("WEB_SURFER_DEBUG_DIR", None),
 )
 
 maestro = Orchestrator(
     "orchestrator",
     agents=[assistant, user_proxy, web_surfer],
     llm_config=llm_config,
-    response_format_is_supported=True,
+    response_format_is_supported=False,
 )
 
 # Login to the necessary websites


### PR DESCRIPTION
## Why are these changes needed?

Update Orchestrator MMSurfer settings to match those used in TwoAgents

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
