### PR TITLE
[Feature]: Redacting sensitive information from Agent Response in Autogenstudio

### DIFF
--- a/samples/apps/autogen-studio/README.md
+++ b/samples/apps/autogen-studio/README.md
@@ -107,7 +107,7 @@ AutoGen Studio proposes some high-level concepts.
 
 **Skills**: Skills are functions (e.g., Python functions) that describe how to solve a task. In general, a good skill has a descriptive name (e.g. `generate_images`), extensive docstrings and good defaults (e.g., writing out files to disk for persistence and reuse). You can add new skills AutoGen Studio app via the provided UI. At inference time, these skills are made available to the assistant agent as they address your tasks.
 
-**Secret Redaction**: A functionality in Agents that allows sensitive data to be redacted from an agent's response. The redaction is done based on secrets stored in these 3 locations: cloud services (i.e. Azure Key Vault), a custom file (Blacklist), and secrets defined in Skills.  
+**Secret Redaction**: A functionality in Agents that allows sensitive data to be redacted from an agent's response. The redaction is done based on secrets stored in these 3 locations: cloud services (i.e. Azure Key Vault), a custom file (Blacklist), and secrets defined in Skills.
 
 To enable this functionality, set the following env variable:
 - Required:
@@ -115,7 +115,7 @@ To enable this functionality, set the following env variable:
   - REDACTION_REPLACEMENT_STRING: The string that secrets will be replaced with
   - SECRET_FETCH_TIMEOUT: The secret fetch time period, in seconds.
 - Optional (ONLY set these env variables if you need them):
-  - CLOUD_SECRET_PROVIDERS: All cloud secret providers. To add more, make sure the extra function is added in secretmanager.py. 
+  - CLOUD_SECRET_PROVIDERS: All cloud secret providers. To add more, make sure the extra function is added in secretmanager.py.
   - AZURE_KEYVAULT_URL: Access Link for Azure Key Vault. More cloud secret providers' urls can be added, in string.
   - BLACKLIST_PATH: Path to user's blacklist, in string. The Blacklist is a txt file containing all the secrets user wants to be redacted.
 ## Example Usage

--- a/samples/apps/autogen-studio/README.md
+++ b/samples/apps/autogen-studio/README.md
@@ -107,6 +107,17 @@ AutoGen Studio proposes some high-level concepts.
 
 **Skills**: Skills are functions (e.g., Python functions) that describe how to solve a task. In general, a good skill has a descriptive name (e.g. `generate_images`), extensive docstrings and good defaults (e.g., writing out files to disk for persistence and reuse). You can add new skills AutoGen Studio app via the provided UI. At inference time, these skills are made available to the assistant agent as they address your tasks.
 
+**Secret Redaction**: A functionality in Agents that allows sensitive data to be redacted from an agent's response. The redaction is done based on secrets stored in these 3 locations: cloud services (i.e. Azure Key Vault), a custom file (Blacklist), and secrets defined in Skills.  
+
+To enable this functionality, set the following env variable:
+- Required:
+  - ENABLE_SECRET_REDACTION: Enable the secret redaction feature or not
+  - REDACTION_REPLACEMENT_STRING: The string that secrets will be replaced with
+  - SECRET_FETCH_TIMEOUT: The secret fetch time period, in seconds.
+- Optional (ONLY set these env variables if you need them):
+  - CLOUD_SECRET_PROVIDERS: All cloud secret providers. To add more, make sure the extra function is added in secretmanager.py. 
+  - AZURE_KEYVAULT_URL: Access Link for Azure Key Vault. More cloud secret providers' urls can be added, in string.
+  - BLACKLIST_PATH: Path to user's blacklist, in string. The Blacklist is a txt file containing all the secrets user wants to be redacted.
 ## Example Usage
 
 Consider the following query.

--- a/samples/apps/autogen-studio/autogenstudio/utils/secretmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/utils/secretmanager.py
@@ -1,20 +1,23 @@
 import os
-from loguru import logger
+from typing import List
+
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
+from loguru import logger
+
 from ..datamodel import Skill
-from typing import List
+
 
 def _get_secrets_from_azure():
     """
-        Get secrets from Azure Key Vault
+    Get secrets from Azure Key Vault
 
-        Returns:
-            List of secrets from Azure Key Vault.
+    Returns:
+        List of secrets from Azure Key Vault.
     """
-    KVUri = os.environ.get('AZURE_KEYVAULT_URL')
+    KVUri = os.environ.get("AZURE_KEYVAULT_URL")
     secrets = []
