### PR TITLE
Fix flaml dependency issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "openai>=1.3",
     "diskcache",
     "termcolor",
-    "flaml",
+    "flaml[automl]",
     # numpy is installed by flaml, but we want to pin the version to below 2.x (see https://github.com/microsoft/autogen/issues/1960)
     "numpy>=1.17.0,<2",
     "python-dotenv",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We have code like below, it requires `flaml[automl]`.
https://github.com/microsoft/autogen/blob/4bc88bed320988db4086f7c017190acdcde3412b/autogen/oai/client.py#L9

## Related issue number
https://github.com/microsoft/FLAML/issues/1355

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
