### PR TITLE
fix for bug-3322: error when configured with environment variables

### DIFF
--- a/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
+++ b/samples/apps/autogen-studio/autogenstudio/workflowmanager.py
@@ -236,11 +236,6 @@ class AutoWorkflowManager:
         if agent.config.llm_config is not False:
             config_list = []
             for llm in agent.config.llm_config.config_list:
-                # check if api_key is present either in llm or env variable
-                if "api_key" not in llm and "OPENAI_API_KEY" not in os.environ:
-                    error_message = f"api_key is not present in llm_config or OPENAI_API_KEY env variable for agent ** {agent.config.name}**. Update your workflow to provide an api_key to use the LLM."
-                    raise ValueError(error_message)
-
                 # only add key if value is not None
                 sanitized_llm = sanitize_model(llm)
                 config_list.append(sanitized_llm)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
@victordibia 
## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
Configuring for Azure OpenAI with the environment variable AZURE_OPENAI_API_KEY throws ValueError 

> "api_key is not present in llm_config or OPENAI_API_KEY env variable for agent..." 

This is due to logic that checks for OPENAI_API_KEY but doesn't include a check for the AZURE_OPENAI_KEY configuration. 
https://github.com/microsoft/autogen/blob/autogenstudio/samples/apps/autogen-studio/autogenstudio/workflowmanager.py#L239-L242

Completely removing the check block allows support of the AZURE_OPENAI_API_KEY configuration and improves the error message

> OpenAIError: Missing credentials. Please pass one of `api_key`, `azure_ad_token`, `azure_ad_token_provider`, or the `AZURE_OPENAI_API_KEY` or `AZURE_OPENAI_AD_TOKEN` environment variables.
## Related issue number
Closes #3322
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
