### PR TITLE
Remove isinstance check from FunctionTool (#3987)

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/tools.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/tools.ipynb
@@ -60,6 +60,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -81,6 +88,11 @@
     "A tool can also be a simple Python function that performs a specific action.\n",
     "To create a custom function tool, you just need to create a Python function\n",
     "and use the {py:class}`~autogen_core.components.tools.FunctionTool` class to wrap it.\n",
+    "\n",
+    "The {py:class}`~autogen_core.components.tools.FunctionTool` class uses descriptions and type annotations\n",
+    "to inform the LLM when and how to use a given function. The description provides context\n",
+    "about the function’s purpose and intended use cases, while type annotations inform the LLM about\n",
+    "the expected parameters and return type.\n",
     "\n",
     "For example, a simple tool to obtain the stock price of a company might look like this:"
    ]
@@ -296,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/python/packages/autogen-core/src/autogen_core/components/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/components/tools/_function_tool.py
@@ -13,7 +13,58 @@ from ._base import BaseTool
 
 
 class FunctionTool(BaseTool[BaseModel, BaseModel]):
+    """
+    Create custom tools by wrapping standard Python functions.
+
+    `FunctionTool` offers an interface for executing Python functions either asynchronously or synchronously.
+    Each function must include type annotations for all parameters and its return type. These annotations
+    enable `FunctionTool` to generate a schema necessary for input validation, serialization, and for informing
+    the LLM about expected parameters. When the LLM prepares a function call, it leverages this schema to
+    generate arguments that align with the function's specifications.
+
+    .. note::
+
+        It is the user's responsibility to verify that the tool's output type matches the expected type.
+
+    Example:
+
+        .. code-block:: python
+
+            import random
+            from autogen_core.base import CancellationToken
+            from autogen_core.components.tools import FunctionTool
+            from typing_extensions import Annotated
+
+
+            async def get_stock_price(ticker: str, date: Annotated[str, "Date in YYYY/MM/DD"]) -> float:
+                # Simulates a stock price retrieval by returning a random float within a specified range.
+                return random.uniform(10, 200)
+
+
+            # Initialize a FunctionTool instance for retrieving stock prices.
+            stock_price_tool = FunctionTool(get_stock_price, description="Fetch the stock price for a given ticker.")
+
+            # Execute the tool with cancellation support.
+            cancellation_token = CancellationToken()
+            result = await stock_price_tool.run_json({"ticker": "AAPL", "date": "2021/01/01"}, cancellation_token)
+
+            # Output the result as a formatted string.
+            print(stock_price_tool.return_value_as_string(result))
+    """
+
     def __init__(self, func: Callable[..., Any], description: str, name: str | None = None) -> None:
+        """
+        Initializes a FunctionTool instance, setting up the Pydantic model for
+        argument validation and determining if the function supports cancellation.
+
+        Args:
+            func (Callable[..., ReturnT | Awaitable[ReturnT]]): The function to wrap and expose as a tool.
+            description (str): A description to inform the model of the function's purpose, specifying what
+                it does and the context in which it should be called.
+            name (str, optional): An optional custom name for the tool. Defaults to
+                the function's original name if not provided.
+        """
+
         self._func = func
         signature = get_typed_signature(func)
         func_name = name or func.__name__
@@ -46,6 +97,4 @@ class FunctionTool(BaseTool[BaseModel, BaseModel]):
                 cancellation_token.link_future(future)
                 result = await future
 
-        if not isinstance(result, self.return_type()):
-            raise ValueError(f"Expected return type {self.return_type()}, got {type(result)}")
         return result

--- a/python/packages/autogen-core/src/autogen_core/components/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/components/tools/_function_tool.py
@@ -26,6 +26,13 @@ class FunctionTool(BaseTool[BaseModel, BaseModel]):
 
         It is the user's responsibility to verify that the tool's output type matches the expected type.
 
+    Args:
+        func (Callable[..., ReturnT | Awaitable[ReturnT]]): The function to wrap and expose as a tool.
+        description (str): A description to inform the model of the function's purpose, specifying what
+            it does and the context in which it should be called.
+        name (str, optional): An optional custom name for the tool. Defaults to
+            the function's original name if not provided.
+
     Example:
 
         .. code-block:: python
@@ -53,18 +60,6 @@ class FunctionTool(BaseTool[BaseModel, BaseModel]):
     """
 
     def __init__(self, func: Callable[..., Any], description: str, name: str | None = None) -> None:
-        """
-        Initializes a FunctionTool instance, setting up the Pydantic model for
-        argument validation and determining if the function supports cancellation.
-
-        Args:
-            func (Callable[..., ReturnT | Awaitable[ReturnT]]): The function to wrap and expose as a tool.
-            description (str): A description to inform the model of the function's purpose, specifying what
-                it does and the context in which it should be called.
-            name (str, optional): An optional custom name for the tool. Defaults to
-                the function's original name if not provided.
-        """
-
         self._func = func
         signature = get_typed_signature(func)
         func_name = name or func.__name__

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Annotated
+from typing import Annotated, List
 
 import pytest
 from autogen_core.base import CancellationToken
@@ -324,3 +324,15 @@ def test_convert_tools_accepts_both_tool_and_schema() -> None:
 
     assert len(converted_tool_schema) == 2
     assert converted_tool_schema[0] == converted_tool_schema[1]
+
+
+@pytest.mark.asyncio
+async def test_func_tool_return_list() -> None:
+    def my_function() -> List[int]:
+        return [1, 2]
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    assert isinstance(result, list)
+    assert result == [1, 2]
+    assert tool.return_value_as_string(result) == "[1, 2]"


### PR DESCRIPTION
## Why are these changes needed?
The following PR includes:

- Removed the isinstance check from the FunctionTool class, allowing users to wrap functions that return lists or other subscripted generics, which was previously not possible. I have added a test for a function that returns a list; this would have failed with the previous implementation (see image 1).
- Added a FunctionTool docstring, including an example (see image 2).
- Expanded the documentation for Custom Function Tools to emphasize the importance of providing a clear description and type annotations when wrapping a function (see image 3).


Image 1
<img src="https://github.com/user-attachments/assets/45fb9edd-965d-44d2-a861-cf1197765584" width="800"/>

Image 2
<img src="https://github.com/user-attachments/assets/473b4da2-20f2-4316-b70d-73d13d924d2f" width="500"/>

Image 3
<img src="https://github.com/user-attachments/assets/882d8ded-895b-4feb-a6db-5f79f7d1afaa" width="400"/>

## Related issue number

Closes #3987 

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
