### PR TITLE
Fix bug for finding key in nested dictionary

### DIFF
--- a/samples/apps/autogen-studio/autogenstudio/utils/utils.py
+++ b/samples/apps/autogen-studio/autogenstudio/utils/utils.py
@@ -511,11 +511,19 @@ def find_key_value(d, target_key):
     """
     Recursively search for a key in a nested dictionary and return its value.
     """
-    for key, value in d.items():
-        if key == target_key:
-            return value
-        elif isinstance(value, dict):
-            result = find_key_value(value, target_key)
-            if result is not None:
-                return result
+    if d is None:
+        return None
+
+    if isinstance(d, dict):
+        if target_key in d:
+            return d[target_key]
+        for k in d:
+            item = find_key_value(d[k], target_key)
+            if item is not None:
+                return item
+    elif isinstance(d, list):
+        for i in d:
+            item = find_key_value(i, target_key)
+            if item is not None:
+                return item
     return None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add a check at the start of the find_key_value function to ensure d is not None before trying to call items on it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Resolve issue of #2372

## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
