### PR TITLE
[CAP] User supplied threads for agents

### DIFF
--- a/samples/apps/cap/py/README.md
+++ b/samples/apps/cap/py/README.md
@@ -26,7 +26,7 @@ class GreeterAgent(Actor):
         super().__init__(
             agent_name="Greeter",
             description="This is the greeter agent, who knows how to greet people.")
-    
+
     # Prints out the message it receives
     def on_txt_msg(self, msg):
         print(f"Greeter received: {msg}")

--- a/samples/apps/cap/py/README.md
+++ b/samples/apps/cap/py/README.md
@@ -15,19 +15,20 @@ AutoGen is about Agents and Agent Orchestration.  CAP extends AutoGen to allows 
 
 Actors can register themselves with CAP, find other agents, construct arbitrary graphs, send and receive messages independently and many, many, many other things.
 ```python
-    # CAP Platform
-    network = LocalActorNetwork()
+    ensemble = ComponentEnsemble()
+    # Create an agent
+    agent = GreeterAgent()
     # Register an agent
-    network.register(GreeterAgent())
-    # Tell agents to connect to other agents
-    network.connect()
+    ensemble.register(agent) # start message processing
+    # call on_connect() on all Agents
+    ensemble.connect()
     # Get a channel to the agent
-    greeter_link = network.lookup_agent("Greeter")
-    # Send a message to the agent
+    greeter_link = ensemble.find_by_name("Greeter")
+    Send a message to the agent
     greeter_link.send_txt_msg("Hello World!")
     # Cleanup
     greeter_link.close()
-    network.disconnect()
+    ensemble.disconnect()
 ```
 ### Check out other demos in the `py/demo` directory.  We show the following: ###
 1) Hello World shown above

--- a/samples/apps/cap/py/README.md
+++ b/samples/apps/cap/py/README.md
@@ -30,7 +30,7 @@ class GreeterAgent(Actor):
     # Prints out the message it receives
     def on_txt_msg(self, msg):
         print(f"Greeter received: {msg}")
-        return "Greeter says: Hello!"
+        return True
 
 ensemble = ComponentEnsemble()
 # Create an agent

--- a/samples/apps/cap/py/README.md
+++ b/samples/apps/cap/py/README.md
@@ -3,7 +3,7 @@
 ## I just want to run the remote AutoGen agents!
 *Python Instructions (Windows, Linux, MacOS):*
 
-pip install autogencap
+pip install autogencap-rajan.jedi
 
 1) AutoGen require OAI_CONFIG_LIST.
    AutoGen python requirements: 3.8 <= python <= 3.11
@@ -14,22 +14,40 @@ pip install autogencap
 AutoGen is about Agents and Agent Orchestration.  CAP extends AutoGen to allows Agents to communicate via a message bus.  CAP, therefore, deals with the space between these components.  CAP is a message based, actor platform that allows actors to be composed into arbitrary graphs.
 
 Actors can register themselves with CAP, find other agents, construct arbitrary graphs, send and receive messages independently and many, many, many other things.
+
 ```python
-    ensemble = ComponentEnsemble()
-    # Create an agent
-    agent = GreeterAgent()
-    # Register an agent
-    ensemble.register(agent) # start message processing
-    # call on_connect() on all Agents
-    ensemble.connect()
-    # Get a channel to the agent
-    greeter_link = ensemble.find_by_name("Greeter")
-    Send a message to the agent
-    greeter_link.send_txt_msg("Hello World!")
-    # Cleanup
-    greeter_link.close()
-    ensemble.disconnect()
+# CAP Library
+from autogencap.ComponentEnsemble import ComponentEnsemble
+from autogencap.Actor import Actor
+
+# A simple Agent
+class GreeterAgent(Actor):
+    def __init__(self):
+        super().__init__(
+            agent_name="Greeter",
+            description="This is the greeter agent, who knows how to greet people.")
+    
+    # Prints out the message it receives
+    def on_txt_msg(self, msg):
+        print(f"Greeter received: {msg}")
+        return "Greeter says: Hello!"
+
+ensemble = ComponentEnsemble()
+# Create an agent
+agent = GreeterAgent()
+# Register an agent
+ensemble.register(agent) # start message processing
+# call on_connect() on all Agents
+ensemble.connect()
+# Get a channel to the agent
+greeter_link = ensemble.find_by_name("Greeter")
+#Send a message to the agent
+greeter_link.send_txt_msg("Hello World!")
+# Cleanup
+greeter_link.close()
+ensemble.disconnect()
 ```
+
 ### Check out other demos in the `py/demo` directory.  We show the following: ###
 1) Hello World shown above
 2) Many CAP Actors interacting with each other
