### PR TITLE
fix: GroupChatManager async run throws an exception if no eligible speaker

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1264,6 +1264,10 @@ class GroupChatManager(ConversableAgent):
                 else:
                     # admin agent is not found in the participants
                     raise
+            except NoEligibleSpeaker:
+                # No eligible speaker, terminate the conversation
+                break
+
             if reply is None:
                 break
             # The speaker sends the message without requesting a reply


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The Autogen introduced an async implementation for the nested chats in v0.2.35, but it currently has an issue with finishing conversation. It rises an exception `NoEligibleSpeaker` as a signal that the nested chat has finished but it doesn't handle properly so the exception interrupts the whole agentic flow.

To fix the issue, the exception should be handled in `GroupChatManager:a_run_chat()` in the same way as the synchronous version does `GroupChatManager:run_chat()`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
