### PR TITLE
Set qdrant version to <1.9.2 to fix test errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ extra_require = {
     "retrievechat-pgvector": retrieve_chat_pgvector,
     "retrievechat-qdrant": [
         *retrieve_chat,
-        "qdrant_client[fastembed]",
+        "qdrant_client[fastembed]<1.9.2",
     ],
     "autobuild": ["chromadb", "sentence-transformers", "huggingface-hub", "pysqlite3"],
     "teachable": ["chromadb"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Qdrant test/agentchat/contrib/retrievechat/test_qdrant_retrievechat.py::test_qdrant_filter started failing as qdrant-client released a new version 1.9.2.

In this PR, we simply fix the version to unblock other PRs. But support for latest version of qdrant-client should be added in another PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
