### PR TITLE
Add tool validation

### DIFF
--- a/autogen/agentchat/contrib/file_surfer/file_surfer.py
+++ b/autogen/agentchat/contrib/file_surfer/file_surfer.py
@@ -1,8 +1,8 @@
 import json
-import time
 import logging
+import time
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union, Callable, Literal, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from .... import Agent, ConversableAgent
 from ....browser_utils import AbstractMarkdownBrowser, RequestsMarkdownBrowser


### PR DESCRIPTION
This pull request primarily focuses on improving the validation for tool calls in the `autogen/agentchat/contrib/file_surfer/file_surfer.py` file. The changes include a reordering of import statements, the addition of a new validation method, and the integration of this validation into the `generate_surfer_reply` method.

* [`autogen/agentchat/contrib/file_surfer/file_surfer.py`](diffhunk://#diff-a2f6268c13d0f9397af6413b05692025b62e39f61be7a7c5cb6b3dbde1509230L2-R5): The import statements have been reordered and slightly modified for better readability and organization.
* [`autogen/agentchat/contrib/file_surfer/file_surfer.py`](diffhunk://#diff-a2f6268c13d0f9397af6413b05692025b62e39f61be7a7c5cb6b3dbde1509230R98-R114): A new method `validate_tool_call` has been added. This method checks if the tool call is valid by checking the tool name and the arguments required for each tool.
* [`autogen/agentchat/contrib/file_surfer/file_surfer.py`](diffhunk://#diff-a2f6268c13d0f9397af6413b05692025b62e39f61be7a7c5cb6b3dbde1509230L130-R154): The `generate_surfer_reply` method has been updated to use the new `validate_tool_call` method. If the validation fails, the method returns an error message.