### PR TITLE
Bugfix: Optional rate limiting

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -1069,7 +1069,7 @@ class OpenAIWrapper:
 
     def _throttle_api_calls(self, idx: int) -> None:
         """Rate limit api calls."""
-        if self._rate_limiters[idx]:
+        if idx < len(self._rate_limiters) and self._rate_limiters[idx]:
             limiter = self._rate_limiters[idx]
 
             assert limiter is not None


### PR DESCRIPTION
## Why are these changes needed?

Simple UserProxyAgent and AssistantAgent flow does not work due to rate limiters not being initialized via the OpenAIWrapper.

Rate Limters seem to be optional, but the code syntax fails when there is not one set.

Adding "api_rate_limit" parameter to the LLM Config does not work when directly using the client:

    assistant = autogen.AssistantAgent(
        name="assistant",
        system_message="You are a helpful assistant ",
        llm_config={"model": "gpt-4", "api_key": os.getenv("OPENAI_API_KEY"), "cache_seed": None,
                    "api_rate_limit": 60.0},
    )

The error is:
Traceback (most recent call last):
  File "/venv/lib/python3.11/site-packages/autogen/oai/client.py", line 775, in create
    self._throttle_api_calls(i)
  File "/venv/lib/python3.11/site-packages/autogen/oai/client.py", line 1073, in _throttle_api_calls
    if self._rate_limiters[idx]:
       ~~~~~~~~~~~~~~~~~~~^^^^^
IndexError: list index out of range