### PR TITLE
Optionally use Azure for webarena evaluation

### DIFF
--- a/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/evaluators.py
+++ b/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/evaluators.py
@@ -177,12 +177,14 @@ class StringEvaluator(Evaluator):
                                 intent=configs["intent"],
                                 ref=configs["eval"]["string_note"],
                                 pred=pred,
-                                azure_config=azure_config
+                                azure_config=azure_config,
                             )
                     else:
                         assert isinstance(value, list)
                         for reference in value:
-                            score *= self.fuzzy_match(ref=reference, pred=pred, intent=intent, azure_config=azure_config)
+                            score *= self.fuzzy_match(
+                                ref=reference, pred=pred, intent=intent, azure_config=azure_config
+                            )
         return score
 
 

--- a/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/evaluators.py
+++ b/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/evaluators.py
@@ -64,6 +64,7 @@ class Evaluator(object):
         config_file: Path | str,
         page: Page | PseudoPage,
         client: CDPSession,
+        azure_config: dict[str, Any] | None = None,
     ) -> float:
         raise NotImplementedError
 
@@ -127,13 +128,13 @@ class StringEvaluator(Evaluator):
 
     @staticmethod
     @beartype
-    def fuzzy_match(ref: str, pred: str, intent: str) -> float:
-        return llm_fuzzy_match(pred, ref, intent)
+    def fuzzy_match(ref: str, pred: str, intent: str, azure_config: dict[str, Any] | None) -> float:
+        return llm_fuzzy_match(pred, ref, intent, azure_config)
 
     @staticmethod
     @beartype
-    def ua_match(ref: str, pred: str, intent: str) -> float:
-        return llm_ua_match(pred, ref, intent)
+    def ua_match(ref: str, pred: str, intent: str, azure_config: dict[str, Any] | None) -> float:
+        return llm_ua_match(pred, ref, intent, azure_config)
 
     def __call__(
         self,
@@ -141,6 +142,7 @@ class StringEvaluator(Evaluator):
         config_file: Path | str,
         page: Page | PseudoPage | None = None,
         client: CDPSession | None = None,
+        azure_config: dict[str, Any] | None = None,
     ) -> float:
         with open(config_file, "r") as f:
             configs = json.load(f)
@@ -175,11 +177,12 @@ class StringEvaluator(Evaluator):
                                 intent=configs["intent"],
                                 ref=configs["eval"]["string_note"],
                                 pred=pred,
+                                azure_config=azure_config
                             )
                     else:
                         assert isinstance(value, list)
                         for reference in value:
-                            score *= self.fuzzy_match(ref=reference, pred=pred, intent=intent)
+                            score *= self.fuzzy_match(ref=reference, pred=pred, intent=intent, azure_config=azure_config)
         return score
 
 
@@ -193,6 +196,7 @@ class URLEvaluator(Evaluator):
         config_file: Path | str,
         page: Page | PseudoPage,
         client: CDPSession | None = None,
+        azure_config: dict[str, Any] | None = None,
     ) -> float:
         with open(config_file, "r") as f:
             configs = json.load(f)
@@ -256,6 +260,7 @@ class HTMLContentEvaluator(Evaluator):
         config_file: Path | str,
         page: Page | PseudoPage,
         client: CDPSession | None = None,
+        azure_config: dict[str, Any] | None = None,
     ) -> float:
         with open(config_file, "r") as f:
             configs = json.load(f)
@@ -343,10 +348,11 @@ class EvaluatorComb:
         config_file: Path | str,
         page: Page | PseudoPage,
         client: CDPSession,
+        azure_config: dict[str, Any] | None = None,
     ) -> float:
         score = 1.0
         for evaluator in self.evaluators:
-            cur_score = evaluator(trajectory, config_file, page, client)
+            cur_score = evaluator(trajectory, config_file, page, client, azure_config)
             score *= cur_score
         return score
 

--- a/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/openai_utils.py
+++ b/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/openai_utils.py
@@ -14,6 +14,9 @@ from openai import AsyncOpenAI, OpenAI
 
 client = None
 aclient = None
+if "OPENAI_API_KEY" not in os.environ and "OAI_CONFIG_LIST" not in os.environ:
+    raise ValueError("Neither OPENAI_API_KEY nor OAI_CONFIG_LIST is defined in the environment.")
+
 if "OPENAI_API_KEY" in os.environ:
     client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
     aclient = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])

--- a/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/openai_utils.py
+++ b/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/openai_utils.py
@@ -12,6 +12,8 @@ import aiolimiter
 import openai
 from openai import AsyncOpenAI, OpenAI
 
+client = None
+aclient = None
 if "OPENAI_API_KEY" in os.environ:
     client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
     aclient = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])

--- a/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/openai_utils.py
+++ b/samples/tools/autogenbench/scenarios/WebArena/Templates/Common/evaluation_harness/openai_utils.py
@@ -12,8 +12,9 @@ import aiolimiter
 import openai
 from openai import AsyncOpenAI, OpenAI
 
-client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
-aclient = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
+if "OPENAI_API_KEY" in os.environ:
+    client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+    aclient = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
 from tqdm.asyncio import tqdm_asyncio
 
 

--- a/samples/tools/autogenbench/scenarios/WebArena/Templates/Orchestrator/scenario.py
+++ b/samples/tools/autogenbench/scenarios/WebArena/Templates/Orchestrator/scenario.py
@@ -302,7 +302,7 @@ score = evaluator(
     config_file=config_file,
     page=page,
     client=cdp_session,
-    azure_config=llm_config
+    azure_config=llm_config,
 )
 
 if logging_enabled():

--- a/samples/tools/autogenbench/scenarios/WebArena/Templates/Orchestrator/scenario.py
+++ b/samples/tools/autogenbench/scenarios/WebArena/Templates/Orchestrator/scenario.py
@@ -292,12 +292,17 @@ page = web_surfer._page
 cdp_session = context.new_cdp_session(page)
 config_file = "full_task.json"
 
+import nltk
+
+nltk.download("punkt")
+
 evaluator = evaluation_harness.evaluator_router(config_file)
 score = evaluator(
     trajectory=evaluation_harness.make_answer_trajecotry(final_answer),
     config_file=config_file,
     page=page,
     client=cdp_session,
+    azure_config=llm_config
 )
 
 if logging_enabled():


### PR DESCRIPTION
Allows use of Azure endpoint for webarena evaluation.

One remaining issue that could be done in another PR: Startup checks for the existence of an openai key, even if its never used