### PR TITLE
Correct link to Jupyter Code Executor in code-executors.ipynb

### DIFF
--- a/website/docs/tutorial/code-executors.ipynb
+++ b/website/docs/tutorial/code-executors.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "In this chapter, we will focus on the command line code executors.\n",
     "For the Jupyter code executor, please refer to the topic page for \n",
-    "[Jupyter Code Executor](../topics/code-execution/jupyter-code-executor)."
+    "[Jupyter Code Executor](../../topics/code-execution/jupyter-code-executor)."
    ]
   },
   {
@@ -674,7 +674,7 @@
     "Contrast to the command line code executor, the Jupyter code executor\n",
     "runs all code blocks in the same Jupyter kernel, which keeps the state\n",
     "in memory between executions.\n",
-    "See the topic page for [Jupyter Code Executor](../topics/code-execution/jupyter-code-executor).\n",
+    "See the topic page for [Jupyter Code Executor](../../topics/code-execution/jupyter-code-executor).\n",
     "\n",
     "The choice between command line and Jupyter code executor depends on the\n",
     "nature of the code blocks in agents' conversation.\n",

--- a/website/docs/tutorial/code-executors.ipynb
+++ b/website/docs/tutorial/code-executors.ipynb
@@ -674,7 +674,7 @@
     "Contrast to the command line code executor, the Jupyter code executor\n",
     "runs all code blocks in the same Jupyter kernel, which keeps the state\n",
     "in memory between executions.\n",
-    "See the topic page for [Jupyter Code Executor](../../topics/code-execution/jupyter-code-executor).\n",
+    "See the topic page for [Jupyter Code Executor](/docs/topics/code-execution/jupyter-code-executor).\n",
     "\n",
     "The choice between command line and Jupyter code executor depends on the\n",
     "nature of the code blocks in agents' conversation.\n",

--- a/website/docs/tutorial/code-executors.ipynb
+++ b/website/docs/tutorial/code-executors.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "In this chapter, we will focus on the command line code executors.\n",
     "For the Jupyter code executor, please refer to the topic page for \n",
-    "[Jupyter Code Executor](../../topics/code-execution/jupyter-code-executor)."
+    "[Jupyter Code Executor](/docs/topics/code-execution/jupyter-code-executor)."
    ]
   },
   {


### PR DESCRIPTION
The link to the Jupyter code executor was referencing the wrong path.
Current: https://microsoft.github.io/autogen/docs/tutorial/topics/code-execution/jupyter-code-executor
Fixed: https://microsoft.github.io/autogen/docs/topics/code-execution/jupyter-code-executor

## Reviewer
@ekzhu 


## Why are these changes needed?

The link to the Jupyter Code Executor is broken

## Related issue number
Closes #2588 

## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
