### PR TITLE
Add contributor list via contributors.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,4 +30,3 @@
 
 ## Acknowledgements
 This template was adapted from [GitHub Template Guide](https://github.com/cezaraugusto/github-template-guidelines/blob/master/.github/CONTRIBUTORS.md) by [cezaraugusto](https://github.com/cezaraugusto).
-

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,11 +18,11 @@
 | Xiaoyun Zhang | [LittleLittleCloud](https://github.com/LittleLittleCloud) | Microsoft | AutoGen.Net, group chat | Yes | [Backlog - AutoGen.Net](https://github.com/microsoft/autogen/issues) - Available most of the time (PST) |
 | Yiran Wu | [yiranwu0](https://github.com/yiranwu0) | Penn State University | alt-models, group chat, logging | Yes | |
 | Beibin Li | [BeibinLi](https://github.com/BeibinLi) | Microsoft Research | alt-models | Yes | |
-| Gagan Bansal | [gagb](https://github.com/gagb) | Microsoft Research |  | - | |
-| Adam Fourney | [afourney](https://github.com/afourney) | Microsoft Research |  | - | |
-| Ricky Loynd | [rickyloyn-microsoft](https://github.com/rickyloynd-microsoft) | Microsoft Research |  | - | |
-| Eric Zhu | [ekzhu](https://github.com/ekzhu) | Microsoft Research |  | - | |
-| Jack Gerrits | [jackgerrits](https://github.com/jackgerrits) | Microsoft Research |  | - | |
+| Gagan Bansal | [gagb](https://github.com/gagb) | Microsoft Research |  | Complex Tasks | |
+| Adam Fourney | [afourney](https://github.com/afourney) | Microsoft Research |  | Complex Tasks | |
+| Ricky Loynd | [rickyloyn-microsoft](https://github.com/rickyloynd-microsoft) | Microsoft Research |  | Learning | |
+| Eric Zhu | [ekzhu](https://github.com/ekzhu) | Microsoft Research |  | Infra | |
+| Jack Gerrits | [jackgerrits](https://github.com/jackgerrits) | Microsoft Research |  | Infra | |
 
 
 ## I would like to join this list. How can I help the project?

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,14 +1,7 @@
 # Contributors
 
-
-
 ## Special thanks to all the people who have helped this project so far:
-
-
-
 > These individuals have dedicated their time and expertise to improve this project. We are deeply grateful for their contributions.
-
-
 
 | Name | GitHub Handle | Organization | Features | Roadmap Lead | Additional  Information |
 |---|---|---|---|---|---|
@@ -27,16 +20,13 @@
 | Beibin Li | [BeibinLi](https://github.com/BeibinLi) | Microsoft Research | alt-models | Yes | |
 
 
-
 ## I would like to join this list. How can I help the project?
-
 > We're always looking for new contributors to join our team and help improve the project.
 
 
-
 ## Are you missing from this list?
-
 > Please open a PR to help us fix this.
+
 
 For more information, please refer to our [CONTRIBUTING](CONTRIBUTING.md) guide.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,7 @@
 # Contributors
 
-## Special thanks to all the people who have helped this project so far:
-> These individuals have dedicated their time and expertise to improve this project. We are deeply grateful for their contributions.
+## Special thanks to all the people who help this project so far:
+> These individuals dedicate their time and expertise to improve this project. We are deeply grateful for their contributions.
 
 | Name | GitHub Handle | Organization | Features | Roadmap Lead | Additional  Information |
 |---|---|---|---|---|---|
@@ -18,6 +18,11 @@
 | Xiaoyun Zhang | [LittleLittleCloud](https://github.com/LittleLittleCloud) | Microsoft | AutoGen.Net, group chat | Yes | [Backlog - AutoGen.Net](https://github.com/microsoft/autogen/issues) - Available most of the time (PST) |
 | Yiran Wu | [yiranwu0](https://github.com/yiranwu0) | Penn State University | alt-models, group chat, logging | Yes | |
 | Beibin Li | [BeibinLi](https://github.com/BeibinLi) | Microsoft Research | alt-models | Yes | |
+| Gagan Bansal | [gagb](https://github.com/gagb) | Microsoft Research |  | - | |
+| Adam Fourney | [afourney](https://github.com/afourney) | Microsoft Research |  | - | |
+| Ricky Loynd | [rickyloyn-microsoft](https://github.com/rickyloynd-microsoft) | Microsoft Research |  | - | |
+| Eric Zhu | [ekzhu](https://github.com/ekzhu) | Microsoft Research |  | - | |
+| Jack Gerrits | [jackgerrits](https://github.com/jackgerrits) | Microsoft Research |  | - | |
 
 
 ## I would like to join this list. How can I help the project?

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 # Contributors
 
-## Special thanks to all the people who help this project so far:
+## Special thanks to all the people who help this project:
 > These individuals dedicate their time and expertise to improve this project. We are deeply grateful for their contributions.
 
 | Name | GitHub Handle | Organization | Features | Roadmap Lead | Additional  Information |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,3 +32,4 @@ For more information, please refer to our [CONTRIBUTING](CONTRIBUTING.md) guide.
 
 ## Acknowledgements
 This template was adapted from [GitHub Template Guide](https://github.com/cezaraugusto/github-template-guidelines/blob/master/.github/CONTRIBUTORS.md) by [cezaraugusto](https://github.com/cezaraugusto).
+

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,7 +9,7 @@
 | Chi Wang | [sonichi](https://github.com/sonichi) | - | all | Yes | |
 | Li Jiang | [thinkall](https://github.com/thinkall) | Microsoft | rag, autobuilder, group chat | Yes | [Issue #1657](https://github.com/microsoft/autogen/issues/1657) - Beijing, GMT+8 |
 | Mark Sze | [marklysze](https://github.com/marklysze) | - | alt-models, group chat | No | Generally available (Sydney, AU time) - Group Chat "auto" speaker selection |
-| Hrushikesh Dokala | [Hk669](https://github.com/Hk669) | - | alt-models, swebench, logging, rag | No | [Issue #2946](https://github.com/microsoft/autogen/issues/2946), [Pull Request #2933](https://github.com/microsoft/autogen/pull/2933) - Available most of the time (IST, GMT+5:30) |
+| Hrushikesh Dokala | [Hk669](https://github.com/Hk669) | - | alt-models, swebench, logging, rag | No | [Issue #2946](https://github.com/microsoft/autogen/issues/2946), [Pull Request #2933](https://github.com/microsoft/autogen/pull/2933) - Available most of the time (India, GMT+5:30) |
 | Jiale Liu | [LeoLjl](https://github.com/LeoLjl) | Penn State University | autobuild, group chat | No | |
 | Shaokun Zhang | [skzhang1](https://github.com/skzhang1) | Penn State University | AgentOptimizer, Teachability            | Yes | [Issue #521](https://github.com/microsoft/autogen/issues/521)                         |
 | Rajan Chari | [rajan-chari](https://github.com/rajan-chari) | Microsoft Research | CAP, Survey of other frameworks | No | |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,14 +21,12 @@
 
 
 ## I would like to join this list. How can I help the project?
-> We're always looking for new contributors to join our team and help improve the project.
+> We're always looking for new contributors to join our team and help improve the project. For more information, please refer to our [CONTRIBUTING](CONTRIBUTING.md) guide.
 
 
 ## Are you missing from this list?
 > Please open a PR to help us fix this.
 
-
-For more information, please refer to our [CONTRIBUTING](CONTRIBUTING.md) guide.
 
 ## Acknowledgements
 This template was adapted from [GitHub Template Guide](https://github.com/cezaraugusto/github-template-guidelines/blob/master/.github/CONTRIBUTORS.md) by [cezaraugusto](https://github.com/cezaraugusto).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,44 @@
+# Contributors
+
+
+
+## Special thanks to all the people who have helped this project so far:
+
+
+
+> These individuals have dedicated their time and expertise to improve this project. We are deeply grateful for their contributions.
+
+
+
+| Name | GitHub Handle | Organization | Features | Roadmap Lead | Additional  Information |
+|---|---|---|---|---|---|
+| Qingyun Wu | [qingyun-wu](https://github.com/qingyun-wu) | Penn State University | all, alt-models, autobuilder | Yes | Available most of the time (US Eastern Time) |
+| Chi Wang | [sonichi](https://github.com/sonichi) | - | all | Yes | |
+| Li Jiang | [thinkall](https://github.com/thinkall) | Microsoft | rag, autobuilder, group chat | Yes | [Issue #1657](https://github.com/microsoft/autogen/issues/1657) - Beijing, GMT+8 |
+| Mark Sze | [marklysze](https://github.com/marklysze) | - | alt-models, group chat | No | Generally available (Sydney, AU time) - Group Chat "auto" speaker selection |
+| Hrushikesh Dokala | [Hk669](https://github.com/Hk669) | - | alt-models, swebench, logging, rag | No | [Issue #2946](https://github.com/microsoft/autogen/issues/2946), [Pull Request #2933](https://github.com/microsoft/autogen/pull/2933) - Available most of the time (IST, GMT+5:30) |
+| Jiale Liu | [LeoLjl](https://github.com/LeoLjl) | Penn State University | autobuild, group chat | No | |
+| Shaokun Zhang | [skzhang1](https://github.com/skzhang1) | Penn State University | AgentOptimizer, Teachability            | Yes | [Issue #521](https://github.com/microsoft/autogen/issues/521)                         |
+| Rajan Chari | [rajan-chari](https://github.com/rajan-chari) | Microsoft Research | CAP, Survey of other frameworks | No | |
+| Victor Dibia | [victordibia](https://github.com/victordibia) | Microsoft Research | autogenstudio | Yes | [Issue #737](https://github.com/microsoft/autogen/issues/737) |
+| Yixuan Zhai | [randombet](https://github.com/randombet) | Meta | group chat, sequential_chats, rag       | No | |
+| Xiaoyun Zhang | [LittleLittleCloud](https://github.com/LittleLittleCloud) | Microsoft | AutoGen.Net, group chat | Yes | [Backlog - AutoGen.Net](https://github.com/microsoft/autogen/issues) - Available most of the time (PST) |
+| Yiran Wu | [yiranwu0](https://github.com/yiranwu0) | Penn State University | alt-models, group chat, logging | Yes | |
+| Beibin Li | [BeibinLi](https://github.com/BeibinLi) | Microsoft Research | alt-models | Yes | |
+
+
+
+## I would like to join this list. How can I help the project?
+
+> We're always looking for new contributors to join our team and help improve the project.
+
+
+
+## Are you missing from this list?
+
+> Please open a PR to help us fix this.
+
+For more information, please refer to our [CONTRIBUTING](CONTRIBUTING.md) guide.
+
+## Acknowledgements
+This template was adapted from [GitHub Template Guide](https://github.com/cezaraugusto/github-template-guidelines/blob/master/.github/CONTRIBUTORS.md) by [cezaraugusto](https://github.com/cezaraugusto).

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@
 
 AutoGen is an open-source programming framework for building AI agents and facilitating cooperation among multiple agents to solve tasks. AutoGen aims to streamline the development and research of agentic AI, much like PyTorch does for Deep Learning. It offers features such as agents capable of interacting with each other, facilitates the use of various large language models (LLMs) and tool use support, autonomous and human-in-the-loop workflows, and multi-agent conversation patterns.
 
+We welcome contributions from developers and organizations worldwide. Our goal is to foster a collaborative and inclusive community where diverse perspectives and expertise can drive innovation and enhance the project's capabilities. We acknowledge the invaluable contributions from our existing contributors, as listed in [contributors.md](./CONTRIBUTORS.md). Whether you are an individual contributor or represent an organization, we invite you to join us in shaping the future of this project.
+
 ![AutoGen Overview](https://github.com/microsoft/autogen/blob/main/website/static/img/autogen_agentchat.png)
 
 - AutoGen enables building next-gen LLM applications based on [multi-agent conversations](https://microsoft.github.io/autogen/docs/Use-Cases/agent_chat) with minimal effort. It simplifies the orchestration, automation, and optimization of a complex LLM workflow. It maximizes the performance of LLM models and overcomes their weaknesses.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 
 AutoGen is an open-source programming framework for building AI agents and facilitating cooperation among multiple agents to solve tasks. AutoGen aims to streamline the development and research of agentic AI, much like PyTorch does for Deep Learning. It offers features such as agents capable of interacting with each other, facilitates the use of various large language models (LLMs) and tool use support, autonomous and human-in-the-loop workflows, and multi-agent conversation patterns.
 
-We welcome contributions from developers and organizations worldwide. Our goal is to foster a collaborative and inclusive community where diverse perspectives and expertise can drive innovation and enhance the project's capabilities. We acknowledge the invaluable contributions from our existing contributors, as listed in [contributors.md](./CONTRIBUTORS.md). Whether you are an individual contributor or represent an organization, we invite you to join us in shaping the future of this project.
+We welcome contributions from developers and organizations worldwide. Our goal is to foster a collaborative and inclusive community where diverse perspectives and expertise can drive innovation and enhance the project's capabilities. We acknowledge the invaluable contributions from our existing contributors, as listed in [contributors.md](./CONTRIBUTORS.md). Whether you are an individual contributor or represent an organization, we invite you to join us in shaping the future of this project. For further information please also see [Microsoft open-source contributing guidelines](https://github.com/microsoft/autogen?tab=readme-ov-file#contributing).
 
 ![AutoGen Overview](https://github.com/microsoft/autogen/blob/main/website/static/img/autogen_agentchat.png)
 


### PR DESCRIPTION
Add CONTRIBUTORS.md to acknowledge key contributors via a standard conventions. List is maintained more visibly in the repo it self instead of external links and documents that are not part of the project.