### PR TITLE
Ability to ignore Select Speaker Prompt for GroupChat

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -39,6 +39,7 @@ class GroupChat:
                 Then select the next role from {agentlist} to play. Only return the role."
     - select_speaker_prompt_template: customize the select speaker prompt (used in "auto" speaker selection), which appears last in the message context and generally includes the list of agents and guidance for the LLM to select the next agent. If the string contains "{agentlist}" it will be replaced with a comma-separated list of agent names in square brackets. The default value is:
         "Read the above conversation. Then select the next role from {agentlist} to play. Only return the role."
+        To ignore this prompt being used, set this to None. If set to None, ensure your instructions for selecting a speaker are in the select_speaker_message_template string.
     - select_speaker_auto_multiple_template: customize the follow-up prompt used when selecting a speaker fails with a response that contains multiple agent names. This prompt guides the LLM to return just one agent name. Applies only to "auto" speaker selection method. If the string contains "{agentlist}" it will be replaced with a comma-separated list of agent names in square brackets. The default value is:
         "You provided more than one name in your text, please return just the name of the next speaker. To determine the speaker use these prioritised rules:
                 1. If the context refers to themselves as a speaker e.g. "As the..." , choose that speaker's name
@@ -225,8 +226,8 @@ class GroupChat:
         if self.select_speaker_message_template is None or len(self.select_speaker_message_template) == 0:
             raise ValueError("select_speaker_message_template cannot be empty or None.")
 
-        if self.select_speaker_prompt_template is None or len(self.select_speaker_prompt_template) == 0:
-            raise ValueError("select_speaker_prompt_template cannot be empty or None.")
+        if self.select_speaker_prompt_template is not None and len(self.select_speaker_prompt_template) == 0:
+            self.select_speaker_prompt_template = None
 
         if self.role_for_select_speaker_messages is None or len(self.role_for_select_speaker_messages) == 0:
             raise ValueError("role_for_select_speaker_messages cannot be empty or None.")
@@ -330,7 +331,13 @@ class GroupChat:
         return return_msg
 
     def select_speaker_prompt(self, agents: Optional[List[Agent]] = None) -> str:
-        """Return the floating system prompt selecting the next speaker. This is always the *last* message in the context."""
+        """Return the floating system prompt selecting the next speaker.
+        This is always the *last* message in the context.
+        Will return None if the select_speaker_prompt_template is None."""
+
+        if self.select_speaker_prompt_template is None:
+            return None
+
         if agents is None:
             agents = self.agents
 
@@ -624,23 +631,35 @@ class GroupChat:
             remove_other_reply_funcs=True,
         )
 
+        # NOTE: Do we have a speaker prompt (select_speaker_prompt_template is not None)? If we don't, we need to feed in the last message to start the nested chat
+
         # Agent for selecting a single agent name from the response
         speaker_selection_agent = ConversableAgent(
             "speaker_selection_agent",
             system_message=self.select_speaker_msg(agents),
-            chat_messages={checking_agent: messages},
+            chat_messages=(
+                {checking_agent: messages}
+                if self.select_speaker_prompt_template is not None
+                else {checking_agent: messages[:-1]}
+            ),
             llm_config=selector.llm_config,
             human_input_mode="NEVER",  # Suppresses some extra terminal outputs, outputs will be handled by select_speaker_auto_verbose
         )
+
+        # Create the starting message
+        if self.select_speaker_prompt_template is not None:
+            start_message = {
+                "content": self.select_speaker_prompt(agents),
+                "override_role": self.role_for_select_speaker_messages,
+            }
+        else:
+            start_message = messages[-1]
 
         # Run the speaker selection chat
         result = checking_agent.initiate_chat(
             speaker_selection_agent,
             cache=None,  # don't use caching for the speaker selection chat
-            message={
-                "content": self.select_speaker_prompt(agents),
-                "override_role": self.role_for_select_speaker_messages,
-            },
+            message=start_message,
             max_turns=2
             * max(1, max_attempts),  # Limiting the chat to the number of attempts, including the initial one
             clear_history=False,
@@ -711,6 +730,8 @@ class GroupChat:
             remove_other_reply_funcs=True,
         )
 
