### PR TITLE
Avoid requests 2.32.0 to fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Test with pytest skipping openai tests
         if: matrix.python-version != '3.10' && matrix.os == 'ubuntu-latest'
         run: |
+          # Remove the line below once https://github.com/docker/docker-py/issues/3256 is merged
+          pip install requests<2.32.0
           pytest test --ignore=test/agentchat/contrib --skip-openai --durations=10 --durations-min=1.0
       - name: Test with pytest skipping openai and docker tests
         if: matrix.python-version != '3.10' && matrix.os != 'ubuntu-latest'


### PR DESCRIPTION
Fix build failures caused by `requests` 2.32.0. 

e.g.: https://github.com/microsoft/autogen/actions/runs/9183464819/job/25291075659

Revert this once the hot fix is merged to `docker` library: https://github.com/docker/docker-py/issues/3256