-    try: 
+    try:
         credential = DefaultAzureCredential()
         client = SecretClient(vault_url=KVUri, credential=credential)
 
@@ -22,17 +25,18 @@ def _get_secrets_from_azure():
         secrets = [client.get_secret(secret_name).value for secret_name in secret_names]
     except Exception as e:
         logger.error("Error while retrieving from Azure Key Vault: " + str(e))
-    
+
     return secrets
+
 
 def get_secrets_from_cloud(secret_providers: List[str]):
     """
-        Get secrets from cloud providers
-        Args:
-            secret_providers: List of cloud providers to get secrets from. For example: export CLOUD_SECRET_PROVIDERS=azure,aws
+    Get secrets from cloud providers
+    Args:
+        secret_providers: List of cloud providers to get secrets from. For example: export CLOUD_SECRET_PROVIDERS=azure,aws
 
-        Returns:
-            List of secrets from all specified cloud providers
+    Returns:
+        List of secrets from all specified cloud providers
 
     """
     secrets = []
@@ -43,17 +47,18 @@ def get_secrets_from_cloud(secret_providers: List[str]):
 
     return secrets
 
+
 def get_secrets_from_file(filepath):
     """
-        Get secrets from a file
-        Args: 
-            filepath: Path to the file containing secrets
+    Get secrets from a file
+    Args:
+        filepath: Path to the file containing secrets
 
-        Returns:
-            List of secrets from the file.
+    Returns:
+        List of secrets from the file.
     """
-    secrets=[]
-    env_keys=[]
+    secrets = []
+    env_keys = []
     try:
         with open(filepath, "r") as f:
             env_keys = f.read().split()
@@ -65,22 +70,23 @@ def get_secrets_from_file(filepath):
         logger.error("Error while retrieving secrets for blacklist keys: " + str(e))
 
     return secrets
-    
+
+
 def get_secrets_from_skills(dbmanager):
     """
-        Get secrets from skills in the database
-        Args:
-            dbmanager: Database manager object
+    Get secrets from skills in the database
+    Args:
+        dbmanager: Database manager object
 
-        Returns:
-            List of secrets from skills in the database
+    Returns:
+        List of secrets from skills in the database
     """
     secrets = []
     try:
         for skill in dbmanager.get(model_class=Skill).data:
             for secret in skill.secrets:
-                if secret['value'] != (None or ''):
-                    secrets.append(secret['value'])
+                if secret["value"] != (None or ""):
+                    secrets.append(secret["value"])
     except Exception as e:
         logger.error("Error while retrieving secrets from agent Skills: " + str(e))
 

--- a/samples/apps/autogen-studio/autogenstudio/utils/secretmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/utils/secretmanager.py
@@ -1,0 +1,72 @@
+import os
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.secrets import SecretClient
+from ..datamodel import Skill
+from typing import List
+
+def _get_secrets_from_azure():
+    """
+        Get secrets from Azure Key Vault
+
+        Returns:
+            List of secrets from Azure Key Vault.
+    """
+    KVUri = os.environ['AZURE_KEYVAULT_URL']
+
+    credential = DefaultAzureCredential()
+    client = SecretClient(vault_url=KVUri, credential=credential)
+
+    secret_names = [secret.name for secret in client.list_properties_of_secrets()]
+    secrets = [client.get_secret(secret_name).value for secret_name in secret_names]
+    
+    return secrets
+
+def get_secrets_from_cloud(secret_providers: List[str]):
+    """
+        Get secrets from cloud providers
+        Args:
+            secret_providers: List of cloud providers to get secrets from. For example: export CLOUD_SECRET_PROVIDERS=azure,aws
+
+        Returns:
+            List of secrets from all specified cloud providers
+
+    """
+    secrets = []
+    for provider in secret_providers:
+        if provider == "azure":
+            secrets.extend(_get_secrets_from_azure())
+        # more providers can be added here
+
+    return secrets
+
+def get_secrets_from_file(filepath):
+    """
+        Get secrets from a file
+        Args: 
+            filepath: Path to the file containing secrets
+
+        Returns:
+            List of secrets from the file.
+    """
+    secrets=[]
+    with open(filepath, "r") as f:
+        secrets = f.read().split()
+    
+    return secrets
+    
+def get_secrets_from_skills(dbmanager):
+    """
+        Get secrets from skills in the database
+        Args:
+            dbmanager: Database manager object
+
+        Returns:
+            List of secrets from skills in the database
+    """
+    secrets = []
+    for skill in dbmanager.get(model_class=Skill).data:
+        for secret in skill.secrets:
+            if secret['value'] != (None or ''):
+                secrets.append(secret['value'])
+    
+    return secrets

