### PR TITLE
set client default to None, then if None, init a chromadb.Client()

### DIFF
--- a/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
+++ b/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
@@ -253,7 +253,9 @@ class RetrieveUserProxyAgent(UserProxyAgent):
         self._task = self._retrieve_config.get("task", "default")
         self._vector_db = self._retrieve_config.get("vector_db", "chroma")
         self._db_config = self._retrieve_config.get("db_config", {})
-        self._client = self._retrieve_config.get("client", chromadb.Client())
+        self._client = self._retrieve_config.get("client", None)
+        if self._client is None:
+            self._client = chromadb.Client()
         self._docs_path = self._retrieve_config.get("docs_path", None)
         self._extra_docs = self._retrieve_config.get("extra_docs", False)
         self._new_docs = self._retrieve_config.get("new_docs", True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For the original way `self._client = self._retrieve_config.get("client", chromadb.Client())`, we won't be able to send our own initialized chromadb client in, it will still initialize a chromadb client.

When I send an initialized client into `RetrieveUserProxyAgent` by passing it in `retrieve_config`, it will shows `ValueError: An instance of Chroma already exists for ephemeral with different settings`; because it has been initialized somehow after `.get()`.

So I change the default to `None`, it will be able to accept a initialized chromadb client, or not given; it will work property just like the comment it mentions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#2829 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
