### PR TITLE
Fix chromadb get_collection ignores custom embedding_function

### DIFF
--- a/autogen/agentchat/contrib/vectordb/chromadb.py
+++ b/autogen/agentchat/contrib/vectordb/chromadb.py
@@ -83,7 +83,7 @@ class ChromaVectorDB(VectorDB):
             if self.active_collection and self.active_collection.name == collection_name:
                 collection = self.active_collection
             else:
-                collection = self.client.get_collection(collection_name)
+                collection = self.client.get_collection(collection_name, embedding_function=self.embedding_function)
         except ValueError:
             collection = None
         if collection is None:
@@ -126,7 +126,9 @@ class ChromaVectorDB(VectorDB):
                 )
         else:
             if not (self.active_collection and self.active_collection.name == collection_name):
-                self.active_collection = self.client.get_collection(collection_name)
+                self.active_collection = self.client.get_collection(
+                    collection_name, embedding_function=self.embedding_function
+                )
         return self.active_collection
 
     def delete_collection(self, collection_name: str) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

ChromaDB get_collection always returns the collection with a default embedding function, thus when it's called when a custom embedding function is used, the returned collection will use the wrong embedding function. This PR fixes it by passing in the correct embedding function explicitly.

## Related issue number
Closes #2540 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
