### PR TITLE
Add system msg when calling inside the assistant tool loop (#4308)

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -279,8 +279,9 @@ class AssistantAgent(BaseChatAgent):
                 return
 
             # Generate an inference result based on the current model context.
+            llm_messages = self._system_messages + self._model_context
             result = await self._model_client.create(
-                self._model_context, tools=self._tools + self._handoff_tools, cancellation_token=cancellation_token
+                llm_messages, tools=self._tools + self._handoff_tools, cancellation_token=cancellation_token
             )
             self._model_context.append(AssistantMessage(content=result.content, source=self.name))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The [AssistantAgent](https://github.com/microsoft/autogen/blob/eb67e4ac93ea85621e6a604c95d38d47104a73b8/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py#L82) determines when it needs to use tools. After all necessary tools are used during the [tool execution while loop](https://github.com/microsoft/autogen/blob/eb67e4ac93ea85621e6a604c95d38d47104a73b8/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py#L247) the agent makes one [model_client call](https://github.com/microsoft/autogen/blob/eb67e4ac93ea85621e6a604c95d38d47104a73b8/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py#L282) to generate a response based on the tool results.
The issue is that this model client call doesn't include the system message.


## Related issue number
#4308 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