--- a/samples/apps/autogen-studio/autogenstudio/utils/secretmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/utils/secretmanager.py
@@ -43,15 +43,19 @@ def get_secrets_from_file(filepath):
     """
         Get secrets from a file
         Args: 
-            filepath: Path to the file containing secrets
+            filepath: Path to the file containing secret keys in env variable
 
         Returns:
             List of secrets from the file.
     """
     secrets=[]
+    env_keys=[]
     with open(filepath, "r") as f:
-        secrets = f.read().split()
+        env_keys = f.read().split()
     
+    for key in env_keys:
+        secrets.append(os.environ[key])
+
     return secrets
     
 def get_secrets_from_skills(dbmanager):

--- a/samples/apps/autogen-studio/autogenstudio/web/app.py
+++ b/samples/apps/autogen-studio/autogenstudio/web/app.py
@@ -1,11 +1,12 @@
 import asyncio
+import json
 import os
 import queue
 import threading
 import traceback
 from contextlib import asynccontextmanager
+from distutils.util import strtobool
 from typing import Any, Union
-import json
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
@@ -19,9 +20,8 @@ from ..database.dbmanager import DBManager
 from ..datamodel import Agent, Message, Model, Response, Session, Skill, Workflow
 from ..profiler import Profiler
 from ..utils import check_and_cast_datetime_fields, init_app_folders, md5_hash, test_model
-from ..version import VERSION
 from ..utils.secretmanager import *
-from distutils.util import strtobool
+from ..version import VERSION
 
 profiler = Profiler()
 managers = {"chat": None}  # manage calls to autogen
@@ -67,15 +67,26 @@ ui_folder_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ui")
 database_engine_uri = folders["database_engine_uri"]
 dbmanager = DBManager(engine_uri=database_engine_uri)
 
+
 async def get_all_secrets(interval_time: int):
-        
+
     while True:
-        os.environ['ALL_SECRETS'] = "|".join(map(str, (get_secrets_from_cloud(secret_providers=os.environ.get('CLOUD_SECRET_PROVIDERS').split(',')) if 'CLOUD_SECRET_PROVIDERS' in os.environ else []) + 
-                                                    (get_secrets_from_file(os.environ.get('BLACKLIST_PATH')) if 'BLACKLIST_PATH' in os.environ else []) +
-                                                    (get_secrets_from_skills(dbmanager))))
+        os.environ["ALL_SECRETS"] = "|".join(
+            map(
+                str,
+                (
+                    get_secrets_from_cloud(secret_providers=os.environ.get("CLOUD_SECRET_PROVIDERS").split(","))
+                    if "CLOUD_SECRET_PROVIDERS" in os.environ
+                    else []
+                )
+                + (get_secrets_from_file(os.environ.get("BLACKLIST_PATH")) if "BLACKLIST_PATH" in os.environ else [])
+                + (get_secrets_from_skills(dbmanager)),
+            )
+        )
 
         logger.info("Secrets updated")
         await asyncio.sleep(interval_time)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -83,8 +94,8 @@ async def lifespan(app: FastAPI):
     managers["chat"] = AutoGenChatManager(message_queue=message_queue)
     dbmanager.create_db_and_tables()
 
-    if strtobool(os.environ['ENABLE_SECRET_REDACTION']):
-        asyncio.create_task(get_all_secrets(int(os.environ['SECRET_FETCH_TIMEOUT'])))
+    if strtobool(os.environ["ENABLE_SECRET_REDACTION"]):
+        asyncio.create_task(get_all_secrets(int(os.environ["SECRET_FETCH_TIMEOUT"])))
 
     yield
     # Close all active connections

--- a/samples/apps/autogen-studio/autogenstudio/web/app.py
+++ b/samples/apps/autogen-studio/autogenstudio/web/app.py
@@ -68,12 +68,13 @@ database_engine_uri = folders["database_engine_uri"]
 dbmanager = DBManager(engine_uri=database_engine_uri)
 
 async def get_all_secrets(interval_time: int):
+        
     while True:
