### PR TITLE
Fix Outdated `gpt-4o` Model Reference to Eliminate Warning

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/components/models/_model_info.py
+++ b/python/packages/autogen-core/src/autogen_core/components/models/_model_info.py
@@ -5,7 +5,7 @@ from ._model_client import ModelCapabilities
 # Based on: https://platform.openai.com/docs/models/continuous-model-upgrades
 # This is a moving target, so correctness is checked by the model value returned by openai against expected values at runtime``
 _MODEL_POINTERS = {
-    "gpt-4o": "gpt-4o-2024-05-13",
+    "gpt-4o": "gpt-4o-2024-08-06",
     "gpt-4o-mini": "gpt-4o-mini-2024-07-18",
     "gpt-4-turbo": "gpt-4-turbo-2024-04-09",
     "gpt-4-turbo-preview": "gpt-4-0125-preview",


### PR DESCRIPTION
## Why are these changes needed?

This PR updates the `gpt-4o` model reference in `_model_info.py` to `gpt-4o-2024-08-06`, aligning with the latest model version and eliminating the incorrect warning message that appears when using the most recent model.

This fix may overlap with the model migration in PR #3848. However, by resolving this independently ensures that the warning is eliminated without waiting for the larger restructuring to be merged.

## Related issue number

n/a

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally. (n/a)
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. (n/a)
- [x] I've made sure all auto checks have passed.
