### PR TITLE
[.Net] Add Ollama Support

### DIFF
--- a/dotnet/sample/AutoGen.BasicSamples/Example15_Ollama.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example15_Ollama.cs
@@ -1,0 +1,33 @@
+﻿using AutoGen.Core;
+using AutoGen.Ollama;
+
+namespace AutoGen.BasicSample;
+
+public class Example15_Ollama
+{
+    public static async Task RunAsync()
+    {
+        var config = new OllamaConfig("localhost", 11434);
+
+        // create assistant agent
+        // You can specify any model Ollama supports.
+        // See list here: https://ollama.com/library
+        // Just make sure you "pull" the model using "ollama pull" first.
+        var assistantAgent = new OllamaAgent("asssistant", config: config, "llama3")
+            .RegisterPrintMessage();
+
+        // set human input mode to ALWAYS so that user always provide input
+        var userProxyAgent = new UserProxyAgent(
+            name: "user",
+            humanInputMode: HumanInputMode.ALWAYS)
+            .RegisterPrintMessage();
+
+        // start the conversation
+        await userProxyAgent.InitiateChatAsync(
+            receiver: assistantAgent,
+            message: "Why is the sky blue?",
+            maxRound: 10);
+
+        Console.WriteLine("Thanks for using Ollama. https://ollama.com/blog/");
+    }
+}

--- a/dotnet/src/AutoGen.Ollama/AutoGen.Ollama.csproj
+++ b/dotnet/src/AutoGen.Ollama/AutoGen.Ollama.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>AutoGen.Ollama</RootNamespace>
+  </PropertyGroup>
+
+  <Import Project="$(RepoRoot)/dotnet/nuget/nuget-package.props" />
+
+  <PropertyGroup>
+    <!-- NuGet Package Settings -->
+    <Title>AutoGen.Ollama</Title>
+    <Description>
+      Provide support for consuming Ollama openai-like API service in AutoGen
+    </Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoGen.Core\AutoGen.Core.csproj" />
+    <ProjectReference Include="..\AutoGen.OpenAI\AutoGen.OpenAI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/AutoGen.Ollama/GlobalUsing.cs
+++ b/dotnet/src/AutoGen.Ollama/GlobalUsing.cs
@@ -1,0 +1,4 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// GlobalUsing.cs
+
+global using AutoGen.Core;

