### PR TITLE
Update README.md to clarify v2 vs v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 # AutoGen
 
 > [!IMPORTANT]
-> - (10/13/24) Interested in *AutoGen v0.2*? Checkout the actively-maintained [0.2 branch](https://github.com/microsoft/autogen/tree/0.2) and `autogen-agentchat` PyPi package.
+> - (10/13/24) Interested in the standard AutoGen as a prior user? Find it at the actively-maintained *AutoGen* [0.2 branch](https://github.com/microsoft/autogen/tree/0.2) and `autogen-agentchat~=0.2` PyPi package.
 > - (10/02/24) [AutoGen 0.4](https://microsoft.github.io/autogen/dev) is a from-the-ground-up rewrite of AutoGen. Learn more about the history, goals and future at [this blog post](https://microsoft.github.io/autogen/blog). We’re excited to work with the community to gather feedback, refine, and improve the project before we officially release 0.4. This is a big change, so AutoGen 0.2 is still available, maintained, and developed in the [0.2 branch](https://github.com/microsoft/autogen/tree/0.2).
 
 AutoGen is an open-source framework for building AI agent systems.


### PR DESCRIPTION
## Why are these changes needed?

I was scrolling through various forms of social media, and I noticed a lot of confusion about what autogen v0.2 vs v0.4 and the standard autogen functionality. 

I think we can clarify this in the readme much better, a prior user might not know they were using v0.2, so we should mention explicitly that the old autogen is v0.2.  That is the change I made to the readme. 



 
## Related issue number



## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
