### PR TITLE
Run LocalCommandLineCodeExecutor within a virtual environment

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/command-line-code-executors.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/command-line-code-executors.ipynb
@@ -136,6 +136,66 @@
     "    )\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Local within a Virtual Environment\n",
+    "\n",
+    "If you want the code to run within a virtual environment created as part of the application’s setup, you can specify a directory for the newly created environment and pass its context to  {py:class}`~autogen_core.components.code_executor.LocalCommandLineCodeExecutor`. This setup allows the executor to use the specified virtual environment consistently throughout the application's lifetime, ensuring isolated dependencies and a controlled runtime environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CommandLineCodeResult(exit_code=0, output='', code_file='/Users/gziz/Dev/autogen/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/coding/tmp_code_d2a7db48799db3cc785156a11a38822a45c19f3956f02ec69b92e4169ecbf2ca.bash')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from autogen_core.base import CancellationToken\n",
+    "from autogen_core.components.code_executor import CodeBlock, LocalCommandLineCodeExecutor, create_virtual_env\n",
+    "\n",
+    "work_dir = Path(\"coding\")\n",
+    "work_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "venv_dir = \".venv\"\n",
+    "venv_context = create_virtual_env(venv_dir)\n",
+    "\n",
+    "local_executor = LocalCommandLineCodeExecutor(work_dir=work_dir, virtual_env_context=venv_context)\n",
+    "await local_executor.execute_code_blocks(\n",
+    "    code_blocks=[\n",
+    "        CodeBlock(language=\"bash\", code=\"pip install matplotlib\"),\n",
+    "    ],\n",
+    "    cancellation_token=CancellationToken(),\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see, the code has executed successfully, and the installation has been isolated to the newly created virtual environment, without affecting our global environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -154,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/python/packages/autogen-core/src/autogen_core/components/code_executor/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/components/code_executor/__init__.py
@@ -11,7 +11,7 @@ from ._func_with_reqs import (
 )
 from ._impl.command_line_code_result import CommandLineCodeResult
 from ._impl.local_commandline_code_executor import LocalCommandLineCodeExecutor
-from ._impl.utils import get_file_name_from_content, get_required_packages, lang_to_cmd, silence_pip
+from ._impl.utils import create_virtual_env, get_file_name_from_content, get_required_packages, lang_to_cmd, silence_pip
 from ._utils import extract_markdown_code_blocks
 
 __all__ = [
@@ -34,4 +34,5 @@ __all__ = [
     "lang_to_cmd",
     "get_file_name_from_content",
     "silence_pip",
+    "create_virtual_env",
 ]

--- a/python/packages/autogen-core/src/autogen_core/components/code_executor/_impl/local_commandline_code_executor.py
+++ b/python/packages/autogen-core/src/autogen_core/components/code_executor/_impl/local_commandline_code_executor.py
@@ -3,12 +3,14 @@
 
 import asyncio
 import logging
+import os
 import sys
 import warnings
 from hashlib import sha256
 from pathlib import Path
 from string import Template
-from typing import Any, Callable, ClassVar, List, Sequence, Union
+from types import SimpleNamespace
+from typing import Any, Callable, ClassVar, List, Optional, Sequence, Union
 
 from typing_extensions import ParamSpec
 
@@ -54,6 +56,7 @@ class LocalCommandLineCodeExecutor(CodeExecutor):
             directory is the current directory ".".
         functions (List[Union[FunctionWithRequirements[Any, A], Callable[..., Any]]]): A list of functions that are available to the code executor. Default is an empty list.
         functions_module (str, optional): The name of the module that will be created to store the functions. Defaults to "functions".
+        virtual_env_context (Optional[SimpleNamespace], optional): The virtual environment context. Defaults to None.
 
     """
 
@@ -86,6 +89,7 @@ $functions"""
             ]
         ] = [],
         functions_module: str = "functions",