+        # NOTE: Do we have a speaker prompt (select_speaker_prompt_template is not None)? If we don't, we need to feed in the last message to start the nested chat
+
         # Agent for selecting a single agent name from the response
         speaker_selection_agent = ConversableAgent(
             "speaker_selection_agent",
@@ -720,11 +741,20 @@ class GroupChat:
             human_input_mode="NEVER",  # Suppresses some extra terminal outputs, outputs will be handled by select_speaker_auto_verbose
         )
 
+        # Create the starting message
+        if self.select_speaker_prompt_template is not None:
+            start_message = {
+                "content": self.select_speaker_prompt(agents),
+                "override_role": self.role_for_select_speaker_messages,
+            }
+        else:
+            start_message = messages[-1]
+
         # Run the speaker selection chat
         result = await checking_agent.a_initiate_chat(
             speaker_selection_agent,
             cache=None,  # don't use caching for the speaker selection chat
-            message=self.select_speaker_prompt(agents),
+            message=start_message,
             max_turns=2
             * max(1, max_attempts),  # Limiting the chat to the number of attempts, including the initial one
             clear_history=False,

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -1321,15 +1321,17 @@ def test_select_speaker_message_and_prompt_templates():
             select_speaker_prompt_template="Not empty.",
         )
 
-    with pytest.raises(ValueError, match="select_speaker_prompt_template cannot be empty or None."):
-        groupchat = autogen.GroupChat(
-            agents=[agent1, agent2],
-            messages=[],
-            speaker_selection_method="auto",
-            max_round=10,
-            select_speaker_message_template="Not empty.",
-            select_speaker_prompt_template="",
-        )
+    # Will not throw an exception, prompt can be empty/None (empty is converted to None)
+    groupchat = autogen.GroupChat(
+        agents=[agent1, agent2],
+        messages=[],
+        speaker_selection_method="auto",
+        max_round=10,
+        select_speaker_message_template="Not empty.",
+        select_speaker_prompt_template="",
+    )
+
+    assert groupchat.select_speaker_prompt_template is None
 
     # Test with None
     with pytest.raises(ValueError, match="select_speaker_message_template cannot be empty or None."):
@@ -1342,15 +1344,17 @@ def test_select_speaker_message_and_prompt_templates():
             select_speaker_prompt_template="Not empty.",
         )
 
-    with pytest.raises(ValueError, match="select_speaker_prompt_template cannot be empty or None."):
-        groupchat = autogen.GroupChat(
-            agents=[agent1, agent2],
-            messages=[],
-            speaker_selection_method="auto",
-            max_round=10,
-            select_speaker_message_template="Not empty.",
-            select_speaker_prompt_template=None,
-        )
+    # Will not throw an exception, prompt can be empty/None (empty is converted to None)
+    groupchat = autogen.GroupChat(
+        agents=[agent1, agent2],
+        messages=[],
+        speaker_selection_method="auto",
+        max_round=10,
+        select_speaker_message_template="Not empty.",
+        select_speaker_prompt_template=None,
+    )
+
+    assert groupchat.select_speaker_prompt_template is None
 
 
 def test_speaker_selection_agent_name_match():
@@ -2023,14 +2027,12 @@ if __name__ == "__main__":
     # test_clear_agents_history()
     # test_custom_speaker_selection_overrides_transition_graph()
     # test_role_for_select_speaker_messages()
-    # test_select_speaker_message_and_prompt_templates()
+    test_select_speaker_message_and_prompt_templates()
     # test_speaker_selection_agent_name_match()
     # test_role_for_reflection_summary()
     # test_speaker_selection_auto_process_result()
     # test_speaker_selection_validate_speaker_name()
     # test_select_speaker_auto_messages()
-    # test_speaker_selection_auto_process_result()
-    # test_speaker_selection_validate_speaker_name()
     # test_select_speaker_auto_messages()
     # test_manager_messages_to_string()
     # test_manager_messages_from_string()


### PR DESCRIPTION
Currently, the nested select speaker chat supports two customisable system messages when in `auto` speaker selection mode, `select_speaker_message_template` and `select_speaker_prompt_template`. The message template is inserted as the first message and the prompt template is added to the end of the messages when prompting the LLM to select the next speaker.

In testing of non-OpenAI models, I have found that having these two system messages is less effective than having just one upfront.

I am proposing, with this change, that the `select_speaker_prompt_template` can be set to `None` in order to, effectively, ignore it in the select speaker process.

## Why are these changes needed?

These changes are needed to improve the reliability of non-OpenAI models during the speaker selection process in `auto` mode.

No documentation changes have been added, existing tests have been updated.

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
