### PR TITLE
docs: fix bullet formatting for kubernetes pod executor

### DIFF
--- a/website/docs/topics/code-execution/kubernetes-pod-commandline-code-executor.ipynb
+++ b/website/docs/topics/code-execution/kubernetes-pod-commandline-code-executor.ipynb
@@ -15,6 +15,7 @@
     "It functions similarly to the `DockerCommandLineCodeExecutor`, but specifically creates container within Kubernetes environments.\n",
     "\n",
     "There are two condition to use PodCommandLineCodeExecutor.\n",
+    "\n",
     "- Access to a Kubernetes cluster\n",
     "- installation `autogen` with the extra requirements `'pyautogen[kubernetes]'`\n",
     "\n",
@@ -38,6 +39,7 @@
    "metadata": {},
    "source": [
     "There are four options PodCommandLineCodeExecutor to access kubernetes API server.\n",
+    "\n",
     "- default kubeconfig file path: `~/.kube/config`\n",
     "- Provide a custom kubeconfig file path using the `kube_config_file` argument of `PodCommandLineCodeExecutor`.\n",
     "- Set the kubeconfig file path using the `KUBECONFIG` environment variable.\n",


### PR DESCRIPTION
While the bullets are rendered correctly in GitHub when looking at this file, the bullet formatting is incorrect on the actual documentation site [[1]]. This patch adds a newline to fix that formatting.

A screenshot of the incorrect formatting on the site is included in the PR.

[1]: https://microsoft.github.io/autogen/0.2/docs/topics/code-execution/kubernetes-pod-commandline-code-executor

## Screenshot

![image](https://github.com/user-attachments/assets/dceeb8d7-2d4b-4f22-b912-98df14777469)

---

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To improve the formatting of the documentation

## Related issue number

N/A.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
