### PR TITLE
Refactor logging in agentchat

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/__init__.py
@@ -1,0 +1,2 @@
+TRACE_LOGGER_NAME = "autogen_agentchat"
+EVENT_LOGGER_NAME = "autogen_agentchat.events"

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/logging/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/logging/__init__.py
@@ -1,0 +1,4 @@
+from ._console_log_handler import ConsoleLogHandler
+from ._file_log_handler import FileLogHandler
+
+__all__ = ["ConsoleLogHandler", "FileLogHandler"]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/logging/_console_log_handler.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/logging/_console_log_handler.py
@@ -1,15 +1,17 @@
 import json
 import logging
 import sys
-from dataclasses import asdict, is_dataclass
 from datetime import datetime
-from typing import Any
 
+from .. import EVENT_LOGGER_NAME
 from ..agents import ChatMessage, StopMessage, TextMessage
-from ._events import ContentPublishEvent, SelectSpeakerEvent, TerminationEvent, ToolCallEvent, ToolCallResultEvent
-
-TRACE_LOGGER_NAME = "autogen_agentchat"
-EVENT_LOGGER_NAME = "autogen_agentchat.events"
+from ..teams._events import (
+    ContentPublishEvent,
+    SelectSpeakerEvent,
+    TerminationEvent,
+    ToolCallEvent,
+    ToolCallResultEvent,
+)
 
 
 class ConsoleLogHandler(logging.Handler):
@@ -68,55 +70,6 @@ class ConsoleLogHandler(logging.Handler):
             raise ValueError(f"Unexpected log record: {record.msg}")
 
 
-class FileLogHandler(logging.Handler):
-    def __init__(self, filename: str) -> None:
-        super().__init__()
-        self.filename = filename
-        self.file_handler = logging.FileHandler(filename)
-
-    def emit(self, record: logging.LogRecord) -> None:
-        ts = datetime.fromtimestamp(record.created).isoformat()
-        if isinstance(record.msg, ContentPublishEvent | ToolCallEvent | ToolCallResultEvent | TerminationEvent):
-            log_entry = json.dumps(
-                {
-                    "timestamp": ts,
-                    "source": record.msg.source,
-                    "agent_message": record.msg.agent_message.model_dump(),
-                    "type": record.msg.__class__.__name__,
-                },
-                default=self.json_serializer,
-            )
-        elif isinstance(record.msg, SelectSpeakerEvent):
-            log_entry = json.dumps(
-                {
-                    "timestamp": ts,
-                    "source": record.msg.source,
-                    "selected_speaker": record.msg.selected_speaker,
-                    "type": "SelectSpeakerEvent",
-                },
-                default=self.json_serializer,
-            )
-        else:
-            raise ValueError(f"Unexpected log record: {record.msg}")
-        file_record = logging.LogRecord(
-            name=record.name,
-            level=record.levelno,
-            pathname=record.pathname,
-            lineno=record.lineno,
-            msg=log_entry,
-            args=(),
-            exc_info=record.exc_info,
-        )
-        self.file_handler.emit(file_record)
-
-    def close(self) -> None:
-        self.file_handler.close()
-        super().close()
-
-    @staticmethod
-    def json_serializer(obj: Any) -> Any:
-        if is_dataclass(obj) and not isinstance(obj, type):
-            return asdict(obj)
-        elif isinstance(obj, type):
-            return str(obj)
-        return str(obj)
+logger = logging.getLogger(EVENT_LOGGER_NAME)
+logger.setLevel(logging.INFO)
+logger.addHandler(ConsoleLogHandler())

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/logging/_file_log_handler.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/logging/_file_log_handler.py
@@ -1,0 +1,67 @@
+import json
+import logging
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from typing import Any
+
+from ..teams._events import (
+    ContentPublishEvent,
+    SelectSpeakerEvent,
+    TerminationEvent,
+    ToolCallEvent,
+    ToolCallResultEvent,
+)
+
+
+class FileLogHandler(logging.Handler):
+    def __init__(self, filename: str) -> None:
+        super().__init__()
+        self.filename = filename
+        self.file_handler = logging.FileHandler(filename)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        ts = datetime.fromtimestamp(record.created).isoformat()
+        if isinstance(record.msg, ContentPublishEvent | ToolCallEvent | ToolCallResultEvent | TerminationEvent):
+            log_entry = json.dumps(
+                {
+                    "timestamp": ts,
+                    "source": record.msg.source,
+                    "agent_message": record.msg.agent_message.model_dump(),
+                    "type": record.msg.__class__.__name__,
+                },
+                default=self.json_serializer,
+            )
+        elif isinstance(record.msg, SelectSpeakerEvent):
+            log_entry = json.dumps(
+                {
+                    "timestamp": ts,
+                    "source": record.msg.source,
+                    "selected_speaker": record.msg.selected_speaker,
+                    "type": "SelectSpeakerEvent",
+                },
+                default=self.json_serializer,
+            )
+        else:
+            raise ValueError(f"Unexpected log record: {record.msg}")
+        file_record = logging.LogRecord(
+            name=record.name,
+            level=record.levelno,
+            pathname=record.pathname,
+            lineno=record.lineno,
+            msg=log_entry,
+            args=(),
+            exc_info=record.exc_info,
+        )
+        self.file_handler.emit(file_record)
+
+    def close(self) -> None:
+        self.file_handler.close()
+        super().close()
+
+    @staticmethod
+    def json_serializer(obj: Any) -> Any:
+        if is_dataclass(obj) and not isinstance(obj, type):
+            return asdict(obj)
+        elif isinstance(obj, type):
+            return str(obj)
+        return str(obj)

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/__init__.py
@@ -1,13 +1,8 @@
-from ._logging import EVENT_LOGGER_NAME, TRACE_LOGGER_NAME, ConsoleLogHandler, FileLogHandler
-from ._termination import MaxMessageTermination, StopMessageTermination, TerminationCondition, TextMentionTermination
 from ._group_chat._round_robin_group_chat import RoundRobinGroupChat
 from ._group_chat._selector_group_chat import SelectorGroupChat
