### PR TITLE
Remove unused benchmarks folder and README

### DIFF
--- a/python/benchmarks/.gitignore
+++ b/python/benchmarks/.gitignore
@@ -1,2 +1,0 @@
-*/Results/
-*/Tasks/

--- a/python/benchmarks/README.md
+++ b/python/benchmarks/README.md
@@ -1,1 +1,0 @@
-Moved to another repo.


### PR DESCRIPTION
The /python/benchmarks folder simply contained a note indicating that the benchmarks were moved. This commit deletes this note and directory.