### PR TITLE
.NET add document on packaging && disable uploading artifacts folder to pipeline by default

### DIFF
--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -3,8 +3,8 @@ trigger:
     include:
     - main
   paths:
-    exclude:
-    - samples
+    include:
+    - dotnet
 
 schedules:
 - cron: "0 0 * * *"
@@ -12,7 +12,6 @@ schedules:
   branches:
     include:
     - main
-    - 3.x
   always: true
 
 parameters:
@@ -45,6 +44,10 @@ parameters:
     default: false
   - name: publish_nightly
     displayName: Publish to autogen-nightly
+    type: boolean
+    default: true
+  - name: publish_artifacts
+    displayName: Publish artifacts
     type: boolean
     default: false
   - name: runCodeQL3000
@@ -88,3 +91,4 @@ extends:
           publish_nightly: ${{ parameters.publish_nightly }}
           publish_nuget: ${{ parameters.publish_nuget }}
           runCodeQL3000: ${{ parameters.runCodeQL3000 }}
+          publish_artifacts: ${{ parameters.publish_artifacts }}

--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -30,6 +30,10 @@ parameters:
     displayName: Publish to nuget.org
     type: boolean
     default: false
+  - name: publish_artifacts
+    displayName: Publish artifacts
+    type: boolean
+    default: false
   - name: runCodeQL3000
     default: false
     displayName: Run CodeQL3000 tasks
@@ -49,9 +53,11 @@ jobs:
   ${{ if ne(variables['System.TeamProject'], 'GitHub - PR Builds') }}:
     templateContext:
       outputs:
-      - output: pipelineArtifact
-        targetPath: '$(build.sourcesdirectory)/dotnet/artifacts'
-        artifactName: artifacts folder
+      # Publish artifacts if enabled
+      - ${{ if eq(parameters.publish_artifacts, true) }}: # TODO add eq(parameters.codesign, true)
+        - output: pipelineArtifact
+          targetPath: '$(build.sourcesdirectory)/dotnet/artifacts'
+          artifactName: artifacts folder
       # Publish packages to nightly
       - ${{ if eq(parameters.publish_nightly, true) }}: # TODO add eq(parameters.codesign, true)
         - output: nuget

--- a/dotnet/PACKAGING.md
+++ b/dotnet/PACKAGING.md
@@ -20,7 +20,7 @@ dotnet build --configuration Release --no-restore
 dotnet pack --configuration Release --no-build
 ```
 
-This will generate both the `.nupkg` file and the `.nuspec` file in the `./artifacts/package/release` directory.
+This will generate both the `.nupkg` file and the `.snupkg` file in the `./artifacts/package/release` directory.
 
 For more details, refer to the [official .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack).
 

--- a/dotnet/PACKAGING.md
+++ b/dotnet/PACKAGING.md
@@ -1,0 +1,41 @@
+# Packaging AutoGen.NET
+
+This document describes the steps to pack the `AutoGen.NET` project.
+
+## Prerequisites
+
+- .NET SDK
+
+## Create Package
+
+1. **Restore and Build the Project**
+```bash
+dotnet restore
+dotnet build --configuration Release --no-restore
+```
+
+
+2. **Create the NuGet Package**
+```bash
+dotnet pack --configuration Release --no-build
+```
+
+This will generate both the `.nupkg` file and the `.nuspec` file in the `./artifacts/package/release` directory.
+
+For more details, refer to the [official .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack).
+
+## Add new project to package list.
+By default, when you add a new project to `AutoGen.sln`, it will not be included in the package list. To include the new project in the package, you need to add the following line to the new project's `.csproj` file
+
+e.g.
+
+```xml
+<Import Project="$(RepoRoot)/nuget/nuget-package.props" />
+```
+
+The `nuget-packages.props` enables `IsPackable` to `true` for the project, it also sets nenecessary metadata for the package.
+
+For more details, refer to the [NuGet folder](./nuget/README.md).
+
+## Package versioning
+The version of the package is defined by `VersionPrefix` and `VersionPrefixForAutoGen0_2` in [MetaInfo.props](./eng/MetaInfo.props). If the name of your project starts with `AutoGen.`, the version will be set to `VersionPrefixForAutoGen0_2`, otherwise it will be set to `VersionPrefix`.

--- a/dotnet/nuget/README.md
+++ b/dotnet/nuget/README.md
@@ -1,0 +1,13 @@
+# NuGet Directory
+
+This directory contains resources and metadata for packaging the AutoGen.NET SDK as a NuGet package.
+
+## Files
+
+- **icon.png**: The icon used for the NuGet package.
+- **NUGET.md**: The readme file displayed on the NuGet package page.
+- **NUGET-PACKAGE.PROPS**: The MSBuild properties file that defines the packaging settings for the NuGet package.
+
+## Purpose
+
+The files in this directory are used to configure and build the NuGet package for the AutoGen.NET SDK, ensuring that it includes necessary metadata, documentation, and resources.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

# Why disable uploading artifacts folder to pipeline by default?
It's too large (~1GB), preventing the ado pipeliine to upload entire artifacts saves tons  of space

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
