### PR TITLE
Do not exclude Properties or appsettings.json via .gitignore

### DIFF
--- a/dotnet/.gitignore
+++ b/dotnet/.gitignore
@@ -37,9 +37,6 @@ bld/
 # vs code cache
 .vscode/
 
-# Properties
-Properties/
-
 artifacts/
 output/
 
@@ -55,8 +52,6 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
-
-appsettings.json
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/dotnet/samples/AutoGen.WebAPI.Sample/Properties/launchSettings.json
+++ b/dotnet/samples/AutoGen.WebAPI.Sample/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "AutoGen.WebAPI.Sample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:50675;http://localhost:50676"
+    }
+  }
+}

--- a/dotnet/samples/Hello/Backend/Properties/launchSettings.json
+++ b/dotnet/samples/Hello/Backend/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Backend": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:53071;http://localhost:53072"
+    }
+  }
+}

--- a/dotnet/samples/Hello/Hello.AppHost/Properties/launchSettings.json
+++ b/dotnet/samples/Hello/Hello.AppHost/Properties/launchSettings.json
@@ -1,0 +1,43 @@
+{
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        //"DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16037",
+        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:16038",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        //"DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
+        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16032",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17031",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  },
+  "$schema": "https://json.schemastore.org/launchsettings.json"
+}

--- a/dotnet/samples/Hello/HelloAIAgents/Properties/launchSettings.json
+++ b/dotnet/samples/Hello/HelloAIAgents/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "HelloAIAgents": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:53139;http://localhost:53140"
+    }
+  }
+}

--- a/dotnet/samples/Hello/HelloAgent/Properties/launchSettings.json
+++ b/dotnet/samples/Hello/HelloAgent/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "HelloAgent": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:53113;http://localhost:53114"
+    }
+  }
+}

--- a/dotnet/samples/Hello/HelloAgentState/Properties/launchSettings.json
+++ b/dotnet/samples/Hello/HelloAgentState/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "HelloAgentState": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:53136;http://localhost:53137"
+    }
+  }
+}

--- a/dotnet/samples/dev-team/DevTeam.AgentHost/Properties/launchSettings.json
+++ b/dotnet/samples/dev-team/DevTeam.AgentHost/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "DevTeam.AgentHost": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:50670;http://localhost:50673"
+    }
+  }
+}

--- a/dotnet/samples/dev-team/DevTeam.Agents/Properties/launchSettings.json
+++ b/dotnet/samples/dev-team/DevTeam.Agents/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "DevTeam.Agents": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:50669;http://localhost:50671"
+    }
+  }
+}

--- a/dotnet/samples/dev-team/DevTeam.Backend/Properties/launchSettings.json
+++ b/dotnet/samples/dev-team/DevTeam.Backend/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "DevTeam.Backend": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:50672;http://localhost:50674"
+    }
+  }
+}


### PR DESCRIPTION
This change removes the exclusion of appsettings.json and any file under the 'Properties' directory from the dotnet tree's .gitignore files and includes files which were being excluded because of it. This should make it easier to run samples.