### PR TITLE
Missing backticks breaking documentation in groupchat.last_speaker

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1050,6 +1050,7 @@ class GroupChatManager(ConversableAgent):
         groupchat_result = agent_a.initiate_chat(
             chat_manager, message="Hi, there, I'm agent A."
         )
+        ```
         """
         return self._last_speaker
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
There are missing backticks in docstring causing the generated reference documentation formatting to break.
## Related issue number

<!-- For example: "Closes #1234" -->
N/A
## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
