### PR TITLE
allow function to remove termination string in groupchat

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1157,7 +1157,7 @@ class GroupChatManager(ConversableAgent):
     def resume(
         self,
         messages: Union[List[Dict], str],
-        remove_termination_string: str = None,
+        remove_termination_string: Union[str, Callable[[str], str]] = None,
         silent: Optional[bool] = False,
     ) -> Tuple[ConversableAgent, Dict]:
         """Resumes a group chat using the previous messages as a starting point. Requires the agents, group chat, and group chat manager to be established
@@ -1165,7 +1165,9 @@ class GroupChatManager(ConversableAgent):
 
         Args:
             - messages Union[List[Dict], str]: The content of the previous chat's messages, either as a Json string or a list of message dictionaries.
-            - remove_termination_string str: Remove the provided string from the last message to prevent immediate termination
+            - remove_termination_string (str or function): Remove the termination string from the last message to prevent immediate termination
+                If a string is provided, this string will be removed from last message.
+                If a function is provided, the last message will be passed to this function.
             - silent (bool or None): (Experimental) whether to print the messages for this conversation. Default is False.
 
         Returns:
@@ -1260,7 +1262,7 @@ class GroupChatManager(ConversableAgent):
     async def a_resume(
         self,
         messages: Union[List[Dict], str],
-        remove_termination_string: str = None,
+        remove_termination_string: Union[str, Callable[[str], str]],
         silent: Optional[bool] = False,
     ) -> Tuple[ConversableAgent, Dict]:
         """Resumes a group chat using the previous messages as a starting point, asynchronously. Requires the agents, group chat, and group chat manager to be established
@@ -1268,7 +1270,9 @@ class GroupChatManager(ConversableAgent):
 
         Args:
             - messages Union[List[Dict], str]: The content of the previous chat's messages, either as a Json string or a list of message dictionaries.
-            - remove_termination_string str: Remove the provided string from the last message to prevent immediate termination
+            - remove_termination_string (str or function): Remove the termination string from the last message to prevent immediate termination
+                If a string is provided, this string will be removed from last message.
+                If a function is provided, the last message will be passed to this function.
             - silent (bool or None): (Experimental) whether to print the messages for this conversation. Default is False.
 
         Returns:
@@ -1387,11 +1391,15 @@ class GroupChatManager(ConversableAgent):
                 ):
                     raise Exception(f"Agent name in message doesn't exist as agent in group chat: {message['name']}")
 
