### PR TITLE
fix_new_session_bug

### DIFF
--- a/samples/apps/autogen-studio/frontend/src/components/views/playground/sessions.tsx
+++ b/samples/apps/autogen-studio/frontend/src/components/views/playground/sessions.tsx
@@ -371,6 +371,7 @@ const SessionsView = ({}: any) => {
         <WorkflowSelector
           workflow={workflow}
           setWorkflow={setWorkflow}
+          workflow_id={selectedSession?.workflow_id}
           disabled={sessionExists}
         />
         <div className="my-2 text-xs"> Session Name </div>

--- a/samples/apps/autogen-studio/frontend/src/components/views/playground/utils/selectors.tsx
+++ b/samples/apps/autogen-studio/frontend/src/components/views/playground/utils/selectors.tsx
@@ -9,10 +9,12 @@ import { Link } from "gatsby";
 const WorkflowSelector = ({
   workflow,
   setWorkflow,
+  workflow_id,
   disabled,
 }: {
   workflow: IWorkflow | null;
   setWorkflow: (workflow: IWorkflow) => void;
+  workflow_id: number | undefined
   disabled?: boolean;
 }) => {
   const [error, setError] = React.useState<IStatus | null>({
@@ -42,7 +44,15 @@ const WorkflowSelector = ({
         // message.success(data.message);
         setWorkflows(data.data);
         if (data.data.length > 0) {
-          setWorkflow(data.data[0]);
+          if (!disabled) {
+            setWorkflow(data.data[0]);
+          } else {
+            const index = data.data.findIndex((item:IWorkflow) => item.id === workflow_id);
+            if (index !== -1) {
+              setSelectedWorkflow(index);
+              setWorkflow(data.data[index]);
+            }
+          }
         }
       } else {
         message.error(data.message);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When I create a new session on the playground page in AutoGen Studio, I select a workflow that is not displayed by default (for example, selecting the second Travel Planning Workflow). 
![image](https://github.com/user-attachments/assets/9099d7b3-a561-49a9-b34b-4d2f29faf242)
![image](https://github.com/user-attachments/assets/96a439e8-ec41-4cd4-8584-fd7bfac0559a)
After creating the session, when I click to edit the session, the default workflow (for example, Default Workflow) is displayed. The correct display should be the workflow selected when creating the new session (Travel Planning Workflow).
![image](https://github.com/user-attachments/assets/b5a7eeca-df32-4ba5-a49b-b14c1d96a998)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
