### PR TITLE
[.Net] only add the last message to chat history in GroupChatExtension.SendAsync

### DIFF
--- a/dotnet/src/AutoGen.Core/Extension/GroupChatExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/GroupChatExtension.cs
@@ -51,7 +51,10 @@ public static class GroupChatExtension
                 yield break;
             }
 
-            chatHistory = messages;
+            // messages will contain the complete chat history, include initalize messages
+            // but we only need to add the last message to the chat history
+            // fix #3268
+            chatHistory = chatHistory.Append(lastMessage);
         }
     }
 

--- a/dotnet/test/AutoGen.Tests/GroupChat/GroupChatTests.cs
+++ b/dotnet/test/AutoGen.Tests/GroupChat/GroupChatTests.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace AutoGen.Tests;
@@ -50,5 +52,37 @@ public class GroupChatTests
 
         chatHistory.Count().Should().Be(3);
         chatHistory.Last().From.Should().Be("Cathy");
+    }
+
+    [Fact]
+    public async Task ItSendAsyncDoesntAddDuplicateInitializeMessagesTest()
+    {
+        // fix #3268
+        var alice = new DefaultReplyAgent("Alice", "I am alice");
+        var bob = new DefaultReplyAgent("Bob", "I am bob");
+        var cathy = new DefaultReplyAgent("Cathy", $"I am cathy, {GroupChatExtension.TERMINATE}");
+
+        var roundRobinOrchestrator = new RoundRobinOrchestrator();
+        var orchestrator = Mock.Of<IOrchestrator>();
+        Mock.Get(orchestrator).Setup(x => x.GetNextSpeakerAsync(It.IsAny<OrchestrationContext>(), It.IsAny<CancellationToken>()))
+            .Returns((OrchestrationContext context, CancellationToken token) =>
+            {
+                // determine if initialize message is already sent and not added twice
+                context.ChatHistory.Where(x => x.From == alice.Name).Count().Should().Be(1);
+
+                return roundRobinOrchestrator.GetNextSpeakerAsync(context, token);
+            });
+
+        var groupChat = new GroupChat([alice, bob, cathy], orchestrator);
+        groupChat.AddInitializeMessage(new TextMessage(Role.User, "Hello", from: alice.Name));
+
+        var maxRound = 2;
+        var chatHistory = new List<IMessage>();
+        await foreach (var message in groupChat.SendAsync(chatHistory, maxRound))
+        {
+            chatHistory.Add(message);
+        }
+
+        chatHistory.Count().Should().Be(2);
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
fix #3268 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
