### PR TITLE
Add value error on FunctionTool type error

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/components/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/components/tools/_function_tool.py
@@ -46,5 +46,6 @@ class FunctionTool(BaseTool[BaseModel, BaseModel]):
                 cancellation_token.link_future(future)
                 result = await future
 
-        assert isinstance(result, self.return_type())
+        if not isinstance(result, self.return_type()):
+            raise ValueError(f"Expected return type {self.return_type()}, got {type(result)}")
         return result


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If the parsed tool output type does not correspond to the expected return type, an assertion is raised with no descriptive message, which makes it hard to debug.

## Related issue number

Raised in the context of #3799 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
