### PR TITLE
Fix for group chat resume - full chat history for each agent

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1264,11 +1264,10 @@ class GroupChatManager(ConversableAgent):
             if not message_speaker_agent and message["name"] == self.name:
                 message_speaker_agent = self
 
-            # Add previous messages to each agent (except their own messages and the last message, as we'll kick off the conversation with it)
+            # Add previous messages to each agent (except the last message, as we'll kick off the conversation with it)
             if i != len(messages) - 1:
                 for agent in self._groupchat.agents:
-                    if agent.name != message["name"]:
-                        self.send(message, self._groupchat.agent_by_name(agent.name), request_reply=False, silent=True)
+                    self.send(message, self._groupchat.agent_by_name(agent.name), request_reply=False, silent=True)
 
                 # Add previous message to the new groupchat, if it's an admin message the name may not match so add the message directly
                 if message_speaker_agent:


### PR DESCRIPTION
## Why are these changes needed?

As per Issue #3408, resuming when function calls have occurred is causing an issue. This addresses it by restoring chat message state to agents with the full message history rather than everything minus their own.

## Related issue number

Will close #3408 
May help #3155 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