+from ._termination import MaxMessageTermination, StopMessageTermination, TerminationCondition, TextMentionTermination
 
 __all__ = [
-    "TRACE_LOGGER_NAME",
-    "EVENT_LOGGER_NAME",
-    "ConsoleLogHandler",
-    "FileLogHandler",
     "TerminationCondition",
     "MaxMessageTermination",
     "TextMentionTermination",

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_base_team.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_base_team.py
@@ -1,15 +1,8 @@
-import logging
 from dataclasses import dataclass
 from typing import List, Protocol
 
 from ..agents import ChatMessage
-from ._logging import EVENT_LOGGER_NAME, ConsoleLogHandler
 from ._termination import TerminationCondition
-
-logger = logging.getLogger(EVENT_LOGGER_NAME)
-logger.setLevel(logging.INFO)
-console_handler = ConsoleLogHandler()
-logger.addHandler(console_handler)
 
 
 @dataclass

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_chat_agent_container.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_chat_agent_container.py
@@ -7,9 +7,9 @@ from autogen_core.components import DefaultTopicId, event
 from autogen_core.components.models import FunctionExecutionResult
 from autogen_core.components.tool_agent import ToolException
 
+from ... import EVENT_LOGGER_NAME
 from ...agents import BaseChatAgent, MultiModalMessage, StopMessage, TextMessage, ToolCallMessage, ToolCallResultMessage
 from .._events import ContentPublishEvent, ContentRequestEvent, ToolCallEvent, ToolCallResultEvent
-from .._logging import EVENT_LOGGER_NAME
 from ._sequential_routed_agent import SequentialRoutedAgent
 
 event_logger = logging.getLogger(EVENT_LOGGER_NAME)

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -5,8 +5,8 @@ from typing import List
 from autogen_core.base import MessageContext, TopicId
 from autogen_core.components import event
 
+from ... import EVENT_LOGGER_NAME
 from .._events import ContentPublishEvent, ContentRequestEvent, TerminationEvent
-from .._logging import EVENT_LOGGER_NAME
 from .._termination import TerminationCondition
 from ._sequential_routed_agent import SequentialRoutedAgent
 

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -4,9 +4,9 @@ from typing import Callable, Dict, List
 
 from autogen_core.components.models import ChatCompletionClient, SystemMessage
 
+from ... import EVENT_LOGGER_NAME, TRACE_LOGGER_NAME
 from ...agents import BaseChatAgent, MultiModalMessage, StopMessage, TextMessage
 from .._events import ContentPublishEvent, SelectSpeakerEvent
-from .._logging import EVENT_LOGGER_NAME, TRACE_LOGGER_NAME
 from .._termination import TerminationCondition
 from ._base_group_chat import BaseGroupChat
 from ._base_group_chat_manager import BaseGroupChatManager

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -5,6 +5,7 @@ import tempfile
 from typing import Any, AsyncGenerator, List, Sequence
 
 import pytest
+from autogen_agentchat import EVENT_LOGGER_NAME
 from autogen_agentchat.agents import (
     BaseChatAgent,
     ChatMessage,
@@ -14,9 +15,8 @@ from autogen_agentchat.agents import (
     TextMessage,
     ToolUseAssistantAgent,
 )
+from autogen_agentchat.logging import FileLogHandler
 from autogen_agentchat.teams import (
-    EVENT_LOGGER_NAME,
-    FileLogHandler,
     RoundRobinGroupChat,
     SelectorGroupChat,
     StopMessageTermination,

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/guides/tool_use.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/guides/tool_use.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "from autogen_agentchat.agents import ToolUseAssistantAgent\n",
-    "from autogen_agentchat.teams import EVENT_LOGGER_NAME, RoundRobinGroupChat, StopMessageTermination\n",
+    "from autogen_agentchat.teams import RoundRobinGroupChat, StopMessageTermination\n",
     "from autogen_core.components.models import OpenAIChatCompletionClient\n",
     "from autogen_core.components.tools import FunctionTool"
    ]
@@ -177,7 +177,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Moving agentchat log handlers to `autogen_agentchat.logging`, and move logger names to top level. 