### PR TITLE
Improve docs

### DIFF
--- a/python/packages/autogen-core/docs/src/conf.py
+++ b/python/packages/autogen-core/docs/src/conf.py
@@ -90,7 +90,7 @@ html_theme_options = {
 
     "header_links_before_dropdown": 4,
     "navbar_align": "left",
-    "show_nav_level": 3,
+    "show_nav_level": 4,
     "check_switcher": False,
     # "navbar_start": ["navbar-logo", "version-switcher"],
     # "switcher": {

--- a/python/packages/autogen-core/docs/src/conf.py
+++ b/python/packages/autogen-core/docs/src/conf.py
@@ -81,6 +81,8 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
+add_module_names = False
+
 html_logo = "_static/images/logo/logo.svg"
 html_favicon = "_static/images/logo/favicon-512x512.png"
 

--- a/python/packages/autogen-core/docs/src/conf.py
+++ b/python/packages/autogen-core/docs/src/conf.py
@@ -88,6 +88,7 @@ html_theme_options = {
 
     "header_links_before_dropdown": 4,
     "navbar_align": "left",
+    "show_nav_level": 3,
     "check_switcher": False,
     # "navbar_start": ["navbar-logo", "version-switcher"],
     # "switcher": {


### PR DESCRIPTION
1. Added `show_nav_level` configuration to control the navigation level displayed in the documentation.
2. Removed repetitive module name from docs using `add_module_names = False`.

The API reference will by default show more details as a result, as shown below.
<img width="807" alt="image" src="https://github.com/user-attachments/assets/8758b6fd-905a-4720-9c42-0570c9164dc8">

Docs won't repeat the module/submodules on the page:
<img width="755" alt="image" src="https://github.com/user-attachments/assets/d56a5365-512b-4993-9142-d863143ea5b8">

Currently its too crowded:

<img width="687" alt="image" src="https://github.com/user-attachments/assets/4f3c238c-ae78-4b8d-88a1-c4035e83c993">



Related to #4379