+        virtual_env_context: Optional[SimpleNamespace] = None,
     ):
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
@@ -109,6 +113,8 @@ $functions"""
             self._setup_functions_complete = False
         else:
             self._setup_functions_complete = True
+
+        self._virtual_env_context: Optional[SimpleNamespace] = virtual_env_context
 
     def format_functions_for_prompt(self, prompt_template: str = FUNCTION_PROMPT_TEMPLATE) -> str:
         """(Experimental) Format the functions for a prompt.
@@ -164,9 +170,14 @@ $functions"""
             cmd_args = ["-m", "pip", "install"]
             cmd_args.extend(required_packages)
 
+            if self._virtual_env_context:
+                py_executable = self._virtual_env_context.env_exe
+            else:
+                py_executable = sys.executable
+
             task = asyncio.create_task(
                 asyncio.create_subprocess_exec(
-                    sys.executable,
+                    py_executable,
                     *cmd_args,
                     cwd=self._work_dir,
                     stdout=asyncio.subprocess.PIPE,
@@ -253,7 +264,17 @@ $functions"""
                 f.write(code)
             file_names.append(written_file)
 
-            program = sys.executable if lang.startswith("python") else lang_to_cmd(lang)
+            env = os.environ.copy()
+            
+            if self._virtual_env_context:
+                virtual_env_exe_abs_path = os.path.abspath(self._virtual_env_context.env_exe)
+                virtual_env_bin_abs_path = os.path.abspath(self._virtual_env_context.bin_path)
+                env["PATH"] = f"{virtual_env_bin_abs_path}{os.pathsep}{env['PATH']}"
+               
+                program = virtual_env_exe_abs_path if lang.startswith("python") else lang_to_cmd(lang)
+            else:
+                program = sys.executable if lang.startswith("python") else lang_to_cmd(lang)
+
             # Wrap in a task to make it cancellable
             task = asyncio.create_task(
                 asyncio.create_subprocess_exec(
@@ -262,6 +283,7 @@ $functions"""
                     cwd=self._work_dir,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    env=env
                 )
             )
             cancellation_token.link_future(task)

--- a/python/packages/autogen-core/src/autogen_core/components/code_executor/_impl/utils.py
+++ b/python/packages/autogen-core/src/autogen_core/components/code_executor/_impl/utils.py
@@ -3,7 +3,9 @@
 
 # Will return the filename relative to the workspace path
 import re
+import venv
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional
 
 
@@ -104,3 +106,46 @@ def infer_lang(code: str) -> str:
     except SyntaxError:
         # not a valid python code
         return "unknown"
+
+
+def create_virtual_env(
+    dir_path: str,
+    system_site_packages: bool = False,
+    clear: bool = False,
+    symlinks: bool = False,
+    upgrade: bool = False,
+    with_pip: bool = True,
+    prompt: Optional[str] = None,
+    upgrade_deps: bool = False,
+) -> SimpleNamespace:
+    """Creates a python virtual environment and returns the context.
+
+    Args:
+        dir_path: The directory path where the virtual environment will be created
+        system_site_packages: If True, the system (global) site-packages
+                                    dir is available to created environments.
+        clear: If True, delete the contents of the environment directory if
+                    it already exists, before environment creation.
+        symlinks: If True, attempt to symlink rather than copy files into
+                        virtual environment.
+        upgrade: If True, upgrade an existing virtual environment.
+        with_pip: If True, ensure pip is installed in the virtual
+                        environment
+        prompt: Alternative terminal prefix for the environment.
+        upgrade_deps: Update the base venv modules to the latest on PyPI
+
+    Returns:
+        Context for the virtual environment.
+    """
+    env_builder = venv.EnvBuilder(
+        system_site_packages=system_site_packages,
+        clear=clear,
+        symlinks=symlinks,
+        upgrade=upgrade,
+        with_pip=with_pip,
+        prompt=prompt,
+        upgrade_deps=upgrade_deps,
+    )
+
+    env_builder.create(dir_path)
+    return env_builder.ensure_directories(dir_path)

--- a/python/packages/autogen-core/tests/execution/test_commandline_code_executor.py
+++ b/python/packages/autogen-core/tests/execution/test_commandline_code_executor.py
@@ -2,16 +2,20 @@
 # Credit to original authors
 
 import asyncio
+import os
+import shutil
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from typing import AsyncGenerator, TypeAlias
+import venv
 
 import pytest
 import pytest_asyncio
 from aiofiles import open
 from autogen_core.base import CancellationToken
-from autogen_core.components.code_executor import CodeBlock, LocalCommandLineCodeExecutor
+from autogen_core.components.code_executor import CodeBlock, LocalCommandLineCodeExecutor, create_virtual_env
 
 
 @pytest_asyncio.fixture(scope="function")  # type: ignore
@@ -143,3 +147,58 @@ print("hello world")
     assert "test.py" in result.code_file
     assert (temp_dir / Path("test.py")).resolve() == Path(result.code_file).resolve()
     assert (temp_dir / Path("test.py")).exists()
+
+
+def test_create_virtual_env():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        venv_context = create_virtual_env(temp_dir)
+        assert isinstance(venv_context, SimpleNamespace)
+        assert venv_context.env_name == os.path.split(temp_dir)[1]
+
+
+@pytest.mark.asyncio
+async def test_local_executor_with_custom_venv() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        env_builder = venv.EnvBuilder(with_pip=True)
+        env_builder.create(temp_dir)
+        env_builder_context = env_builder.ensure_directories(temp_dir)
+
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir, virtual_env_context=env_builder_context)
+        code_blocks = [
+            # https://stackoverflow.com/questions/1871549/how-to-determine-if-python-is-running-inside-a-virtualenv
+            CodeBlock(code="import sys; print(sys.prefix != sys.base_prefix)", language="python"),
+        ]
+        cancellation_token = CancellationToken()
+        result = await executor.execute_code_blocks(code_blocks, cancellation_token=cancellation_token)
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "True"
+
+
+@pytest.mark.asyncio
+async def test_local_executor_with_custom_venv_in_local_relative_path() -> None:
+    try:
+        relative_folder_path = "tmp_dir"
+        if not os.path.isdir(relative_folder_path):
+            os.mkdir(relative_folder_path)
+
+        env_path = os.path.join(relative_folder_path, ".venv")
+        env_builder = venv.EnvBuilder(with_pip=True)
+        env_builder.create(env_path)
+        env_builder_context = env_builder.ensure_directories(env_path)
+
+        executor = LocalCommandLineCodeExecutor(work_dir=relative_folder_path, virtual_env_context=env_builder_context)
+        code_blocks = [
+            CodeBlock(code="import sys; print(sys.executable)", language="python"),
+        ]
+        cancellation_token = CancellationToken()
+        result = await executor.execute_code_blocks(code_blocks, cancellation_token=cancellation_token)
+
+        assert result.exit_code == 0
+
+        # Check if the expected venv has been used
+        bin_path = os.path.abspath(env_builder_context.bin_path)
+        assert Path(result.output.strip()).parent.samefile(bin_path)
+    finally:
+        if os.path.isdir(relative_folder_path):
+            shutil.rmtree(relative_folder_path)


### PR DESCRIPTION
## Why are these changes needed?
In AutoGen version 0.4, the current `LocalCommandLineCodeExecutor` doesn’t provide the feature to create a virtual environment on the fly for an application. This feature has been requested in https://github.com/microsoft/autogen/issues/2613.

This PR includes:
- Modifications to `LocalCommandLineCodeExecutor` to add this functionality.
- A function to create the virtual environment.
- Relevant tests for the new functionality and environment creation.
- Updates to the documentation of `LocalCommandLineCodeExecutor` to reflect this new feature.


## Related issue number
https://github.com/microsoft/autogen/issues/2613


## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ x] I've made sure all auto checks have passed.

## Others
Here's an image showing the newly added documentation
<img src="https://github.com/user-attachments/assets/376c07d3-d81c-4611-b177-930d4dd27c42" alt="Documentation Image" width="400" />