@@ -37,4 +55,4 @@ Actors can register themselves with CAP, find other agents, construct arbitrary 
 4) CAP wrapped AutoGen Agents in a group chat
 5) Two AutoGen Agents running in different processes and communicating through CAP
 6) List all registered agents in CAP
-7) AutoGen integration to list all registered agents
+7) Run Agent in user supplied message loop

--- a/samples/apps/cap/py/autogencap/Actor.py
+++ b/samples/apps/cap/py/autogencap/Actor.py
@@ -1,19 +1,17 @@
 import threading
-import time
 import traceback
-
 import zmq
-
 from .Config import xpub_url
 from .DebugLog import Debug, Error, Info
 
 
 class Actor:
-    def __init__(self, agent_name: str, description: str):
+    def __init__(self, agent_name: str, description: str, start_thread: bool = True):
         self.actor_name: str = agent_name
         self.agent_description: str = description
         self.run = False
         self._start_event = threading.Event()
+        self._start_thread = start_thread
 
     def on_connect(self, network):
         Debug(self.actor_name, f"is connecting to {network}")
@@ -27,37 +25,50 @@ class Actor:
         Info(self.actor_name, f"Msg: receiver=[{receiver}], msg_type=[{msg_type}]")
         return True
 
-    def _recv_thread(self):
+    def _msg_loop_init(self):
+        Debug(self.actor_name, "recv thread started")
+        self._socket: zmq.Socket = self._context.socket(zmq.SUB)
+        self._socket.setsockopt(zmq.RCVTIMEO, 500)
+        self._socket.connect(xpub_url)
+        str_topic = f"{self.actor_name}"
+        Debug(self.actor_name, f"subscribe to: {str_topic}")
+        self._socket.setsockopt_string(zmq.SUBSCRIBE, f"{str_topic}")
+        self._start_event.set()
+
+    def get_message(self):
         try:
-            Debug(self.actor_name, "recv thread started")
-            self._socket: zmq.Socket = self._context.socket(zmq.SUB)
-            self._socket.setsockopt(zmq.RCVTIMEO, 500)
-            self._socket.connect(xpub_url)
-            str_topic = f"{self.actor_name}"
-            Debug(self.actor_name, f"subscribe to: {str_topic}")
-            self._socket.setsockopt_string(zmq.SUBSCRIBE, f"{str_topic}")
-            self._start_event.set()
+            topic, msg_type, sender_topic, msg = self._socket.recv_multipart()
+            topic = topic.decode("utf-8")  # Convert bytes to string
+            msg_type = msg_type.decode("utf-8")  # Convert bytes to string
+            sender_topic = sender_topic.decode("utf-8")  # Convert bytes to string
+        except zmq.Again:
+            return None  # No message received, continue to next iteration
+        except Exception as e:
+            Error(self.actor_name, f"recv thread encountered an error: {e}")
+            traceback.print_exc()
+            return None
+        return topic, msg_type, sender_topic, msg
+    
+    def dispatch_message(self, message):
+        if message is None:
+            return
+        topic, msg_type, sender_topic, msg = message
+        if msg_type == "text":
+            msg = msg.decode("utf-8")  # Convert bytes to string
+            if not self.on_txt_msg(msg, msg_type, topic, sender_topic):
+                msg = "quit"
+            if msg.lower() == "quit":
+                self.run = False
+        else:
+            if not self.on_bin_msg(msg, msg_type, topic, sender_topic):
+                self.run = False
+    
+    def _msg_loop(self):
+        try:
+            self._msg_loop_init()
             while self.run:
-                try:
-                    topic, msg_type, sender_topic, msg = self._socket.recv_multipart()
-                    topic = topic.decode("utf-8")  # Convert bytes to string
-                    msg_type = msg_type.decode("utf-8")  # Convert bytes to string
-                    sender_topic = sender_topic.decode("utf-8")  # Convert bytes to string
-                except zmq.Again:
-                    continue  # No message received, continue to next iteration
-                except Exception as e:
-                    Error(self.actor_name, f"recv thread encountered an error: {e}")
-                    traceback.print_exc()
-                    continue
-                if msg_type == "text":
-                    msg = msg.decode("utf-8")  # Convert bytes to string
-                    if not self.on_txt_msg(msg, msg_type, topic, sender_topic):
-                        msg = "quit"
-                    if msg.lower() == "quit":
-                        break
-                else:
-                    if not self.on_bin_msg(msg, msg_type, topic, sender_topic):
-                        break
+                message = self.get_message()
+                self.dispatch_message(message)
         except Exception as e:
             Debug(self.actor_name, f"recv thread encountered an error: {e}")
             traceback.print_exc()
@@ -68,12 +79,15 @@ class Actor:
             self._start_event.set()
             Debug(self.actor_name, "recv thread ended")
 
-    def start(self, context: zmq.Context):
+    def on_start(self, context: zmq.Context):
         self._context = context
         self.run: bool = True
