### PR TITLE
Ollama library v0.3.3 update with changes to options handling

### DIFF
--- a/autogen/oai/ollama.py
+++ b/autogen/oai/ollama.py
@@ -127,7 +127,7 @@ class OllamaClient:
 
         if "num_predict" in params:
             # Maximum number of tokens to predict, note: -1 is infinite, -2 is fill context, 128 is default
-            ollama_params["num_predict"] = validate_parameter(params, "num_predict", int, False, 128, None, None)
+            options_dict["num_predict"] = validate_parameter(params, "num_predict", int, False, 128, None, None)
 
         if "repeat_penalty" in params:
             options_dict["repeat_penalty"] = validate_parameter(
@@ -138,15 +138,15 @@ class OllamaClient:
             options_dict["seed"] = validate_parameter(params, "seed", int, False, 42, None, None)
 
         if "temperature" in params:
-            ollama_params["temperature"] = validate_parameter(
+            options_dict["temperature"] = validate_parameter(
                 params, "temperature", (int, float), False, 0.8, None, None
             )
 
         if "top_k" in params:
-            ollama_params["top_k"] = validate_parameter(params, "top_k", int, False, 40, None, None)
+            options_dict["top_k"] = validate_parameter(params, "top_k", int, False, 40, None, None)
 
         if "top_p" in params:
-            ollama_params["top_p"] = validate_parameter(params, "top_p", (int, float), False, 0.9, None, None)
+            options_dict["top_p"] = validate_parameter(params, "top_p", (int, float), False, 0.9, None, None)
 
         if self._native_tool_calls and self._tools_in_conversation and not self._should_hide_tools:
             ollama_params["tools"] = params["tools"]

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ extra_require = {
     "mistral": ["mistralai>=1.0.1"],
     "groq": ["groq>=0.9.0"],
     "cohere": ["cohere>=5.5.8"],
-    "ollama": ["ollama>=0.3.1", "fix_busted_json>=0.0.18"],
+    "ollama": ["ollama>=0.3.3", "fix_busted_json>=0.0.18"],
     "bedrock": ["boto3>=1.34.149"],
 }
 

--- a/test/oai/test_ollama.py
+++ b/test/oai/test_ollama.py
@@ -65,13 +65,13 @@ def test_parsing_params(ollama_client):
     }
     expected_params = {
         "model": "llama3.1:8b",
-        "temperature": 0.8,
-        "num_predict": 128,
-        "top_k": 40,
-        "top_p": 0.9,
         "options": {
             "repeat_penalty": 1.1,
             "seed": 42,
+            "temperature": 0.8,
+            "num_predict": 128,
+            "top_k": 40,
+            "top_p": 0.9,
         },
         "stream": False,
     }


### PR DESCRIPTION
## Why are these changes needed?

Ollama v0.3.3 has been released and they have changed the handling of parameters, moving some into the options dictionary within the parameters. This updates that.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
