### PR TITLE
Enable embedding_function in RetrieveUserProxyAgent to create initial…

### DIFF
--- a/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
+++ b/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
@@ -379,11 +379,24 @@ class RetrieveUserProxyAgent(UserProxyAgent):
             )
             chunk_ids_set = set(chunk_ids)
             chunk_ids_set_idx = [chunk_ids.index(hash_value) for hash_value in chunk_ids_set]
-            docs = [
-                Document(id=chunk_ids[idx], content=chunks[idx], metadata=sources[idx])
-                for idx in chunk_ids_set_idx
-                if chunk_ids[idx] not in all_docs_ids
-            ]
+            
+            if self._embedding_function is None:
+                docs = [
+                    Document(id=chunk_ids[idx], content=chunks[idx], metadata=sources[idx])
+                    for idx in chunk_ids_set_idx
+                    if chunk_ids[idx] not in all_docs_ids
+                ]
+            else:
+                docs = [
+                    Document(
+                        id=chunk_ids[idx],
+                        content=chunks[idx],
+                        metadata=sources[idx],
+                        embedding=self._embedding_function([chunks[idx]])[0]
+                    )
+                    for idx in chunk_ids_set_idx
+                    if chunk_ids[idx] not in all_docs_ids
+                ]
 
         self._vector_db.insert_docs(docs=docs, collection_name=self._collection_name, upsert=True)
 


### PR DESCRIPTION
… vector_db

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Current RetrieveUserProxyAgent doesn't create initial vector_db with embedding_function, which always cause "No content embedding is provided. Will use the VectorDB's embedding function to generate the content embedding." wanring.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
