### PR TITLE
Console to return last processed (#4277)

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/task/_console.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/task/_console.py
@@ -22,19 +22,25 @@ async def Console(
     stream: AsyncGenerator[AgentMessage | TaskResult, None] | AsyncGenerator[AgentMessage | Response, None],
     *,
     no_inline_images: bool = False,
-) -> None:
-    """Consume the stream from  :meth:`~autogen_agentchat.base.Team.run_stream`
+) -> TaskResult | Response:
+    """
+    Consume the stream from :meth:`~autogen_agentchat.base.Team.run_stream`
     or :meth:`~autogen_agentchat.base.ChatAgent.on_messages_stream`
-    and print the messages to the console.
+    print the messages to the console and return the last processed TaskResult or Response.
 
     Args:
         stream (AsyncGenerator[AgentMessage | TaskResult, None] | AsyncGenerator[AgentMessage | Response, None]): Stream to render
         no_inline_images (bool, optional): If terminal is iTerm2 will render images inline. Use this to disable this behavior. Defaults to False.
-    """
 
+    Returns:
+        last_processed: The last processed TaskResult or Response.
+    """
     render_image_iterm = _is_running_in_iterm() and _is_output_a_tty() and not no_inline_images
     start_time = time.time()
     total_usage = RequestUsage(prompt_tokens=0, completion_tokens=0)
+
+    last_processed: TaskResult | Response | None = None
+
     async for message in stream:
         if isinstance(message, TaskResult):
             duration = time.time() - start_time
@@ -47,6 +53,8 @@ async def Console(
                 f"Duration: {duration:.2f} seconds\n"
             )
             sys.stdout.write(output)
+            last_processed = message
+
         elif isinstance(message, Response):
             duration = time.time() - start_time
 
@@ -71,6 +79,8 @@ async def Console(
                 f"Duration: {duration:.2f} seconds\n"
             )
             sys.stdout.write(output)
+            last_processed = message
+
         else:
             output = f"{'-' * 10} {message.source} {'-' * 10}\n{_message_to_str(message, render_image_iterm=render_image_iterm)}\n"
             if message.models_usage:
@@ -78,6 +88,11 @@ async def Console(
                 total_usage.completion_tokens += message.models_usage.completion_tokens
                 total_usage.prompt_tokens += message.models_usage.prompt_tokens
             sys.stdout.write(output)
+
+    if last_processed is None:
+        raise ValueError("No TaskResult or Response was processed.")
+
+    return last_processed
 
 
 # iTerm2 image rendering protocol: https://iterm2.com/documentation-images.html


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

[Console](https://github.com/microsoft/autogen/blob/b35977ce564e5a6e013cfb6836299685d2c0a899/python/packages/autogen-agentchat/src/autogen_agentchat/task/_console.py#L21) can be modified to return the last processed message instead of just printing it, which would be useful.

## Related issue number
 #4277 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
