### PR TITLE
[.Net] update oai tests by using new OpenAI resources

### DIFF
--- a/dotnet/eng/MetaInfo.props
+++ b/dotnet/eng/MetaInfo.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <VersionPrefix>0.0.14</VersionPrefix>
+        <VersionPrefix>0.0.15</VersionPrefix>
         <Authors>AutoGen</Authors>
         <PackageProjectUrl>https://microsoft.github.io/autogen-for-net/</PackageProjectUrl>
         <RepositoryUrl>https://github.com/microsoft/autogen</RepositoryUrl>

--- a/dotnet/sample/AutoGen.BasicSamples/Example13_OpenAIAgent_JsonMode.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Example13_OpenAIAgent_JsonMode.cs
@@ -16,7 +16,7 @@ public class Example13_OpenAIAgent_JsonMode
     public static async Task RunAsync()
     {
         #region create_agent
-        var config = LLMConfiguration.GetAzureOpenAIGPT3_5_Turbo(deployName: "gpt-35-turbo-0125"); // json mode only works with 0125 and later model.
+        var config = LLMConfiguration.GetAzureOpenAIGPT3_5_Turbo(deployName: "gpt-35-turbo"); // json mode only works with 0125 and later model.
         var apiKey = config.ApiKey;
         var endPoint = new Uri(config.Endpoint);
 

--- a/dotnet/sample/AutoGen.BasicSamples/LLMConfiguration.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/LLMConfiguration.cs
@@ -22,11 +22,11 @@ internal static class LLMConfiguration
         return new OpenAIConfig(openAIKey, modelId);
     }
 
-    public static AzureOpenAIConfig GetAzureOpenAIGPT3_5_Turbo(string deployName = "gpt-35-turbo-16k")
+    public static AzureOpenAIConfig GetAzureOpenAIGPT3_5_Turbo(string? deployName = null)
     {
         var azureOpenAIKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
-
+        deployName = deployName ?? Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         return new AzureOpenAIConfig(endpoint, deployName, azureOpenAIKey);
     }
 

--- a/dotnet/test/AutoGen.OpenAI.Tests/MathClassTest.cs
+++ b/dotnet/test/AutoGen.OpenAI.Tests/MathClassTest.cs
@@ -96,16 +96,15 @@ teacher, please create the next math question";
         }
 
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task OpenAIAgentMathChatTestAsync()
         {
             var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new ArgumentException("AZURE_OPENAI_API_KEY is not set");
             var endPoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new ArgumentException("AZURE_OPENAI_ENDPOINT is not set");
-
+            var deployName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new ArgumentException("AZURE_OPENAI_DEPLOY_NAME is not set");
             var openaiClient = new OpenAIClient(new Uri(endPoint), new Azure.AzureKeyCredential(key));
-            var model = "gpt-35-turbo-16k";
-            var teacher = await CreateTeacherAgentAsync(openaiClient, model);
-            var student = await CreateStudentAssistantAgentAsync(openaiClient, model);
+            var teacher = await CreateTeacherAgentAsync(openaiClient, deployName);
+            var student = await CreateStudentAssistantAgentAsync(openaiClient, deployName);
 
             var adminFunctionMiddleware = new FunctionCallMiddleware(
                 functions: [this.UpdateProgressFunctionContract],
@@ -115,7 +114,7 @@ teacher, please create the next math question";
                 });
             var admin = new OpenAIChatAgent(
                 openAIClient: openaiClient,
-                modelName: model,
+                modelName: deployName,
                 name: "Admin",
                 systemMessage: $@"You are admin. You update progress after each question is answered.")
                 .RegisterMessageConnector()
@@ -124,7 +123,7 @@ teacher, please create the next math question";
 
             var groupAdmin = new OpenAIChatAgent(
                 openAIClient: openaiClient,
-                modelName: model,
+                modelName: deployName,
                 name: "GroupAdmin",
                 systemMessage: "You are group admin. You manage the group chat.")
                 .RegisterMessageConnector()

