### PR TITLE
Fix issue caused by chromadb error type change

### DIFF
--- a/autogen/agentchat/contrib/vectordb/chromadb.py
+++ b/autogen/agentchat/contrib/vectordb/chromadb.py
@@ -1,6 +1,8 @@
 import os
 from typing import Callable, List
 
+import chromadb.errors
+
 from .base import Document, ItemID, QueryResults, VectorDB
 from .utils import chroma_results_to_query_results, filter_results_by_distance, get_logger
 
@@ -84,7 +86,7 @@ class ChromaVectorDB(VectorDB):
                 collection = self.active_collection
             else:
                 collection = self.client.get_collection(collection_name, embedding_function=self.embedding_function)
-        except ValueError:
+        except (ValueError, chromadb.errors.ChromaError):
             collection = None
         if collection is None:
             return self.client.create_collection(

--- a/autogen/agentchat/contrib/vectordb/chromadb.py
+++ b/autogen/agentchat/contrib/vectordb/chromadb.py
@@ -1,8 +1,6 @@
 import os
 from typing import Callable, List
 
-import chromadb.errors
-
 from .base import Document, ItemID, QueryResults, VectorDB
 from .utils import chroma_results_to_query_results, filter_results_by_distance, get_logger
 
@@ -15,6 +13,11 @@ try:
     from chromadb.api.models.Collection import Collection
 except ImportError:
     raise ImportError("Please install chromadb: `pip install chromadb`")
+
+try:
+    from chromadb.errors import ChromaError
+except ImportError:
+    ChromaError = Exception
 
 CHROMADB_MAX_BATCH_SIZE = os.environ.get("CHROMADB_MAX_BATCH_SIZE", 40000)
 logger = get_logger(__name__)
@@ -86,7 +89,7 @@ class ChromaVectorDB(VectorDB):
                 collection = self.active_collection
             else:
                 collection = self.client.get_collection(collection_name, embedding_function=self.embedding_function)
-        except (ValueError, chromadb.errors.ChromaError):
+        except (ValueError, ChromaError):
             collection = None
         if collection is None:
             return self.client.create_collection(

--- a/notebook/agentchat_RetrieveChat.ipynb
+++ b/notebook/agentchat_RetrieveChat.ipynb
@@ -31,7 +31,7 @@
     "pip install pyautogen[retrievechat] flaml[automl]\n",
     "```\n",
     "\n",
-    "> _You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551)_\n",
+    "> You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).\n",
     "\n",
     "For more information, please refer to the [installation guide](/docs/installation/).\n",
     ":::\n",

--- a/notebook/agentchat_RetrieveChat.ipynb
+++ b/notebook/agentchat_RetrieveChat.ipynb
@@ -31,7 +31,7 @@
     "pip install pyautogen[retrievechat] flaml[automl]\n",
     "```\n",
     "\n",
-    "> You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).\n",
+    "*You'll need to install `chromadb<=0.5.0` if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).*\n",
     "\n",
     "For more information, please refer to the [installation guide](/docs/installation/).\n",
     ":::\n",

--- a/notebook/agentchat_RetrieveChat.ipynb
+++ b/notebook/agentchat_RetrieveChat.ipynb
@@ -31,6 +31,8 @@
     "pip install pyautogen[retrievechat] flaml[automl]\n",
     "```\n",
     "\n",
+    "> _You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551)_\n",
+    "\n",
     "For more information, please refer to the [installation guide](/docs/installation/).\n",
     ":::\n",
     "````"
@@ -2785,7 +2787,7 @@
    ]
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "autogen312",
    "language": "python",
    "name": "python3"
   },

--- a/test/agentchat/contrib/vectordb/test_chromadb.py
+++ b/test/agentchat/contrib/vectordb/test_chromadb.py
@@ -15,6 +15,11 @@ except ImportError:
 else:
     skip = False
 
+try:
+    from chromadb.errors import ChromaError
+except ImportError:
+    ChromaError = Exception
+
 
 @pytest.mark.skipif(skip, reason="dependency is not installed")
 def test_chromadb():
@@ -26,12 +31,14 @@ def test_chromadb():
 
     # test_delete_collection
     db.delete_collection(collection_name)
-    pytest.raises(ValueError, db.get_collection, collection_name)
+    pytest.raises((ValueError, ChromaError), db.get_collection, collection_name)
 
     # test more create collection
     collection = db.create_collection(collection_name, overwrite=False, get_or_create=False)
     assert collection.name == collection_name
-    pytest.raises(ValueError, db.create_collection, collection_name, overwrite=False, get_or_create=False)
+    pytest.raises(
+        (ValueError, ChromaError), db.create_collection, collection_name, overwrite=False, get_or_create=False
+    )
     collection = db.create_collection(collection_name, overwrite=True, get_or_create=False)
     assert collection.name == collection_name
     collection = db.create_collection(collection_name, overwrite=False, get_or_create=True)

--- a/website/blog/2023-10-18-RetrieveChat/index.mdx
+++ b/website/blog/2023-10-18-RetrieveChat/index.mdx
@@ -4,7 +4,7 @@ authors: thinkall
 tags: [LLM, RAG]
 ---
 
-*Last update: August 14, 2024; AutoGen version: v0.2.35*
+*Last update: September 23, 2024; AutoGen version: v0.2.35*
 
 ![RAG Architecture](img/retrievechat-arch.png)
 
