### PR TITLE
allow serialize_to_str to work with non ascii when dumping via json.d…

### DIFF
--- a/autogen/function_utils.py
+++ b/autogen/function_utils.py
@@ -353,4 +353,4 @@ def serialize_to_str(x: Any) -> str:
     elif isinstance(x, BaseModel):
         return model_dump_json(x)
     else:
-        return json.dumps(x)
+        return json.dumps(x, ensure_ascii=False)

--- a/test/test_function_utils.py
+++ b/test/test_function_utils.py
@@ -391,6 +391,10 @@ async def test_load_basemodels_if_needed_async() -> None:
     assert actual[1] == "EUR"
 
 
+def test_serialize_to_str_with_nonascii() -> None:
+    assert serialize_to_str("中文") == "中文"
+
+
 def test_serialize_to_json() -> None:
     assert serialize_to_str("abc") == "abc"
     assert serialize_to_str(123) == "123"


### PR DESCRIPTION
…umps

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
developers will use serialize_to_str with non ascii characters, this allows them to do that.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #2511


## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
