### PR TITLE
Adding an action to set workflow as success when no change is made in target paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ jobs:
               - "autogen/**"
             test:
               - "test/**"
-            workflows:
-              - ".github/workflows/build.yml"
             setup:
               - "setup.py"
       - name: autogen has changes
@@ -40,9 +38,6 @@ jobs:
       - name: test has changes
         run: echo "test has changes"
         if: steps.filter.outputs.test == 'true'
-      - name: workflows has changes
-        run: echo "workflows has changes"
-        if: steps.filter.outputs.workflows == 'true'
       - name: setup has changes
         run: echo "setup has changes"
         if: steps.filter.outputs.setup == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
         if: steps.filter.outputs.setup == 'true'
   build:
     needs: paths-filter
-    if: needs.paths-filter.outputs.hasChanges == 'true'
     runs-on: ${{ matrix.os }}
     env:
       AUTOGEN_USE_DOCKER: ${{ matrix.os != 'ubuntu-latest'  && 'False' }}
@@ -63,6 +62,9 @@ jobs:
           - os: macos-latest
             python-version: "3.9"
     steps:
+      - name: Exit early if hasChanges is false
+        run: exit 0
+        if: needs.paths-filter.outputs.hasChanges != 'true'
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
         if: steps.filter.outputs.setup == 'true'
   build:
     needs: paths-filter
+    if: needs.paths-filter.outputs.hasChanges == 'true'
     runs-on: ${{ matrix.os }}
     env:
       AUTOGEN_USE_DOCKER: ${{ matrix.os != 'ubuntu-latest'  && 'False' }}
@@ -57,9 +58,6 @@ jobs:
           - os: macos-latest
             python-version: "3.9"
     steps:
-      - name: Exit early if hasChanges is false
-        run: exit 0
-        if: needs.paths-filter.outputs.hasChanges != 'true'
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -106,3 +104,32 @@ jobs:
         with:
           file: ./coverage.xml
           flags: unittests
+  build-check:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Get Date
+        shell: bash
+        run: |
+          echo "date=$(date +'%m/%d/%Y %H:%M:%S')" >> "$GITHUB_ENV"
+
+      - name: Run Type is ${{ github.event_name }}
+        if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'}}
+        shell: bash
+        run: |
+          echo "run_type=${{ github.event_name }}" >> "$GITHUB_ENV"
+
+      - name: Fail workflow if build failed
+        id: check_build_failed
+        if: contains(join(needs.*.result, ','), 'failure')
+        uses: actions/github-script@v6
+        with:
+          script: core.setFailed('Build Failed!')
+
+      - name: Fail workflow if build cancelled
+        id: check_build_cancelled
+        if: contains(join(needs.*.result, ','), 'cancelled')
+        uses: actions/github-script@v6
+        with:
+          script: core.setFailed('Build Cancelled!')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,4 +111,3 @@ jobs:
         with:
           file: ./coverage.xml
           flags: unittests
-          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
               - "autogen/**"
             test:
               - "test/**"
+            workflows:
+              - ".github/workflows/**"
             setup:
               - "setup.py"
       - name: autogen has changes
@@ -38,6 +40,9 @@ jobs:
       - name: test has changes
         run: echo "test has changes"
         if: steps.filter.outputs.test == 'true'
+      - name: workflows has changes
+        run: echo "workflows has changes"
+        if: steps.filter.outputs.workflows == 'true'
       - name: setup has changes
         run: echo "setup has changes"
         if: steps.filter.outputs.setup == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,3 +111,4 @@ jobs:
         with:
           file: ./coverage.xml
           flags: unittests
+          

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -67,7 +67,7 @@ jobs:
     defaults:
       run:
         working-directory: dotnet
-    if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dotnet')
+    if: success() && (github.ref == 'refs/heads/main')
     needs: build
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR add a `build_check` job to track the succeed of build and its derived actions.
### When no files has changed under path-filter 

![image](https://github.com/microsoft/autogen/assets/16876986/8afbc701-4f6d-4a88-8b16-4a607ad22086)

### When file changed under path filter

![image](https://github.com/microsoft/autogen/assets/16876986/7ffd4fbe-f18b-4c99-abba-7caa9bd949b5)


<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
