### PR TITLE
Refactor agent chat to prepare for handoff/swarm

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/__init__.py
@@ -1,11 +1,10 @@
-from ._base_chat_agent import BaseChatAgent, BaseToolUseChatAgent
+from ._base_chat_agent import BaseChatAgent
 from ._code_executor_agent import CodeExecutorAgent
 from ._coding_assistant_agent import CodingAssistantAgent
 from ._tool_use_assistant_agent import ToolUseAssistantAgent
 
 __all__ = [
     "BaseChatAgent",
-    "BaseToolUseChatAgent",
     "CodeExecutorAgent",
     "CodingAssistantAgent",
     "ToolUseAssistantAgent",

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_base_chat_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_base_chat_agent.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import List, Sequence
+from typing import Sequence
 
 from autogen_core.base import CancellationToken
-from autogen_core.components.tools import Tool
 
-from ..base import ChatAgent, TaskResult, TerminationCondition, ToolUseChatAgent
+from ..base import ChatAgent, TaskResult, TerminationCondition
 from ..messages import ChatMessage
 from ..teams import RoundRobinGroupChat
 
@@ -51,21 +50,3 @@ class BaseChatAgent(ChatAgent, ABC):
             termination_condition=termination_condition,
         )
         return result
-
-
-class BaseToolUseChatAgent(BaseChatAgent, ToolUseChatAgent):
-    """Base class for a chat agent that can use tools.
-
-    Subclass this base class to create an agent class that uses tools by returning
-    ToolCallMessage message from the :meth:`on_messages` method and receiving
-    ToolCallResultMessage message from the input to the :meth:`on_messages` method.
-    """
-
-    def __init__(self, name: str, description: str, registered_tools: List[Tool]) -> None:
-        super().__init__(name, description)
-        self._registered_tools = registered_tools
-
-    @property
-    def registered_tools(self) -> List[Tool]:
-        """The list of tools that the agent can use."""
-        return self._registered_tools

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/__init__.py
@@ -1,11 +1,10 @@
-from ._chat_agent import ChatAgent, ToolUseChatAgent
+from ._chat_agent import ChatAgent
 from ._task import TaskResult, TaskRunner
 from ._team import Team
 from ._termination import TerminatedException, TerminationCondition
 
 __all__ = [
     "ChatAgent",
-    "ToolUseChatAgent",
     "Team",
     "TerminatedException",
     "TerminationCondition",

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_chat_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_chat_agent.py
@@ -1,7 +1,6 @@
-from typing import List, Protocol, Sequence, runtime_checkable
+from typing import Protocol, Sequence, runtime_checkable
 
 from autogen_core.base import CancellationToken
-from autogen_core.components.tools import Tool
 
 from ..messages import ChatMessage
 from ._task import TaskResult, TaskRunner
@@ -37,14 +36,4 @@ class ChatAgent(TaskRunner, Protocol):
         termination_condition: TerminationCondition | None = None,
     ) -> TaskResult:
         """Run the agent with the given task and return the result."""
-        ...
-
-
-@runtime_checkable
-class ToolUseChatAgent(ChatAgent, Protocol):
-    """Protocol for a chat agent that can use tools."""
-
-    @property
-    def registered_tools(self) -> List[Tool]:
-        """The list of tools that the agent can use."""
         ...

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/logging/_console_log_handler.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/logging/_console_log_handler.py
@@ -3,13 +3,12 @@ import logging
 import sys
 from datetime import datetime
 
+from ..agents._tool_use_assistant_agent import ToolCallEvent, ToolCallResultEvent
 from ..messages import ChatMessage, StopMessage, TextMessage
 from ..teams._events import (
-    ContentPublishEvent,
-    SelectSpeakerEvent,
+    GroupChatPublishEvent,
+    GroupChatSelectSpeakerEvent,
     TerminationEvent,
-    ToolCallEvent,
-    ToolCallResultEvent,
 )
 
 