--- a/dotnet/src/AutoGen.Ollama/OllamaAgent.cs
+++ b/dotnet/src/AutoGen.Ollama/OllamaAgent.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// OllamaAgent.cs
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoGen.OpenAI;
+using Azure.AI.OpenAI;
+using Azure.Core.Pipeline;
+using Azure.Core;
+
+namespace AutoGen.Ollama;
+
+/// <summary>
+/// agent that consumes local server from LM Studio
+/// </summary>
+/// <example>
+/// [!code-csharp[OllamaAgent](../../sample/AutoGen.BasicSamples/Example08_Ollama.cs?name=Ollama_example_1)]
+/// </example>
+public class OllamaAgent : IAgent
+{
+    private readonly GPTAgent innerAgent;
+
+    public OllamaAgent(
+        string name,
+        OllamaConfig config,
+        string modelName = "llama3:latest",
+        string systemMessage = "You are a helpful AI assistant",
+        float temperature = 0.7f,
+        int maxTokens = 1024,
+        IEnumerable<FunctionDefinition>? functions = null,
+        IDictionary<string, Func<string, Task<string>>>? functionMap = null)
+    {
+        var client = ConfigOpenAIClientForOllama(config);
+        innerAgent = new GPTAgent(
+            name: name,
+            modelName: modelName,
+            systemMessage: systemMessage,
+            openAIClient: client,
+            temperature: temperature,
+            maxTokens: maxTokens,
+            functions: functions,
+            functionMap: functionMap);
+    }
+
+    public string Name => innerAgent.Name;
+
+    public Task<IMessage> GenerateReplyAsync(
+        IEnumerable<IMessage> messages,
+        GenerateReplyOptions? options = null,
+        System.Threading.CancellationToken cancellationToken = default)
+    {
+        return innerAgent.GenerateReplyAsync(messages, options, cancellationToken);
+    }
+
+    private OpenAIClient ConfigOpenAIClientForOllama(OllamaConfig config)
+    {
+        // create uri from host and port
+        var uri = config.Uri;
+        var accessToken = new AccessToken(string.Empty, DateTimeOffset.Now.AddDays(180));
+        var tokenCredential = DelegatedTokenCredential.Create((_, _) => accessToken);
+        var openAIClient = new OpenAIClient(uri, tokenCredential);
+
+        // remove authenication header from pipeline
+        var pipeline = HttpPipelineBuilder.Build(
+            new OpenAIClientOptions(OpenAIClientOptions.ServiceVersion.V2022_12_01),
+            Array.Empty<HttpPipelinePolicy>(),
+            [],
+            new ResponseClassifier());
+
+        // use reflection to override _pipeline field
+        var field = typeof(OpenAIClient).GetField("_pipeline", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        field.SetValue(openAIClient, pipeline);
+
+        // use reflection to set _isConfiguredForAzureOpenAI to false
+        var isConfiguredForAzureOpenAIField = typeof(OpenAIClient).GetField("_isConfiguredForAzureOpenAI", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        isConfiguredForAzureOpenAIField.SetValue(openAIClient, false);
+
+        return openAIClient;
+    }
+}

--- a/dotnet/src/AutoGen.Ollama/OllamaConfig.cs
+++ b/dotnet/src/AutoGen.Ollama/OllamaConfig.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+/// <summary>
+/// Add support for consuming openai-like API from LM Studio
+/// </summary>
+public class OllamaConfig : ILLMConfig
+{
+    public OllamaConfig(string host, int port, int version = 1)
+    {
+        this.Host = host;
+        this.Port = port;
+        this.Version = version;
+    }
+
+    public string Host { get; }
+
+    public int Port { get; }
+
+    public int Version { get; }
+
+    public Uri Uri => new Uri($"http://{Host}:{Port}/v{Version}");
+}

--- a/dotnet/src/AutoGen.Ollama/README.md
+++ b/dotnet/src/AutoGen.Ollama/README.md
@@ -1,0 +1,45 @@
+## AutoGen.LMStudio
+
+This package provides support for consuming openai-like API from Ollama local server.
+
+## Installation
+To use `AutoGen.Ollama`, add the following package to your `.csproj` file:
+
+```xml
+<ItemGroup>
+    <PackageReference Include="AutoGen.Ollama" Version="AUTOGEN_VERSION" />
+</ItemGroup>
+```
+
+## Usage
+```csharp
+sing AutoGen;
+using AutoGen.Core;
+using AutoGen.Ollama;
+
+var config = new OllamaConfig("localhost", 11434);
+
+// You can specify any model Ollama supports.
+// See list here: https://ollama.com/library
+// Just make sure you "pull" the model using "ollama pull" first.
+var assistantAgent = new OllamaAgent("asssistant", config: config, "llama3")
+    .RegisterPrintMessage();
+
+// set human input mode to ALWAYS so that user always provide input
+var userProxyAgent = new UserProxyAgent(
+    name: "user",
+    humanInputMode: HumanInputMode.ALWAYS)
+    .RegisterPrintMessage();
+
+// start the conversation
+await userProxyAgent.InitiateChatAsync(
+    receiver: assistantAgent,
+    message: "Why is the sky blue?",
+    maxRound: 10);
+
+Console.WriteLine("Thanks for using Ollama. https://ollama.com/blog/");
+
+
+## Update history
+### Update on 0.0.7 (2024-02-11)
+- Add `OllamaAgent` to support consuming openai-like API from Ollama local server.

--- a/dotnet/src/AutoGen.Ollama/README.md
+++ b/dotnet/src/AutoGen.Ollama/README.md
@@ -1,4 +1,4 @@
-## AutoGen.LMStudio
+## AutoGen.Ollama
 
 This package provides support for consuming openai-like API from Ollama local server.
 
@@ -13,7 +13,6 @@ To use `AutoGen.Ollama`, add the following package to your `.csproj` file:
 
 ## Usage
 ```csharp
-sing AutoGen;
 using AutoGen.Core;
 using AutoGen.Ollama;
 
@@ -38,8 +37,3 @@ await userProxyAgent.InitiateChatAsync(
     maxRound: 10);
 
 Console.WriteLine("Thanks for using Ollama. https://ollama.com/blog/");
-
-
-## Update history
-### Update on 0.0.7 (2024-02-11)
-- Add `OllamaAgent` to support consuming openai-like API from Ollama local server.

--- a/dotnet/src/AutoGen.OpenAI/Agent/GPTAgent.cs
+++ b/dotnet/src/AutoGen.OpenAI/Agent/GPTAgent.cs
@@ -66,6 +66,31 @@ public class GPTAgent : IStreamingAgent
 
     public GPTAgent(
         string name,
+        string modelName,
+        string systemMessage,
+        ILLMConfig config,
+        float temperature = 0.7f,
+        int maxTokens = 1024,
+        int? seed = null,
+        ChatCompletionsResponseFormat? responseFormat = null,
+        IEnumerable<FunctionDefinition>? functions = null,
+        IDictionary<string, Func<string, Task<string>>>? functionMap = null)
+    {
+        openAIClient = config switch
+        {
+            AzureOpenAIConfig azureConfig => new OpenAIClient(new Uri(azureConfig.Endpoint), new Azure.AzureKeyCredential(azureConfig.ApiKey)),
+            OpenAIConfig openAIConfig => new OpenAIClient(openAIConfig.ApiKey),
+            _ => throw new ArgumentException($"Unsupported config type {config.GetType()}"),
+        };
+
+        this.modelName = modelName;
+        _innerAgent = new OpenAIChatAgent(openAIClient, name, modelName, systemMessage, temperature, maxTokens, seed, responseFormat, functions);
+        Name = name;
+        this.functionMap = functionMap;
+    }
+
+    public GPTAgent(
+        string name,
         string systemMessage,
         OpenAIClient openAIClient,
         string modelName,

--- a/dotnet/src/AutoGen/AutoGen.csproj
+++ b/dotnet/src/AutoGen/AutoGen.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net.Generation" Version="$(JsonSchemaVersion)" />
     <ProjectReference Include="..\AutoGen.LMStudio\AutoGen.LMStudio.csproj" />
+        <ProjectReference Include="..\AutoGen.Ollama\AutoGen.Ollama.csproj" />
     <ProjectReference Include="..\AutoGen.Mistral\AutoGen.Mistral.csproj" />
     <ProjectReference Include="..\AutoGen.SemanticKernel\AutoGen.SemanticKernel.csproj" />
     <ProjectReference Include="..\AutoGen.SourceGenerator\AutoGen.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Added support for [Ollama](https://www.ollama.com). Ollama allows you to run Llama 3, Phi 3, Mistral, Gemma, and other models locally. 

This is basic support and utilizes Ollama's OpenAI compatibility. More robust support can be added in a future release. The current model is heavily based on Azure's OpenAI service. I'd be happy to collaborate on a reviewing a future implementation that allows support for more LLM hosting options, and specifics.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