-        os.environ['ALL_SECRETS'] = "|".join(map(str, (get_secrets_from_cloud(secret_providers=os.environ['CLOUD_SECRET_PROVIDERS'].split(',')) if os.environ['CLOUD_SECRET_PROVIDERS'] else "") + 
-                                                      (get_secrets_from_file(os.environ['BLACKLIST_PATH']) if os.environ['BLACKLIST_PATH'] else "") +
-                                                      (get_secrets_from_skills(dbmanager))))
+        os.environ['ALL_SECRETS'] = "|".join(map(str, (get_secrets_from_cloud(secret_providers=os.environ.get('CLOUD_SECRET_PROVIDERS').split(',')) if 'CLOUD_SECRET_PROVIDERS' in os.environ else []) + 
+                                                    (get_secrets_from_file(os.environ.get('BLACKLIST_PATH')) if 'BLACKLIST_PATH' in os.environ else []) +
+                                                    (get_secrets_from_skills(dbmanager))))
 
-        print("Secrets updated")
+        logger.info("Secrets updated")
         await asyncio.sleep(interval_time)
 
 @asynccontextmanager

--- a/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
@@ -82,7 +82,7 @@ class AutoWorkflowManager:
         self.history = history or []
         self.sender = None
         self.receiver = None
-        self.secrets = list(map(str, os.environ['ALL_SECRETS'].split("|"))) if 'ALL_SECRETS' in os.environ else None
+        self.secrets = list(map(str, os.environ.get('ALL_SECRETS').split("|"))) if 'ALL_SECRETS' in os.environ else None
         
 
     def _run_workflow(self, message: str, history: Optional[List[Message]] = None, clear_history: bool = False) -> None:
@@ -268,7 +268,7 @@ class AutoWorkflowManager:
             Returns:
                 The transformed message.
         """
-        replacementString = os.environ['REDACTION_REPLACEMENT_STRING']
+        replacementString = os.environ.get('REDACTION_REPLACEMENT_STRING')
         temp_message = copy.deepcopy(message)
 
         if isinstance(temp_message, Dict):
@@ -316,7 +316,7 @@ class AutoWorkflowManager:
                 llm_config=agent.config.llm_config.model_dump(),
             )
 
-            if strtobool(os.environ['ENABLE_SECRET_REDACTION']):
+            if 'ENABLE_SECRET_REDACTION' in os.environ and strtobool(os.environ.get('ENABLE_SECRET_REDACTION')):
                 agent.register_hook(hookable_method="process_message_before_send", hook=self.transform_generated_response)
             
             return agent
@@ -335,7 +335,7 @@ class AutoWorkflowManager:
             else:
                 raise ValueError(f"Unknown agent type: {agent.type}")
             
-            if strtobool(os.environ['ENABLE_SECRET_REDACTION']):
+            if 'ENABLE_SECRET_REDACTION' in os.environ and strtobool(os.environ.get('ENABLE_SECRET_REDACTION')):
                 agent.register_hook(hookable_method="process_message_before_send", hook=self.transform_generated_response)
             
             return agent

--- a/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
@@ -273,7 +273,7 @@ class AutoWorkflowManager:
         replacementString = os.environ.get("REDACTION_REPLACEMENT_STRING")
         temp_message = copy.deepcopy(message)
 
-        if isinstance(temp_message, Dict):
+        if isinstance(temp_message, Dict) and self.secrets is not None:
             for secret in self.secrets:
                 if secret == "":
                     continue

--- a/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
@@ -1,9 +1,10 @@
+import copy
 import json
-import os, copy
+import os
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
 from distutils.util import strtobool
+from typing import Any, Dict, List, Optional, Union
 
 import autogen
 
@@ -82,8 +83,7 @@ class AutoWorkflowManager:
         self.history = history or []
         self.sender = None
         self.receiver = None
-        self.secrets = list(map(str, os.environ.get('ALL_SECRETS').split("|"))) if 'ALL_SECRETS' in os.environ else None
-        
+        self.secrets = list(map(str, os.environ.get("ALL_SECRETS").split("|"))) if "ALL_SECRETS" in os.environ else None
 
     def _run_workflow(self, message: str, history: Optional[List[Message]] = None, clear_history: bool = False) -> None:
         """
@@ -256,24 +256,27 @@ class AutoWorkflowManager:
                 agent.config.system_message = get_default_system_message(agent.type) + "\n\n" + skills_prompt
         return agent
 
