### PR TITLE
Add inner message flag and options to maximum message termination

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -244,7 +244,9 @@ class AssistantAgent(BaseChatAgent):
 
         # Run tool calls until the model produces a string response.
         while isinstance(result.content, list) and all(isinstance(item, FunctionCall) for item in result.content):
-            tool_call_msg = ToolCallMessage(content=result.content, source=self.name, models_usage=result.usage)
+            tool_call_msg = ToolCallMessage(
+                content=result.content, source=self.name, models_usage=result.usage, is_inner_message=True
+            )
             event_logger.debug(tool_call_msg)
             # Add the tool call message to the output.
             inner_messages.append(tool_call_msg)
@@ -254,7 +256,7 @@ class AssistantAgent(BaseChatAgent):
             results = await asyncio.gather(
                 *[self._execute_tool_call(call, cancellation_token) for call in result.content]
             )
-            tool_call_result_msg = ToolCallResultMessage(content=results, source=self.name)
+            tool_call_result_msg = ToolCallResultMessage(content=results, source=self.name, is_inner_message=True)
             event_logger.debug(tool_call_result_msg)
             self._model_context.append(FunctionExecutionResultMessage(content=results))
             inner_messages.append(tool_call_result_msg)

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
@@ -11,6 +11,9 @@ class BaseMessage(BaseModel):
     source: str
     """The name of the agent that sent this message."""
 
+    is_inner_message: bool = False
+    """Whether this message is an inner message."""
+
     models_usage: RequestUsage | None = None
     """The model client usage incurred when producing this message."""
 
@@ -62,10 +65,6 @@ class ToolCallResultMessage(BaseMessage):
     """The tool call results."""
 
 
-InnerMessage = ToolCallMessage | ToolCallResultMessage
-"""Messages for intra-agent monologues."""
-
-
 ChatMessage = TextMessage | MultiModalMessage | StopMessage | HandoffMessage
 """Messages for agent-to-agent communication."""
 
@@ -83,6 +82,5 @@ __all__ = [
     "ToolCallMessage",
     "ToolCallResultMessage",
     "ChatMessage",
-    "InnerMessage",
     "AgentMessage",
 ]

--- a/python/packages/autogen-agentchat/tests/test_termination_condition.py
+++ b/python/packages/autogen-agentchat/tests/test_termination_condition.py
@@ -68,6 +68,33 @@ async def test_max_message_termination() -> None:
         is not None
     )
 
+    # Test exclude_inner_message
+    termination = MaxMessageTermination(2, exclude_inner_message=True)
+    assert await termination([]) is None
+    await termination.reset()
+    assert (
+        await termination(
+            [
+                TextMessage(content="Hello", source="user", is_inner_message=True),
+                TextMessage(content="Hello", source="assistant"),
+            ]
+        )
+        is None
+    )
+    await termination.reset()
+
+    # Test exclude_source
+    termination = MaxMessageTermination(2, exclude_source="user")
+    assert await termination([]) is None
+    await termination.reset()
+    assert (
+        await termination(
+            [TextMessage(content="Hello", source="user"), TextMessage(content="Hello", source="assistant")]
+        )
+        is None
+    )
+    await termination.reset()
+
 
 @pytest.mark.asyncio
 async def test_mention_termination() -> None:


### PR DESCRIPTION
This is important for scenario that we only want a fixed number of agents from a team to respond before returning control back to application. In that case, you use it like this:


```python
termination = MaxMessageTermination(1, exclude_inner_message=True, exclude_source="user")
team = RoundRobinGroupChat([agent1, agent2, agent3], termination_condition=termination)
result = await team.run(task="....")

# The team will stop after 1 agent respond, without counting the inner messages.

```

Also, the `is_inner_message` flag allows the application receving the stream of messages to have custom handling, such as auto collapsing in UI, for inner messages. 