@@ -56,6 +56,7 @@ Please install pyautogen with the [retrievechat] option before using RAG agents.
 ```bash
 pip install "pyautogen[retrievechat]"
 ```
+> _You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551)_
 
 RetrieveChat can handle various types of documents. By default, it can process
 plain text and PDF files, including formats such as 'txt', 'json', 'csv', 'tsv',

--- a/website/blog/2023-10-18-RetrieveChat/index.mdx
+++ b/website/blog/2023-10-18-RetrieveChat/index.mdx
@@ -56,7 +56,7 @@ Please install pyautogen with the [retrievechat] option before using RAG agents.
 ```bash
 pip install "pyautogen[retrievechat]"
 ```
-> _You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551)_
+> You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).
 
 RetrieveChat can handle various types of documents. By default, it can process
 plain text and PDF files, including formats such as 'txt', 'json', 'csv', 'tsv',

--- a/website/blog/2023-10-18-RetrieveChat/index.mdx
+++ b/website/blog/2023-10-18-RetrieveChat/index.mdx
@@ -56,7 +56,8 @@ Please install pyautogen with the [retrievechat] option before using RAG agents.
 ```bash
 pip install "pyautogen[retrievechat]"
 ```
-> You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).
+
+*You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).*
 
 RetrieveChat can handle various types of documents. By default, it can process
 plain text and PDF files, including formats such as 'txt', 'json', 'csv', 'tsv',

--- a/website/blog/2023-10-18-RetrieveChat/index.mdx
+++ b/website/blog/2023-10-18-RetrieveChat/index.mdx
@@ -57,7 +57,7 @@ Please install pyautogen with the [retrievechat] option before using RAG agents.
 pip install "pyautogen[retrievechat]"
 ```
 
-*You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).*
+*You'll need to install `chromadb<=0.5.0` if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).*
 
 RetrieveChat can handle various types of documents. By default, it can process
 plain text and PDF files, including formats such as 'txt', 'json', 'csv', 'tsv',

--- a/website/docs/installation/Optional-Dependencies.md
+++ b/website/docs/installation/Optional-Dependencies.md
@@ -49,7 +49,7 @@ Example notebooks:
 ```bash
 pip install "pyautogen[retrievechat]"
 ```
-> _You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551)_
+> You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).
 
 Alternatively `pyautogen` also supports PGVector and Qdrant which can be installed in place of ChromaDB, or alongside it.
 

--- a/website/docs/installation/Optional-Dependencies.md
+++ b/website/docs/installation/Optional-Dependencies.md
@@ -49,6 +49,7 @@ Example notebooks:
 ```bash
 pip install "pyautogen[retrievechat]"
 ```
+> _You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551)_
 
 Alternatively `pyautogen` also supports PGVector and Qdrant which can be installed in place of ChromaDB, or alongside it.
 

--- a/website/docs/installation/Optional-Dependencies.md
+++ b/website/docs/installation/Optional-Dependencies.md
@@ -49,7 +49,7 @@ Example notebooks:
 ```bash
 pip install "pyautogen[retrievechat]"
 ```
-> You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).
+*You'll need to install `chromadb<=0.5.0` if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).*
 
 Alternatively `pyautogen` also supports PGVector and Qdrant which can be installed in place of ChromaDB, or alongside it.
 

--- a/website/docs/topics/retrieval_augmentation.md
+++ b/website/docs/topics/retrieval_augmentation.md
@@ -56,7 +56,7 @@ ragproxyagent.initiate_chat(
     assistant, message=ragproxyagent.message_generator, problem=code_problem, search_string="spark"
 )  # search_string is used as an extra filter for the embeddings search, in this case, we only want to search documents that contain "spark".
 ```
-> You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).
+*You'll need to install `chromadb<=0.5.0` if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).*
 
 ## Example Setup: RAG with Retrieval Augmented Agents with PGVector
 The following is an example setup demonstrating how to create retrieval augmented agents in AutoGen:

--- a/website/docs/topics/retrieval_augmentation.md
+++ b/website/docs/topics/retrieval_augmentation.md
@@ -56,7 +56,7 @@ ragproxyagent.initiate_chat(
     assistant, message=ragproxyagent.message_generator, problem=code_problem, search_string="spark"
 )  # search_string is used as an extra filter for the embeddings search, in this case, we only want to search documents that contain "spark".
 ```
-> _You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551)_
+> You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551).
 
 ## Example Setup: RAG with Retrieval Augmented Agents with PGVector
 The following is an example setup demonstrating how to create retrieval augmented agents in AutoGen:

--- a/website/docs/topics/retrieval_augmentation.md
+++ b/website/docs/topics/retrieval_augmentation.md
@@ -56,6 +56,7 @@ ragproxyagent.initiate_chat(
     assistant, message=ragproxyagent.message_generator, problem=code_problem, search_string="spark"
 )  # search_string is used as an extra filter for the embeddings search, in this case, we only want to search documents that contain "spark".
 ```
+> _You'll need to install chromadb<=0.5.0 if you see issue like [#3551](https://github.com/microsoft/autogen/issues/3551)_
 
 ## Example Setup: RAG with Retrieval Augmented Agents with PGVector
 The following is an example setup demonstrating how to create retrieval augmented agents in AutoGen:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The new chromadb version has changed the error type of `get_collection`, thus caused issue #3551 . This PR fixes the issue by adding the new error type to the exception handling in `create_collection` method. We also updates related docs so that users can bypass the error when they're using the current version of AutoGen.

## Related issue number

Closes #3551 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