--- a/dotnet/test/AutoGen.OpenAI.Tests/OpenAIChatAgentTest.cs
+++ b/dotnet/test/AutoGen.OpenAI.Tests/OpenAIChatAgentTest.cs
@@ -25,16 +25,17 @@ public partial class OpenAIChatAgentTest
         return $"The weather in {location} is sunny.";
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task BasicConversationTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deployName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var openaiClient = new OpenAIClient(new Uri(endpoint), new Azure.AzureKeyCredential(key));
         var openAIChatAgent = new OpenAIChatAgent(
             openAIClient: openaiClient,
             name: "assistant",
-            modelName: "gpt-35-turbo-16k");
+            modelName: deployName);
 
         // By default, OpenAIChatClient supports the following message types
         // - IMessage<ChatRequestMessage>
@@ -56,16 +57,17 @@ public partial class OpenAIChatAgentTest
         }
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task OpenAIChatMessageContentConnectorTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deployName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var openaiClient = new OpenAIClient(new Uri(endpoint), new Azure.AzureKeyCredential(key));
         var openAIChatAgent = new OpenAIChatAgent(
             openAIClient: openaiClient,
             name: "assistant",
-            modelName: "gpt-35-turbo-16k");
+            modelName: deployName);
 
         MiddlewareStreamingAgent<OpenAIChatAgent> assistant = openAIChatAgent
             .RegisterMessageConnector();
@@ -102,16 +104,17 @@ public partial class OpenAIChatAgentTest
         }
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task OpenAIChatAgentToolCallTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deployName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var openaiClient = new OpenAIClient(new Uri(endpoint), new Azure.AzureKeyCredential(key));
         var openAIChatAgent = new OpenAIChatAgent(
             openAIClient: openaiClient,
             name: "assistant",
-            modelName: "gpt-35-turbo-16k");
+            modelName: deployName);
 
         var functionCallMiddleware = new FunctionCallMiddleware(
             functions: [this.GetWeatherAsyncFunctionContract]);
@@ -170,16 +173,17 @@ public partial class OpenAIChatAgentTest
         }
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task OpenAIChatAgentToolCallInvokingTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deployName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var openaiClient = new OpenAIClient(new Uri(endpoint), new Azure.AzureKeyCredential(key));
         var openAIChatAgent = new OpenAIChatAgent(
             openAIClient: openaiClient,
             name: "assistant",
-            modelName: "gpt-35-turbo-16k");
+            modelName: deployName);
 
         var functionCallMiddleware = new FunctionCallMiddleware(
             functions: [this.GetWeatherAsyncFunctionContract],

--- a/dotnet/test/AutoGen.SemanticKernel.Tests/KernelFunctionMiddlewareTests.cs
+++ b/dotnet/test/AutoGen.SemanticKernel.Tests/KernelFunctionMiddlewareTests.cs
@@ -13,18 +13,19 @@ namespace AutoGen.SemanticKernel.Tests;
 
 public class KernelFunctionMiddlewareTests
 {
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task ItRegisterKernelFunctionMiddlewareFromTestPluginTests()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deployName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var openaiClient = new OpenAIClient(new Uri(endpoint), new Azure.AzureKeyCredential(key));
 
         var kernel = new Kernel();
         var plugin = kernel.ImportPluginFromType<TestPlugin>();
         var kernelFunctionMiddleware = new KernelPluginMiddleware(kernel, plugin);
 
-        var agent = new OpenAIChatAgent(openaiClient, "assistant", modelName: "gpt-35-turbo-16k")
+        var agent = new OpenAIChatAgent(openaiClient, "assistant", modelName: deployName)
             .RegisterMessageConnector()
             .RegisterMiddleware(kernelFunctionMiddleware);
 
@@ -56,11 +57,12 @@ public class KernelFunctionMiddlewareTests
         }
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task ItRegisterKernelFunctionMiddlewareFromMethodTests()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deployName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var openaiClient = new OpenAIClient(new Uri(endpoint), new Azure.AzureKeyCredential(key));
 
         var kernel = new Kernel();
@@ -69,7 +71,7 @@ public class KernelFunctionMiddlewareTests
         var plugin = kernel.ImportPluginFromFunctions("plugin", [getWeatherMethod, createPersonObjectMethod]);
         var kernelFunctionMiddleware = new KernelPluginMiddleware(kernel, plugin);
 
-        var agent = new OpenAIChatAgent(openaiClient, "assistant", modelName: "gpt-35-turbo-16k")
+        var agent = new OpenAIChatAgent(openaiClient, "assistant", modelName: deployName)
             .RegisterMessageConnector()
             .RegisterMiddleware(kernelFunctionMiddleware);
 

--- a/dotnet/test/AutoGen.SemanticKernel.Tests/SemanticKernelAgentTest.cs
+++ b/dotnet/test/AutoGen.SemanticKernel.Tests/SemanticKernelAgentTest.cs
@@ -25,13 +25,14 @@ public partial class SemanticKernelAgentTest
         return $"The weather in {location} is sunny.";
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task BasicConversationTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var builder = Kernel.CreateBuilder()
-            .AddAzureOpenAIChatCompletion("gpt-35-turbo-16k", endpoint, key);
+            .AddAzureOpenAIChatCompletion(deploymentName, endpoint, key);
 
         var kernel = builder.Build();
 
@@ -53,13 +54,14 @@ public partial class SemanticKernelAgentTest
         }
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task SemanticKernelChatMessageContentConnectorTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var builder = Kernel.CreateBuilder()
-            .AddAzureOpenAIChatCompletion("gpt-35-turbo-16k", endpoint, key);
+            .AddAzureOpenAIChatCompletion(deploymentName, endpoint, key);
 
         var kernel = builder.Build();
 
