### PR TITLE
Magnetic One - readme update

### DIFF
--- a/python/packages/autogen-magentic-one/README.md
+++ b/python/packages/autogen-magentic-one/README.md
@@ -57,7 +57,7 @@ You can install the Magentic-One package and then run the example code to see ho
 1. Clone the code and install the package:
 
 ```bash
-git clone -b staging https://github.com/microsoft/autogen.git
+git clone https://github.com/microsoft/autogen.git
 cd autogen/python/packages/autogen-magentic-one
 pip install -e .
 ```
@@ -85,10 +85,10 @@ playwright install --with-deps chromium
   python examples/example.py --logs_dir ./my_logs
 
   # Enable human-in-the-loop mode
-  python examples/example.py -logs_dir ./my_logs --hil_mode
+  python examples/example.py --logs_dir ./my_logs --hil_mode
 
   # Save screenshots of browser
-  python examples/example.py -logs_dir ./my_logs --save_screenshots
+  python examples/example.py --logs_dir ./my_logs --save_screenshots
   ```
 
   Arguments:


### PR DESCRIPTION
## Why are these changes needed?

While trying to run the Magnetic One examples, I noticed that the readme was:
- cloning from the staging branch
- had a couple of parameters missing the second `-`, e.g. `-logs_dir` instead of `--logs_dir`

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
