### PR TITLE
Fix missing messages in Gemini history

### DIFF
--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -32,6 +32,7 @@ Resources:
 from __future__ import annotations
 
 import base64
+import logging
 import os
 import random
 import re
@@ -43,6 +44,7 @@ from typing import Any, Dict, List, Mapping, Union
 import google.generativeai as genai
 import requests
 import vertexai
+from flaml.automl.logger import logger_formatter
 from google.ai.generativelanguage import Content, Part
 from google.api_core.exceptions import InternalServerError
 from openai.types.chat import ChatCompletion
@@ -51,7 +53,12 @@ from openai.types.completion_usage import CompletionUsage
 from PIL import Image
 from vertexai.generative_models import Content as VertexAIContent
 from vertexai.generative_models import GenerativeModel
+from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
+from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
 from vertexai.generative_models import Part as VertexAIPart
+from vertexai.generative_models import SafetySetting as VertexAISafetySetting
+
+logger = logging.getLogger(__name__)
 
 
 class GeminiClient:
@@ -166,6 +173,7 @@ class GeminiClient:
             if autogen_term in params
         }
         safety_settings = params.get("safety_settings", {})
+        vertexai_safety_settings = GeminiClient._to_vertexai_safety_settings(safety_settings)
 
         if stream:
             warnings.warn(
@@ -181,7 +189,7 @@ class GeminiClient:
             gemini_messages = self._oai_messages_to_gemini_messages(messages)
             if self.use_vertexai:
                 model = GenerativeModel(
-                    model_name, generation_config=generation_config, safety_settings=safety_settings
+                    model_name, generation_config=generation_config, safety_settings=vertexai_safety_settings
                 )
             else:
                 # we use chat model by default
@@ -218,7 +226,7 @@ class GeminiClient:
             # B. handle the vision model
             if self.use_vertexai:
                 model = GenerativeModel(
-                    model_name, generation_config=generation_config, safety_settings=safety_settings
+                    model_name, generation_config=generation_config, safety_settings=vertexai_safety_settings
                 )
             else:
                 model = genai.GenerativeModel(
@@ -371,6 +379,24 @@ class GeminiClient:
                 rst.append(Content(parts=self._oai_content_to_gemini_content("continue"), role="user"))
 
         return rst
+
+    @staticmethod
+    def _to_vertexai_safety_settings(safety_settings):
+        vertexai_safety_settings = []
+        for safety_setting in safety_settings:
+            if safety_setting["category"] not in VertexAIHarmCategory.__members__:
+                invalid_category = safety_setting["category"]
+                logger.error(f"Safety setting category {invalid_category} is invalid")
+            elif safety_setting["threshold"] not in VertexAIHarmBlockThreshold.__members__:
+                invalid_threshold = safety_setting["threshold"]
+                logger.error(f"Safety threshold {invalid_threshold} is invalid")
+            else:
+                vertexai_safety_setting = VertexAISafetySetting(
+                    category=safety_setting["category"],
+                    threshold=safety_setting["threshold"],
+                )
+                vertexai_safety_settings.append(vertexai_safety_setting)
+        return vertexai_safety_settings
 
 
 def _to_pil(data: str) -> Image.Image:

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -194,7 +194,7 @@ class GeminiClient:
             for attempt in range(max_retries):
                 ans = None
                 try:
-                    response = chat.send_message(gemini_messages[-1].parts[0].text, stream=stream)
+                    response = chat.send_message(gemini_messages[-1], stream=stream)
                 except InternalServerError:
                     delay = 5 * (2**attempt)
                     warnings.warn(
@@ -348,17 +348,17 @@ class GeminiClient:
                 curr_parts += parts
             elif role != prev_role:
                 if self.use_vertexai:
-                    rst.append(VertexAIContent(parts=self._concat_parts(curr_parts), role=prev_role))
+                    rst.append(VertexAIContent(parts=curr_parts, role=prev_role))
                 else:
-                    rst.append(Content(parts=self._concat_parts(curr_parts), role=prev_role))
+                    rst.append(Content(parts=curr_parts, role=prev_role))
                 curr_parts = parts
             prev_role = role
 
         # handle the last message
         if self.use_vertexai:
-            rst.append(VertexAIContent(parts=self._concat_parts(curr_parts), role=role))
+            rst.append(VertexAIContent(parts=curr_parts, role=role))
         else:
-            rst.append(Content(parts=self._concat_parts(curr_parts), role=role))
+            rst.append(Content(parts=curr_parts, role=role))
 
         # The Gemini is restrict on order of roles, such that
         # 1. The messages should be interleaved between user and model.

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -344,21 +344,21 @@ class GeminiClient:
         for i, message in enumerate(messages):
             parts = self._oai_content_to_gemini_content(message["content"])
             role = "user" if message["role"] in ["user", "system"] else "model"
-
-            if prev_role is None or role == prev_role:
+            if (prev_role is None) or (role == prev_role):
                 curr_parts += parts
             elif role != prev_role:
                 if self.use_vertexai:
                     rst.append(VertexAIContent(parts=self._concat_parts(curr_parts), role=prev_role))
                 else:
                     rst.append(Content(parts=curr_parts, role=prev_role))
+                curr_parts = parts
             prev_role = role
 
         # handle the last message
         if self.use_vertexai:
             rst.append(VertexAIContent(parts=self._concat_parts(curr_parts), role=role))
         else:
-            rst.append(Content(parts=curr_parts, role=role))
+            rst.append(Content(parts=self._concat_parts(curr_parts), role=role))
 
         # The Gemini is restrict on order of roles, such that
         # 1. The messages should be interleaved between user and model.

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -350,7 +350,7 @@ class GeminiClient:
                 if self.use_vertexai:
                     rst.append(VertexAIContent(parts=self._concat_parts(curr_parts), role=prev_role))
                 else:
-                    rst.append(Content(parts=curr_parts, role=prev_role))
+                    rst.append(Content(parts=self._concat_parts(curr_parts), role=prev_role))
                 curr_parts = parts
             prev_role = role
 

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -4,9 +4,6 @@ import pytest
 
 try:
     from google.api_core.exceptions import InternalServerError
-    from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
-    from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
-    from vertexai.generative_models import SafetySetting as VertexAISafetySetting
 
     from autogen.oai.gemini import GeminiClient
 
@@ -53,38 +50,6 @@ def gemini_google_auth_default_client():
 @pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
 def test_valid_initialization(gemini_client):
     assert gemini_client.api_key == "fake_api_key", "API Key should be correctly set"
-
-
-@pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
-def test_vertexai_safety_setting_conversion(gemini_client):
-    safety_settings = [
-        {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_ONLY_HIGH"},
-        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_ONLY_HIGH"},
-        {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_ONLY_HIGH"},
-        {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_ONLY_HIGH"},
-    ]
-    converted_safety_settings = GeminiClient._to_vertexai_safety_settings(safety_settings)
-    harm_categories = [
-        VertexAIHarmCategory.HARM_CATEGORY_HARASSMENT,
-        VertexAIHarmCategory.HARM_CATEGORY_HATE_SPEECH,
-        VertexAIHarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-        VertexAIHarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-    ]
-    expected_safety_settings = [
-        VertexAISafetySetting(category=category, threshold=VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH)
-        for category in harm_categories
-    ]
-
-    def compare_safety_settings(converted_safety_settings, expected_safety_settings):
-        for i, expected_setting in enumerate(expected_safety_settings):
-            converted_setting = converted_safety_settings[i]
-            yield expected_setting.to_dict() == converted_setting.to_dict()
-
-    assert len(converted_safety_settings) == len(
-        expected_safety_settings
-    ), "The length of the safety settings is incorrect"
-    settings_comparison = compare_safety_settings(converted_safety_settings, expected_safety_settings)
-    assert all(settings_comparison), "Converted safety settings are incorrect"
 
 
 @pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -52,6 +52,23 @@ def test_valid_initialization(gemini_client):
     assert gemini_client.api_key == "fake_api_key", "API Key should be correctly set"
 
 
+@patch("autogen.oai.gemini.genai")
+@pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
+def test_gemini_message_handling(mock_genai, gemini_client):
+    messages = [
+        {"role": "system", "content": "You are my personal assistant."},
+        {"role": "model", "content": "How can I help you?"},
+        {"role": "user", "content": "Which planet is the nearest to the sun?"},
+        {"role": "user", "content": "Which planet is the farthest from the sun?"},
+    ]
+    converted_messages = gemini_client._oai_messages_to_gemini_messages(messages)
+    assert len(converted_messages) == 3, "The number of messages is not as expected"
+    assert converted_messages[0].parts[0].text == messages[0]["content"]
+    assert converted_messages[1].parts[0].text == messages[1]["content"]
+    assert converted_messages[2].parts[0].text == messages[2]["content"]
+    assert converted_messages[2].parts[1].text == messages[3]["content"]
+
+
 # Test error handling
 @patch("autogen.oai.gemini.genai")
 @pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -60,13 +60,39 @@ def test_gemini_message_handling(mock_genai, gemini_client):
         {"role": "model", "content": "How can I help you?"},
         {"role": "user", "content": "Which planet is the nearest to the sun?"},
         {"role": "user", "content": "Which planet is the farthest from the sun?"},
+        {"role": "model", "content": "Mercury is the closest palnet to the sun."},
+        {"role": "model", "content": "Neptune is the farthest palnet from the sun."},
+        {"role": "user", "content": "How can we determine the mass of a black hole?"},
     ]
+
+    # The datastructure below defines what the structure of the messages
+    # should resemble after converting to Gemini format.
+    # Messages of similar roles are expected to be merged to a single message,
+    # where the contents of the original messages will be included in
+    # consecutive parts of the converted Gemini message
+    expected_gemini_struct = [
+        # system role is converted to user role
+        {"role": "user", "parts": ["You are my personal assistant."]},
+        {"role": "model", "parts": ["How can I help you?"]},
+        {
+            "role": "user",
+            "parts": ["Which planet is the nearest to the sun?", "Which planet is the farthest from the sun?"],
+        },
+        {
+            "role": "model",
+            "parts": ["Mercury is the closest palnet to the sun.", "Neptune is the farthest palnet from the sun."],
+        },
+        {"role": "user", "parts": ["How can we determine the mass of a black hole?"]},
+    ]
+
     converted_messages = gemini_client._oai_messages_to_gemini_messages(messages)
-    assert len(converted_messages) == 3, "The number of messages is not as expected"
-    assert converted_messages[0].parts[0].text == messages[0]["content"]
-    assert converted_messages[1].parts[0].text == messages[1]["content"]
-    assert converted_messages[2].parts[0].text == messages[2]["content"]
-    assert converted_messages[2].parts[1].text == messages[3]["content"]
+
+    assert len(converted_messages) == len(expected_gemini_struct), "The number of messages is not as expected"
+
+    for i, expected_msg in enumerate(expected_gemini_struct):
+        assert expected_msg["role"] == converted_messages[i].role
+        for j, part in enumerate(expected_msg["parts"]):
+            assert converted_messages[i].parts[j].text == part
 
 
 # Test error handling

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -4,6 +4,9 @@ import pytest
 
 try:
     from google.api_core.exceptions import InternalServerError
+    from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
+    from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
+    from vertexai.generative_models import SafetySetting as VertexAISafetySetting
 
     from autogen.oai.gemini import GeminiClient
 
@@ -52,9 +55,40 @@ def test_valid_initialization(gemini_client):
     assert gemini_client.api_key == "fake_api_key", "API Key should be correctly set"
 
 
-@patch("autogen.oai.gemini.genai")
 @pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
-def test_gemini_message_handling(mock_genai, gemini_client):
+def test_vertexai_safety_setting_conversion(gemini_client):
+    safety_settings = [
+        {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_ONLY_HIGH"},
+    ]
+    converted_safety_settings = GeminiClient._to_vertexai_safety_settings(safety_settings)
+    harm_categories = [
+        VertexAIHarmCategory.HARM_CATEGORY_HARASSMENT,
+        VertexAIHarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        VertexAIHarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        VertexAIHarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+    ]
+    expected_safety_settings = [
+        VertexAISafetySetting(category=category, threshold=VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH)
+        for category in harm_categories
+    ]
+
+    def compare_safety_settings(converted_safety_settings, expected_safety_settings):
+        for i, expected_setting in enumerate(expected_safety_settings):
+            converted_setting = converted_safety_settings[i]
+            yield expected_setting.to_dict() == converted_setting.to_dict()
+
+    assert len(converted_safety_settings) == len(
+        expected_safety_settings
+    ), "The length of the safety settings is incorrect"
+    settings_comparison = compare_safety_settings(converted_safety_settings, expected_safety_settings)
+    assert all(settings_comparison), "Converted safety settings are incorrect"
+
+
+@pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
+def test_gemini_message_handling(gemini_client):
     messages = [
         {"role": "system", "content": "You are my personal assistant."},
         {"role": "model", "content": "How can I help you?"},

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -90,9 +90,9 @@ def test_gemini_message_handling(mock_genai, gemini_client):
     assert len(converted_messages) == len(expected_gemini_struct), "The number of messages is not as expected"
 
     for i, expected_msg in enumerate(expected_gemini_struct):
-        assert expected_msg["role"] == converted_messages[i].role
+        assert expected_msg["role"] == converted_messages[i].role, "Incorrect mapped message role"
         for j, part in enumerate(expected_msg["parts"]):
-            assert converted_messages[i].parts[j].text == part
+            assert converted_messages[i].parts[j].text == part, "Incorrect mapped message text"
 
 
 # Test error handling


### PR DESCRIPTION
## Why are these changes needed?

Message is missing from history with Gemini.
Supplying safety settings in Vertex AI format, when VertexAI is used.

## Related issue number

Closes  [#2900](https://github.com/microsoft/autogen/issues/2900)

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
