### PR TITLE
fix: `created` in ChatCompletion in non-oai clients

### DIFF
--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -181,7 +181,7 @@ class AnthropicClient:
         response_oai = ChatCompletion(
             id=response.id,
             model=anthropic_params["model"],
-            created=int(time.time() * 1000),
+            created=int(time.time()),
             object="chat.completion",
             choices=choices,
             usage=CompletionUsage(

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -253,7 +253,7 @@ class GeminiClient:
         response_oai = ChatCompletion(
             id=str(random.randint(0, 1000)),
             model=model_name,
-            created=int(time.time() * 1000),
+            created=int(time.time()),
             object="chat.completion",
             choices=choices,
             usage=CompletionUsage(

--- a/autogen/oai/mistral.py
+++ b/autogen/oai/mistral.py
@@ -175,7 +175,7 @@ class MistralAIClient:
         response_oai = ChatCompletion(
             id=mistral_response.id,
             model=mistral_response.model,
-            created=int(time.time() * 1000),
+            created=int(time.time()),
             object="chat.completion",
             choices=choices,
             usage=CompletionUsage(

--- a/autogen/oai/together.py
+++ b/autogen/oai/together.py
@@ -209,7 +209,7 @@ class TogetherClient:
         response_oai = ChatCompletion(
             id=response.id,
             model=together_params["model"],
-            created=int(time.time() * 1000),
+            created=int(time.time()),
             object="chat.completion",
             choices=choices,
             usage=CompletionUsage(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I know this is not a big deal, but keeping the arguments as mentioned in the API library looks appropriate for not raising any issues or breakage of the completion in future.

the units for the `created` is converted into milli seconds. the correct units mentioned in the API is seconds.
https://github.com/openai/openai-python/blob/main/src/openai/types/chat/chat_completion.py#L50

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