-    def _process_resume_termination(self, remove_termination_string: str, messages: List[Dict]):
+    def _process_resume_termination(
+        self, remove_termination_string: Union[str, Callable[[str], str]], messages: List[Dict]
+    ):
         """Removes termination string, if required, and checks if termination may occur.
 
         args:
-            remove_termination_string (str): termination string to remove from the last message
+            remove_termination_string (str or function): Remove the termination string from the last message to prevent immediate termination
+                If a string is provided, this string will be removed from last message.
+                If a function is provided, the last message will be passed to this function.
 
         returns:
             None
@@ -1400,9 +1408,17 @@ class GroupChatManager(ConversableAgent):
         last_message = messages[-1]
 
         # Replace any given termination string in the last message
-        if remove_termination_string:
-            if messages[-1].get("content") and remove_termination_string in messages[-1]["content"]:
-                messages[-1]["content"] = messages[-1]["content"].replace(remove_termination_string, "")
+        if isinstance(remove_termination_string, str):
+
+            def _remove_termination_string(content: str) -> str:
+                return content.replace(remove_termination_string, "")
+
+        else:
+            _remove_termination_string = remove_termination_string
+
+        if _remove_termination_string:
+            if messages[-1].get("content"):
+                messages[-1]["content"] = _remove_termination_string(messages[-1]["content"])
 
         # Check if the last message meets termination (if it has one)
         if self._is_termination_msg:

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1272,7 +1272,7 @@ class GroupChatManager(ConversableAgent):
             - messages Union[List[Dict], str]: The content of the previous chat's messages, either as a Json string or a list of message dictionaries.
             - remove_termination_string (str or function): Remove the termination string from the last message to prevent immediate termination
                 If a string is provided, this string will be removed from last message.
-                If a function is provided, the last message will be passed to this function.
+                If a function is provided, the last message will be passed to this function, and the function returns the string after processing.
             - silent (bool or None): (Experimental) whether to print the messages for this conversation. Default is False.
 
         Returns:

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1399,7 +1399,7 @@ class GroupChatManager(ConversableAgent):
         args:
             remove_termination_string (str or function): Remove the termination string from the last message to prevent immediate termination
                 If a string is provided, this string will be removed from last message.
-                If a function is provided, the last message will be passed to this function.
+                If a function is provided, the last message will be passed to this function, and the function returns the string after processing.
 
         returns:
             None

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -1916,6 +1916,51 @@ def test_manager_resume_functions():
     # TERMINATE should be removed
     assert messages[-1]["content"] == final_msg.replace("TERMINATE", "")
 
+    # Tests termination message replacement with function
+    def termination_func(x: str) -> str:
+        if "APPROVED" in x:
+            x = x.replace("APPROVED", "")
+        else:
+            x = x.replace("TERMINATE", "")
+        return x
+
+    final_msg1 = "Product_Manager has created 3 new product ideas. APPROVED"
+    messages1 = [
+        {
+            "content": "You are an expert at finding the next speaker.",
+            "role": "system",
+        },
+        {
+            "content": final_msg1,
+            "name": "Coder",
+            "role": "assistant",
+        },
+    ]
+
+    manager._process_resume_termination(remove_termination_string=termination_func, messages=messages1)
+
+    # APPROVED should be removed
+    assert messages1[-1]["content"] == final_msg1.replace("APPROVED", "")
+
+    final_msg2 = "Idea has been approved. TERMINATE"
+    messages2 = [
+        {
+            "content": "You are an expert at finding the next speaker.",
+            "role": "system",
+        },
+        {
+            "content": final_msg2,
+            "name": "Coder",
+            "role": "assistant",
+        },
+    ]
+
+    manager._process_resume_termination(remove_termination_string=termination_func, messages=messages2)
+
+    # TERMINATE should be removed, "approved" should still be present
+    assert messages2[-1]["content"] == final_msg2.replace("TERMINATE", "")
+    assert "approved" in messages2[-1]["content"]
+
     # Check if the termination string doesn't exist there's no replacing of content
     final_msg = (
         "Let's get this meeting started. First the Product_Manager will create 3 new product ideas. TERMINATE this."
@@ -2027,7 +2072,7 @@ if __name__ == "__main__":
     # test_clear_agents_history()
     # test_custom_speaker_selection_overrides_transition_graph()
     # test_role_for_select_speaker_messages()
-    test_select_speaker_message_and_prompt_templates()
+    # test_select_speaker_message_and_prompt_templates()
     # test_speaker_selection_agent_name_match()
     # test_role_for_reflection_summary()
     # test_speaker_selection_auto_process_result()
@@ -2036,7 +2081,7 @@ if __name__ == "__main__":
     # test_select_speaker_auto_messages()
     # test_manager_messages_to_string()
     # test_manager_messages_from_string()
-    # test_manager_resume_functions()
+    test_manager_resume_functions()
     # test_manager_resume_returns()
     # test_manager_resume_messages()
     pass

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -1957,7 +1957,7 @@ def test_manager_resume_functions():
 
     manager._process_resume_termination(remove_termination_string=termination_func, messages=messages2)
 
-    # TERMINATE should be removed, "approved" should still be present
+    # TERMINATE should be removed, "approved" should still be present as the termination_func only replaces upper-cased "APPROVED".
     assert messages2[-1]["content"] == final_msg2.replace("TERMINATE", "")
     assert "approved" in messages2[-1]["content"]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In common groupchat scenario of multiple agents, the chat may terminate due to any agent's termination message and the termination condition/keyword of each agent may be different.

Think of an example like this:
```python
 math_solver = autogen.AssistantAgent(
    ..,
    system_message="Answer only if user query is related to mathematics, otherwise say 'TERMINATE'",
    is_termination_msg="TERMINATE",
  )

  critic = autogen.AssistantAgent(
    ...,
    system_message="Think step-by-step and analyze the solution. If everything looks good, say 'APPROVED'",
    is_termination_msg="APPROVED",
  )
```

Now, when resuming the chat, the `GroupChatManager.resume` method does allow a `remove_termination_string` but the user isn't sure which termination string caused termination.

Therefore, allowing the `remove_termination_string` to be a function provides more flexibility to remove any termination string based on the groupchat setup.

## Related issue number
#2627

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
