### PR TITLE
Broken links fix

### DIFF
--- a/notebook/JSON_mode_example.ipynb
+++ b/notebook/JSON_mode_example.ipynb
@@ -15,7 +15,7 @@
     "The group chat manager can perfrom some simple maths encoded into the agent descriptions on the rating values (made reliable by json mode) and direct requests deemed too coersive to the \"suspicious agent\" \n",
     "\n",
     "\n",
-    "![agent flow](https://media.githubusercontent.com/media/krishnashed/autogen/broken-links-fix/notebook/friendly_and_suspicous.jpg)\n",
+    "![agent flow](https://media.githubusercontent.com/media/microsoft/autogen/main/notebook/friendly_and_suspicous.jpg)\n",
     "\n",
     "\n",
     "Please find documentation about this feature in OpenAI  [here](https://platform.openai.com/docs/guides/text-generation/json-mode).\n",

--- a/notebook/JSON_mode_example.ipynb
+++ b/notebook/JSON_mode_example.ipynb
@@ -15,7 +15,7 @@
     "The group chat manager can perfrom some simple maths encoded into the agent descriptions on the rating values (made reliable by json mode) and direct requests deemed too coersive to the \"suspicious agent\" \n",
     "\n",
     "\n",
-    "![agent flow](friendly_and_suspicous.jpg)\n",
+    "![agent flow](./friendly_and_suspicous.jpg)\n",
     "\n",
     "\n",
     "Please find documentation about this feature in OpenAI  [here](https://platform.openai.com/docs/guides/text-generation/json-mode).\n",

--- a/notebook/JSON_mode_example.ipynb
+++ b/notebook/JSON_mode_example.ipynb
@@ -15,7 +15,7 @@
     "The group chat manager can perfrom some simple maths encoded into the agent descriptions on the rating values (made reliable by json mode) and direct requests deemed too coersive to the \"suspicious agent\" \n",
     "\n",
     "\n",
-    "![agent flow](https://github.com/microsoft/autogen/blob/main/notebook/friendly_and_suspicous.jpg)\n",
+    "![agent flow](https://media.githubusercontent.com/media/krishnashed/autogen/broken-links-fix/notebook/friendly_and_suspicous.jpg)\n",
     "\n",
     "\n",
     "Please find documentation about this feature in OpenAI  [here](https://platform.openai.com/docs/guides/text-generation/json-mode).\n",

--- a/notebook/JSON_mode_example.ipynb
+++ b/notebook/JSON_mode_example.ipynb
@@ -15,7 +15,7 @@
     "The group chat manager can perfrom some simple maths encoded into the agent descriptions on the rating values (made reliable by json mode) and direct requests deemed too coersive to the \"suspicious agent\" \n",
     "\n",
     "\n",
-    "![agent flow](./friendly_and_suspicous.jpg)\n",
+    "![agent flow](https://github.com/microsoft/autogen/blob/main/notebook/friendly_and_suspicous.jpg)\n",
     "\n",
     "\n",
     "Please find documentation about this feature in OpenAI  [here](https://platform.openai.com/docs/guides/text-generation/json-mode).\n",

--- a/notebook/agentchat_agentoptimizer.ipynb
+++ b/notebook/agentchat_agentoptimizer.ipynb
@@ -16,7 +16,7 @@
         "Specifically, given a set of training data, AgentOptimizer would iteratively prompt the LLM to optimize the existing function list of the AssistantAgent and UserProxyAgent with code implementation if necessary. It also includes two strategies, roll-back, and early-stop, to streamline the training process.\n",
         "In the example scenario, we test the proposed AgentOptimizer in solving problems from the [MATH dataset](https://github.com/hendrycks/math). \n",
         "\n",
-        "![AgentOptimizer](../website/blog/2023-12-23-AgentOptimizer/img/agentoptimizer.png)\n",
+        "![AgentOptimizer](https://media.githubusercontent.com/media/microsoft/autogen/main/website/blog/2023-12-23-AgentOptimizer/img/agentoptimizer.png)\n",
         "\n",
         "More information could be found in the [paper](https://arxiv.org/abs/2402.11359).\n",
         "\n",

--- a/notebook/agentchat_nested_chats_chess.ipynb
+++ b/notebook/agentchat_nested_chats_chess.ipynb
@@ -298,7 +298,7 @@
     "\n",
     "The following diagram illustrates the nested chat between the player agent and the board agent.\n",
     "\n",
-    "![Conversational Chess](nested-chats-chess.png)\n",
+    "![Conversational Chess](https://media.githubusercontent.com/media/microsoft/autogen/main/notebook/nested-chats-chess.png)\n",
     "\n",
     "See [nested chats tutorial chapter](/docs/tutorial/conversation-patterns#nested-chats)\n",
     "for more information."

