### PR TITLE
[.Net] Fix #2660 and add tests for AutoGen.DotnetInteractive

### DIFF
--- a/dotnet/AutoGen.sln
+++ b/dotnet/AutoGen.sln
@@ -33,7 +33,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoGen.Mistral", "src\Auto
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoGen.Mistral.Tests", "test\AutoGen.Mistral.Tests\AutoGen.Mistral.Tests.csproj", "{15441693-3659-4868-B6C1-B106F52FF3BA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoGen.SemanticKernel.Tests", "test\AutoGen.SemanticKernel.Tests\AutoGen.SemanticKernel.Tests.csproj", "{1DFABC4A-8458-4875-8DCB-59F3802DAC65}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoGen.SemanticKernel.Tests", "test\AutoGen.SemanticKernel.Tests\AutoGen.SemanticKernel.Tests.csproj", "{1DFABC4A-8458-4875-8DCB-59F3802DAC65}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoGen.DotnetInteractive.Tests", "test\AutoGen.DotnetInteractive.Tests\AutoGen.DotnetInteractive.Tests.csproj", "{B61388CA-DC73-4B7F-A7B2-7B9A86C9229E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -93,6 +95,10 @@ Global
 		{1DFABC4A-8458-4875-8DCB-59F3802DAC65}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1DFABC4A-8458-4875-8DCB-59F3802DAC65}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DFABC4A-8458-4875-8DCB-59F3802DAC65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B61388CA-DC73-4B7F-A7B2-7B9A86C9229E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B61388CA-DC73-4B7F-A7B2-7B9A86C9229E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B61388CA-DC73-4B7F-A7B2-7B9A86C9229E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B61388CA-DC73-4B7F-A7B2-7B9A86C9229E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -111,6 +117,7 @@ Global
 		{6585D1A4-3D97-4D76-A688-1933B61AEB19} = {18BF8DD7-0585-48BF-8F97-AD333080CE06}
 		{15441693-3659-4868-B6C1-B106F52FF3BA} = {F823671B-3ECA-4AE6-86DA-25E920D3FE64}
 		{1DFABC4A-8458-4875-8DCB-59F3802DAC65} = {F823671B-3ECA-4AE6-86DA-25E920D3FE64}
+		{B61388CA-DC73-4B7F-A7B2-7B9A86C9229E} = {F823671B-3ECA-4AE6-86DA-25E920D3FE64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {93384647-528D-46C8-922C-8DB36A382F0B}

--- a/dotnet/NuGet.config
+++ b/dotnet/NuGet.config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources />

--- a/dotnet/eng/Version.props
+++ b/dotnet/eng/Version.props
@@ -10,7 +10,7 @@
         <FluentAssertionVersion>6.8.0</FluentAssertionVersion>
         <XUnitVersion>2.4.2</XUnitVersion>
         <MicrosoftNETTestSdkVersion>17.7.0</MicrosoftNETTestSdkVersion>
-        <MicrosoftDotnetInteractive>1.0.0-beta.23523.2</MicrosoftDotnetInteractive>
+        <MicrosoftDotnetInteractive>1.0.0-beta.24229.4</MicrosoftDotnetInteractive>
         <MicrosoftSourceLinkGitHubVersion>8.0.0</MicrosoftSourceLinkGitHubVersion>
         <JsonSchemaVersion>4.0.0</JsonSchemaVersion>
     </PropertyGroup>

--- a/dotnet/src/AutoGen.DotnetInteractive/AutoGen.DotnetInteractive.csproj
+++ b/dotnet/src/AutoGen.DotnetInteractive/AutoGen.DotnetInteractive.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>AutoGen.DotnetInteractive</RootNamespace>
@@ -19,7 +19,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-		<PackageReference Include="Microsoft.DotNet.Interactive.VisualStudio" Version="$(MicrosoftDotnetInteractive)" />
+    <PackageReference Include="Microsoft.DotNet.Interactive" Version="$(MicrosoftDotnetInteractive)" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -27,14 +27,12 @@
 	  <EmbeddedResource Include="RestoreInteractive.config" />
 	</ItemGroup>
 
-
-	<ItemGroup>
+  <ItemGroup>
 		<PackageReference Include="Azure.AI.OpenAI" Version="$(AzureOpenAIVersion)" />
 	</ItemGroup>
 
-
 	<ItemGroup>
-	  <ProjectReference Include="..\AutoGen\AutoGen.csproj" />
+	  <ProjectReference Include="..\AutoGen.Core\AutoGen.Core.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/dotnet/src/AutoGen.DotnetInteractive/AutoGen.DotnetInteractive.csproj
+++ b/dotnet/src/AutoGen.DotnetInteractive/AutoGen.DotnetInteractive.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>AutoGen.DotnetInteractive</RootNamespace>

--- a/dotnet/src/AutoGen.DotnetInteractive/InteractiveService.cs
+++ b/dotnet/src/AutoGen.DotnetInteractive/InteractiveService.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Reflection;
 using Microsoft.DotNet.Interactive;
-using Microsoft.DotNet.Interactive.App.Connection;
 using Microsoft.DotNet.Interactive.Commands;
 using Microsoft.DotNet.Interactive.Connection;
 using Microsoft.DotNet.Interactive.Events;

--- a/dotnet/src/AutoGen.DotnetInteractive/InteractiveService.cs
+++ b/dotnet/src/AutoGen.DotnetInteractive/InteractiveService.cs
@@ -40,7 +40,7 @@ public class InteractiveService : IDisposable
 
     public async Task<bool> StartAsync(string workingDirectory, CancellationToken ct = default)
     {
-        this.kernel = await this.CreateKernelAsync(workingDirectory, ct);
+        this.kernel = await this.CreateKernelAsync(workingDirectory, true, ct);
         return true;
     }
 
@@ -83,7 +83,51 @@ public class InteractiveService : IDisposable
         return await this.SubmitCommandAsync(command, ct);
     }
 
-    private async Task<Kernel> CreateKernelAsync(string workingDirectory, CancellationToken ct = default)
+    public bool RestoreDotnetInteractive()
+    {
+        this.WriteLine("Restore dotnet interactive tool");
+        // write RestoreInteractive.config from embedded resource to this.workingDirectory
+        var assembly = Assembly.GetAssembly(typeof(InteractiveService))!;
+        var resourceName = "AutoGen.DotnetInteractive.RestoreInteractive.config";
+        using (var stream = assembly.GetManifestResourceStream(resourceName)!)
+        using (var fileStream = File.Create(Path.Combine(this.installingDirectory, "RestoreInteractive.config")))
+        {
+            stream.CopyTo(fileStream);
+        }
+
+        // write dotnet-tool.json from embedded resource to this.workingDirectory
+
+        resourceName = "AutoGen.DotnetInteractive.dotnet-tools.json";
+        using (var stream2 = assembly.GetManifestResourceStream(resourceName)!)
+        using (var fileStream2 = File.Create(Path.Combine(this.installingDirectory, "dotnet-tools.json")))
+        {
+            stream2.CopyTo(fileStream2);
+        }
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"tool restore --configfile RestoreInteractive.config",
+            WorkingDirectory = this.installingDirectory,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = new Process { StartInfo = psi };
+        process.OutputDataReceived += this.PrintProcessOutput;
+        process.ErrorDataReceived += this.PrintProcessOutput;
+        process.Start();
+        process.BeginErrorReadLine();
+        process.BeginOutputReadLine();
+        process.WaitForExit();
+
+        return process.ExitCode == 0;
+    }
+
+    private async Task<Kernel> CreateKernelAsync(string workingDirectory, bool restoreWhenFail = true, CancellationToken ct = default)
     {
         try
         {
@@ -138,13 +182,13 @@ public class InteractiveService : IDisposable
 
             return compositeKernel;
         }
-        catch (CommandLineInvocationException ex) when (ex.Message.Contains("Cannot find a tool in the manifest file that has a command named 'dotnet-interactive'"))
+        catch (CommandLineInvocationException) when (restoreWhenFail)
         {
             var success = this.RestoreDotnetInteractive();
 
             if (success)
             {
-                return await this.CreateKernelAsync(workingDirectory, ct);
+                return await this.CreateKernelAsync(workingDirectory, false, ct);
             }
 
             throw;
@@ -173,50 +217,6 @@ public class InteractiveService : IDisposable
     private void WriteLine(string data)
     {
         this.Output?.Invoke(this, data);
-    }
-
-    private bool RestoreDotnetInteractive()
-    {
-        this.WriteLine("Restore dotnet interactive tool");
-        // write RestoreInteractive.config from embedded resource to this.workingDirectory
-        var assembly = Assembly.GetAssembly(typeof(InteractiveService))!;
-        var resourceName = "AutoGen.DotnetInteractive.RestoreInteractive.config";
-        using (var stream = assembly.GetManifestResourceStream(resourceName)!)
-        using (var fileStream = File.Create(Path.Combine(this.installingDirectory, "RestoreInteractive.config")))
-        {
-            stream.CopyTo(fileStream);
-        }
-
-        // write dotnet-tool.json from embedded resource to this.workingDirectory
-
-        resourceName = "AutoGen.DotnetInteractive.dotnet-tools.json";
-        using (var stream2 = assembly.GetManifestResourceStream(resourceName)!)
-        using (var fileStream2 = File.Create(Path.Combine(this.installingDirectory, "dotnet-tools.json")))
-        {
-            stream2.CopyTo(fileStream2);
-        }
-
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = $"tool restore --configfile RestoreInteractive.config",
-            WorkingDirectory = this.installingDirectory,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        using var process = new Process { StartInfo = psi };
-        process.OutputDataReceived += this.PrintProcessOutput;
-        process.ErrorDataReceived += this.PrintProcessOutput;
-        process.Start();
-        process.BeginErrorReadLine();
-        process.BeginOutputReadLine();
-        process.WaitForExit();
-
-        return process.ExitCode == 0;
     }
 
     private void PrintProcessOutput(object sender, DataReceivedEventArgs e)

--- a/dotnet/src/AutoGen.DotnetInteractive/dotnet-tools.json
+++ b/dotnet/src/AutoGen.DotnetInteractive/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "Microsoft.dotnet-interactive": {
-      "version": "1.0.431302",
+      "version": "1.0.522904",
       "commands": [
         "dotnet-interactive"
       ]

--- a/dotnet/test/AutoGen.DotnetInteractive.Tests/AutoGen.DotnetInteractive.Tests.csproj
+++ b/dotnet/test/AutoGen.DotnetInteractive.Tests/AutoGen.DotnetInteractive.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ApprovalTests" Version="$(ApprovalTestVersion)" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.console" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AutoGen.SourceGenerator\AutoGen.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\AutoGen.Tests\AutoGen.Tests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/test/AutoGen.DotnetInteractive.Tests/DotnetInteractiveServiceTest.cs
+++ b/dotnet/test/AutoGen.DotnetInteractive.Tests/DotnetInteractiveServiceTest.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// DotnetInteractiveServiceTest.cs
+
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AutoGen.DotnetInteractive.Tests;
+
+public class DotnetInteractiveServiceTest : IDisposable
+{
+    private ITestOutputHelper _output;
+    private InteractiveService _interactiveService;
+    private string _workingDir;
+
+    public DotnetInteractiveServiceTest(ITestOutputHelper output)
+    {
+        _output = output;
+        _workingDir = Path.Combine(Path.GetTempPath(), "test", Path.GetRandomFileName());
+        if (!Directory.Exists(_workingDir))
+        {
+            Directory.CreateDirectory(_workingDir);
+        }
+
+        _interactiveService = new InteractiveService(_workingDir);
+        _interactiveService.StartAsync(_workingDir, default).Wait();
+    }
+
+    public void Dispose()
+    {
+        _interactiveService.Dispose();
+    }
+
+    [Fact]
+    public async Task ItRunCSharpCodeSnippetTestsAsync()
+    {
+        var cts = new CancellationTokenSource();
+        var isRunning = await _interactiveService.StartAsync(_workingDir, cts.Token);
+
+        isRunning.Should().BeTrue();
+
+        _interactiveService.IsRunning().Should().BeTrue();
+
+        // test code snippet
+        var hello_world = @"
+Console.WriteLine(""hello world"");
+";
+
+        await this.TestCSharpCodeSnippet(_interactiveService, hello_world, "hello world");
+        await this.TestCSharpCodeSnippet(
+            _interactiveService,
+            code: @"
+Console.WriteLine(""hello world""
+",
+            expectedOutput: "Error: (2,32): error CS1026: ) expected");
+
+        await this.TestCSharpCodeSnippet(
+            service: _interactiveService,
+            code: "throw new Exception();",
+            expectedOutput: "Error: System.Exception: Exception of type 'System.Exception' was thrown");
+    }
+
+    [Fact]
+    public async Task ItRunPowershellScriptTestsAsync()
+    {
+        // test power shell
+        var ps = @"Write-Output ""hello world""";
+        await this.TestPowershellCodeSnippet(_interactiveService, ps, "hello world");
+    }
+
+    private async Task TestPowershellCodeSnippet(InteractiveService service, string code, string expectedOutput)
+    {
+        var result = await service.SubmitPowershellCodeAsync(code, CancellationToken.None);
+        result.Should().StartWith(expectedOutput);
+    }
+
+    private async Task TestCSharpCodeSnippet(InteractiveService service, string code, string expectedOutput)
+    {
+        var result = await service.SubmitCSharpCodeAsync(code, CancellationToken.None);
+        result.Should().StartWith(expectedOutput);
+    }
+}

--- a/dotnet/website/articles/Installation.md
+++ b/dotnet/website/articles/Installation.md
@@ -4,12 +4,6 @@
 
 AutoGen.Net provides the following packages, you can choose to install one or more of them based on your needs:
 
-> [!Note]
-> The `AutoGen.DotnetInteractive` has a dependency on `Microsoft.DotNet.Interactive.VisualStudio` which is not available on nuget.org. To restore the dependency, you need to add the following package source to your project:
-> ```bash
-> https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
-> ```
-
 - `AutoGen`: The one-in-all package. This package has dependencies over `AutoGen.Core`, `AutoGen.OpenAI`, `AutoGen.LMStudio`, `AutoGen.SemanticKernel` and `AutoGen.SourceGenerator`.
 - `AutoGen.Core`: The core package, this package provides the abstraction for message type, agent and group chat.
 - `AutoGen.OpenAI`: This package provides the integration agents over openai models.

--- a/dotnet/website/articles/Run-dotnet-code.md
+++ b/dotnet/website/articles/Run-dotnet-code.md
@@ -19,12 +19,6 @@ For example, in data analysis scenario, agent can resolve tasks like "What is th
 ## How to run dotnet code snippet?
 The built-in feature of running dotnet code snippet is provided by [dotnet-interactive](https://github.com/dotnet/interactive). To run dotnet code snippet, you need to install the following package to your project, which provides the intergraion with dotnet-interactive:
 
-> [!Note]
-> The `AutoGen.DotnetInteractive` has a dependency on `Microsoft.DotNet.Interactive.VisualStudio` which is not available on nuget.org. To restore the dependency, you need to add the following package source to your project:
-> ```bash
-> https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
-> ```
-
 ```xml
 <PackageReference Include="AutoGen.DotnetInteractive" />
 ```


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixes #2660 by making `RestoreDotnetInteractive` to public and remove the error message check in restoring condition check.

This PR also upgrade dotnet-interactive package to the latest version and remove dependency of `Microsoft.Interactive.VisualStudio`. This means the user no longer need to add `dotnet-tool` feed before consuming `AutoGen.DotnetInteractive` package
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#2660 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
