### PR TITLE
Skip Bing tests when no API key is present.

### DIFF
--- a/python/packages/autogen-magentic-one/tests/browser_utils/test_bing_markdown_search.py
+++ b/python/packages/autogen-magentic-one/tests/browser_utils/test_bing_markdown_search.py
@@ -16,6 +16,7 @@ BING_QUERY = "Microsoft wikipedia"
 BING_STRING = f"A Bing search for '{BING_QUERY}' found"
 BING_EXPECTED_RESULT = "https://en.wikipedia.org/wiki/Microsoft"
 
+
 @pytest.mark.skipif(
     skip_api,
     reason="skipping tests that require a Bing API key",

--- a/python/packages/autogen-magentic-one/tests/browser_utils/test_bing_markdown_search.py
+++ b/python/packages/autogen-magentic-one/tests/browser_utils/test_bing_markdown_search.py
@@ -16,18 +16,6 @@ BING_QUERY = "Microsoft wikipedia"
 BING_STRING = f"A Bing search for '{BING_QUERY}' found"
 BING_EXPECTED_RESULT = "https://en.wikipedia.org/wiki/Microsoft"
 
-
-@pytest.mark.skipif(
-    skip_all,
-    reason="do not run if dependency is not installed",
-)
-def test_bing_markdown_search() -> None:
-    search_engine = BingMarkdownSearch()
-    results = search_engine.search(BING_QUERY)
-    assert BING_STRING in results
-    assert BING_EXPECTED_RESULT in results
-
-
 @pytest.mark.skipif(
     skip_api,
     reason="skipping tests that require a Bing API key",
@@ -41,5 +29,4 @@ def test_bing_markdown_search_api() -> None:
 
 if __name__ == "__main__":
     """Runs this file's tests from the command line."""
-    test_bing_markdown_search()
     test_bing_markdown_search_api()


### PR DESCRIPTION
Previously, when no Bing API key would fail, the agents would fall bac to web browsing, and the tests would sometimes fail depending on web browsing conditions beyond our control. This PR eliminates tests in those cases.