### PR TITLE
indentation fix to allow assistant agent skills to be generated. reso…

### DIFF
--- a/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
@@ -169,16 +169,16 @@ class AutoGenWorkFlowManager:
             code_execution_config["use_docker"] = False
             agent_spec.config.code_execution_config = code_execution_config
 
-            if agent_spec.skills:
-                # get skill prompt, also write skills to a file named skills.py
-                skills_prompt = ""
-                skills_prompt = get_skills_from_prompt(agent_spec.skills, self.work_dir)
-                if agent_spec.config.system_message:
-                    agent_spec.config.system_message = agent_spec.config.system_message + "\n\n" + skills_prompt
-                else:
-                    agent_spec.config.system_message = (
-                        get_default_system_message(agent_spec.type) + "\n\n" + skills_prompt
-                    )
+        if agent_spec.skills:
+            # get skill prompt, also write skills to a file named skills.py
+            skills_prompt = ""
+            skills_prompt = get_skills_from_prompt(agent_spec.skills, self.work_dir)
+            if agent_spec.config.system_message:
+                agent_spec.config.system_message = agent_spec.config.system_message + "\n\n" + skills_prompt
+            else:
+                agent_spec.config.system_message = (
+                    get_default_system_message(agent_spec.type) + "\n\n" + skills_prompt
+                )
 
         return agent_spec
 

--- a/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
@@ -176,9 +176,7 @@ class AutoGenWorkFlowManager:
             if agent_spec.config.system_message:
                 agent_spec.config.system_message = agent_spec.config.system_message + "\n\n" + skills_prompt
             else:
-                agent_spec.config.system_message = (
-                    get_default_system_message(agent_spec.type) + "\n\n" + skills_prompt
-                )
+                agent_spec.config.system_message = get_default_system_message(agent_spec.type) + "\n\n" + skills_prompt
 
         return agent_spec
 


### PR DESCRIPTION
…lves #2506, resolves #2318, resolves #2029

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
@victordibia @ekzhu 

## Why are these changes needed?

Function `get_skills_from_prompt` was not being reach by assistant type agents, since this logic was nested by `if agent_spec.config.code_execution_config is not False:` which will never be true for assistants and only for user proxy agents.

While investigating, looks like this was introduced on v0.2.20

## Related issue number

resolves #2506, resolves #2318, resolves #2029

## Checks

-  [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
