### PR TITLE
Fix docstring for API reference doc in website

### DIFF
--- a/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
+++ b/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
@@ -136,7 +136,7 @@ class RetrieveUserProxyAgent(UserProxyAgent):
                 - `client` (Optional, chromadb.Client) - the chromadb client. If key not provided, a
                      default client `chromadb.Client()` will be used. If you want to use other
                      vector db, extend this class and override the `retrieve_docs` function.
-                     **Deprecated**: use `vector_db` instead.
+                     *[Deprecated]* use `vector_db` instead.
                 - `docs_path` (Optional, Union[str, List[str]]) - the path to the docs directory. It
                      can also be the path to a single file, the url to a single file or a list
                      of directories, files and urls. Default is None, which works only if the
@@ -150,7 +150,7 @@ class RetrieveUserProxyAgent(UserProxyAgent):
                     By default, "extra_docs" is set to false, starting document IDs from zero.
                     This poses a risk as new documents might overwrite existing ones, potentially
                     causing unintended loss or alteration of data in the collection.
-                    **Deprecated**: use `new_docs` when use `vector_db` instead of `client`.
+                    *[Deprecated]* use `new_docs` when use `vector_db` instead of `client`.
                 - `new_docs` (Optional, bool) - when True, only adds new documents to the collection;
                     when False, updates existing documents and adds new ones. Default is True.
                     Document id is used to determine if a document is new or existing. By default, the
@@ -173,7 +173,7 @@ class RetrieveUserProxyAgent(UserProxyAgent):
                     models can be found at `https://www.sbert.net/docs/pretrained_models.html`.
                     The default model is a fast model. If you want to use a high performance model,
                     `all-mpnet-base-v2` is recommended.
-                    **Deprecated**: no need when use `vector_db` instead of `client`.
+                    *[Deprecated]* no need when use `vector_db` instead of `client`.
                 - `embedding_function` (Optional, Callable) - the embedding function for creating the
                     vector db. Default is None, SentenceTransformer with the given `embedding_model`
                     will be used. If you want to use OpenAI, Cohere, HuggingFace or other embedding
@@ -220,7 +220,7 @@ class RetrieveUserProxyAgent(UserProxyAgent):
 
         Example of overriding retrieve_docs - If you have set up a customized vector db, and it's
         not compatible with chromadb, you can easily plug in it with below code.
-        **Deprecated**: Use `vector_db` instead. You can extend VectorDB and pass it to the agent.
+        *[Deprecated]* use `vector_db` instead. You can extend VectorDB and pass it to the agent.
         ```python
         class MyRetrieveUserProxyAgent(RetrieveUserProxyAgent):
             def query_vector_db(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Current API reference doc is like below:
https://microsoft.github.io/autogen/docs/reference/agentchat/contrib/retrieve_user_proxy_agent/
![image](https://github.com/user-attachments/assets/7127e2f7-4cb8-4ed1-b77f-b2591b4c2452)

With this PR, it will be updated to below:
![image](https://github.com/user-attachments/assets/52958e6c-71b7-45ad-ad0a-77f9bc7eace8)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