@@ -97,13 +99,14 @@ public partial class SemanticKernelAgentTest
         }
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task SemanticKernelPluginTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var builder = Kernel.CreateBuilder()
-            .AddAzureOpenAIChatCompletion("gpt-35-turbo-16k", endpoint, key);
+            .AddAzureOpenAIChatCompletion(deploymentName, endpoint, key);
 
         var parameters = this.GetWeatherAsyncFunctionContract.Parameters!.Select(p => new KernelParameterMetadata(p.Name!)
         {
@@ -129,13 +132,14 @@ public partial class SemanticKernelAgentTest
     }
 
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task BasicSkChatCompletionAgentConversationTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var builder = Kernel.CreateBuilder()
-            .AddAzureOpenAIChatCompletion("gpt-35-turbo-16k", endpoint, key);
+            .AddAzureOpenAIChatCompletion(deploymentName, endpoint, key);
 
         var kernel = builder.Build();
         var agent = new ChatCompletionAgent()
@@ -154,13 +158,14 @@ public partial class SemanticKernelAgentTest
         reply.As<MessageEnvelope<ChatMessageContent>>().From.Should().Be("assistant");
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task SkChatCompletionAgentChatMessageContentConnectorTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var builder = Kernel.CreateBuilder()
-            .AddAzureOpenAIChatCompletion("gpt-35-turbo-16k", endpoint, key);
+            .AddAzureOpenAIChatCompletion(deploymentName, endpoint, key);
 
         var kernel = builder.Build();
 
@@ -193,13 +198,14 @@ public partial class SemanticKernelAgentTest
         }
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task SkChatCompletionAgentPluginTestAsync()
     {
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new Exception("Please set AZURE_OPENAI_ENDPOINT environment variable.");
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new Exception("Please set AZURE_OPENAI_API_KEY environment variable.");
+        var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new Exception("Please set AZURE_OPENAI_DEPLOY_NAME environment variable.");
         var builder = Kernel.CreateBuilder()
-            .AddAzureOpenAIChatCompletion("gpt-35-turbo-16k", endpoint, key);
+            .AddAzureOpenAIChatCompletion(deploymentName, endpoint, key);
 
         var parameters = this.GetWeatherAsyncFunctionContract.Parameters!.Select(p => new KernelParameterMetadata(p.Name!)
         {

--- a/dotnet/test/AutoGen.Tests/BasicSampleTest.cs
+++ b/dotnet/test/AutoGen.Tests/BasicSampleTest.cs
@@ -19,25 +19,25 @@ namespace AutoGen.Tests
             Console.SetOut(new ConsoleWriter(_output));
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task AssistantAgentTestAsync()
         {
             await Example01_AssistantAgent.RunAsync();
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task TwoAgentMathClassTestAsync()
         {
             await Example02_TwoAgent_MathChat.RunAsync();
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task AgentFunctionCallTestAsync()
         {
             await Example03_Agent_FunctionCall.RunAsync();
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task OpenAIAgent_JsonMode()
         {
             await Example13_OpenAIAgent_JsonMode.RunAsync();
@@ -55,7 +55,7 @@ namespace AutoGen.Tests
             await Example04_Dynamic_GroupChat_Coding_Task.RunAsync();
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task DynamicGroupChatCalculateFibonacciAsync()
         {
             await Example07_Dynamic_GroupChat_Calculate_Fibonacci.RunAsync();

--- a/dotnet/test/AutoGen.Tests/SingleAgentTest.cs
+++ b/dotnet/test/AutoGen.Tests/SingleAgentTest.cs
@@ -27,7 +27,8 @@ namespace AutoGen.Tests
         {
             var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new ArgumentException("AZURE_OPENAI_API_KEY is not set");
             var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new ArgumentException("AZURE_OPENAI_ENDPOINT is not set");
-            return new AzureOpenAIConfig(endpoint, "gpt-35-turbo-16k", key);
+            var deployName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new ArgumentException("AZURE_OPENAI_DEPLOY_NAME is not set");
+            return new AzureOpenAIConfig(endpoint, deployName, key);
         }
 
         private ILLMConfig CreateOpenAIGPT4VisionConfig()
@@ -36,7 +37,7 @@ namespace AutoGen.Tests
             return new OpenAIConfig(key, "gpt-4-vision-preview");
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task GPTAgentTestAsync()
         {
             var config = this.CreateAzureOpenAIGPT35TurboConfig();
@@ -111,7 +112,7 @@ namespace AutoGen.Tests
             }
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task GPTFunctionCallAgentTestAsync()
         {
             var config = this.CreateAzureOpenAIGPT35TurboConfig();
@@ -120,7 +121,7 @@ namespace AutoGen.Tests
             await EchoFunctionCallTestAsync(agentWithFunction);
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task AssistantAgentFunctionCallTestAsync()
         {
             var config = this.CreateAzureOpenAIGPT35TurboConfig();
@@ -197,7 +198,7 @@ namespace AutoGen.Tests
             reply.From.Should().Be(assistantAgent.Name);
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task AssistantAgentFunctionCallSelfExecutionTestAsync()
         {
             var config = this.CreateAzureOpenAIGPT35TurboConfig();
@@ -223,7 +224,7 @@ namespace AutoGen.Tests
             await EchoFunctionCallExecutionTestAsync(assistantAgent);
         }
 
-        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+        [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
         public async Task GPTAgentFunctionCallSelfExecutionTestAsync()
         {
             var config = this.CreateAzureOpenAIGPT35TurboConfig();
@@ -240,7 +241,6 @@ namespace AutoGen.Tests
 
             await EchoFunctionCallExecutionStreamingTestAsync(agent);
             await EchoFunctionCallExecutionTestAsync(agent);
-            await UpperCaseTestAsync(agent);
         }
 
         /// <summary>

--- a/dotnet/test/AutoGen.Tests/TwoAgentTest.cs
+++ b/dotnet/test/AutoGen.Tests/TwoAgentTest.cs
@@ -25,12 +25,12 @@ public partial class TwoAgentTest
         return $"[GetWeatherFunction] The weather in {city} is sunny";
     }
 
-    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")]
+    [ApiKeyFact("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOY_NAME")]
     public async Task TwoAgentWeatherChatTestAsync()
     {
         var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new ArgumentException("AZURE_OPENAI_API_KEY is not set");
         var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new ArgumentException("AZURE_OPENAI_ENDPOINT is not set");
-        var deploymentName = "gpt-35-turbo-16k";
+        var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOY_NAME") ?? throw new ArgumentException("AZURE_OPENAI_DEPLOY_NAME is not set");
         var config = new AzureOpenAIConfig(endpoint, deploymentName, key);
 
         var assistant = new AssistantAgent(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The subscription of original aoai resources that we used to run openai test have been deprecated. So I create another subscription to host these aoai resources and update the tests to apply these changes
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
