### PR TITLE
docs: fix autogen install url

### DIFF
--- a/website/docs/topics/non-openai-models/local-litellm-ollama.ipynb
+++ b/website/docs/topics/non-openai-models/local-litellm-ollama.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "Running this stack requires the installation of:\n",
     "\n",
-    "1. AutoGen ([installation instructions](/docs/installation))\n",
+    "1. AutoGen ([installation instructions](https://microsoft.github.io/autogen/docs/installation))\n",
     "2. LiteLLM\n",
     "3. Ollama\n",
     "\n",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

/docs/installation redirects for some reason to /docs/docs/installation. Using the full url is more reliable 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
