### PR TITLE
Add event metadata to agent registration, filter events sent from runtime

### DIFF
--- a/dotnet/src/Microsoft.AutoGen/Agents/Services/Grpc/GrpcAgentWorker.cs
+++ b/dotnet/src/Microsoft.AutoGen/Agents/Services/Grpc/GrpcAgentWorker.cs
@@ -5,6 +5,8 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Channels;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using Grpc.Core;
 using Microsoft.AutoGen.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
@@ -212,7 +214,7 @@ public sealed class GrpcAgentWorker(
         {
             var events = agentType.GetInterfaces()
             .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IHandle<>))
-            .Select(i => i.GetGenericArguments().First().Name);
+            .Select(i => GetDescriptorName(i.GetGenericArguments().First()));
             //var state = agentType.BaseType?.GetGenericArguments().First();
             var topicTypes = agentType.GetCustomAttributes<TopicSubscriptionAttribute>().Select(t => t.Topic);
 
@@ -224,10 +226,24 @@ public sealed class GrpcAgentWorker(
                     RequestId = Guid.NewGuid().ToString(),
                     //TopicTypes = { topicTypes },
                     //StateType = state?.Name,
-                    //Events = { events }
+                    Events = { events }
                 }
             }, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    public static string GetDescriptorName(Type messageType)
+    {
+        if (typeof(IMessage).IsAssignableFrom(messageType))
+        {
+            var descriptorProperty = messageType.GetProperty("Descriptor", BindingFlags.Public | BindingFlags.Static);
+            if (descriptorProperty != null)
+            {
+                var descriptor = descriptorProperty.GetValue(null) as MessageDescriptor;
+                return descriptor?.FullName ?? messageType.Name;
+            }
+        }
+        return messageType.Name;
     }
 
     // new is intentional

--- a/protos/agent_worker.proto
+++ b/protos/agent_worker.proto
@@ -50,6 +50,7 @@ message Event {
 message RegisterAgentTypeRequest {
     string request_id = 1;
     string type = 2;
+    repeated string events = 3;
 }
 
 message RegisterAgentTypeResponse {


### PR DESCRIPTION
Adds events handled per agent type, via the registration message.
Filters events on the runtime side, to be sent only to agents that handle the type of event.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
