### PR TITLE
Fix Anthropic Bedrock support

### DIFF
--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -99,9 +99,6 @@ class AnthropicClient:
         if not self._aws_secret_key:
             self._aws_secret_key = os.getenv("AWS_SECRET_KEY")
 
-        if not self._aws_session_token:
-            self._aws_session_token = os.getenv("AWS_SESSION_TOKEN")
-
         if not self._aws_region:
             self._aws_region = os.getenv("AWS_REGION")
 

--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -108,7 +108,6 @@ class AnthropicClient:
         if self._api_key is None and (
             self._aws_access_key is None
             or self._aws_secret_key is None
-            or self._aws_session_token is None
             or self._aws_region is None
         ):
             raise ValueError("API key or AWS credentials are required to use the Anthropic API.")

--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -103,9 +103,7 @@ class AnthropicClient:
             self._aws_region = os.getenv("AWS_REGION")
 
         if self._api_key is None and (
-            self._aws_access_key is None
-            or self._aws_secret_key is None
-            or self._aws_region is None
+            self._aws_access_key is None or self._aws_secret_key is None or self._aws_region is None
         ):
             raise ValueError("API key or AWS credentials are required to use the Anthropic API.")
 

--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -456,7 +456,7 @@ class OpenAIWrapper:
 
     def _configure_openai_config_for_bedrock(self, config: Dict[str, Any], openai_config: Dict[str, Any]) -> None:
         """Update openai_config with AWS credentials from config."""
-        required_keys = ["aws_access_key", "aws_secret_key", "aws_session_token", "aws_region"]
+        required_keys = ["aws_access_key", "aws_secret_key", "aws_region"]
 
         for key in required_keys:
             if key in config:

--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -454,12 +454,20 @@ class OpenAIWrapper:
                 azure.identity.DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
             )
 
+    def _configure_openai_config_for_bedrock(self, config: Dict[str, Any], openai_config: Dict[str, Any]) -> None:
+        """Update openai_config with AWS credentials from config."""
+        required_keys = ["aws_access_key", "aws_secret_key", "aws_session_token", "aws_region"]
+
+        for key in required_keys:
+            if key in config:
+                openai_config[key] = config[key]
+
     def _register_default_client(self, config: Dict[str, Any], openai_config: Dict[str, Any]) -> None:
         """Create a client with the given config to override openai_config,
         after removing extra kwargs.
 
         For Azure models/deployment names there's a convenience modification of model removing dots in
-        the it's value (Azure deploment names can't have dots). I.e. if you have Azure deployment name
+        the it's value (Azure deployment names can't have dots). I.e. if you have Azure deployment name
         "gpt-35-turbo" and define model "gpt-3.5-turbo" in the config the function will remove the dot
         from the name and create a client that connects to "gpt-35-turbo" Azure deployment.
         """
@@ -485,6 +493,8 @@ class OpenAIWrapper:
                 client = GeminiClient(**openai_config)
                 self._clients.append(client)
             elif api_type is not None and api_type.startswith("anthropic"):
+                if "api_key" not in config:
+                    self._configure_openai_config_for_bedrock(config, openai_config)
                 if anthropic_import_exception:
                     raise ImportError("Please install `anthropic` to use Anthropic API.")
                 client = AnthropicClient(**openai_config)


### PR DESCRIPTION
## Why are these changes needed?

The current implementation of `AnthropicBedrock` as created by @makkzone [here](https://github.com/microsoft/autogen/pull/3103) does not properly add the AWS variables to the `openai_config`. Resulting in the following error:

```
Traceback (most recent call last):
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/pydevd.py", line 1551, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "autogen/autogen_test.py", line 43, in <module>
    classifier = ConversableAgent(
  File "autogen/agentchat/conversable_agent.py", line 159, in __init__
    self._validate_llm_config(llm_config)
  File "autogen/agentchat/conversable_agent.py", line 263, in _validate_llm_config
    self.client = None if self.llm_config is False else OpenAIWrapper(**self.llm_config)
  File "autogen/oai/client.py", line 422, in __init__
    self._register_default_client(config, openai_config)  # could modify the config
  File "autogen/oai/client.py", line 501, in _register_default_client
    client = AnthropicClient(**openai_config)
  File "autogen/oai/anthropic.py", line 114, in __init__
    raise ValueError("API key or AWS credentials are required to use the Anthropic API.")
ValueError: API key or AWS credentials are required to use the Anthropic API.
```

This change introduces the `_configure_openai_config_for_bedrock` method to include the necessary AWS variables (`aws_access_key`, `aws_secret_key`, `aws_session_token`, and `aws_region`) in `openai_config` if no `api_key` is present in the `config` and the `api_type` startswith `anthropic`. This ensures that the `AnthropicBedrock` client can be set correctly and function as expected.

## Related PR number

https://github.com/microsoft/autogen/pull/3103

## Related issue number

Closes [#1234](https://github.com/microsoft/autogen/issues/339)

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. 
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