-        self._thread = threading.Thread(target=self._recv_thread)
-        self._thread.start()
-        self._start_event.wait()
+        if self._start_thread:
+            self._thread = threading.Thread(target=self._msg_loop)
+            self._thread.start()
+            self._start_event.wait()
+        else:
+            self._msg_loop_init()
 
     def disconnect_network(self, network):
         Debug(self.actor_name, f"is disconnecting from {network}")
@@ -82,6 +96,7 @@ class Actor:
 
     def stop(self):
         self.run = False
-        self._thread.join()
+        if self._start_thread:
+            self._thread.join()
         self._socket.setsockopt(zmq.LINGER, 0)
         self._socket.close()

--- a/samples/apps/cap/py/autogencap/Actor.py
+++ b/samples/apps/cap/py/autogencap/Actor.py
@@ -1,6 +1,8 @@
 import threading
 import traceback
+
 import zmq
+
 from .Config import xpub_url
 from .DebugLog import Debug, Error, Info
 
@@ -48,7 +50,7 @@ class Actor:
             traceback.print_exc()
             return None
         return topic, msg_type, sender_topic, msg
-    
+
     def dispatch_message(self, message):
         if message is None:
             return
@@ -62,7 +64,7 @@ class Actor:
         else:
             if not self.on_bin_msg(msg, msg_type, topic, sender_topic):
                 self.run = False
-    
+
     def _msg_loop(self):
         try:
             self._msg_loop_init()

--- a/samples/apps/cap/py/autogencap/ComponentEnsemble.py
+++ b/samples/apps/cap/py/autogencap/ComponentEnsemble.py
@@ -1,8 +1,6 @@
 import time
 from typing import List
-
 import zmq
-
 from .Actor import Actor
 from .ActorConnector import ActorConnector
 from .Broker import Broker
@@ -10,9 +8,6 @@ from .Constants import Termination_Topic
 from .DebugLog import Debug, Warn
 from .DirectorySvc import DirectorySvc
 from .proto.CAP_pb2 import ActorInfo, ActorInfoCollection
-
-# TODO: remove time import
-
 
 class ComponentEnsemble:
     def __init__(self, name: str = "Local Actor Network", start_broker: bool = True):
@@ -43,7 +38,7 @@ class ComponentEnsemble:
         # that we can look up the actor by name
         self._directory_svc.register_actor_by_name(actor.actor_name)
         self.local_actors[actor.actor_name] = actor
-        actor.start(self._context)
+        actor.on_start(self._context)
         Debug("Local_Actor_Network", f"{actor.actor_name} registered in the network.")
 
     def connect(self):

--- a/samples/apps/cap/py/autogencap/ComponentEnsemble.py
+++ b/samples/apps/cap/py/autogencap/ComponentEnsemble.py
@@ -1,6 +1,8 @@
 import time
 from typing import List
+
 import zmq
+
 from .Actor import Actor
 from .ActorConnector import ActorConnector
 from .Broker import Broker
@@ -8,6 +10,7 @@ from .Constants import Termination_Topic
 from .DebugLog import Debug, Warn
 from .DirectorySvc import DirectorySvc
 from .proto.CAP_pb2 import ActorInfo, ActorInfoCollection
+
 
 class ComponentEnsemble:
     def __init__(self, name: str = "Local Actor Network", start_broker: bool = True):

--- a/samples/apps/cap/py/autogencap/DirectorySvc.py
+++ b/samples/apps/cap/py/autogencap/DirectorySvc.py
@@ -121,7 +121,7 @@ class DirectorySvc:
         self._directory_connector = ActorConnector(self._context, Directory_Svc_Topic)
         if self._no_other_directory():
             self._directory_actor = DirectoryActor(Directory_Svc_Topic, "Directory Service")
-            self._directory_actor.start(self._context)
+            self._directory_actor.on_start(self._context)
             Info("DirectorySvc", "Directory service started.")
         else:
             Info("DirectorySvc", "Another directory service is running. This instance will not start.")

--- a/samples/apps/cap/py/autogencap/ag_adapter/AGActor.py
+++ b/samples/apps/cap/py/autogencap/ag_adapter/AGActor.py
@@ -6,8 +6,8 @@ from autogencap.DebugLog import Debug
 
 
 class AGActor(Actor):
-    def start(self, context: zmq.Context):
-        super().start(context)
+    def on_start(self, context: zmq.Context):
+        super().on_start(context)
         str_topic = Termination_Topic
         Debug(self.actor_name, f"subscribe to: {str_topic}")
         self._socket.setsockopt_string(zmq.SUBSCRIBE, f"{str_topic}")

