### PR TITLE
PGVector Support for Custom Connection Object

### DIFF
--- a/autogen/agentchat/contrib/vectordb/pgvectordb.py
+++ b/autogen/agentchat/contrib/vectordb/pgvectordb.py
@@ -610,7 +610,7 @@ class PGVectorDB(VectorDB):
                     host=host,
                     port=port,
                     dbname=dbname,
-                    username=username,
+                    user=username,
                     password=password,
                     connect_timeout=connect_timeout,
                     autocommit=True,

--- a/test/agentchat/contrib/vectordb/test_pgvectordb.py
+++ b/test/agentchat/contrib/vectordb/test_pgvectordb.py
@@ -24,12 +24,32 @@ reason = "do not run on MacOS or windows OR dependency is not installed OR " + r
     reason=reason,
 )
 def test_pgvector():
-    # test create collection
+    # test create collection with connection_string authentication
     db_config = {
         "connection_string": "postgresql://postgres:postgres@localhost:5432/postgres",
     }
 
     db = PGVectorDB(connection_string=db_config["connection_string"])
+    collection_name = "test_collection"
+    collection = db.create_collection(collection_name=collection_name, overwrite=True, get_or_create=True)
+    assert collection.name == collection_name
+
+    # test create collection with basic authentication
+    db_config = {
+        "username": "postgres",
+        "password": "postgres",
+        "host": "localhost",
+        "port": 5432,
+        "dbname": "postgres",
+    }
+
+    db = PGVectorDB(
+        username=db_config["username"],
+        password=db_config["password"],
+        port=db_config["port"],
+        host=db_config["host"],
+        dbname=db_config["dbname"],
+    )
     collection_name = "test_collection"
     collection = db.create_collection(collection_name=collection_name, overwrite=True, get_or_create=True)
     assert collection.name == collection_name


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR contains adding support for custom psycopg connections. 

A user can define the connection: 

```
conn = psycopg.connect(conninfo=connection_string_encoded, autocommit=True)

ragproxyagent = RetrieveUserProxyAgent(
    name="ragproxyagent",
    human_input_mode="NEVER",
    max_consecutive_auto_reply=1,
    retrieve_config={
        "task": "code",
        "docs_path": [
            "https://raw.githubusercontent.com/microsoft/FLAML/main/website/docs/Examples/Integrate%20-%20Spark.md",
            "https://raw.githubusercontent.com/microsoft/FLAML/main/website/docs/Research.md",
            os.path.join(os.path.abspath(""), "..", "website", "docs"),
        ],
        "custom_text_types": ["non-existent-type"],
        "chunk_token_size": 2000,
        "model": config_list[0]["model"],
        "vector_db": "pgvector",  # PGVector database
        "db_config": {
            "conn": psycopg.connect(conninfo=postgresql://postgres:postgres@localhost:5432/postgres)
        },
        "get_or_create": True,  # set to False if you don't want to reuse an existing collection
        "overwrite": False,  # set to True if you want to overwrite an existing collection
    },
    code_execution_config=False,  # set to False if you don't want to execute the code
)

```

And pass that into the db_config for the retrieve agent.

This also contains a fix for the psycopg.connect() using the username field directly.

## Related issue number

NA

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
