### PR TITLE
Update _generate_code_execution_reply_using_executor return with code…

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1470,7 +1470,7 @@ class ConversableAgent(LLMAgent):
             # found code blocks, execute code.
             code_result = self._code_executor.execute_code_blocks(code_blocks)
             exitcode2str = "execution succeeded" if code_result.exit_code == 0 else "execution failed"
-            return True, f"exitcode: {code_result.exit_code} ({exitcode2str})\nCode output: {code_result.output}"
+            return True, f"exitcode: {code_result.exit_code} ({exitcode2str})\nCode file: {code_result.code_file}\nCode output: {code_result.output}"
 
         return False, None
 


### PR DESCRIPTION
…_file

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`code_file` should be exposed cause it's polluting a project.

With this feature I'm then able to cleanup file

```python
result = re.search(r"Code file: (.+)",
                   code_execution_result.chat_history[-2]['content'])
if result:
    code_file = Path(result.group(1))
    print(code_file)

    # Move the code_file to the execution_logs folder
    execution_logs_folder = Path("./logs/execution_logs")
    execution_logs_folder.mkdir(exist_ok=True)
    code_file.rename(execution_logs_folder / code_file.name)
```

## Related issue number

<!-- For example: "Closes #1234" -->
#3253 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