--- a/website/docs/Examples.md
+++ b/website/docs/Examples.md
@@ -19,7 +19,7 @@ Links to notebook examples:
 - Automated Data Visualization by Group Chat (with 3 group member agents and 1 manager agent) - [View Notebook](/docs/notebooks/agentchat_groupchat_vis)
 - Automated Complex Task Solving by Group Chat (with 6 group member agents and 1 manager agent) - [View Notebook](/docs/notebooks/agentchat_groupchat_research)
 - Automated Task Solving with Coding & Planning Agents - [View Notebook](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_planning.ipynb)
-- Automated Task Solving with transition paths specified in a graph - [View Notebook](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_graph_modelling_language_using_select_speaker.ipynb)
+- Automated Task Solving with transition paths specified in a graph - [View Notebook](https://microsoft.github.io/autogen/docs/notebooks/agentchat_groupchat_finite_state_machine)
 - Running a group chat as an inner-monolgue via the SocietyOfMindAgent - [View Notebook](/docs/notebooks/agentchat_society_of_mind)
 - Running a group chat with custom speaker selection function - [View Notebook](/docs/notebooks/agentchat_groupchat_customized)
 

--- a/website/docs/Use-Cases/agent_chat.md
+++ b/website/docs/Use-Cases/agent_chat.md
@@ -82,7 +82,7 @@ AutoGen, by integrating conversation-driven control utilizing both programming a
 With the pluggable auto-reply function, one can choose to invoke conversations with other agents depending on the content of the current message and context. For example:
 - Hierarchical chat like in [OptiGuide](https://github.com/microsoft/optiguide).
 - [Dynamic Group Chat](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_groupchat.ipynb) which is a special form of hierarchical chat. In the system, we register a reply function in the group chat manager, which broadcasts messages and decides who the next speaker will be in a group chat setting.
-- [Using Finite State Machine graph to set speaker transitions](https://microsoft.github.io/autogen/docs/notebooks/agentchat_groupchat_finite_state_machine) which is a special form of dynamic group chat. In this approach, a directed transition matrix is fed into group chat. Users can specify legal transitions or specify disallowed transitions.
+- [Finite State Machine graphs to set speaker transition constraints](https://microsoft.github.io/autogen/docs/notebooks/agentchat_groupchat_finite_state_machine) which is a special form of dynamic group chat. In this approach, a directed transition matrix is fed into group chat. Users can specify legal transitions or specify disallowed transitions.
 - Nested chat like in [conversational chess](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_chess.ipynb).
 
 2. LLM-Based Function Call

--- a/website/docs/Use-Cases/agent_chat.md
+++ b/website/docs/Use-Cases/agent_chat.md
@@ -82,7 +82,7 @@ AutoGen, by integrating conversation-driven control utilizing both programming a
 With the pluggable auto-reply function, one can choose to invoke conversations with other agents depending on the content of the current message and context. For example:
 - Hierarchical chat like in [OptiGuide](https://github.com/microsoft/optiguide).
 - [Dynamic Group Chat](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_groupchat.ipynb) which is a special form of hierarchical chat. In the system, we register a reply function in the group chat manager, which broadcasts messages and decides who the next speaker will be in a group chat setting.
-- [Finite state machine (FSM) based group chat](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_graph_modelling_language_using_select_speaker.ipynb) which is a special form of dynamic group chat. In this approach, a directed transition matrix is fed into group chat. Users can specify legal transitions or specify disallowed transitions.
+- [Using Finite State Machine graph to set speaker transitions](https://microsoft.github.io/autogen/docs/notebooks/agentchat_groupchat_finite_state_machine) which is a special form of dynamic group chat. In this approach, a directed transition matrix is fed into group chat. Users can specify legal transitions or specify disallowed transitions.
 - Nested chat like in [conversational chess](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_chess.ipynb).
 
 2. LLM-Based Function Call

--- a/website/docs/installation/Optional-Dependencies.md
+++ b/website/docs/installation/Optional-Dependencies.md
@@ -119,7 +119,7 @@ To use a graph in `GroupChat`, particularly for graph visualization, please inst
 pip install "pyautogen[graph]"
 ```
 
-Example notebook: [Graph Modeling Language with using select_speaker](https://github.com/microsoft/autogen/blob/main/notebook/agentchat_graph_modelling_language_using_select_speaker.ipynb)
+Example notebook: [Finite State Machine graphs to set speaker transition constraints](https://microsoft.github.io/autogen/docs/notebooks/agentchat_groupchat_finite_state_machine)
 
 ## Long Context Handling
 


### PR DESCRIPTION
## Why are these changes needed?

Fixing broken notebook and image links in documentations

## Related issue number

#2837 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