@@ -25,7 +24,7 @@ class ConsoleLogHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         ts = datetime.fromtimestamp(record.created).isoformat()
-        if isinstance(record.msg, ContentPublishEvent):
+        if isinstance(record.msg, GroupChatPublishEvent):
             if record.msg.source is None:
                 sys.stdout.write(
                     f"\n{'-'*75} \n"
@@ -41,19 +40,15 @@ class ConsoleLogHandler(logging.Handler):
             sys.stdout.flush()
         elif isinstance(record.msg, ToolCallEvent):
             sys.stdout.write(
-                f"\n{'-'*75} \n"
-                f"\033[91m[{ts}], Tool Call:\033[0m\n"
-                f"\n{self.serialize_chat_message(record.msg.agent_message)}"
+                f"\n{'-'*75} \n" f"\033[91m[{ts}], Tool Call:\033[0m\n" f"\n{str(record.msg.model_dump())}"
             )
             sys.stdout.flush()
         elif isinstance(record.msg, ToolCallResultEvent):
             sys.stdout.write(
-                f"\n{'-'*75} \n"
-                f"\033[91m[{ts}], Tool Call Result:\033[0m\n"
-                f"\n{self.serialize_chat_message(record.msg.agent_message)}"
+                f"\n{'-'*75} \n" f"\033[91m[{ts}], Tool Call Result:\033[0m\n" f"\n{str(record.msg.model_dump())}"
             )
             sys.stdout.flush()
-        elif isinstance(record.msg, SelectSpeakerEvent):
+        elif isinstance(record.msg, GroupChatSelectSpeakerEvent):
             sys.stdout.write(
                 f"\n{'-'*75} \n" f"\033[91m[{ts}], Selected Next Speaker:\033[0m\n" f"\n{record.msg.selected_speaker}"
             )

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/logging/_file_log_handler.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/logging/_file_log_handler.py
@@ -4,12 +4,11 @@ from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from typing import Any
 
+from ..agents._tool_use_assistant_agent import ToolCallEvent, ToolCallResultEvent
 from ..teams._events import (
-    ContentPublishEvent,
-    SelectSpeakerEvent,
+    GroupChatPublishEvent,
+    GroupChatSelectSpeakerEvent,
     TerminationEvent,
-    ToolCallEvent,
-    ToolCallResultEvent,
 )
 
 
@@ -21,7 +20,7 @@ class FileLogHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         ts = datetime.fromtimestamp(record.created).isoformat()
-        if isinstance(record.msg, ContentPublishEvent | ToolCallEvent | ToolCallResultEvent | TerminationEvent):
+        if isinstance(record.msg, GroupChatPublishEvent | TerminationEvent):
             log_entry = json.dumps(
                 {
                     "timestamp": ts,
@@ -31,13 +30,31 @@ class FileLogHandler(logging.Handler):
                 },
                 default=self.json_serializer,
             )
-        elif isinstance(record.msg, SelectSpeakerEvent):
+        elif isinstance(record.msg, GroupChatSelectSpeakerEvent):
             log_entry = json.dumps(
                 {
                     "timestamp": ts,
                     "source": record.msg.source,
                     "selected_speaker": record.msg.selected_speaker,
                     "type": "SelectSpeakerEvent",
+                },
+                default=self.json_serializer,
+            )
+        elif isinstance(record.msg, ToolCallEvent):
+            log_entry = json.dumps(
+                {
+                    "timestamp": ts,
+                    "tool_calls": record.msg.model_dump(),
+                    "type": "ToolCallEvent",
+                },
+                default=self.json_serializer,
+            )
+        elif isinstance(record.msg, ToolCallResultEvent):
+            log_entry = json.dumps(
+                {
+                    "timestamp": ts,
+                    "tool_call_results": record.msg.model_dump(),
+                    "type": "ToolCallResultEvent",
                 },
                 default=self.json_serializer,
             )

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
@@ -1,7 +1,6 @@
 from typing import List
 
-from autogen_core.components import FunctionCall, Image
-from autogen_core.components.models import FunctionExecutionResult
+from autogen_core.components import Image
 from pydantic import BaseModel
 
 
@@ -26,20 +25,6 @@ class MultiModalMessage(BaseMessage):
     """The content of the message."""
 
 
-class ToolCallMessage(BaseMessage):
-    """A message containing a list of function calls."""
-
-    content: List[FunctionCall]
-    """The list of function calls."""
-
-
-class ToolCallResultMessage(BaseMessage):
-    """A message containing the results of function calls."""
-
-    content: List[FunctionExecutionResult]
-    """The list of function execution results."""
-
-
 class StopMessage(BaseMessage):
     """A message requesting stop of a conversation."""
 
@@ -54,7 +39,7 @@ class HandoffMessage(BaseMessage):
     """The agent name to handoff the conversation to."""
 
 
-ChatMessage = TextMessage | MultiModalMessage | StopMessage | ToolCallMessage | ToolCallResultMessage | HandoffMessage
+ChatMessage = TextMessage | MultiModalMessage | StopMessage | HandoffMessage
 """A message used by agents in a team."""
 
 
@@ -62,9 +47,7 @@ __all__ = [
     "BaseMessage",
     "TextMessage",
     "MultiModalMessage",
-    "ToolCallMessage",
-    "ToolCallResultMessage",
     "StopMessage",
-    "ChatMessage",
     "HandoffMessage",
+    "ChatMessage",
 ]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
@@ -47,7 +47,14 @@ class StopMessage(BaseMessage):
     """The content for the stop message."""
 
 
-ChatMessage = TextMessage | MultiModalMessage | StopMessage | ToolCallMessage | ToolCallResultMessage
+class HandoffMessage(BaseMessage):
+    """A message requesting handoff of a conversation to another agent."""
+
+    content: str
+    """The agent name to handoff the conversation to."""
+
+
+ChatMessage = TextMessage | MultiModalMessage | StopMessage | ToolCallMessage | ToolCallResultMessage | HandoffMessage
 """A message used by agents in a team."""
 
 
@@ -59,4 +66,5 @@ __all__ = [
     "ToolCallResultMessage",
     "StopMessage",
     "ChatMessage",
+    "HandoffMessage",
 ]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/__init__.py
@@ -1,7 +1,9 @@
 from ._group_chat._round_robin_group_chat import RoundRobinGroupChat
 from ._group_chat._selector_group_chat import SelectorGroupChat
+from ._group_chat._swarm_group_chat import Swarm
 
 __all__ = [
     "RoundRobinGroupChat",
     "SelectorGroupChat",
+    "Swarm",
 ]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_events.py
@@ -1,7 +1,14 @@
 from autogen_core.base import AgentId
 from pydantic import BaseModel, ConfigDict
 
-from ..messages import MultiModalMessage, StopMessage, TextMessage, ToolCallMessage, ToolCallResultMessage
+from ..messages import (
+    HandoffMessage,
+    MultiModalMessage,
+    StopMessage,
+    TextMessage,
+    ToolCallMessage,
+    ToolCallResultMessage,
+)
 
 
 class ContentPublishEvent(BaseModel):
@@ -71,5 +78,17 @@ class TerminationEvent(BaseModel):
 
     source: AgentId
     """The agent ID that triggered the termination."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class HandoffEvent(BaseModel):
+    """An event for handing off a conversation to another agent."""
+
+    agent_message: HandoffMessage
+    """The handoff message that requests the handoff."""
+
+    source: AgentId
+    """The agent ID that triggered the handoff."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_events.py
@@ -1,23 +1,16 @@
 from autogen_core.base import AgentId
 from pydantic import BaseModel, ConfigDict
 
-from ..messages import (
-    HandoffMessage,
-    MultiModalMessage,
-    StopMessage,
-    TextMessage,
-    ToolCallMessage,
-    ToolCallResultMessage,
-)
+from ..messages import ChatMessage, StopMessage
 
 
-class ContentPublishEvent(BaseModel):
-    """An event for sharing some data. Agents receive this event should
+class GroupChatPublishEvent(BaseModel):
+    """An group chat event for sharing some data. Agents receive this event should
     update their internal state (e.g., append to message history) with the
     content of the event.
     """
 
-    agent_message: TextMessage | MultiModalMessage | StopMessage
+    agent_message: ChatMessage
     """The message published by the agent."""
 
     source: AgentId | None = None
@@ -26,39 +19,15 @@ class ContentPublishEvent(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class ContentRequestEvent(BaseModel):
-    """An event for requesting to publish a content event.
-    Upon receiving this event, the agent should publish a ContentPublishEvent.
+class GroupChatRequestPublishEvent(BaseModel):
+    """An event for requesting to publish a group chat publish event.
+    Upon receiving this event, the agent should publish a group chat publish event.
     """
 
     ...
 
 
-class ToolCallEvent(BaseModel):
-    """An event produced when requesting a tool call."""
-
-    agent_message: ToolCallMessage
-    """The tool call message."""
-
-    source: AgentId
-    """The sender of the tool call message."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-class ToolCallResultEvent(BaseModel):
-    """An event produced when a tool call is completed."""
-
-    agent_message: ToolCallResultMessage
-    """The tool call result message."""
-
-    source: AgentId
-    """The sender of the tool call result message."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-class SelectSpeakerEvent(BaseModel):
+class GroupChatSelectSpeakerEvent(BaseModel):
     """An event for selecting the next speaker in a group chat."""
 
     selected_speaker: str
@@ -78,17 +47,5 @@ class TerminationEvent(BaseModel):
 
     source: AgentId
     """The agent ID that triggered the termination."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-class HandoffEvent(BaseModel):
-    """An event for handing off a conversation to another agent."""
-
-    agent_message: HandoffMessage
-    """The handoff message that requests the handoff."""
-
-    source: AgentId
-    """The agent ID that triggered the handoff."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_chat_agent_container.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_chat_agent_container.py
@@ -1,19 +1,12 @@
-import asyncio
-import logging
 from typing import List
 
-from autogen_core.base import AgentId, AgentType, MessageContext
+from autogen_core.base import MessageContext
 from autogen_core.components import DefaultTopicId, event
-from autogen_core.components.models import FunctionExecutionResult
-from autogen_core.components.tool_agent import ToolException
 
-from ... import EVENT_LOGGER_NAME
 from ...base import ChatAgent
-from ...messages import MultiModalMessage, StopMessage, TextMessage, ToolCallMessage, ToolCallResultMessage
+from ...messages import ChatMessage, MultiModalMessage, StopMessage, TextMessage, ToolCallMessage
 from .._events import ContentPublishEvent, ContentRequestEvent, ToolCallEvent, ToolCallResultEvent
 from ._sequential_routed_agent import SequentialRoutedAgent
-
-event_logger = logging.getLogger(EVENT_LOGGER_NAME)
 
 
 class BaseChatAgentContainer(SequentialRoutedAgent):
@@ -24,69 +17,39 @@ class BaseChatAgentContainer(SequentialRoutedAgent):
     Args:
         parent_topic_type (str): The topic type of the parent orchestrator.
         agent (BaseChatAgent): The agent to delegate message handling to.
-        tool_agent_type (AgentType, optional): The agent type of the tool agent. Defaults to None.
     """
 
-    def __init__(self, parent_topic_type: str, agent: ChatAgent, tool_agent_type: AgentType | None = None) -> None:
+    def __init__(self, parent_topic_type: str, agent: ChatAgent) -> None:
         super().__init__(description=agent.description)
         self._parent_topic_type = parent_topic_type
         self._agent = agent
-        self._message_buffer: List[TextMessage | MultiModalMessage | StopMessage] = []
-        self._tool_agent_id = AgentId(type=tool_agent_type, key=self.id.key) if tool_agent_type else None
+        self._message_buffer: List[ChatMessage] = []
 
     @event
-    async def handle_content_publish(self, message: ContentPublishEvent, ctx: MessageContext) -> None:
-        """Handle a content publish event by appending the content to the buffer."""
-        if not isinstance(message.agent_message, TextMessage | MultiModalMessage | StopMessage):
-            raise ValueError(
-                f"Unexpected message type: {type(message.agent_message)}. "
-                "The message must be a text, multimodal, or stop message."
-            )
+    async def handle_message(
+        self, message: ContentPublishEvent | ToolCallEvent | ToolCallResultEvent, ctx: MessageContext
+    ) -> None:
+        """Handle an event by appending the content to the buffer."""
         self._message_buffer.append(message.agent_message)
 
     @event
     async def handle_content_request(self, message: ContentRequestEvent, ctx: MessageContext) -> None:
         """Handle a content request event by passing the messages in the buffer
         to the delegate agent and publish the response."""
+        # Pass the messages in the buffer to the delegate agent.
         response = await self._agent.on_messages(self._message_buffer, ctx.cancellation_token)
 
-        if self._tool_agent_id is not None:
-            # Handle tool calls.
-            while isinstance(response, ToolCallMessage):
-                # Log the tool call.
-                event_logger.debug(ToolCallEvent(agent_message=response, source=self.id))
-
-                results: List[FunctionExecutionResult | BaseException] = await asyncio.gather(
-                    *[
-                        self.send_message(
-                            message=call,
-                            recipient=self._tool_agent_id,
-                            cancellation_token=ctx.cancellation_token,
-                        )
-                        for call in response.content
-                    ]
-                )
-                # Combine the results in to a single response and handle exceptions.
-                function_results: List[FunctionExecutionResult] = []
-                for result in results:
-                    if isinstance(result, FunctionExecutionResult):
-                        function_results.append(result)
-                    elif isinstance(result, ToolException):
-                        function_results.append(
-                            FunctionExecutionResult(content=f"Error: {result}", call_id=result.call_id)
-                        )
-                    elif isinstance(result, BaseException):
-                        raise result  # Unexpected exception.
-                # Create a new tool call result message.
-                feedback = ToolCallResultMessage(content=function_results, source=self._tool_agent_id.type)
-                # Log the feedback.
-                event_logger.debug(ToolCallResultEvent(agent_message=feedback, source=self._tool_agent_id))
-                response = await self._agent.on_messages([feedback], ctx.cancellation_token)
-
         # Publish the response.
-        assert isinstance(response, TextMessage | MultiModalMessage | StopMessage)
         self._message_buffer.clear()
-        await self.publish_message(
-            ContentPublishEvent(agent_message=response, source=self.id),
-            topic_id=DefaultTopicId(type=self._parent_topic_type),
-        )
+        if isinstance(response, ToolCallMessage):
+            await self.publish_message(
+                ToolCallEvent(agent_message=response, source=self.id),
+                topic_id=DefaultTopicId(type=self._parent_topic_type),
+            )
+        elif isinstance(response, TextMessage | MultiModalMessage | StopMessage):
+            await self.publish_message(
+                ContentPublishEvent(agent_message=response, source=self.id),
+                topic_id=DefaultTopicId(type=self._parent_topic_type),
+            )
+        else:
+            raise ValueError(f"Unexpected response type: {type(response)}")

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -18,8 +18,8 @@ from autogen_core.components.tools import Tool
 from ...base import ChatAgent, TaskResult, Team, TerminationCondition, ToolUseChatAgent
 from ...messages import ChatMessage, TextMessage
 from .._events import ContentPublishEvent, ContentRequestEvent, ToolCallEvent, ToolCallResultEvent
-from ._base_chat_agent_container import BaseChatAgentContainer
 from ._base_group_chat_manager import BaseGroupChatManager
+from ._chat_agent_container import ChatAgentContainer
 
 
 class BaseGroupChat(Team, ABC):
@@ -58,11 +58,11 @@ class BaseGroupChat(Team, ABC):
         self,
         parent_topic_type: str,
         agent: ChatAgent,
-    ) -> Callable[[], BaseChatAgentContainer]:
-        def _factory() -> BaseChatAgentContainer:
+    ) -> Callable[[], ChatAgentContainer]:
+        def _factory() -> ChatAgentContainer:
             id = AgentInstantiationContext.current_agent_id()
             assert id == AgentId(type=agent.name, key=self._team_id)
-            container = BaseChatAgentContainer(parent_topic_type, agent)
+            container = ChatAgentContainer(parent_topic_type, agent)
             assert container.id == id
             return container
 
@@ -96,7 +96,7 @@ class BaseGroupChat(Team, ABC):
             agent_type = participant.name
             topic_type = participant.name
             # Register the participant factory.
-            await BaseChatAgentContainer.register(
+            await ChatAgentContainer.register(
                 runtime,
                 type=agent_type,
                 factory=self._create_participant_factory(group_topic_type, participant),

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -1,24 +1,16 @@
-import asyncio
-import json
 import logging
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Any, List
 
-from autogen_core.base import CancellationToken, MessageContext
-from autogen_core.components import DefaultTopicId, FunctionCall, event
-from autogen_core.components.models import FunctionExecutionResult
-from autogen_core.components.tools import Tool
+from autogen_core.base import MessageContext
+from autogen_core.components import DefaultTopicId, event
 
 from ... import EVENT_LOGGER_NAME
 from ...base import TerminationCondition
-from ...messages import ToolCallResultMessage
 from .._events import (
-    ContentPublishEvent,
-    ContentRequestEvent,
-    HandoffEvent,
+    GroupChatPublishEvent,
+    GroupChatRequestPublishEvent,
     TerminationEvent,
-    ToolCallEvent,
-    ToolCallResultEvent,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
 
@@ -42,8 +34,6 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         participant_topic_types (List[str]): The topic types of the participants.
         participant_descriptions (List[str]): The descriptions of the participants
         termination_condition (TerminationCondition, optional): The termination condition for the group chat. Defaults to None.
-        tools (List[Tool], optional): The tools used in the group chat. Defaults to None.
-            The names of the tools must be unique.
 
     Raises:
         ValueError: If the number of participant topic types, agent types, and descriptions are not the same.
@@ -51,7 +41,6 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         ValueError: If the group topic type is in the participant topic types.
         ValueError: If the parent topic type is in the participant topic types.
         ValueError: If the group topic type is the same as the parent topic type.
-        ValueError: If the names of the tools are not unique.
     """
 
     def __init__(
@@ -61,7 +50,6 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         participant_topic_types: List[str],
         participant_descriptions: List[str],
         termination_condition: TerminationCondition | None = None,
-        tools: List[Tool] | None = None,
     ):
         super().__init__(description="Group chat manager")
         self._parent_topic_type = parent_topic_type
@@ -78,91 +66,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
             raise ValueError("The group topic type must not be the same as the parent topic type.")
         self._participant_topic_types = participant_topic_types
         self._participant_descriptions = participant_descriptions
-        self._message_thread: List[ContentPublishEvent | ToolCallEvent | ToolCallResultEvent | HandoffEvent] = []
+        self._message_thread: List[GroupChatPublishEvent] = []
         self._termination_condition = termination_condition
-        if tools is not None:
-            tool_names = [tool.name for tool in tools]
-            if len(tool_names) != len(set(tool_names)):
-                raise ValueError("The names of the tools must be unique.")
-        self._tools = tools
 
     @event
-    async def handle_tool_call(self, message: ToolCallEvent, ctx: MessageContext) -> None:
-        """Handle a tool call event by executing the tool and publishing the result, then
-        selecting a speaker to continue the conversation."""
-        event_logger.debug(message)
-        self._message_thread.append(message)
-
-        # Check if the conversation should be terminated.
-        if self._termination_condition is not None:
-            stop_message = await self._termination_condition([message.agent_message])
-            if stop_message is not None:
-                event_logger.info(TerminationEvent(agent_message=stop_message, source=self.id))
-                # Stop the group chat.
-                return
-
-        # Execute the tool call.
-        results = await asyncio.gather(
-            *[self._execute_tool_call(call, ctx.cancellation_token) for call in message.agent_message.content]
-        )
-        feedback = ToolCallResultEvent(
-            agent_message=ToolCallResultMessage(content=results, source=self.id.type), source=self.id
-        )
-        event_logger.debug(feedback)
-        await self.publish_message(feedback, topic_id=DefaultTopicId(type=self._group_topic_type))
-        self._message_thread.append(feedback)
-
-        # Check if the conversation should be terminated.
-        if self._termination_condition is not None:
-            stop_message = await self._termination_condition([feedback.agent_message])
-            if stop_message is not None:
-                event_logger.info(TerminationEvent(agent_message=stop_message, source=self.id))
-                # Stop the group chat.
-                return
-
-        # Select a speaker to continue the conversation.
-        speaker_topic_type = await self.select_speaker(self._message_thread)
-        await self.publish_message(ContentRequestEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
-
-    async def _execute_tool_call(
-        self, tool_call: FunctionCall, cancellation_token: CancellationToken
-    ) -> FunctionExecutionResult:
-        """Execute a tool call and return the result."""
-        try:
-            if self._tools is None:
-                raise ValueError("No tools are available.")
-            tool = next((t for t in self._tools if t.name == tool_call.name), None)
-            if tool is None:
-                raise ValueError(f"The tool '{tool_call.name}' is not available.")
-            arguments = json.loads(tool_call.arguments)
-            result = await tool.run_json(arguments, cancellation_token)
-            result_as_str = tool.return_value_as_string(result)
-            return FunctionExecutionResult(content=result_as_str, call_id=tool_call.id)
-        except Exception as e:
-            return FunctionExecutionResult(content=f"Error: {e}", call_id=tool_call.id)
-
-    @event
-    async def handle_handoff(self, message: HandoffEvent, ctx: MessageContext) -> None:
-        """Handle a handoff event by selecting a speaker to continue the conversation."""
-        event_logger.info(message)
-        self._message_thread.append(message)
-
-        if self._termination_condition is not None:
-            stop_message = await self._termination_condition([message.agent_message])
-            if stop_message is not None:
-                event_logger.info(TerminationEvent(agent_message=stop_message, source=self.id))
-                # Stop the group chat.
-                return
-
-        if message.agent_message.content not in self._participant_topic_types:
-            raise ValueError("The handoff message must be to a participant.")
-
-        # Select a speaker to continue the conversation.
-        speaker_topic_type = await self.select_speaker(self._message_thread)
-        await self.publish_message(ContentRequestEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
-
-    @event
-    async def handle_content_publish(self, message: ContentPublishEvent, ctx: MessageContext) -> None:
+    async def handle_content_publish(self, message: GroupChatPublishEvent, ctx: MessageContext) -> None:
         """Handle a content publish event.
 
         If the event is from the parent topic, add the message to the thread.
@@ -173,13 +81,22 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
 
         event_logger.info(message)
 
+        if self._termination_condition is not None and self._termination_condition.terminated:
+            # The group chat has been terminated.
+            return
+
         # Process event from parent.
         if ctx.topic_id.type == self._parent_topic_type:
             self._message_thread.append(message)
             await self.publish_message(
-                ContentPublishEvent(agent_message=message.agent_message, source=self.id),
+                GroupChatPublishEvent(agent_message=message.agent_message, source=self.id),
                 topic_id=DefaultTopicId(type=self._group_topic_type),
             )
+            if self._termination_condition is not None:
+                stop_message = await self._termination_condition([message.agent_message])
+                if stop_message is not None:
+                    event_logger.info(TerminationEvent(agent_message=stop_message, source=self.id))
+                    # Stop the group chat.
             return
 
         # Process event from the group chat this agent manages.
@@ -198,23 +115,28 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         # Select a speaker to continue the conversation.
         speaker_topic_type = await self.select_speaker(self._message_thread)
 
-        await self.publish_message(ContentRequestEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
+        await self.publish_message(GroupChatRequestPublishEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
 
     @event
-    async def handle_content_request(self, message: ContentRequestEvent, ctx: MessageContext) -> None:
+    async def handle_content_request(self, message: GroupChatRequestPublishEvent, ctx: MessageContext) -> None:
         """Handle a content request by selecting a speaker to start the conversation."""
         assert ctx.topic_id is not None
         if ctx.topic_id.type == self._group_topic_type:
             raise RuntimeError("Content request event from the group chat topic is not allowed.")
 
+        if self._termination_condition is not None and self._termination_condition.terminated:
+            # The group chat has been terminated.
+            return
+
         speaker_topic_type = await self.select_speaker(self._message_thread)
 
-        await self.publish_message(ContentRequestEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
+        await self.publish_message(GroupChatRequestPublishEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
 
     @abstractmethod
-    async def select_speaker(
-        self, thread: List[ContentPublishEvent | ToolCallEvent | ToolCallResultEvent | HandoffEvent]
-    ) -> str:
+    async def select_speaker(self, thread: List[GroupChatPublishEvent]) -> str:
         """Select a speaker from the participants and return the
         topic type of the selected speaker."""
         ...
+
+    async def on_unhandled_message(self, message: Any, ctx: MessageContext) -> None:
+        raise ValueError(f"Unhandled message in group chat manager: {type(message)}")

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -1,13 +1,18 @@
+import asyncio
+import json
 import logging
 from abc import ABC, abstractmethod
 from typing import List
 
-from autogen_core.base import MessageContext, TopicId
-from autogen_core.components import event
+from autogen_core.base import CancellationToken, MessageContext
+from autogen_core.components import DefaultTopicId, FunctionCall, event
+from autogen_core.components.models import FunctionExecutionResult
+from autogen_core.components.tools import Tool
 
 from ... import EVENT_LOGGER_NAME
 from ...base import TerminationCondition
-from .._events import ContentPublishEvent, ContentRequestEvent, TerminationEvent
+from ...messages import ToolCallResultMessage
+from .._events import ContentPublishEvent, ContentRequestEvent, TerminationEvent, ToolCallEvent, ToolCallResultEvent
 from ._sequential_routed_agent import SequentialRoutedAgent
 
 event_logger = logging.getLogger(EVENT_LOGGER_NAME)
@@ -30,9 +35,16 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         participant_topic_types (List[str]): The topic types of the participants.
         participant_descriptions (List[str]): The descriptions of the participants
         termination_condition (TerminationCondition, optional): The termination condition for the group chat. Defaults to None.
+        tools (List[Tool], optional): The tools used in the group chat. Defaults to None.
+            The names of the tools must be unique.
 
     Raises:
         ValueError: If the number of participant topic types, agent types, and descriptions are not the same.
+        ValueError: If the participant topic types are not unique.
+        ValueError: If the group topic type is in the participant topic types.
+        ValueError: If the parent topic type is in the participant topic types.
+        ValueError: If the group topic type is the same as the parent topic type.
+        ValueError: If the names of the tools are not unique.
     """
 
     def __init__(
@@ -42,6 +54,7 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         participant_topic_types: List[str],
         participant_descriptions: List[str],
         termination_condition: TerminationCondition | None = None,
+        tools: List[Tool] | None = None,
     ):
         super().__init__(description="Group chat manager")
         self._parent_topic_type = parent_topic_type
@@ -58,8 +71,68 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
             raise ValueError("The group topic type must not be the same as the parent topic type.")
         self._participant_topic_types = participant_topic_types
         self._participant_descriptions = participant_descriptions
-        self._message_thread: List[ContentPublishEvent] = []
+        self._message_thread: List[ContentPublishEvent | ToolCallEvent | ToolCallResultEvent] = []
         self._termination_condition = termination_condition
+        if tools is not None:
+            tool_names = [tool.name for tool in tools]
+            if len(tool_names) != len(set(tool_names)):
+                raise ValueError("The names of the tools must be unique.")
+        self._tools = tools
+
+    @event
+    async def handle_tool_call(self, message: ToolCallEvent, ctx: MessageContext) -> None:
+        """Handle a tool call event by executing the tool and publishing the result, then
+        selecting a speaker to continue the conversation."""
+        event_logger.debug(message)
+        self._message_thread.append(message)
+
+        # Check if the conversation should be terminated.
+        if self._termination_condition is not None:
+            stop_message = await self._termination_condition([message.agent_message])
+            if stop_message is not None:
+                event_logger.info(TerminationEvent(agent_message=stop_message, source=self.id))
+                # Stop the group chat.
+                return
+
+        # Execute the tool call.
+        results = await asyncio.gather(
+            *[self._execute_tool_call(call, ctx.cancellation_token) for call in message.agent_message.content]
+        )
+        feedback = ToolCallResultEvent(
+            agent_message=ToolCallResultMessage(content=results, source=self.id.type), source=self.id
+        )
+        event_logger.debug(feedback)
+        await self.publish_message(feedback, topic_id=DefaultTopicId(type=self._group_topic_type))
+        self._message_thread.append(feedback)
+
+        # Check if the conversation should be terminated.
+        if self._termination_condition is not None:
+            stop_message = await self._termination_condition([feedback.agent_message])
+            if stop_message is not None:
+                event_logger.info(TerminationEvent(agent_message=stop_message, source=self.id))
+                # Stop the group chat.
+                return
+
+        # Select a speaker to continue the conversation.
+        speaker_topic_type = await self.select_speaker(self._message_thread)
+        await self.publish_message(ContentRequestEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
+
+    async def _execute_tool_call(
+        self, tool_call: FunctionCall, cancellation_token: CancellationToken
+    ) -> FunctionExecutionResult:
+        """Execute a tool call and return the result."""
+        try:
+            if self._tools is None:
+                raise ValueError("No tools are available.")
+            tool = next((t for t in self._tools if t.name == tool_call.name), None)
+            if tool is None:
+                raise ValueError(f"The tool '{tool_call.name}' is not available.")
+            arguments = json.loads(tool_call.arguments)
+            result = await tool.run_json(arguments, cancellation_token)
+            result_as_str = tool.return_value_as_string(result)
+            return FunctionExecutionResult(content=result_as_str, call_id=tool_call.id)
+        except Exception as e:
+            return FunctionExecutionResult(content=f"Error: {e}", call_id=tool_call.id)
 
     @event
     async def handle_content_publish(self, message: ContentPublishEvent, ctx: MessageContext) -> None:
@@ -70,7 +143,6 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         If the event is from the group chat topic, add the message to the thread and select a speaker to continue the conversation.
         If the event from the group chat session requests a pause, publish the last message to the parent topic."""
         assert ctx.topic_id is not None
-        group_chat_topic_id = TopicId(type=self._group_topic_type, source=ctx.topic_id.source)
 
         event_logger.info(message)
 
@@ -78,7 +150,8 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         if ctx.topic_id.type == self._parent_topic_type:
             self._message_thread.append(message)
             await self.publish_message(
-                ContentPublishEvent(agent_message=message.agent_message, source=self.id), topic_id=group_chat_topic_id
+                ContentPublishEvent(agent_message=message.agent_message, source=self.id),
+                topic_id=DefaultTopicId(type=self._group_topic_type),
             )
             return
 
@@ -91,8 +164,6 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
             stop_message = await self._termination_condition([message.agent_message])
             if stop_message is not None:
                 event_logger.info(TerminationEvent(agent_message=stop_message, source=self.id))
-                # Reset the termination condition.
-                await self._termination_condition.reset()
                 # Stop the group chat.
                 # TODO: this should be different if the group chat is nested.
                 return
@@ -100,9 +171,7 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         # Select a speaker to continue the conversation.
         speaker_topic_type = await self.select_speaker(self._message_thread)
 
-        participant_topic_id = TopicId(type=speaker_topic_type, source=ctx.topic_id.source)
-        group_chat_topic_id = TopicId(type=self._group_topic_type, source=ctx.topic_id.source)
-        await self.publish_message(ContentRequestEvent(), topic_id=participant_topic_id)
+        await self.publish_message(ContentRequestEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
 
     @event
     async def handle_content_request(self, message: ContentRequestEvent, ctx: MessageContext) -> None:
@@ -113,11 +182,10 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
 
         speaker_topic_type = await self.select_speaker(self._message_thread)
 
-        participant_topic_id = TopicId(type=speaker_topic_type, source=ctx.topic_id.source)
-        await self.publish_message(ContentRequestEvent(), topic_id=participant_topic_id)
+        await self.publish_message(ContentRequestEvent(), topic_id=DefaultTopicId(type=speaker_topic_type))
 
     @abstractmethod
-    async def select_speaker(self, thread: List[ContentPublishEvent]) -> str:
+    async def select_speaker(self, thread: List[ContentPublishEvent | ToolCallEvent | ToolCallResultEvent]) -> str:
         """Select a speaker from the participants and return the
         topic type of the selected speaker."""
         ...

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_chat_agent_container.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_chat_agent_container.py
@@ -4,8 +4,8 @@ from autogen_core.base import MessageContext
 from autogen_core.components import DefaultTopicId, event
 
 from ...base import ChatAgent
-from ...messages import ChatMessage, HandoffMessage, MultiModalMessage, StopMessage, TextMessage, ToolCallMessage
-from .._events import ContentPublishEvent, ContentRequestEvent, HandoffEvent, ToolCallEvent, ToolCallResultEvent
+from ...messages import ChatMessage
+from .._events import GroupChatPublishEvent, GroupChatRequestPublishEvent
 from ._sequential_routed_agent import SequentialRoutedAgent
 
 
@@ -26,14 +26,12 @@ class ChatAgentContainer(SequentialRoutedAgent):
         self._message_buffer: List[ChatMessage] = []
 
     @event
-    async def handle_message(
-        self, message: ContentPublishEvent | ToolCallEvent | ToolCallResultEvent | HandoffEvent, ctx: MessageContext
-    ) -> None:
+    async def handle_message(self, message: GroupChatPublishEvent, ctx: MessageContext) -> None:
         """Handle an event by appending the content to the buffer."""
         self._message_buffer.append(message.agent_message)
 
     @event
-    async def handle_content_request(self, message: ContentRequestEvent, ctx: MessageContext) -> None:
+    async def handle_content_request(self, message: GroupChatRequestPublishEvent, ctx: MessageContext) -> None:
         """Handle a content request event by passing the messages in the buffer
         to the delegate agent and publish the response."""
         # Pass the messages in the buffer to the delegate agent.
@@ -41,23 +39,10 @@ class ChatAgentContainer(SequentialRoutedAgent):
 
         # Publish the response.
         self._message_buffer.clear()
-        if isinstance(response, ToolCallMessage):
-            await self.publish_message(
-                ToolCallEvent(agent_message=response, source=self.id),
-                topic_id=DefaultTopicId(type=self._parent_topic_type),
-            )
-        elif isinstance(response, TextMessage | MultiModalMessage | StopMessage):
-            await self.publish_message(
-                ContentPublishEvent(agent_message=response, source=self.id),
-                topic_id=DefaultTopicId(type=self._parent_topic_type),
-            )
-        elif isinstance(response, HandoffMessage):
-            await self.publish_message(
-                HandoffEvent(agent_message=response, source=self.id),
-                topic_id=DefaultTopicId(type=self._parent_topic_type),
-            )
-        else:
-            raise ValueError(f"Unexpected response type: {type(response)}")
+        await self.publish_message(
+            GroupChatPublishEvent(agent_message=response, source=self.id),
+            topic_id=DefaultTopicId(type=self._parent_topic_type),
+        )
 
     async def on_unhandled_message(self, message: Any, ctx: MessageContext) -> None:
         raise ValueError(f"Unhandled message in agent container: {type(message)}")

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_round_robin_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_round_robin_group_chat.py
@@ -32,15 +32,14 @@ class RoundRobinGroupChatManager(BaseGroupChatManager):
             termination_condition,
         )
         self._next_speaker_index = 0
-        self._current_speaker: str | None = None
 
     async def select_speaker(self, thread: List[GroupChatPublishEvent]) -> str:
         """Select a speaker from the participants in a round-robin fashion."""
         current_speaker_index = self._next_speaker_index
         self._next_speaker_index = (current_speaker_index + 1) % len(self._participant_topic_types)
-        self._curr_speaker = self._participant_topic_types[current_speaker_index]
-        event_logger.debug(GroupChatSelectSpeakerEvent(selected_speaker=self._curr_speaker, source=self.id))
-        return self._curr_speaker
+        current_speaker = self._participant_topic_types[current_speaker_index]
+        event_logger.debug(GroupChatSelectSpeakerEvent(selected_speaker=current_speaker, source=self.id))
+        return current_speaker
 
 
 class RoundRobinGroupChat(BaseGroupChat):

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_swarm_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_swarm_group_chat.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Callable, List
+
+from ... import EVENT_LOGGER_NAME
+from ...base import ChatAgent, TerminationCondition
+from ...messages import HandoffMessage
+from .._events import (
+    GroupChatPublishEvent,
+    GroupChatSelectSpeakerEvent,
+)
+from ._base_group_chat import BaseGroupChat
+from ._base_group_chat_manager import BaseGroupChatManager
+
+event_logger = logging.getLogger(EVENT_LOGGER_NAME)
+
+
+class SwarmGroupChatManager(BaseGroupChatManager):
+    """A group chat manager that selects the next speaker based on handoff message only."""
+
+    def __init__(
+        self,
+        parent_topic_type: str,
+        group_topic_type: str,
+        participant_topic_types: List[str],
+        participant_descriptions: List[str],
+        termination_condition: TerminationCondition | None,
+    ) -> None:
+        super().__init__(
+            parent_topic_type,
+            group_topic_type,
+            participant_topic_types,
+            participant_descriptions,
+            termination_condition,
+        )
+        self._current_speaker = participant_topic_types[0]
+
+    async def select_speaker(self, thread: List[GroupChatPublishEvent]) -> str:
+        """Select a speaker from the participants based on handoff message."""
+        if len(thread) > 0 and isinstance(thread[-1].agent_message, HandoffMessage):
+            self._current_speaker = thread[-1].agent_message.content
+            if self._current_speaker not in self._participant_topic_types:
+                raise ValueError("The selected speaker in the handoff message is not a participant.")
+            event_logger.debug(GroupChatSelectSpeakerEvent(selected_speaker=self._current_speaker, source=self.id))
+            return self._current_speaker
+        else:
+            return self._current_speaker
+
+
+class Swarm(BaseGroupChat):
+    """(Experimental) A group chat that selects the next speaker based on handoff message only."""
+
+    def __init__(self, participants: List[ChatAgent]):
+        super().__init__(participants, group_chat_manager_class=SwarmGroupChatManager)
+
+    def _create_group_chat_manager_factory(
+        self,
+        parent_topic_type: str,
+        group_topic_type: str,
+        participant_topic_types: List[str],
+        participant_descriptions: List[str],
+        termination_condition: TerminationCondition | None,
+    ) -> Callable[[], SwarmGroupChatManager]:
+        def _factory() -> SwarmGroupChatManager:
+            return SwarmGroupChatManager(
+                parent_topic_type,
+                group_topic_type,
+                participant_topic_types,
+                participant_descriptions,
+                termination_condition,
+            )
+
+        return _factory

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -13,11 +13,17 @@ from autogen_agentchat.agents import (
     ToolUseAssistantAgent,
 )
 from autogen_agentchat.logging import FileLogHandler
-from autogen_agentchat.messages import ChatMessage, StopMessage, TextMessage, ToolCallMessage, ToolCallResultMessage
-from autogen_agentchat.task import StopMessageTermination
+from autogen_agentchat.messages import (
+    ChatMessage,
+    HandoffMessage,
+    StopMessage,
+    TextMessage,
+)
+from autogen_agentchat.task import MaxMessageTermination, StopMessageTermination
 from autogen_agentchat.teams import (
     RoundRobinGroupChat,
     SelectorGroupChat,
+    Swarm,
 )
 from autogen_core.base import CancellationToken
 from autogen_core.components import FunctionCall
@@ -216,13 +222,11 @@ async def test_round_robin_group_chat_with_tools(monkeypatch: pytest.MonkeyPatch
         "Write a program that prints 'Hello, world!'", termination_condition=StopMessageTermination()
     )
 
-    assert len(result.messages) == 6
+    assert len(result.messages) == 4
     assert isinstance(result.messages[0], TextMessage)  # task
-    assert isinstance(result.messages[1], ToolCallMessage)  # tool call
-    assert isinstance(result.messages[2], ToolCallResultMessage)  # tool call result
-    assert isinstance(result.messages[3], TextMessage)  # tool use agent response
-    assert isinstance(result.messages[4], TextMessage)  # echo agent response
-    assert isinstance(result.messages[5], StopMessage)  # tool use agent response
+    assert isinstance(result.messages[1], TextMessage)  # tool use agent response
+    assert isinstance(result.messages[2], TextMessage)  # echo agent response
+    assert isinstance(result.messages[3], StopMessage)  # tool use agent response
 
     context = tool_use_agent._model_context  # pyright: ignore
     assert context[0].content == "Write a program that prints 'Hello, world!'"
@@ -404,3 +408,29 @@ async def test_selector_group_chat_two_speakers_allow_repeated(monkeypatch: pyte
     assert result.messages[1].source == "agent2"
     assert result.messages[2].source == "agent2"
     assert result.messages[3].source == "agent1"
+
+
+class _HandOffAgent(BaseChatAgent):
+    def __init__(self, name: str, description: str, next_agent: str) -> None:
+        super().__init__(name, description)
+        self._next_agent = next_agent
+
+    async def on_messages(self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken) -> ChatMessage:
+        return HandoffMessage(content=self._next_agent, source=self.name)
+
+
+@pytest.mark.asyncio
+async def test_swarm() -> None:
+    first_agent = _HandOffAgent("first_agent", description="first agent", next_agent="second_agent")
+    second_agent = _HandOffAgent("second_agent", description="second agent", next_agent="third_agent")
+    third_agent = _HandOffAgent("third_agent", description="third agent", next_agent="first_agent")
+
+    team = Swarm([second_agent, first_agent, third_agent])
+    result = await team.run("task", termination_condition=MaxMessageTermination(6))
+    assert len(result.messages) == 6
+    assert result.messages[0].content == "task"
+    assert result.messages[1].content == "third_agent"
+    assert result.messages[2].content == "first_agent"
+    assert result.messages[3].content == "second_agent"
+    assert result.messages[4].content == "third_agent"
+    assert result.messages[5].content == "first_agent"

--- a/python/packages/autogen-agentchat/tests/test_tool_use_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_tool_use_assistant_agent.py
@@ -4,7 +4,7 @@ from typing import Any, AsyncGenerator, List
 
 import pytest
 from autogen_agentchat.agents import ToolUseAssistantAgent
-from autogen_agentchat.messages import StopMessage, TextMessage, ToolCallMessage, ToolCallResultMessage
+from autogen_agentchat.messages import StopMessage, TextMessage
 from autogen_core.components.models import OpenAIChatCompletionClient
 from autogen_core.components.tools import FunctionTool
 from openai.resources.chat.completions import AsyncCompletions
@@ -103,9 +103,7 @@ async def test_round_robin_group_chat_with_tools(monkeypatch: pytest.MonkeyPatch
         registered_tools=[_pass_function, _fail_function, FunctionTool(_echo_function, description="Echo")],
     )
     result = await tool_use_agent.run("task")
-    assert len(result.messages) == 5
+    assert len(result.messages) == 3
     assert isinstance(result.messages[0], TextMessage)
-    assert isinstance(result.messages[1], ToolCallMessage)
-    assert isinstance(result.messages[2], ToolCallResultMessage)
-    assert isinstance(result.messages[3], TextMessage)
-    assert isinstance(result.messages[4], StopMessage)
+    assert isinstance(result.messages[1], TextMessage)
+    assert isinstance(result.messages[2], StopMessage)

--- a/python/packages/autogen-agentchat/tests/test_tool_use_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_tool_use_assistant_agent.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncGenerator, List
 
 import pytest
 from autogen_agentchat.agents import ToolUseAssistantAgent
+from autogen_agentchat.messages import StopMessage, TextMessage, ToolCallMessage, ToolCallResultMessage
 from autogen_core.components.models import OpenAIChatCompletionClient
 from autogen_core.components.tools import FunctionTool
 from openai.resources.chat.completions import AsyncCompletions
@@ -102,6 +103,9 @@ async def test_round_robin_group_chat_with_tools(monkeypatch: pytest.MonkeyPatch
         registered_tools=[_pass_function, _fail_function, FunctionTool(_echo_function, description="Echo")],
     )
     result = await tool_use_agent.run("task")
-    assert len(result.messages) == 3
-    # assert isinstance(result.messages[1], ToolCallMessage)
-    # assert isinstance(result.messages[2], TextMessage)
+    assert len(result.messages) == 5
+    assert isinstance(result.messages[0], TextMessage)
+    assert isinstance(result.messages[1], ToolCallMessage)
+    assert isinstance(result.messages[2], ToolCallResultMessage)
+    assert isinstance(result.messages[3], TextMessage)
+    assert isinstance(result.messages[4], StopMessage)


### PR DESCRIPTION
1. Add handoff message type to chat message types
2. Add `Swarm` group chat that uses handoff message to select next speaker

```python
from autogen_agentchat.teams import Swarm

# agent1, agent2, agent3 must be able to generate `HandoffMessage`. 

swarm = Swarm([agent1, agent2, agent3])
result = await swarm.run("task")
```

3. Remove tool call and tool call result message types from chat message types
4. Remove `BaseToolUseChatAgent`, move tool call handling from group chat's chat agent container upward to the `ToolUseAssistantAgent` implementation, which subclasses `BaseChatAgent` directly. 
5. Renaming for better clarity 




TODO as next PRs:
1. Implement mechanism inside a chat agent to generate handoff message
2. Consider merging `CodingAssistantAgent` and `ToolUseAssistantAgent` into a single agent class `AssistantAgent`, which also has the ability to generate handoff messages. 
3. Rename `registered_tools` to `tools`. 
4. Should we consider chat agent returning a sequence of chat messages rather than a single one -- what is the usage case? 

Partially resolves - #3946 and #3864 