--- a/samples/apps/cap/py/demo/App.py
+++ b/samples/apps/cap/py/demo/App.py
@@ -15,6 +15,7 @@ from ComplexActorDemo import complex_actor_demo
 from list_agents import list_agents
 from RemoteAGDemo import remote_ag_demo
 from SimpleActorDemo import simple_actor_demo
+from single_threaded import single_threaded_demo
 
 ####################################################################################################
 
@@ -46,6 +47,7 @@ def main():
         print("4. AutoGen GroupChat")
         print("5. AutoGen Agents in different processes")
         print("6. List Actors in CAP (Registry)")
+        print("7. Agent loop in main thread (no background thread for Agent)")
         choice = input("Enter your choice (1-6): ")
 
         if choice == "1":
@@ -64,6 +66,8 @@ def main():
             remote_ag_demo()
         elif choice == "6":
             list_agents()
+        elif choice == "7":
+            single_threaded_demo()
         else:
             print("Quitting...")
             break

--- a/samples/apps/cap/py/demo/AppAgents.py
+++ b/samples/apps/cap/py/demo/AppAgents.py
@@ -17,10 +17,11 @@ class GreeterAgent(Actor):
 
     def __init__(
         self,
+        start_thread=True,
         agent_name="Greeter",
         description="This is the greeter agent, who knows how to greet people.",
     ):
-        super().__init__(agent_name, description)
+        super().__init__(agent_name, description, start_thread=start_thread)
 
 
 class FidelityAgent(Actor):

--- a/samples/apps/cap/py/demo/SimpleActorDemo.py
+++ b/samples/apps/cap/py/demo/SimpleActorDemo.py
@@ -1,9 +1,5 @@
-import time
-
 from AppAgents import GreeterAgent
 from autogencap.ComponentEnsemble import ComponentEnsemble
-from autogencap.DebugLog import Error
-from autogencap.proto.CAP_pb2 import Ping
 
 
 def simple_actor_demo():

--- a/samples/apps/cap/py/demo/single_threaded.py
+++ b/samples/apps/cap/py/demo/single_threaded.py
@@ -1,5 +1,4 @@
 import _paths
-
 from AppAgents import GreeterAgent
 from autogencap.ComponentEnsemble import ComponentEnsemble
 from autogencap.DebugLog import Error
@@ -14,7 +13,7 @@ def single_threaded_demo():
     # CAP Platform
     ensemble = ComponentEnsemble()
     agent = GreeterAgent(start_thread=False)
-    ensemble.register(agent)    
+    ensemble.register(agent)
     ensemble.connect()
     greeter_link = ensemble.find_by_name("Greeter")
     greeter_link.send_txt_msg("Hello World!")
@@ -23,15 +22,18 @@ def single_threaded_demo():
     while no_msg < 5:
         message = agent.get_message()
         agent.dispatch_message(message)
-        if message is None: no_msg += 1
-            
+        if message is None:
+            no_msg += 1
+
     message = agent.get_message()
     agent.dispatch_message(message)
-    
+
     ensemble.disconnect()
+
 
 def main():
     single_threaded_demo()
+
 
 if __name__ == "__main__":
     main()

--- a/samples/apps/cap/py/demo/single_threaded.py
+++ b/samples/apps/cap/py/demo/single_threaded.py
@@ -1,4 +1,4 @@
-import time
+import _paths
 
 from AppAgents import GreeterAgent
 from autogencap.ComponentEnsemble import ComponentEnsemble
@@ -6,16 +6,32 @@ from autogencap.DebugLog import Error
 from autogencap.proto.CAP_pb2 import Ping
 
 
-def simple_actor_demo():
+def single_threaded_demo():
     """
     Demonstrates the usage of the CAP platform by registering an actor, connecting to the actor,
     sending a message, and performing cleanup operations.
     """
     # CAP Platform
     ensemble = ComponentEnsemble()
-    agent = GreeterAgent()
-    ensemble.register(agent)
+    agent = GreeterAgent(start_thread=False)
+    ensemble.register(agent)    
     ensemble.connect()
     greeter_link = ensemble.find_by_name("Greeter")
     greeter_link.send_txt_msg("Hello World!")
+
+    no_msg = 0
+    while no_msg < 5:
+        message = agent.get_message()
+        agent.dispatch_message(message)
+        if message is None: no_msg += 1
+            
+    message = agent.get_message()
+    agent.dispatch_message(message)
+    
     ensemble.disconnect()
+
+def main():
+    single_threaded_demo()
+
+if __name__ == "__main__":
+    main()

--- a/samples/apps/cap/py/pyproject.toml
+++ b/samples/apps/cap/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autogencap_rajan.jedi"
-version = "0.0.9"
+version = "0.0.10"
 authors = [
   { name="Rajan Chari", email="rajan.jedi@gmail.com" },
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Agents in CAP start their own thread.  This provides the user a choice to supply the message loop in their own thread.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
