### PR TITLE
Enhance vertexai integration (safety settings, authentication...)

### DIFF
--- a/autogen/agentchat/chat.py
+++ b/autogen/agentchat/chat.py
@@ -107,6 +107,15 @@ def __find_async_chat_order(chat_ids: Set[int], prerequisites: List[Prerequisite
     return chat_order
 
 
+def _post_process_carryover_item(carryover_item):
+    if isinstance(carryover_item, str):
+        return carryover_item
+    elif isinstance(carryover_item, dict) and "content" in carryover_item:
+        return str(carryover_item["content"])
+    else:
+        return str(carryover_item)
+
+
 def __post_carryover_processing(chat_info: Dict[str, Any]) -> None:
     iostream = IOStream.get_default()
 
@@ -116,7 +125,7 @@ def __post_carryover_processing(chat_info: Dict[str, Any]) -> None:
             UserWarning,
         )
     print_carryover = (
-        ("\n").join([t for t in chat_info["carryover"]])
+        ("\n").join([_post_process_carryover_item(t) for t in chat_info["carryover"]])
         if isinstance(chat_info["carryover"], list)
         else chat_info["carryover"]
     )

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Ty
 
 from openai import BadRequestError
 
+from autogen.agentchat.chat import _post_process_carryover_item
 from autogen.exception_utils import InvalidCarryOverType, SenderRequired
 
 from .._pydantic import model_dump
@@ -2364,7 +2365,7 @@ class ConversableAgent(LLMAgent):
         if isinstance(kwargs["carryover"], str):
             content += "\nContext: \n" + kwargs["carryover"]
         elif isinstance(kwargs["carryover"], list):
-            content += "\nContext: \n" + ("\n").join([t for t in kwargs["carryover"]])
+            content += "\nContext: \n" + ("\n").join([_post_process_carryover_item(t) for t in kwargs["carryover"]])
         else:
             raise InvalidCarryOverType(
                 "Carryover should be a string or a list of strings. Not adding carryover to the message."

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -41,6 +41,7 @@ import warnings
 from io import BytesIO
 from typing import Any, Dict, List, Mapping, Union
 
+from google.auth.credentials import Credentials
 import google.generativeai as genai
 import requests
 import vertexai
@@ -83,11 +84,14 @@ class GeminiClient:
             # Path to JSON Keyfile
             os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = params["google_application_credentials"]
         vertexai_init_args = {}
-        if "project_id" in params:
-            vertexai_init_args["project"] = params["project_id"]
+        if "project" in params:
+            vertexai_init_args["project"] = params["project"]
         if "location" in params:
             vertexai_init_args["location"] = params["location"]
         if "credentials" in params:
+            assert isinstance(
+                params["credentials"], Credentials
+            ), "Object type google.auth.credentials.Credentials is expected!"
             vertexai_init_args["credentials"] = params["credentials"]
         if vertexai_init_args:
             vertexai.init(**vertexai_init_args)
@@ -96,7 +100,7 @@ class GeminiClient:
         """Uses either either api_key for authentication from the LLM config
         (specifying the GOOGLE_API_KEY environment variable also works),
         or follows the Google authentication mechanism for VertexAI in Google Cloud if no api_key is specified,
-        where project_id and location can also be passed as parameters. Service account key file can also be used.
+        where project and location can also be passed as parameters. Service account key file can also be used.
         If neither a service account key file, nor the api_key are passed, then the default credentials will be used,
         which could be a personal account if the user is already authenticated in, like in Google Cloud Shell.
 
@@ -105,7 +109,8 @@ class GeminiClient:
             google_application_credentials (str): Path to the JSON service account key file of the service account.
             Alternatively, the GOOGLE_APPLICATION_CREDENTIALS environment variable
             can also be set instead of using this argument.
-            project_id (str): Google Cloud project id, which is only valid in case no API key is specified.
+
+            project (str): Google Cloud project, which is only valid in case no API key is specified.
             location (str): Compute region to be used, like 'us-west1'.
             This parameter is only valid in case no API key is specified.
         """
@@ -120,7 +125,7 @@ class GeminiClient:
         else:
             self.use_vertexai = False
         if not self.use_vertexai:
-            assert ("project_id" not in kwargs) and (
+            assert ("project" not in kwargs) and (
                 "location" not in kwargs
             ), "Google Cloud project and compute location cannot be set when using an API Key!"
 
@@ -152,7 +157,7 @@ class GeminiClient:
         if self.use_vertexai:
             self._initialize_vartexai(**params)
         else:
-            assert ("project_id" not in params) and (
+            assert ("project" not in params) and (
                 "location" not in params
             ), "Google Cloud project and compute location cannot be set when using an API Key!"
         model_name = params.get("model", "gemini-pro")

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -87,6 +87,8 @@ class GeminiClient:
             vertexai_init_args["project"] = params["project_id"]
         if "location" in params:
             vertexai_init_args["location"] = params["location"]
+        if "credentials" in params:
+            vertexai_init_args["credentials"] = params["credentials"]
         if vertexai_init_args:
             vertexai.init(**vertexai_init_args)
 

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -393,7 +393,10 @@ class GeminiClient:
         like when specifying them in the OAI_CONFIG_LIST
         """
         if isinstance(safety_settings, list) and all(
-            [isinstance(safety_setting, dict)] for safety_setting in safety_settings
+            [
+                isinstance(safety_setting, dict) and not isinstance(safety_setting, VertexAISafetySetting)
+                for safety_setting in safety_settings
+            ]
         ):
             vertexai_safety_settings = []
             for safety_setting in safety_settings:

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -234,11 +234,17 @@ class GeminiClient:
             # B. handle the vision model
             if self.use_vertexai:
                 model = GenerativeModel(
-                    model_name, generation_config=generation_config, safety_settings=safety_settings
+                    model_name,
+                    generation_config=generation_config,
+                    safety_settings=safety_settings,
+                    system_instruction=system_instruction,
                 )
             else:
                 model = genai.GenerativeModel(
-                    model_name, generation_config=generation_config, safety_settings=safety_settings
+                    model_name,
+                    generation_config=generation_config,
+                    safety_settings=safety_settings,
+                    system_instruction=system_instruction,
                 )
                 genai.configure(api_key=self.api_key)
             # Gemini's vision model does not support chat history yet

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -165,6 +165,7 @@ class GeminiClient:
         messages = params.get("messages", [])
         stream = params.get("stream", False)
         n_response = params.get("n", 1)
+        system_instruction = params.get("system_instruction", None)
 
         generation_config = {
             gemini_term: params[autogen_term]
@@ -190,12 +191,18 @@ class GeminiClient:
             gemini_messages = self._oai_messages_to_gemini_messages(messages)
             if self.use_vertexai:
                 model = GenerativeModel(
-                    model_name, generation_config=generation_config, safety_settings=safety_settings
+                    model_name,
+                    generation_config=generation_config,
+                    safety_settings=safety_settings,
+                    system_instruction=system_instruction,
                 )
             else:
                 # we use chat model by default
                 model = genai.GenerativeModel(
-                    model_name, generation_config=generation_config, safety_settings=safety_settings
+                    model_name,
+                    generation_config=generation_config,
+                    safety_settings=safety_settings,
+                    system_instruction=system_instruction,
                 )
                 genai.configure(api_key=self.api_key)
             chat = model.start_chat(history=gemini_messages[:-1])

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -32,6 +32,7 @@ Resources:
 from __future__ import annotations
 
 import base64
+import logging
 import os
 import logging
 import random
@@ -52,9 +53,9 @@ from openai.types.completion_usage import CompletionUsage
 from PIL import Image
 from vertexai.generative_models import Content as VertexAIContent
 from vertexai.generative_models import GenerativeModel
-from vertexai.generative_models import Part as VertexAIPart
 from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
 from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
+from vertexai.generative_models import Part as VertexAIPart
 from vertexai.generative_models import SafetySetting as VertexAISafetySetting
 
 logger = logging.getLogger(__name__)
@@ -393,8 +394,8 @@ class GeminiClient:
         """Convert safety settings to VertexAI format if needed,
         like when specifying them in the OAI_CONFIG_LIST
         """
-        if (type(safety_settings) == list) and all(
-            [type(safety_setting) == dict] for safety_setting in safety_settings
+        if isinstance(safety_settings, list) and all(
+            [isinstance(safety_setting, dict)] for safety_setting in safety_settings
         ):
             vertexai_safety_settings = []
             for safety_setting in safety_settings:

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -41,12 +41,12 @@ import warnings
 from io import BytesIO
 from typing import Any, Dict, List, Mapping, Union
 
-from google.auth.credentials import Credentials
 import google.generativeai as genai
 import requests
 import vertexai
 from google.ai.generativelanguage import Content, Part
 from google.api_core.exceptions import InternalServerError
+from google.auth.credentials import Credentials
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion import ChatCompletionMessage, Choice
 from openai.types.completion_usage import CompletionUsage
@@ -90,7 +90,7 @@ class GeminiClient:
             vertexai_init_args["location"] = params["location"]
         if "credentials" in params:
             assert isinstance(
-                params["credentials"], Credentials
+                params["credentials"], type(Credentials)
             ), "Object type google.auth.credentials.Credentials is expected!"
             vertexai_init_args["credentials"] = params["credentials"]
         if vertexai_init_args:

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -100,12 +100,14 @@ class GeminiClient:
         """Uses either either api_key for authentication from the LLM config
         (specifying the GOOGLE_API_KEY environment variable also works),
         or follows the Google authentication mechanism for VertexAI in Google Cloud if no api_key is specified,
-        where project and location can also be passed as parameters. Service account key file can also be used.
-        If neither a service account key file, nor the api_key are passed, then the default credentials will be used,
-        which could be a personal account if the user is already authenticated in, like in Google Cloud Shell.
+        where project and location can also be passed as parameters. Previously created credentials object can be provided,
+        or a Service account key file can also be used. If neither a service account key file, nor the api_key are passed,
+        then the default credentials will be used, which could be a personal account if the user is already authenticated in,
+        like in Google Cloud Shell.
 
         Args:
             api_key (str): The API key for using Gemini.
+            credentials (google.auth.credentials.Credentials): credentials to be used for authentication.
             google_application_credentials (str): Path to the JSON service account key file of the service account.
             Alternatively, the GOOGLE_APPLICATION_CREDENTIALS environment variable
             can also be set instead of using this argument.

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -90,7 +90,7 @@ class GeminiClient:
             vertexai_init_args["location"] = params["location"]
         if "credentials" in params:
             assert isinstance(
-                params["credentials"], type(Credentials)
+                params["credentials"], Credentials
             ), "Object type google.auth.credentials.Credentials is expected!"
             vertexai_init_args["credentials"] = params["credentials"]
         if vertexai_init_args:

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -107,7 +107,7 @@ class GeminiClient:
 
         Args:
             api_key (str): The API key for using Gemini.
-            credentials (google.auth.credentials.Credentials): credentials to be used for authentication.
+            credentials (google.auth.credentials.Credentials): credentials to be used for authentication with vertexai.
             google_application_credentials (str): Path to the JSON service account key file of the service account.
             Alternatively, the GOOGLE_APPLICATION_CREDENTIALS environment variable
             can also be set instead of using this argument.
@@ -175,6 +175,7 @@ class GeminiClient:
         stream = params.get("stream", False)
         n_response = params.get("n", 1)
         system_instruction = params.get("system_instruction", None)
+        response_validation = params.get("response_validation", True)
 
         generation_config = {
             gemini_term: params[autogen_term]
@@ -205,6 +206,7 @@ class GeminiClient:
                     safety_settings=safety_settings,
                     system_instruction=system_instruction,
                 )
+                chat = model.start_chat(history=gemini_messages[:-1], response_validation=response_validation)
             else:
                 # we use chat model by default
                 model = genai.GenerativeModel(
@@ -214,7 +216,7 @@ class GeminiClient:
                     system_instruction=system_instruction,
                 )
                 genai.configure(api_key=self.api_key)
-            chat = model.start_chat(history=gemini_messages[:-1])
+                chat = model.start_chat(history=gemini_messages[:-1])
             max_retries = 5
             for attempt in range(max_retries):
                 ans = None

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -210,7 +210,9 @@ class GeminiClient:
             for attempt in range(max_retries):
                 ans = None
                 try:
-                    response = chat.send_message(gemini_messages[-1].parts, stream=stream)
+                    response = chat.send_message(
+                        gemini_messages[-1].parts, stream=stream, safety_settings=safety_settings
+                    )
                 except InternalServerError:
                     delay = 5 * (2**attempt)
                     warnings.warn(

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -53,8 +53,6 @@ from openai.types.completion_usage import CompletionUsage
 from PIL import Image
 from vertexai.generative_models import Content as VertexAIContent
 from vertexai.generative_models import GenerativeModel
-from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
-from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
 from vertexai.generative_models import Part as VertexAIPart
 from vertexai.generative_models import SafetySetting as VertexAISafetySetting
 

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import base64
 import logging
 import os
-import logging
 import random
 import re
 import time
@@ -53,6 +52,8 @@ from openai.types.completion_usage import CompletionUsage
 from PIL import Image
 from vertexai.generative_models import Content as VertexAIContent
 from vertexai.generative_models import GenerativeModel
+from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
+from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
 from vertexai.generative_models import Part as VertexAIPart
 from vertexai.generative_models import SafetySetting as VertexAISafetySetting
 

--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -13,7 +13,15 @@ from openai import OpenAI
 from openai.types.beta.assistant import Assistant
 from packaging.version import parse
 
-NON_CACHE_KEY = ["api_key", "base_url", "api_type", "api_version", "azure_ad_token", "azure_ad_token_provider"]
+NON_CACHE_KEY = [
+    "api_key",
+    "base_url",
+    "api_type",
+    "api_version",
+    "azure_ad_token",
+    "azure_ad_token_provider",
+    "credentials",
+]
 DEFAULT_AZURE_API_VERSION = "2024-02-01"
 OAI_PRICE1K = {
     # https://openai.com/api/pricing/

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -33,10 +33,10 @@ def mock_response():
 
 @pytest.fixture
 def gemini_client():
-    system_instruction = [
+    system_message = [
         "You are a helpful AI assistant.",
     ]
-    return GeminiClient(api_key="fake_api_key", system_instruction=system_instruction)
+    return GeminiClient(api_key="fake_api_key", system_message=system_message)
 
 
 # Test compute location initialization and configuration
@@ -50,10 +50,10 @@ def test_compute_location_initialization():
 
 @pytest.fixture
 def gemini_google_auth_default_client():
-    system_instruction = [
+    system_message = [
         "You are a helpful AI assistant.",
     ]
-    return GeminiClient(system_instruction=system_instruction)
+    return GeminiClient(system_message=system_message)
 
 
 @pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -135,6 +135,63 @@ def test_vertexai_safety_setting_conversion(gemini_client):
     assert all(settings_comparison), "Converted safety settings are incorrect"
 
 
+@pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
+def test_vertexai_default_safety_settings_dict(gemini_client):
+    safety_settings = {
+        VertexAIHarmCategory.HARM_CATEGORY_HARASSMENT: VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH,
+        VertexAIHarmCategory.HARM_CATEGORY_HATE_SPEECH: VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH,
+        VertexAIHarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH,
+        VertexAIHarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH,
+    }
+    converted_safety_settings = GeminiClient._to_vertexai_safety_settings(safety_settings)
+
+    expected_safety_settings = {
+        category: VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH for category in safety_settings.keys()
+    }
+
+    def compare_safety_settings(converted_safety_settings, expected_safety_settings):
+        for expected_setting_key in expected_safety_settings.keys():
+            expected_setting = expected_safety_settings[expected_setting_key]
+            converted_setting = converted_safety_settings[expected_setting_key]
+            yield expected_setting == converted_setting
+
+    assert len(converted_safety_settings) == len(
+        expected_safety_settings
+    ), "The length of the safety settings is incorrect"
+    settings_comparison = compare_safety_settings(converted_safety_settings, expected_safety_settings)
+    assert all(settings_comparison), "Converted safety settings are incorrect"
+
+
+@pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
+def test_vertexai_safety_setting_list(gemini_client):
+    harm_categories = [
+        VertexAIHarmCategory.HARM_CATEGORY_HARASSMENT,
+        VertexAIHarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        VertexAIHarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        VertexAIHarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+    ]
+
+    expected_safety_settings = safety_settings = [
+        VertexAISafetySetting(category=category, threshold=VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH)
+        for category in harm_categories
+    ]
+
+    print(safety_settings)
+
+    converted_safety_settings = GeminiClient._to_vertexai_safety_settings(safety_settings)
+
+    def compare_safety_settings(converted_safety_settings, expected_safety_settings):
+        for i, expected_setting in enumerate(expected_safety_settings):
+            converted_setting = converted_safety_settings[i]
+            yield expected_setting.to_dict() == converted_setting.to_dict()
+
+    assert len(converted_safety_settings) == len(
+        expected_safety_settings
+    ), "The length of the safety settings is incorrect"
+    settings_comparison = compare_safety_settings(converted_safety_settings, expected_safety_settings)
+    assert all(settings_comparison), "Converted safety settings are incorrect"
+
+
 # Test error handling
 @patch("autogen.oai.gemini.genai")
 @pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -4,6 +4,9 @@ import pytest
 
 try:
     from google.api_core.exceptions import InternalServerError
+    from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
+    from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
+    from vertexai.generative_models import SafetySetting as VertexAISafetySetting
 
     from autogen.oai.gemini import GeminiClient
 
@@ -92,6 +95,38 @@ def test_gemini_message_handling(gemini_client):
         assert expected_msg["role"] == converted_messages[i].role, "Incorrect mapped message role"
         for j, part in enumerate(expected_msg["parts"]):
             assert converted_messages[i].parts[j].text == part, "Incorrect mapped message text"
+
+
+@pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
+def test_vertexai_safety_setting_conversion(gemini_client):
+    safety_settings = [
+        {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_ONLY_HIGH"},
+        {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_ONLY_HIGH"},
+    ]
+    converted_safety_settings = GeminiClient._to_vertexai_safety_settings(safety_settings)
+    harm_categories = [
+        VertexAIHarmCategory.HARM_CATEGORY_HARASSMENT,
+        VertexAIHarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        VertexAIHarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        VertexAIHarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+    ]
+    expected_safety_settings = [
+        VertexAISafetySetting(category=category, threshold=VertexAIHarmBlockThreshold.BLOCK_ONLY_HIGH)
+        for category in harm_categories
+    ]
+
+    def compare_safety_settings(converted_safety_settings, expected_safety_settings):
+        for i, expected_setting in enumerate(expected_safety_settings):
+            converted_setting = converted_safety_settings[i]
+            yield expected_setting.to_dict() == converted_setting.to_dict()
+
+    assert len(converted_safety_settings) == len(
+        expected_safety_settings
+    ), "The length of the safety settings is incorrect"
+    settings_comparison = compare_safety_settings(converted_safety_settings, expected_safety_settings)
+    assert all(settings_comparison), "Converted safety settings are incorrect"
 
 
 # Test error handling

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -48,6 +48,15 @@ def test_compute_location_initialization():
         )  # Should raise an AssertionError due to specifying API key and compute location
 
 
+# Test project initialization and configuration
+@pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")
+def test_project_initialization():
+    with pytest.raises(AssertionError):
+        GeminiClient(
+            api_key="fake_api_key", project="fake-project-id"
+        )  # Should raise an AssertionError due to specifying API key and compute location
+
+
 @pytest.fixture
 def gemini_google_auth_default_client():
     system_message = [

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -5,6 +5,7 @@ import pytest
 try:
     import google.auth
     from google.api_core.exceptions import InternalServerError
+    from google.auth.credentials import Credentials
     from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
     from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
     from vertexai.generative_models import SafetySetting as VertexAISafetySetting
@@ -49,8 +50,8 @@ def gemini_google_auth_default_client():
 
 
 @pytest.fixture
-@patch("autogen.oai.gemini.Credentials")
-def gemini_client_with_credentials(mock_credentials):
+def gemini_client_with_credentials():
+    mock_credentials = MagicMock(Credentials)
     return GeminiClient(credentials=mock_credentials)
 
 

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -3,11 +3,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 try:
+    import google.auth
     from google.api_core.exceptions import InternalServerError
     from vertexai.generative_models import HarmBlockThreshold as VertexAIHarmBlockThreshold
     from vertexai.generative_models import HarmCategory as VertexAIHarmCategory
     from vertexai.generative_models import SafetySetting as VertexAISafetySetting
-    import google.auth
 
     from autogen.oai.gemini import GeminiClient
 

--- a/test/oai/test_gemini.py
+++ b/test/oai/test_gemini.py
@@ -33,7 +33,10 @@ def mock_response():
 
 @pytest.fixture
 def gemini_client():
-    return GeminiClient(api_key="fake_api_key")
+    system_instruction = [
+        "You are a helpful AI assistant.",
+    ]
+    return GeminiClient(api_key="fake_api_key", system_instruction=system_instruction)
 
 
 # Test compute location initialization and configuration
@@ -47,7 +50,10 @@ def test_compute_location_initialization():
 
 @pytest.fixture
 def gemini_google_auth_default_client():
-    return GeminiClient()
+    system_instruction = [
+        "You are a helpful AI assistant.",
+    ]
+    return GeminiClient(system_instruction=system_instruction)
 
 
 @pytest.mark.skipif(skip, reason="Google GenAI dependency is not installed")


### PR DESCRIPTION
## Why are these changes needed?

- Enhance VertexAI authentication by supporting `credentials` objects in the `llm_config` for more flexibility:
```python
import google.auth

credentials, project = google.auth.default()

from google.auth import impersonated_credentials

target_scopes = [
    'https://www.googleapis.com/auth/cloud-platform']

target_credentials = impersonated_credentials.Credentials(
  source_credentials=credentials,
  target_principal='autogen@autogen-with-gemini.iam.gserviceaccount.com',
  target_scopes = target_scopes,
  lifetime=500
)

llm_config = {
        "config_list": [
            { 
                "model": "gemini-1.5-pro",
                "api_type": "google",
                "credentials": target_credentials,
                "project": "autogen-with-gemini"
            }
         ],
}
assistant = AssistantAgent(
    "assistant", llm_config=llm_config, max_consecutive_auto_reply=5
)

```
- Adding safety settings conversion to VertexAI format from the OAI_CONFIG_LIST

- Support `system_message`, which are called `system_instructions` with Gemini 

- Consolidate message handling in `send_message` to use the officially supported [`PartsType` for the  `content`](https://github.com/googleapis/python-aiplatform/blob/02ffd278a16fad4ccbdc698d76a8e6c289a5fddd/vertexai/generative_models/_generative_models.py#L891) argument

- Use `project` instead of `project_id` argument for the `GeminiClient` to follow the same naming convention as the `vertexai.init()` method does

## Related issue number

Relates to [#2387 ](https://github.com/microsoft/autogen/issues/2387)

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
