### PR TITLE
Fix small typos in AutoGen 0.4 docs

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/core-concepts/agent-identity-and-lifecycle.md
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/core-concepts/agent-identity-and-lifecycle.md
@@ -20,7 +20,7 @@ Agent ID = (Agent Type, Agent Key)
 ```
 
 The agent type is not an agent class.
-It associate an agent with a specific
+It associates an agent with a specific
 factory function, which produces instances of agents
 of the same agent type.
 For example, different factory functions can produce the same

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/quickstart.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/quickstart.ipynb
@@ -93,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You might have already noticed, The agents' logic, whether it is using model or code executor,\n",
+    "You might have already noticed, the agents' logic, whether it is using model or code executor,\n",
     "is completely decoupled from\n",
     "how messages are delivered. This is the core idea: the framework provides\n",
     "a communication infrastructure, and the agents are responsible for their own\n",


### PR DESCRIPTION
## Why are these changes needed?

Spotted two small typos while reviewing the in-progress 0.4 docs. Might be premature given the in-progress nature of 0.4, but thought I'd drop them in.

Keep up the great work!

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
