### PR TITLE
add traceback to tool execution error

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/components/tool_agent/_tool_agent.py
+++ b/python/packages/autogen-core/src/autogen_core/components/tool_agent/_tool_agent.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from dataclasses import dataclass
 from typing import List
 
@@ -88,5 +89,6 @@ class ToolAgent(RoutedAgent):
                     call_id=message.id, content=f"Error: Invalid arguments: {message.arguments}"
                 ) from e
             except Exception as e:
-                raise ToolExecutionException(call_id=message.id, content=f"Error: {e}") from e
+                tb = traceback.format_exc()
+                raise ToolExecutionException(call_id=message.id, content=f"Error: {e}\n{tb}") from e
         return FunctionExecutionResult(content=result_as_str, call_id=message.id)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

ToolExecutionException isn't properly displaying the error trace if sometihng happens during the function call, which makes it hard to debug why function call failed. This PR adds the traceback to the exception message. An example output is as follows.

```sh
Error processing publish message
Traceback (most recent call last):
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\components\tool_agent\_tool_agent.py", line 85, in handle_function_call
    result = await tool.run_json(args=arguments, cancellation_token=ctx.cancellation_token)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\components\tools\_base.py", line 120, in run_json
    return_value = await self.run(self._args_type.model_validate(args), cancellation_token)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\components\tools\_function_tool.py", line 31, in run
    result = await self._func(**args.model_dump())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\graphrag_agentchat_demo.py", line 161, in local_search
    result = await search_engine.asearch(question)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\graphrag\query\structured_search\local_search\search.py", line 67, in asearch
    context_text, context_records = self.context_builder.build_context(
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\graphrag\query\structured_search\local_search\mixed_context.py", line 140, in build_context
    selected_entities = map_query_to_entities(
                        ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\graphrag\query\context_builder\entity_extraction.py", line 57, in map_query_to_entities
    search_results = text_embedding_vectorstore.similarity_search_by_text(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\graphrag\vector_stores\lancedb.py", line 136, in similarity_search_by_text
    return self.similarity_search_by_vector(query_embedding, k)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\graphrag\vector_stores\lancedb.py", line 115, in similarity_search_by_vector
    .to_list()
     ^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\lancedb\query.py", line 320, in to_list
    return self.to_arrow().to_pylist()
           ^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\lancedb\query.py", line 647, in to_arrow
    return self.to_batches().read_all()
           ^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\lancedb\query.py", line 678, in to_batches        
    result_set = self._table._execute_query(query, batch_size)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\lancedb\table.py", line 1742, in _execute_query   
    return ds.scanner(
           ^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\lance\dataset.py", line 369, in scanner
    builder = builder.nearest(**nearest)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\lance\dataset.py", line 2449, in nearest
    raise TypeError(
TypeError: Query column vector must be a vector. Got list<item: double>.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\application\_single_threaded_agent_runtime.py", line 385, in _process_publish
    await asyncio.gather(*responses)
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\application\_single_threaded_agent_runtime.py", line 377, in _on_message
    return await agent.on_message(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_agentchat\teams\_group_chat\_sequential_routed_agent.py", line 49, in on_message
    return await super().on_message(message, ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\components\_routed_agent.py", line 468, in on_message
    return await h(self, message, ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\components\_routed_agent.py", line 267, in wrapper
    return_value = await func(self, message, ctx)  # type: ignore
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_agentchat\teams\_group_chat\_base_chat_agent_container.py", line 59, in handle_content_request
    results: List[FunctionExecutionResult | BaseException] = await asyncio.gather(
                                                             ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\base\_base_agent.py", line 120, in send_message
    return await self._runtime.send_message(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\application\_single_threaded_agent_runtime.py", line 233, in send_message
    return await future
           ^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\application\_single_threaded_agent_runtime.py", line 315, in _process_send
    response = await recipient_agent.on_message(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\components\_routed_agent.py", line 148, in wrapper
    return_value = await func(self, message, ctx)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\lpinheiro\Github\autogen-test\.venv\Lib\site-packages\autogen_core\components\tool_agent\_tool_agent.py", line 93, in handle_function_call
    raise ToolExecutionException(call_id=message.id, content=f"Error: {e}\n{tb}") from e
autogen_core.components.tool_agent._tool_agent.ToolExecutionException
```

## Related issue number

Issue raised while debugging #3799 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
