### PR TITLE
[Add] Fix invoking Assistant API

### DIFF
--- a/autogen/agentchat/contrib/gpt_assistant_agent.py
+++ b/autogen/agentchat/contrib/gpt_assistant_agent.py
@@ -172,7 +172,7 @@ class GPTAssistantAgent(ConversableAgent):
         # lazily create threads
         self._openai_threads = {}
         self._unread_index = defaultdict(int)
-        self.register_reply(Agent, GPTAssistantAgent._invoke_assistant, position=2)
+        self.register_reply([Agent, None], GPTAssistantAgent._invoke_assistant, position=2)
 
     def _invoke_assistant(
         self,


### PR DESCRIPTION
## Why are these changes needed?

Calling generate_reply without a sender on a GPTAssistantAgent won't invoke Assistant API -- it uses the ChatCompletion API.

This change fixes invoking of  ChatCompletion API issue, when calling generate_reply without a sender on a GPTAssistantAgent. Now it invokes Assistant API

## Related issue number

#2697 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