-    def transform_generated_response(self, message: Union[Dict, str], sender: Optional[Agent] = None, recipient: Agent = None, silent: bool = None) -> Union[Dict, str]:
+    def transform_generated_response(
+        self, message: Union[Dict, str], sender: Optional[Agent] = None, recipient: Agent = None, silent: bool = None
+    ) -> Union[Dict, str]:
         """
-            Transforms the generated response by redacting secrets.
-            Args:  
-                message: The message to be transformed.
-                sender: The sender of the message.
-                recipient: The recipient of the message.
-                silent: determining verbosity.
-            
-            Returns:
-                The transformed message.
+        Transforms the generated response by redacting secrets.
+        Args:
+            message: The message to be transformed.
+            sender: The sender of the message.
+            recipient: The recipient of the message.
+            silent: determining verbosity.
+
+        Returns:
+            The transformed message.
         """
-        replacementString = os.environ.get('REDACTION_REPLACEMENT_STRING')
+        replacementString = os.environ.get("REDACTION_REPLACEMENT_STRING")
         temp_message = copy.deepcopy(message)
 
         if isinstance(temp_message, Dict):
             for secret in self.secrets:
-                if secret == '': continue
+                if secret == "":
+                    continue
                 if isinstance(temp_message["content"], str):
                     temp_message["content"] = temp_message["content"].replace(secret, replacementString)
                 elif isinstance(temp_message["content"], list):
@@ -283,9 +286,9 @@ class AutoWorkflowManager:
 
         if isinstance(temp_message, str):
             for secret in self.secrets:
-                if secret != '' and secret in temp_message:
+                if secret != "" and secret in temp_message:
                     temp_message = temp_message.replace(secret, replacementString)
-        
+
         return temp_message
 
     def load(self, agent: Any) -> autogen.Agent:
@@ -316,9 +319,11 @@ class AutoWorkflowManager:
                 llm_config=agent.config.llm_config.model_dump(),
             )
 
-            if 'ENABLE_SECRET_REDACTION' in os.environ and strtobool(os.environ.get('ENABLE_SECRET_REDACTION')):
-                agent.register_hook(hookable_method="process_message_before_send", hook=self.transform_generated_response)
-            
+            if "ENABLE_SECRET_REDACTION" in os.environ and strtobool(os.environ.get("ENABLE_SECRET_REDACTION")):
+                agent.register_hook(
+                    hookable_method="process_message_before_send", hook=self.transform_generated_response
+                )
+
             return agent
 
         else:
@@ -334,10 +339,12 @@ class AutoWorkflowManager:
                 )
             else:
                 raise ValueError(f"Unknown agent type: {agent.type}")
-            
-            if 'ENABLE_SECRET_REDACTION' in os.environ and strtobool(os.environ.get('ENABLE_SECRET_REDACTION')):
-                agent.register_hook(hookable_method="process_message_before_send", hook=self.transform_generated_response)
-            
+
+            if "ENABLE_SECRET_REDACTION" in os.environ and strtobool(os.environ.get("ENABLE_SECRET_REDACTION")):
+                agent.register_hook(
+                    hookable_method="process_message_before_send", hook=self.transform_generated_response
+                )
+
             return agent
 
     def _generate_output(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds some changes to Autogenstudio that allows the backend to hide sensitive data from cloud services (i.e. Azure Key Vault), a custom file (Blacklist), and secrets defined in Skills after an agent's response. If the user enables this feature via env variable the data will be updated every user defined period in env variable (for example, 1hr).

All env variables that are used in the changes:
ENABLE_SECRET_REDACTION: Enable the secret redaction feature or not
CLOUD_SECRET_PROVIDERS: All cloud secret providers
AZURE_KEYVAULT_URL: Access Link for Azure Key Vault. More cloud secret providers' urls can be added, in string
REDACTION_REPLACEMENT_STRING: The string that secrets will be replaced with
SECRET_FETCH_TIMEOUT: The secret fetch time period, in seconds. 
BLACKLIST_PATH: Path to user's blacklist, in string. The Blacklist is a txt file containing all the secrets user wants to be redacted.

i.e.
ENABLE_SECRET_REDACTION=True
CLOUD_SECRET_PROVIDERS=azure,aws
AZURE_KEYVAULT_URL=<Link to Azure Key Vault>
REDACTION_REPLACEMENT_STRING="REDACTED"
SECRET_FETCH_TIMEOUT=30
BLACKLIST_PATH=<Path to user's blacklist>


## Related issue number

The changes are for #3255

## Checks

- [*] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [*] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [*] I've made sure all auto checks have passed.
