### PR TITLE
Refactor hook registration and processing methods

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -242,7 +242,7 @@ class ConversableAgent(LLMAgent):
 
         # Registered hooks are kept in lists, indexed by hookable method, to be called in their order of registration.
         # New hookable methods should be added to this list as required to support new agent capabilities.
-        self.hook_lists : Dict[str, List[Callable[[List[Dict]], List[Dict]]]] = {
+        self.hook_lists: Dict[str, List[Callable[[List[Dict]], List[Dict]]]] = {
             "process_last_received_message": [],
             "process_all_messages_before_reply": [],
             "process_message_before_send": [],
@@ -2724,7 +2724,7 @@ class ConversableAgent(LLMAgent):
             processed_messages = hook(processed_messages)
         return processed_messages
 
-    def process_last_received_message(self, messages:List[Dict]) -> List[Dict]:
+    def process_last_received_message(self, messages: List[Dict]) -> List[Dict]:
         """
         Calls any registered capability hooks to use and potentially modify the text of the last message,
         as long as the last message is not a function call or exit command.

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -242,7 +242,7 @@ class ConversableAgent(LLMAgent):
 
         # Registered hooks are kept in lists, indexed by hookable method, to be called in their order of registration.
         # New hookable methods should be added to this list as required to support new agent capabilities.
-        self.hook_lists = {
+        self.hook_lists : Dict[str, List[Callable[[List[Dict]], List[Dict]]]] = {
             "process_last_received_message": [],
             "process_all_messages_before_reply": [],
             "process_message_before_send": [],
@@ -2695,7 +2695,7 @@ class ConversableAgent(LLMAgent):
         """
         self.client.register_model_client(model_client_cls, **kwargs)
 
-    def register_hook(self, hookable_method: str, hook: Callable):
+    def register_hook(self, hookable_method: str, hook: Callable[[List[Dict]], List[Dict]]):
         """
         Registers a hook to be called by a hookable method, in order to add a capability to the agent.
         Registered hooks are kept in lists (one per hookable method), and are called in their order of registration.
@@ -2724,7 +2724,7 @@ class ConversableAgent(LLMAgent):
             processed_messages = hook(processed_messages)
         return processed_messages
 
-    def process_last_received_message(self, messages):
+    def process_last_received_message(self, messages:List[Dict]) -> List[Dict]:
         """
         Calls any registered capability hooks to use and potentially modify the text of the last message,
         as long as the last message is not a function call or exit command.

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -2695,7 +2695,7 @@ class ConversableAgent(LLMAgent):
         """
         self.client.register_model_client(model_client_cls, **kwargs)
 
-    def register_hook(self, hookable_method: str, hook: Callable[[List[Dict]], List[Dict]]):
+    def register_hook(self, hookable_method: str, hook: Callable):
         """
         Registers a hook to be called by a hookable method, in order to add a capability to the agent.
         Registered hooks are kept in lists (one per hookable method), and are called in their order of registration.

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -605,12 +605,7 @@ class ConversableAgent(LLMAgent):
         """Process the message before sending it to the recipient."""
         hook_list = self.hook_lists["process_message_before_send"]
         for hook in hook_list:
-            if isinstance(hook, Callable[[Agent, Union[Dict, str], Agent, bool], Union[Dict, str]]):
-                message = hook(sender=self, message=message, recipient=recipient, silent=silent)
-            else:
-                raise ValueError(
-                    "process_message_before_send hook must be a callable with signature (Agent, Union[Dict, str], Agent, bool) -> Union[Dict, str]"
-                )
+            message = hook(sender=self, message=message, recipient=recipient, silent=silent)
         return message
 
     def send(
@@ -2726,12 +2721,7 @@ class ConversableAgent(LLMAgent):
         # Call each hook (in order of registration) to process the messages.
         processed_messages = messages
         for hook in hook_list:
-            if isinstance(hook, Callable[[List[Dict]], List[Dict]]):
-                processed_messages = hook(processed_messages)
-            else:
-                raise TypeError(
-                    "process_all_messages_before_reply hook must be a callable with signature (Callable[[List[Dict]], List[Dict]])."
-                )
+            processed_messages = hook(processed_messages)
         return processed_messages
 
     def process_last_received_message(self, messages: List[Dict]) -> List[Dict]:
@@ -2767,12 +2757,7 @@ class ConversableAgent(LLMAgent):
         # Call each hook (in order of registration) to process the user's message.
         processed_user_content = user_content
         for hook in hook_list:
-            if isinstance(hook, Callable[[List[Dict]], List[Dict]]):
-                processed_user_content = hook(processed_user_content)
-            else:
-                raise TypeError(
-                    "process_last_received_message hook must be a callable with signature (Callable[[List[Dict]], List[Dict]])."
-                )
+            processed_user_content = hook(processed_user_content)
 
         if processed_user_content == user_content:
             return messages  # No hooks actually modified the user's message.


### PR DESCRIPTION
- Refactored the `hook_lists` dictionary to use type hints for better readability.
- Updated the `register_hook` method signature to include type hints for the `hook` parameter.
- Added type hints to the `process_last_received_message` method parameters and return value.

This commit refactors the code related to hook registration and processing in the `conversable_agent.py` file. The changes improve code readability and maintainability by using type hints and updating method signatures.
