### PR TITLE
Fix for bug #3106 dict skills and test

### DIFF
--- a/samples/apps/autogen-studio/autogenstudio/utils/utils.py
+++ b/samples/apps/autogen-studio/autogenstudio/utils/utils.py
@@ -306,14 +306,14 @@ install via pip and use --quiet option.
 
          """
     prompt = ""  # filename:  skills.py
+
     for skill in skills:
-        if skill.secrets:
-            for secret in skill.secrets:
-                print(">> Secret", secret)
-                if secret.get("value"):
-                    os.environ[secret["secret"]] = secret["value"]
-        if not isinstance(skill, Skill):
+        if not isinstance(skill, Skill): 
             skill = Skill(**skill)
+        if(skill.secrets): 
+            for secret in skill.secrets:
+                if secret.get("value") != None:
+                    os.environ[secret["secret"]] = secret["value"]
         prompt += f"""
 
 ##### Begin of {skill.name} #####

--- a/samples/apps/autogen-studio/test/test_skills.py
+++ b/samples/apps/autogen-studio/test/test_skills.py
@@ -1,0 +1,43 @@
+import logging
+import pytest
+import os
+from autogenstudio.utils import utils
+from autogenstudio.datamodel import Skill
+
+class TestUtilGetSkillFromPrompt:
+
+    def test_get_skills_from_prompt(self):
+
+        skill_clazz = Skill( name="skill_clazz",
+            description="skill_clazz",
+            user_id="guestuser@gmail.com",
+            libraries=['lib1.0','lib1.1'],
+            content='I am the skill clazz content',
+            secrets=[{"secret":"secret_1", "value":"value_1"}],
+            agents=[])
+
+        skill_dict = Skill( name="skill_dict",
+            description="skill_dict",
+            user_id="guestuser@gmail.com",
+            libraries=['lib2.0','lib2.1'],
+            content='I am the skill dict content',
+            secrets=[{"secret":"secret_2", "value":"value_2"}],
+            agents=[])
+
+        skills = [skill_dict.__dict__, skill_clazz]
+
+        prompt = utils.get_skills_from_prompt(skills,work_dir='work_dir')
+    
+        # test that prompt contains contents of skills class and dict
+        assert prompt.find(skill_clazz.content) > 0 
+        assert prompt.find(skill_dict.content) > 0 
+
+        # test that secrets are set in environ
+        assert os.getenv('secret_1') == 'value_1'
+        assert os.getenv('secret_2') == 'value_2'
+
+        # cleanup test work_dir
+        try:
+            os.system("rm -rf work_dir")
+        except:
+            pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Using the export of the 'default_workflow' causes the skill to be seen as a dict instead of the Skill class in util.util.get_skills_from_prompt().  Change checks for skill to be a class, if not it converts it to a class.  

## Related issue number #3106

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
