### PR TITLE
Fix typo in agentchat_nestedchat.ipynb

### DIFF
--- a/notebook/agentchat_nestedchat.ipynb
+++ b/notebook/agentchat_nestedchat.ipynb
@@ -100,7 +100,7 @@
     "    system_message=\"\"\"\n",
     "    You are a professional writer, known for your insightful and engaging articles.\n",
     "    You transform complex concepts into compelling narratives.\n",
-    "    You should imporve the quality of the content based on the feedback from the user.\n",
+    "    You should improve the quality of the content based on the feedback from the user.\n",
     "    \"\"\",\n",
     ")\n",
     "\n",


### PR DESCRIPTION
## Why are these changes needed?

It fixes the typo.

Related page https://microsoft.github.io/autogen/docs/notebooks/agentchat_nestedchat/