### PR TITLE
#3219 Fix ConversableAgent break link in agent_chat.md file

### DIFF
--- a/website/docs/Use-Cases/agent_chat.md
+++ b/website/docs/Use-Cases/agent_chat.md
@@ -18,7 +18,7 @@ designed to solve tasks through inter-agent conversations. Specifically, the age
 The figure below shows the built-in agents in AutoGen.
 ![Agent Chat Example](images/autogen_agents.png)
 
-We have designed a generic [`ConversableAgent`](../reference/agentchat/conversable_agent#conversableagent-objects)
+We have designed a generic [`ConversableAgent`](../reference/agentchat/conversable_agent.md#conversableagent-objects)
  class for Agents that are capable of conversing with each other through the exchange of messages to jointly finish a task. An agent can communicate with other agents and perform actions. Different agents can differ in what actions they perform after receiving messages. Two representative subclasses are [`AssistantAgent`](../reference/agentchat/assistant_agent.md#assistantagent-objects) and [`UserProxyAgent`](../reference/agentchat/user_proxy_agent.md#userproxyagent-objects)
 
 - The [`AssistantAgent`](../reference/agentchat/assistant_agent.md#assistantagent-objects) is designed to act as an AI assistant, using LLMs by default but not requiring human input or code execution. It could write Python code (in a Python coding block) for a user to execute when a message (typically a description of a task that needs to be solved) is received. Under the hood, the Python code is written by LLM (e.g., GPT-4). It can also receive the execution results and suggest corrections or bug fixes. Its behavior can be altered by passing a new system message. The LLM [inference](#enhanced-inference) configuration can be configured via [`llm_config`].


### PR DESCRIPTION
Fix ConversableAgent break link in website/docs/Use-Cases/agent_chat.md file to  include the .md extension in the link for ConversableAgent.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
 website/docs/Use-Cases/agent_chat.md has a break link, and reader can not open its corresponding webpage with correct link. 

Fix: include the .md extension in the link for ConversableAgent.

## Related issue number

"Closes #3219" 
[#3219](https://github.com/microsoft/autogen/issues/3219)

## Checks

- [ X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ X] I've made sure all auto checks have passed.
