### PR TITLE
Parse and correctly set Gemini safety settings

### DIFF
--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -165,8 +165,21 @@ class GeminiClient:
             for autogen_term, gemini_term in self.PARAMS_MAPPING.items()
             if autogen_term in params
         }
-        safety_settings = params.get("safety_settings", {})
+        
+        safety_settings_json = params.get("safety_settings", [])
 
+        safety_settings = []
+        for setting in safety_settings_json:
+            category = getattr(vertexai.generative_models.HarmCategory, setting['category'], None)
+            threshold = getattr(vertexai.generative_models.HarmBlockThreshold, setting['threshold'], None)
+
+            if category is not None and threshold is not None:
+                safety_setting = vertexai.generative_models.SafetySetting(
+                    category=category,
+                    threshold=threshold
+                )
+                safety_settings.append(safety_setting)
+                
         if stream:
             warnings.warn(
                 "Streaming is not supported for Gemini yet, and it will have no effect. Please set stream=False.",


### PR DESCRIPTION
## Why are these changes needed?

The provided example at the top of this file did not work correctly. Safety settings need to be parsed into Vertex AI objects and cannot just be a dictionary of simple objects.

## Checks

- [ X ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ X ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ X ] I've made sure all auto checks have passed.
