### PR TITLE
Fix windows build error

### DIFF
--- a/samples/apps/autogen-studio/frontend/gatsby-config.ts
+++ b/samples/apps/autogen-studio/frontend/gatsby-config.ts
@@ -14,7 +14,7 @@ require("dotenv").config({
 });
 
 const config: GatsbyConfig = {
-  pathPrefix: `${process.env.PREFIX_PATH_VALUE}`,
+  pathPrefix: process.env.PREFIX_PATH_VALUE || '',
   siteMetadata: {
     title: `AutoGen Studio [Beta]`,
     description: `Build Multi-Agent Apps`,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When I built AutoGen Studio locally in Windows environment, after executing the build command(
  gatsby clean && rmdir /s /q ..\\autogenstudio\\web\\ui 2>nul & (set \"PREFIX_PATH_VALUE=\" || ver>nul) && gatsby build --prefix-paths && xcopy /E /I /Y public ..\\autogenstudio\\web\\ui
), the frontend could not find the page after clicking. After analysis, I found that this was because when the Windows environment variable was set to empty, the process.env.PREFIX_PATH_VALUE value read by the code was undefined, which caused the path problem. So I modified the gatsby-config.ts code and tested it under Windows and Linux without any problems.

<!-- Please give a short summary of the change and the problem this solves. -->
The change mainly adds an OR operation.When the value of process.env.PREFIX_PATH_VALUE is undefined in Windows, the pathPrefix value is empty. The change can solve the problem that the frontend page cannot be displayed when PREFIX_PATH_VALUE is set to empty in Windows.
## Related issue number
Closes #3109

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
