### PR TITLE
Fix argument parsing and validation

### DIFF
--- a/autogen/agentchat/contrib/file_surfer/file_surfer.py
+++ b/autogen/agentchat/contrib/file_surfer/file_surfer.py
@@ -102,6 +102,11 @@ class FileSurferAgent(ConversableAgent):
         if tool_name not in tool_names:
             return False, f"Invalid tool name '{tool_name}'. Please choose from the following: {tool_names}"
 
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            return False, f"Invalid JSON format for arguments '{arguments}'."
+
         # validate the arguments
         if tool_name == "open_local_file":
             if "path" not in arguments:
@@ -145,12 +150,14 @@ class FileSurferAgent(ConversableAgent):
             tool_calls = response.message.tool_calls
             for tool_call in tool_calls:
                 tool_name = tool_call.function.name
-                arguments = json.loads(tool_call.function.arguments)
+                arguments = tool_call.function.arguments
 
                 is_valid, reason = self.validate_tool_call(tool_name, arguments)
 
                 if not is_valid:
                     return True, reason
+
+                arguments = json.loads(arguments)
 
                 self._log_to_console(tool_name, arguments)
 


### PR DESCRIPTION
This pull request primarily focuses on improving the handling of arguments in the `file_surfer.py` script. The changes ensure that arguments are validated and correctly parsed as JSON before being used in the `validate_tool_call` and `generate_surfer_reply` functions.

Here are the key changes:

* `autogen/agentchat/contrib/file_surfer/file_surfer.py`:
  * `def validate_tool_call(self, tool_name, arguments)`: Added a try-except block to parse the arguments as JSON and return an error message if the parsing fails. This ensures that the arguments are in a valid JSON format before any further processing.
  * [`def generate_surfer_reply(`](diffhunk://#diff-a2f6268c13d0f9397af6413b05692025b62e39f61be7a7c5cb6b3dbde1509230L148-R161): Moved the parsing of arguments as JSON from the start of the function to after the call to `validate_tool_call`. This ensures that the arguments are validated before being parsed.