### PR TITLE
Updated Program.cs for Autogen.BasicSample to give menu driven options

### DIFF
--- a/dotnet/sample/AutoGen.BasicSamples/Program.cs
+++ b/dotnet/sample/AutoGen.BasicSamples/Program.cs
@@ -1,4 +1,59 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Program.cs
 
-await Example07_Dynamic_GroupChat_Calculate_Fibonacci.RunAsync();
+//await Example07_Dynamic_GroupChat_Calculate_Fibonacci.RunAsync();
+
+using AutoGen.BasicSample;
+
+//Define allSamples collection for all examples
+List<Tuple<string, Func<Task>>> allSamples = new List<Tuple<string, Func<Task>>>();
+
+// When a new sample is created please add them to the allSamples collection
+allSamples.Add(new Tuple<string, Func<Task>>("Assistant Agent", async () => { await Example01_AssistantAgent.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("Two-agent Math Chat", async () => { await Example02_TwoAgent_MathChat.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("Agent Function Call", async () => { await Example03_Agent_FunctionCall.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("Dynamic Group Chat Coding Task", async () => { await Example04_Dynamic_GroupChat_Coding_Task.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("DALL-E and GPT4v", async () => { await Example05_Dalle_And_GPT4V.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("User Proxy Agent", async () => { await Example06_UserProxyAgent.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("Dynamic Group Chat - Calculate Fibonacci", async () => { await Example07_Dynamic_GroupChat_Calculate_Fibonacci.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("LM Studio", async () => { await Example08_LMStudio.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("LM Studio - Function Call", async () => { await Example09_LMStudio_FunctionCall.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("Semantic Kernel", async () => { await Example10_SemanticKernel.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("Sequential Group Chat", async () => { await Sequential_GroupChat_Example.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("Two Agent - Fill Application", async () => { await TwoAgent_Fill_Application.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("Mistal Client Agent - Token Count", async () => { await Example14_MistralClientAgent_TokenCount.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("GPT4v - Binary Data Image", async () => { await Example15_GPT4V_BinaryDataImageMessage.RunAsync(); }));
+allSamples.Add(new Tuple<string, Func<Task>>("ReAct Agent", async () => { await Example17_ReActAgent.RunAsync(); }));
+
+
+int idx = 1;
+Dictionary<int, Tuple<string, Func<Task>>> map = new Dictionary<int, Tuple<string, Func<Task>>>();
+Console.WriteLine("Available Examples:\n\n");
+foreach (Tuple<string, Func<Task>> sample in allSamples)
+{
+    map.Add(idx, sample);
+    Console.WriteLine("{0}. {1}", idx++, sample.Item1);
+}
+
+Console.WriteLine("\n\nEnter your selection:");
+
+try
+{
+    int val = Convert.ToInt32(Console.ReadLine());
+
+    if (!map.ContainsKey(val))
+    {
+        Console.WriteLine("Invalid choice");
+    }
+    else
+    {
+        Console.WriteLine("\nRunning {0}", map[val].Item1);
+        await map[val].Item2.Invoke();
+    }
+}
+catch
+{
+    Console.WriteLine("Error encountered, please check your entry and run again");
+}
+
+


### PR DESCRIPTION
Updated Program.cs in Autogen.BasicSample to give a menu driven option making it easier to run various Agent config.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Added a menu driven option to run the Agent samples

<!-- Please give a short summary of the change and the problem this solves. -->

Makes all the sample easily available and run them without making any code changes in the program.cs

## Related issue number
N/A
<!-- For example: "Closes #1234" -->

## Checks

- [ x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
Change in only on program.cs
- [ x] I've made sure all auto checks have passed.

Ran test for models which I have access to. However no changes were done in any class libraries.
