### PR TITLE
Fix typo in Agent Runtime Environments doc

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/core-concepts/architecture.md
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/core-concepts/architecture.md
@@ -1,6 +1,6 @@
 # Agent Runtime Environments
 
-At the foundation level, the framework provides a _runtime envionment_, which facilitates
+At the foundation level, the framework provides a _runtime environment_, which facilitates
 communication between agents, manages their identities and lifecycles,
 and enforce security and privacy boundaries.
 


### PR DESCRIPTION
## Why are these changes needed?
Just fixing a typo in the documentation.

## Checks
- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
