### PR TITLE
Add packaging explicitly to fix build error in macos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requires = [
     # Disallowing 2.6.0 can be removed when this is fixed https://github.com/pydantic/pydantic/issues/8705
     "pydantic>=1.10,<3,!=2.6.0",  # could be both V1 and V2
     "docker",
+    "packaging",
 ]
 
 jupyter_executor = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`packaging` is used in `autogen/oai/openai_utils.py`, it should be installed as a dependency of docker. But in recent tests such as https://github.com/microsoft/autogen/actions/runs/9205177548/job/25330124434 , packaging is not installed and thus failed the build.

In this PR, adding packaging explicitly to fix it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
