### PR TITLE
Decrease doc font size

### DIFF
--- a/python/packages/autogen-core/docs/src/_static/custom.css
+++ b/python/packages/autogen-core/docs/src/_static/custom.css
@@ -2,6 +2,10 @@
   font-size: 0.8rem;
 }
 
+html {
+  --pst-font-size-base: 0.8rem;
+}
+
 html[data-theme="light"] {
   --pst-color-primary: hsl(222.2 47.4% 11.2%);
   --pst-color-secondary: #007bff;

--- a/python/packages/autogen-core/docs/src/conf.py
+++ b/python/packages/autogen-core/docs/src/conf.py
@@ -90,7 +90,7 @@ html_theme_options = {
 
     "header_links_before_dropdown": 4,
     "navbar_align": "left",
-    "show_nav_level": 3,
+    "show_nav_level": 4,
     "check_switcher": False,
     # "navbar_start": ["navbar-logo", "version-switcher"],
     # "switcher": {

--- a/python/packages/autogen-core/docs/src/conf.py
+++ b/python/packages/autogen-core/docs/src/conf.py
@@ -81,6 +81,8 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
+add_module_names = False
+
 html_logo = "_static/images/logo/logo.svg"
 html_favicon = "_static/images/logo/favicon-512x512.png"
 

--- a/python/packages/autogen-core/docs/src/conf.py
+++ b/python/packages/autogen-core/docs/src/conf.py
@@ -88,6 +88,7 @@ html_theme_options = {
 
     "header_links_before_dropdown": 4,
     "navbar_align": "left",
+    "show_nav_level": 3,
     "check_switcher": False,
     # "navbar_start": ["navbar-logo", "version-switcher"],
     # "switcher": {


### PR DESCRIPTION
This pull request includes a small change to the `python/packages/autogen-core/docs/src/_static/custom.css` file. The change introduces a new CSS variable to set the base font size for the HTML element.

* [`python/packages/autogen-core/docs/src/_static/custom.css`](diffhunk://#diff-68d73fbc191ffa270b525bc76cdae144374bcbc9c91d08f867c5e2717abc2993R5-R8): Added `--pst-font-size-base` CSS variable to set the base font size for the HTML element.

Old (landing page requires scrolling)

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/9c990517-7b6a-4154-81d8-48852a2ffdbb">


New (landing page fits and looks spacier; makes it easier to read the API reference as well)

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/bf759ecd-03f9-4bc7-a5f8-80da865da3ff">
