### PR TITLE
Correct documentation: Replace NEVER with TERMINATE in human-in-the-loop.ipynb

### DIFF
--- a/website/docs/tutorial/human-in-the-loop.ipynb
+++ b/website/docs/tutorial/human-in-the-loop.ipynb
@@ -41,7 +41,7 @@
     "    termination based on `max_consecutive_auto_reply` is ignored.\n",
     "\n",
     "The previous chapters already showed many examples of the cases when `human_input_mode` is `NEVER`. \n",
-    "Below we show one such example again and then show the differences when this mode is set to `ALWAYS` and `NEVER` instead."
+    "Below we show one such example again and then show the differences when this mode is set to `ALWAYS` and `TERMINATE` instead."
    ]
   },
   {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

According to the context of the document, this section should be introducing ALWAYS and TERMINATE, not ALWAYS and NEVER.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
