### PR TITLE
Updated the azure client to support AAD auth.

### DIFF
--- a/autogen/logger/sqlite_logger.py
+++ b/autogen/logger/sqlite_logger.py
@@ -236,7 +236,16 @@ class SqliteLogger(BaseLogger):
 
         args = to_dict(
             init_args,
-            exclude=("self", "__class__", "api_key", "organization", "base_url", "azure_endpoint"),
+            exclude=(
+                "self",
+                "__class__",
+                "api_key",
+                "organization",
+                "base_url",
+                "azure_endpoint",
+                "azure_ad_token",
+                "azure_ad_token_provider",
+            ),
             no_recursive=(Agent,),
         )
 
@@ -301,7 +310,17 @@ class SqliteLogger(BaseLogger):
             return
 
         args = to_dict(
-            init_args, exclude=("self", "__class__", "api_key", "organization", "base_url", "azure_endpoint")
+            init_args,
+            exclude=(
+                "self",
+                "__class__",
+                "api_key",
+                "organization",
+                "base_url",
+                "azure_endpoint",
+                "azure_ad_token",
+                "azure_ad_token_provider",
+            ),
         )
 
         query = """
@@ -323,7 +342,17 @@ class SqliteLogger(BaseLogger):
             return
 
         args = to_dict(
-            init_args, exclude=("self", "__class__", "api_key", "organization", "base_url", "azure_endpoint")
+            init_args,
+            exclude=(
+                "self",
+                "__class__",
+                "api_key",
+                "organization",
+                "base_url",
+                "azure_endpoint",
+                "azure_ad_token",
+                "azure_ad_token_provider",
+            ),
         )
 
         query = """

--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -407,6 +407,14 @@ class OpenAIWrapper:
             openai_config["azure_deployment"] = openai_config["azure_deployment"].replace(".", "")
         openai_config["azure_endpoint"] = openai_config.get("azure_endpoint", openai_config.pop("base_url", None))
 
+        # Create a default Azure token provider if requested
+        if openai_config.get("azure_ad_token_provider") == "DEFAULT":
+            import azure.identity
+
+            openai_config["azure_ad_token_provider"] = azure.identity.get_bearer_token_provider(
+                azure.identity.DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+            )
+
     def _register_default_client(self, config: Dict[str, Any], openai_config: Dict[str, Any]) -> None:
         """Create a client with the given config to override openai_config,
         after removing extra kwargs.

--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -13,7 +13,7 @@ from openai import OpenAI
 from openai.types.beta.assistant import Assistant
 from packaging.version import parse
 
-NON_CACHE_KEY = ["api_key", "base_url", "api_type", "api_version"]
+NON_CACHE_KEY = ["api_key", "base_url", "api_type", "api_version", "azure_ad_token", "azure_ad_token_provider"]
 DEFAULT_AZURE_API_VERSION = "2024-02-15-preview"
 OAI_PRICE1K = {
     # https://openai.com/api/pricing/


### PR DESCRIPTION
## Why are these changes needed?

Cleanly supports AAD auth in AutoGen, including the parameters `azure_ad_token`, `azure_ad_token_provider`, keeping them out of cache, logs, etc.

`azure_ad_token_provider` can be set to a function, as per the usual practice, or to the string "DEFAULT", in which case the default provider is automatically constructed. This is helpful when using JSON OAI_CONFIG_LISTS:

```
[
  {
      "model": "gpt-4",
      "base_url": "YOUR_BASE_URL",
      "api_type": "azure",
      "api_version": "2024-02-01",
      "max_tokens": 1000,
      "azure_ad_token_provider": "DEFAULT"
  }
]
``` 

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
