### PR TITLE
Fixed a typo in tool-use.ipynb

### DIFF
--- a/website/docs/tutorial/tool-use.ipynb
+++ b/website/docs/tutorial/tool-use.ipynb
@@ -21,7 +21,7 @@
     "````mdx-code-block\n",
     ":::note\n",
     "Tool use is currently only available for LLMs\n",
-    "that support OpenAI-comaptible tool call API.\n",
+    "that support OpenAI-compatible tool call API.\n",
     ":::\n",
     "````"
    ]


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes a typo in the tool-use page https://microsoft.github.io/autogen/docs/tutorial/tool-use. The typo is in the note box: comaptible -> compatible

