### PR TITLE
Update to correct pip install for litellm

### DIFF
--- a/website/docs/topics/non-openai-models/local-litellm-ollama.md
+++ b/website/docs/topics/non-openai-models/local-litellm-ollama.md
@@ -18,7 +18,7 @@ Note: We recommend using a virtual environment for your stack, see [this article
 Install LiteLLM with the proxy server functionality:
 
 ```bash
-pip install litellm[proxy]
+pip install 'litellm[proxy]'
 ```
 
 Note: If using Windows, run LiteLLM and Ollama within a [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is because the default command mentioned for pip install of litellm does not work. The doc mentions `pip install litellm[proxy]` which won't work. The correct command is  `pip install 'litellm[proxy]'`.

## Related issue number

Nothing.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
