### PR TITLE
Fix broken links in tool-use.ipynb

### DIFF
--- a/website/docs/tutorial/tool-use.ipynb
+++ b/website/docs/tutorial/tool-use.ipynb
@@ -734,10 +734,10 @@
     "the [OpenAI's Assistant](https://platform.openai.com/docs/assistants/how-it-works)\n",
     "which executes built-in tools internally.\n",
     "\n",
-    "To achieve this, you can use [nested chats](/docs/tutorial/conversation-patterns#nested-chats).\n",
+    "To achieve this, you can use [nested chats](/tutorial/conversation-patterns#nested-chats).\n",
     "Nested chats allow you to create \"internal monologues\" within an agent\n",
     "to call and execute tools. This works for code execution as well.\n",
-    "See [nested chats for tool use](/docs/notebooks/agentchat_nested_chats_chess) for an example."
+    "See [nested chats for tool use](/notebooks/agentchat_nested_chats_chess) for an example."
    ]
   },
   {


### PR DESCRIPTION
Removed unnecessary extra "docs/" which was causing links to be broken.

For example, one of the links that was fixed was: https://microsoft.github.io/autogen/docs/docs/tutorial/conversation-patterns#nested-chats

Afterwards it is:
https://microsoft.github.io/autogen/docs/tutorial/conversation-patterns#nested-chats

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
