### PR TITLE
Update on gpt-4o azure version date

### DIFF
--- a/OAI_CONFIG_LIST_sample
+++ b/OAI_CONFIG_LIST_sample
@@ -9,11 +9,12 @@
         "tags": ["gpt-4", "tool"]
     },
     {
-        "model": "<your Azure OpenAI deployment name>",
-        "api_key": "<your Azure OpenAI API key here>",
-        "base_url": "<your Azure OpenAI API base here>",
+        "model": "gpt-4o",
+        "api_key": "AZURE_OPENAI_API_KEY",
+        "base_url": "https://URL.azure.com/ ",
         "api_type": "azure",
-        "api_version": "2024-02-15-preview"
+        "api_version": "2024-05-13",
+        "tags": ["gpt-4o", "gpt-4", "tool"]
     },
     {
         "model": "<your Azure OpenAI deployment name>",


### PR DESCRIPTION
For Azure gpt-4o : 2024-05-13
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Use the latest and available version of gpt-4o on azure

<!-- Please give a short summary of the change and the problem this solves. -->
Make it useable.
Note: You can deploy GPT-4o in the following US regions only at this time: eastus, eastus2, northcentralus, southcentralus, westus, westus3.
https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#gpt-4o-and-gpt-4-turbo 




