### PR TITLE
use conditional check to replace path filter in build and dotnet-ci workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,6 @@ name: Build
 on:
   push:
     branches: ["main"]
-    paths:
-      - "autogen/**"
-      - "test/**"
-      - ".github/workflows/build.yml"
-      - "setup.py"
   pull_request:
     branches: ["main"]
   merge_group:
@@ -21,7 +16,39 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 permissions: {}
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      hasChanges: ${{ steps.filter.outputs.autogen || steps.filter.outputs.test || steps.filter.outputs.workflows || steps.filter.outputs.setup }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            autogen:
+              - "autogen/**"
+            test:
+              - "test/**"
+            workflows:
+              - ".github/workflows/build.yml"
+            setup:
+              - "setup.py"
+      - name: autogen has changes
+        run: echo "autogen has changes"
+        if: steps.filter.outputs.autogen
+      - name: test has changes
+        run: echo "test has changes"
+        if: steps.filter.outputs.test
+      - name: workflows has changes
+        run: echo "workflows has changes"
+        if: steps.filter.outputs.workflows
+      - name: setup has changes
+        run: echo "setup has changes"
+        if: steps.filter.outputs.setup
   build:
+    needs: paths-filter
+    if: needs.paths-filter.outputs.hasChanges == 'true'
     runs-on: ${{ matrix.os }}
     env:
       AUTOGEN_USE_DOCKER: ${{ matrix.os != 'ubuntu-latest'  && 'False' }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -7,8 +7,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'dotnet/**'
   push:
     branches: [ "main" ]
 
@@ -21,9 +19,26 @@ permissions:
   packages: write
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      hasChanges: ${{ steps.filter.outputs.dotnet }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            dotnet:
+              - "dotnet/**"
+      - name: dotnet has changes
+        run: echo "dotnet has changes"
+        if: steps.filter.outputs.dotnet
   build:
     name: Dotnet Build
     runs-on: ubuntu-latest
+    needs: paths-filter
+    if: needs.paths-filter.outputs.hasChanges == 'true'
     defaults:
       run:
         working-directory: dotnet


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Conditional check would make a  workflow return as completed instead of canceled. This allows PRs which doesn't make change to specific paths also meet the check status requirement (like #2545)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
