### PR TITLE
Fix invalid pip syntax, use double quotes for portable version (zsh/windows)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pydoc-markdown pyyaml termcolor
           # Pin databind packages as version 4.5.0 is not compatible with pydoc-markdown.
-          pip install databind.core==4.4.2 databind.json==4.4.2
+          pip install "databind.core==4.4.2" "databind.json==4.4.2"
       - name: pydoc-markdown run
         run: |
           pydoc-markdown

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We look forward to your contributions!
 First install the packages:
 
 ```bash
-pip install autogen-agentchat==0.4.0.dev8 autogen-ext[openai]==0.4.0.dev8
+pip install "autogen-agentchat==0.4.0.dev8" "autogen-ext[openai]==0.4.0.dev8"
 ```
 
 The following code uses OpenAI's GPT-4o model and you need to provide your
@@ -294,7 +294,7 @@ changes to your code, and are willing to try it out, then yes.
 AutoGen 0.2 can be installed with:
 
 ```sh
-pip install autogen-agentchat~=0.2
+pip install "autogen-agentchat~=0.2"
 ```
 
 ### Will AutoGen Studio be supported in 0.4?

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We look forward to your contributions!
 First install the packages:
 
 ```bash
-pip install 'autogen-agentchat==0.4.0.dev8' 'autogen-ext[openai]==0.4.0.dev8'
+pip install autogen-agentchat==0.4.0.dev8 autogen-ext[openai]==0.4.0.dev8
 ```
 
 The following code uses OpenAI's GPT-4o model and you need to provide your

--- a/dotnet/website/articles/Function-call-with-ollama-and-litellm.md
+++ b/dotnet/website/articles/Function-call-with-ollama-and-litellm.md
@@ -18,7 +18,7 @@ ollama pull dolphincoder:latest
 
 You can install LiteLLM by following the instructions on the [LiteLLM website](https://docs.litellm.ai/docs/).
 ```bash
-pip install 'litellm[proxy]'
+pip install "litellm[proxy]"
 ```
 
 Then, start the proxy server by running the following command:

--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -61,7 +61,7 @@ AgentChat </div>
 High-level API that includes preset agents and teams for building multi-agent systems.
 
 ```sh
-pip install 'autogen-agentchat==0.4.0.dev8'
+pip install "autogen-agentchat==0.4.0.dev8"
 ```
 
 💡 *Start here if you are looking for an API similar to AutoGen 0.2*
@@ -82,7 +82,7 @@ Get Started
 Provides building blocks for creating asynchronous, event driven multi-agent systems.
 
 ```sh
-pip install 'autogen-core==0.4.0.dev8'
+pip install "autogen-core==0.4.0.dev8"
 ```
 
 +++

--- a/python/packages/autogen-core/docs/src/packages/index.md
+++ b/python/packages/autogen-core/docs/src/packages/index.md
@@ -31,7 +31,7 @@ myst:
 Library that is at a similar level of abstraction as AutoGen 0.2, including default agents and group chat.
 
 ```sh
-pip install 'autogen-agentchat==0.4.0.dev8'
+pip install "autogen-agentchat==0.4.0.dev8"
 ```
 
 [{fas}`circle-info;pst-color-primary` User Guide](/user-guide/agentchat-user-guide/index.md) | [{fas}`file-code;pst-color-primary` API Reference](/reference/python/autogen_agentchat/autogen_agentchat.rst) | [{fab}`python;pst-color-primary` PyPI](https://pypi.org/project/autogen-agentchat/0.4.0.dev8/) | [{fab}`github;pst-color-primary` Source](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-agentchat)
@@ -46,7 +46,7 @@ pip install 'autogen-agentchat==0.4.0.dev8'
 Implements the core functionality of the AutoGen framework, providing basic building blocks for creating multi-agent systems.
 
 ```sh
-pip install 'autogen-core==0.4.0.dev8'
+pip install "autogen-core==0.4.0.dev8"
 ```
 
 [{fas}`circle-info;pst-color-primary` User Guide](/user-guide/core-user-guide/index.md) | [{fas}`file-code;pst-color-primary` API Reference](/reference/python/autogen_core/autogen_core.rst) | [{fab}`python;pst-color-primary` PyPI](https://pypi.org/project/autogen-core/0.4.0.dev8/) | [{fab}`github;pst-color-primary` Source](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-core)
@@ -61,7 +61,7 @@ pip install 'autogen-core==0.4.0.dev8'
 Implementations of core components that interface with external services, or use extra dependencies. For example, Docker based code execution.
 
 ```sh
-pip install 'autogen-ext==0.4.0.dev8'
+pip install "autogen-ext==0.4.0.dev8"
 ```
 
 Extras:
@@ -99,7 +99,7 @@ Not yet available on PyPI.
 Existing AutoGen library that provides a high-level abstraction for building multi-agent systems.
 
 ```sh
-pip install 'autogen-agentchat~=0.2'
+pip install "autogen-agentchat~=0.2"
 ```
 
 [{fas}`circle-info;pst-color-primary` Documentation](https://microsoft.github.io/autogen/0.2/) | [{fab}`python;pst-color-primary` PyPI](https://pypi.org/project/autogen-agentchat/0.2.38/) | [{fab}`github;pst-color-primary` Source](https://github.com/microsoft/autogen/tree/0.2/)

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/installation.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/installation.md
@@ -61,7 +61,7 @@ Install the `autogen-agentchat` package using pip:
 
 ```bash
 
-pip install 'autogen-agentchat==0.4.0.dev8'
+pip install "autogen-agentchat==0.4.0.dev8"
 ```
 
 ```{note}
@@ -74,7 +74,7 @@ To use the OpenAI and Azure OpenAI models, you need to install the following
 extensions:
 
 ```bash
-pip install 'autogen-ext[openai]==0.4.0.dev8'
+pip install "autogen-ext[openai]==0.4.0.dev8"
 ```
 
 ## Install Docker for Code Execution

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/quickstart.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/quickstart.ipynb
@@ -1,160 +1,134 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Quickstart"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "```{include} warning.md\n",
-                "\n",
-                "```\n",
-                "\n",
-                ":::{note}\n",
-                "For installation instructions, please refer to the [installation guide](./installation).\n",
-                ":::\n",
-                "\n",
-                "In AutoGen AgentChat, you can build applications quickly using preset agents.\n",
-                "To illustrate this, we will begin with creating a team of a single agent\n",
-                "that can use tools and respond to messages.\n",
-                "\n",
-                "The following code uses the OpenAI model. If you haven't already, you need to\n",
-                "install the following package and extension:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "vscode": {
-                    "languageId": "shellscript"
-                }
-            },
-            "outputs": [],
-            "source": [
-                "pip install 'autogen-agentchat==0.4.0.dev8' 'autogen-ext[openai]==0.4.0.dev8'"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "To use Azure OpenAI models and AAD authentication,\n",
-                "you can follow the instructions [here](./tutorial/models.ipynb#azure-openai)."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "---------- user ----------\n",
-                        "What is the weather in New York?\n",
-                        "---------- weather_agent ----------\n",
-                        "[FunctionCall(id='call_AhTZ2q3TNL8x0qs00e3wIZ7y', arguments='{\"city\":\"New York\"}', name='get_weather')]\n",
-                        "[Prompt tokens: 79, Completion tokens: 15]\n",
-                        "---------- weather_agent ----------\n",
-                        "[FunctionExecutionResult(content='The weather in New York is 73 degrees and Sunny.', call_id='call_AhTZ2q3TNL8x0qs00e3wIZ7y')]\n",
-                        "---------- weather_agent ----------\n",
-                        "The weather in New York is currently 73 degrees and sunny.\n",
-                        "[Prompt tokens: 90, Completion tokens: 14]\n",
-                        "---------- weather_agent ----------\n",
-                        "TERMINATE\n",
-                        "[Prompt tokens: 137, Completion tokens: 4]\n",
-                        "---------- Summary ----------\n",
-                        "Number of messages: 5\n",
-                        "Finish reason: Text 'TERMINATE' mentioned\n",
-                        "Total prompt tokens: 306\n",
-                        "Total completion tokens: 33\n",
-                        "Duration: 1.43 seconds\n"
-                    ]
-                }
-            ],
-            "source": [
-                "from autogen_agentchat.agents import AssistantAgent\n",
-                "from autogen_agentchat.task import Console, TextMentionTermination\n",
-                "from autogen_agentchat.teams import RoundRobinGroupChat\n",
-                "from autogen_ext.models import OpenAIChatCompletionClient\n",
-                "\n",
-                "\n",
-                "# Define a tool\n",
-                "async def get_weather(city: str) -> str:\n",
-                "    return f\"The weather in {city} is 73 degrees and Sunny.\"\n",
-                "\n",
-                "\n",
-                "async def main() -> None:\n",
-                "    # Define an agent\n",
-                "    weather_agent = AssistantAgent(\n",
-                "        name=\"weather_agent\",\n",
-                "        model_client=OpenAIChatCompletionClient(\n",
-                "            model=\"gpt-4o-2024-08-06\",\n",
-                "            # api_key=\"YOUR_API_KEY\",\n",
-                "        ),\n",
-                "        tools=[get_weather],\n",
-                "    )\n",
-                "\n",
-                "    # Define termination condition\n",
-                "    termination = TextMentionTermination(\"TERMINATE\")\n",
-                "\n",
-                "    # Define a team\n",
-                "    agent_team = RoundRobinGroupChat([weather_agent], termination_condition=termination)\n",
-                "\n",
-                "    # Run the team and stream messages to the console\n",
-                "    stream = agent_team.run_stream(task=\"What is the weather in New York?\")\n",
-                "    await Console(stream)\n",
-                "\n",
-                "\n",
-                "# NOTE: if running this inside a Python script you'll need to use asyncio.run(main()).\n",
-                "await main()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "The code snippet above introduces two high level concepts in AgentChat: *Agent* and *Team*.  An Agent helps us define what actions are taken when a message is received. Specifically, we use the {py:class}`~autogen_agentchat.agents.AssistantAgent` preset - an agent that can be given access to a model (e.g., LLM) and tools (functions) that it can then use to address tasks.  A Team helps us define the rules for how agents interact with each other.  In the  {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` team, agents respond in a sequential round-robin fashion.\n",
-                "In this case, we have a single agent, so the same agent is used for each round."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## What's Next?\n",
-                "\n",
-                "Now that you have a basic understanding of how to define an agent and a team, consider following the [tutorial](./tutorial/index) for a walkthrough on other features of AgentChat.\n",
-                "\n"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": ".venv",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.11.5"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 2
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quickstart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{include} warning.md\n",
+    "\n",
+    "```\n",
+    "\n",
+    ":::{note}\n",
+    "For installation instructions, please refer to the [installation guide](./installation).\n",
+    ":::\n",
+    "\n",
+    "In AutoGen AgentChat, you can build applications quickly using preset agents.\n",
+    "To illustrate this, we will begin with creating a team of a single agent\n",
+    "that can use tools and respond to messages.\n",
+    "\n",
+    "The following code uses the OpenAI model. If you haven't already, you need to\n",
+    "install the following package and extension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pip install \"autogen-agentchat==0.4.0.dev8\" \"autogen-ext[openai]==0.4.0.dev8\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To use Azure OpenAI models and AAD authentication,\n",
+    "you can follow the instructions [here](./tutorial/models.ipynb#azure-openai)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen_agentchat.agents import AssistantAgent\n",
+    "from autogen_agentchat.task import Console, TextMentionTermination\n",
+    "from autogen_agentchat.teams import RoundRobinGroupChat\n",
+    "from autogen_ext.models import OpenAIChatCompletionClient\n",
+    "\n",
+    "\n",
+    "# Define a tool\n",
+    "async def get_weather(city: str) -> str:\n",
+    "    return f\"The weather in {city} is 73 degrees and Sunny.\"\n",
+    "\n",
+    "\n",
+    "async def main() -> None:\n",
+    "    # Define an agent\n",
+    "    weather_agent = AssistantAgent(\n",
+    "        name=\"weather_agent\",\n",
+    "        model_client=OpenAIChatCompletionClient(\n",
+    "            model=\"gpt-4o-2024-08-06\",\n",
+    "            # api_key=\"YOUR_API_KEY\",\n",
+    "        ),\n",
+    "        tools=[get_weather],\n",
+    "    )\n",
+    "\n",
+    "    # Define termination condition\n",
+    "    termination = TextMentionTermination(\"TERMINATE\")\n",
+    "\n",
+    "    # Define a team\n",
+    "    agent_team = RoundRobinGroupChat([weather_agent], termination_condition=termination)\n",
+    "\n",
+    "    # Run the team and stream messages to the console\n",
+    "    stream = agent_team.run_stream(task=\"What is the weather in New York?\")\n",
+    "    await Console(stream)\n",
+    "\n",
+    "\n",
+    "# NOTE: if running this inside a Python script you'll need to use asyncio.run(main()).\n",
+    "await main()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The code snippet above introduces two high level concepts in AgentChat: *Agent* and *Team*.  An Agent helps us define what actions are taken when a message is received. Specifically, we use the {py:class}`~autogen_agentchat.agents.AssistantAgent` preset - an agent that can be given access to a model (e.g., LLM) and tools (functions) that it can then use to address tasks.  A Team helps us define the rules for how agents interact with each other.  In the  {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` team, agents respond in a sequential round-robin fashion.\n",
+    "In this case, we have a single agent, so the same agent is used for each round."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What's Next?\n",
+    "\n",
+    "Now that you have a basic understanding of how to define an agent and a team, consider following the [tutorial](./tutorial/index) for a walkthrough on other features of AgentChat.\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
@@ -1,187 +1,179 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Models\n",
-                "\n",
-                "In many cases, agents need access to model services such as OpenAI, Azure OpenAI, and local models.\n",
-                "AgentChat utilizes model clients provided by the\n",
-                "[`autogen-ext`](../../core-user-guide/framework/model-clients.ipynb) package."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## OpenAI\n",
-                "\n",
-                "To access OpenAI models, you need to install the `openai` extension to use the {py:class}`~autogen_ext.models.OpenAIChatCompletionClient`."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "vscode": {
-                    "languageId": "shellscript"
-                }
-            },
-            "outputs": [],
-            "source": [
-                "pip install 'autogen-ext[openai]==0.4.0.dev8'"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "You will also need to obtain an [API key](https://platform.openai.com/account/api-keys) from OpenAI."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 10,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from autogen_ext.models import OpenAIChatCompletionClient\n",
-                "\n",
-                "opneai_model_client = OpenAIChatCompletionClient(\n",
-                "    model=\"gpt-4o-2024-08-06\",\n",
-                "    # api_key=\"sk-...\", # Optional if you have an OPENAI_API_KEY environment variable set.\n",
-                ")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "To test the model client, you can use the following code:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 11,
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "CreateResult(finish_reason='stop', content='The capital of France is Paris.', usage=RequestUsage(prompt_tokens=15, completion_tokens=7), cached=False, logprobs=None)\n"
-                    ]
-                }
-            ],
-            "source": [
-                "from autogen_core.components.models import UserMessage\n",
-                "\n",
-                "result = await opneai_model_client.create([UserMessage(content=\"What is the capital of France?\", source=\"user\")])\n",
-                "print(result)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "```{note}\n",
-                "You can use this client with models hosted on OpenAI-compatible endpoints, however, we have not tested this functionality.\n",
-                "See {py:class}`~autogen_ext.models.OpenAIChatCompletionClient` for more information.\n",
-                "```"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Azure OpenAI\n",
-                "\n",
-                "Install the `azure` and `openai` extensions to use the {py:class}`~autogen_ext.models.AzureOpenAIChatCompletionClient`."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "vscode": {
-                    "languageId": "shellscript"
-                }
-            },
-            "outputs": [],
-            "source": [
-                "pip install 'autogen-ext[openai,azure]==0.4.0.dev8'"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "To use the client, you need to provide your deployment id, Azure Cognitive Services endpoint, api version, and model capabilities.\n",
-                "For authentication, you can either provide an API key or an Azure Active Directory (AAD) token credential.\n",
-                "\n",
-                "The following code snippet shows how to use AAD authentication.\n",
-                "The identity used must be assigned the [Cognitive Services OpenAI User](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/role-based-access-control#cognitive-services-openai-user) role."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from autogen_ext.models import AzureOpenAIChatCompletionClient\n",
-                "from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
-                "\n",
-                "# Create the token provider\n",
-                "token_provider = get_bearer_token_provider(DefaultAzureCredential(), \"https://cognitiveservices.azure.com/.default\")\n",
-                "\n",
-                "az_model_client = AzureOpenAIChatCompletionClient(\n",
-                "    azure_deployment=\"{your-azure-deployment}\",\n",
-                "    model=\"{model-name, such as gpt-4o}\",\n",
-                "    api_version=\"2024-06-01\",\n",
-                "    azure_endpoint=\"https://{your-custom-endpoint}.openai.azure.com/\",\n",
-                "    azure_ad_token_provider=token_provider,  # Optional if you choose key-based authentication.\n",
-                "    # api_key=\"sk-...\", # For key-based authentication.\n",
-                ")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "See [here](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity#chat-completions) for how to use the Azure client directly or for more info."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## Local Models\n",
-                "\n",
-                "We are working on it. Stay tuned!"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": ".venv",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.11.5"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 2
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Models\n",
+    "\n",
+    "In many cases, agents need access to model services such as OpenAI, Azure OpenAI, and local models.\n",
+    "AgentChat utilizes model clients provided by the\n",
+    "[`autogen-ext`](../../core-user-guide/framework/model-clients.ipynb) package."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## OpenAI\n",
+    "\n",
+    "To access OpenAI models, you need to install the `openai` extension to use the {py:class}`~autogen_ext.models.OpenAIChatCompletionClient`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pip install \"autogen-ext[openai]==0.4.0.dev8\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You will also need to obtain an [API key](https://platform.openai.com/account/api-keys) from OpenAI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen_ext.models import OpenAIChatCompletionClient\n",
+    "\n",
+    "opneai_model_client = OpenAIChatCompletionClient(\n",
+    "    model=\"gpt-4o-2024-08-06\",\n",
+    "    # api_key=\"sk-...\", # Optional if you have an OPENAI_API_KEY environment variable set.\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To test the model client, you can use the following code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen_core.components.models import UserMessage\n",
+    "\n",
+    "result = await opneai_model_client.create([UserMessage(content=\"What is the capital of France?\", source=\"user\")])\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "You can use this client with models hosted on OpenAI-compatible endpoints, however, we have not tested this functionality.\n",
+    "See {py:class}`~autogen_ext.models.OpenAIChatCompletionClient` for more information.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Azure OpenAI\n",
+    "\n",
+    "Install the `azure` and `openai` extensions to use the {py:class}`~autogen_ext.models.AzureOpenAIChatCompletionClient`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pip install \"autogen-ext[openai,azure]==0.4.0.dev8\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To use the client, you need to provide your deployment id, Azure Cognitive Services endpoint, api version, and model capabilities.\n",
+    "For authentication, you can either provide an API key or an Azure Active Directory (AAD) token credential.\n",
+    "\n",
+    "The following code snippet shows how to use AAD authentication.\n",
+    "The identity used must be assigned the [Cognitive Services OpenAI User](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/role-based-access-control#cognitive-services-openai-user) role."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen_ext.models import AzureOpenAIChatCompletionClient\n",
+    "from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
+    "\n",
+    "# Create the token provider\n",
+    "token_provider = get_bearer_token_provider(DefaultAzureCredential(), \"https://cognitiveservices.azure.com/.default\")\n",
+    "\n",
+    "az_model_client = AzureOpenAIChatCompletionClient(\n",
+    "    azure_deployment=\"{your-azure-deployment}\",\n",
+    "    model=\"{model-name, such as gpt-4o}\",\n",
+    "    api_version=\"2024-06-01\",\n",
+    "    azure_endpoint=\"https://{your-custom-endpoint}.openai.azure.com/\",\n",
+    "    azure_ad_token_provider=token_provider,  # Optional if you choose key-based authentication.\n",
+    "    # api_key=\"sk-...\", # For key-based authentication.\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See [here](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity#chat-completions) for how to use the Azure client directly or for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Local Models\n",
+    "\n",
+    "We are working on it. Stay tuned!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/local-llms-ollama-litellm.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/local-llms-ollama-litellm.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "ollama pull llama3:instruct\n",
     "\n",
-    "pip install 'litellm[proxy]'\n",
+    "pip install \"litellm[proxy]\"\n",
     "litellm --model ollama/llama3:instruct\n",
     "```  \n",
     "\n",
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,38 +174,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_1417357/2124203426.py:22: UserWarning: Resolved model mismatch: gpt-4o-2024-05-13 != ollama/llama3.1:8b. Model mapping may be incorrect.\n",
-      "  result = await self._model_client.create(self._system_messages + await self._model_context.get_messages())\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Joe: Joe, tell me a joke.\n",
-      "\n",
-      "Cathy: Here's one:\n",
-      "\n",
-      "Why couldn't the bicycle stand up by itself?\n",
-      "\n",
-      "(waiting for your reaction...)\n",
-      "\n",
-      "Joe: *laughs* It's because it was two-tired! Ahahaha! That's a good one! I love it!\n",
-      "\n",
-      "Cathy: *roars with laughter* HAHAHAHA! Oh man, that's a classic! I'm glad you liked it! The setup is perfect and the punchline is just... *chuckles* Two-tired! I mean, come on! That's genius! We should definitely add that one to our act!\n",
-      "\n",
-      "Joe: I need to go now.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "runtime.start()\n",
     "await runtime.send_message(\n",

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/agent-and-agent-runtime.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/agent-and-agent-runtime.ipynb
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,20 +117,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AgentType(type='my_agent')"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from autogen_core.application import SingleThreadedAgentRuntime\n",
     "\n",
@@ -150,17 +139,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Received message: Hello, World!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "agent_id = AgentId(\"my_agent\", \"default\")\n",
     "runtime.start()  # Start processing messages in the background.\n",
@@ -194,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/distributed-agent-runtime.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/distributed-agent-runtime.ipynb
@@ -1,223 +1,206 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Distributed Agent Runtime\n",
-                "\n",
-                "```{attention}\n",
-                "The distributed agent runtime is an experimental feature. Expect breaking changes\n",
-                "to the API.\n",
-                "```\n",
-                "\n",
-                "A distributed agent runtime facilitates communication and agent lifecycle management\n",
-                "across process boundaries.\n",
-                "It consists of a host service and at least one worker runtime.\n",
-                "\n",
-                "The host service maintains connections to all active worker runtimes,\n",
-                "facilitates message delivery, and keeps sessions for all direct messages (i.e., RPCs).\n",
-                "A worker runtime processes application code (agents) and connects to the host service.\n",
-                "It also advertises the agents which they support to the host service,\n",
-                "so the host service can deliver messages to the correct worker.\n",
-                "\n",
-                "````{note}\n",
-                "The distributed agent runtime requires extra dependencies, install them using:\n",
-                "```bash\n",
-                "pip install autogen-core[grpc]==0.4.0.dev8\n",
-                "```\n",
-                "````\n",
-                "\n",
-                "We can start a host service using {py:class}`~autogen_core.application.WorkerAgentRuntimeHost`."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 1,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from autogen_core.application import WorkerAgentRuntimeHost\n",
-                "\n",
-                "host = WorkerAgentRuntimeHost(address=\"localhost:50051\")\n",
-                "host.start()  # Start a host service in the background."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "The above code starts the host service in the background and accepts\n",
-                "worker connections on port 50051.\n",
-                "\n",
-                "Before running worker runtimes, let's define our agent.\n",
-                "The agent will publish a new message on every message it receives.\n",
-                "It also keeps track of how many messages it has published, and \n",
-                "stops publishing new messages once it has published 5 messages."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from dataclasses import dataclass\n",
-                "\n",
-                "from autogen_core.base import MessageContext\n",
-                "from autogen_core.components import DefaultTopicId, RoutedAgent, default_subscription, message_handler\n",
-                "\n",
-                "\n",
-                "@dataclass\n",
-                "class MyMessage:\n",
-                "    content: str\n",
-                "\n",
-                "\n",
-                "@default_subscription\n",
-                "class MyAgent(RoutedAgent):\n",
-                "    def __init__(self, name: str) -> None:\n",
-                "        super().__init__(\"My agent\")\n",
-                "        self._name = name\n",
-                "        self._counter = 0\n",
-                "\n",
-                "    @message_handler\n",
-                "    async def my_message_handler(self, message: MyMessage, ctx: MessageContext) -> None:\n",
-                "        self._counter += 1\n",
-                "        if self._counter > 5:\n",
-                "            return\n",
-                "        content = f\"{self._name}: Hello x {self._counter}\"\n",
-                "        print(content)\n",
-                "        await self.publish_message(MyMessage(content=content), DefaultTopicId())"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Now we can set up the worker agent runtimes.\n",
-                "We use {py:class}`~autogen_core.application.WorkerAgentRuntime`.\n",
-                "We set up two worker runtimes. Each runtime hosts one agent.\n",
-                "All agents publish and subscribe to the default topic, so they can see all\n",
-                "messages being published.\n",
-                "\n",
-                "To run the agents, we publishes a message from a worker."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 3,
-            "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "worker1: Hello x 1\n",
-                        "worker2: Hello x 1\n",
-                        "worker2: Hello x 2\n",
-                        "worker1: Hello x 2\n",
-                        "worker1: Hello x 3\n",
-                        "worker2: Hello x 3\n",
-                        "worker2: Hello x 4\n",
-                        "worker1: Hello x 4\n",
-                        "worker1: Hello x 5\n",
-                        "worker2: Hello x 5\n"
-                    ]
-                }
-            ],
-            "source": [
-                "import asyncio\n",
-                "\n",
-                "from autogen_core.application import WorkerAgentRuntime\n",
-                "\n",
-                "worker1 = WorkerAgentRuntime(host_address=\"localhost:50051\")\n",
-                "worker1.start()\n",
-                "await MyAgent.register(worker1, \"worker1\", lambda: MyAgent(\"worker1\"))\n",
-                "\n",
-                "worker2 = WorkerAgentRuntime(host_address=\"localhost:50051\")\n",
-                "worker2.start()\n",
-                "await MyAgent.register(worker2, \"worker2\", lambda: MyAgent(\"worker2\"))\n",
-                "\n",
-                "await worker2.publish_message(MyMessage(content=\"Hello!\"), DefaultTopicId())\n",
-                "\n",
-                "# Let the agents run for a while.\n",
-                "await asyncio.sleep(5)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "We can see each agent published exactly 5 messages.\n",
-                "\n",
-                "To stop the worker runtimes, we can call {py:meth}`~autogen_core.application.WorkerAgentRuntime.stop`."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 4,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "await worker1.stop()\n",
-                "await worker2.stop()\n",
-                "\n",
-                "# To keep the worker running until a termination signal is received (e.g., SIGTERM).\n",
-                "# await worker1.stop_when_signal()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "We can call {py:meth}`~autogen_core.application.WorkerAgentRuntimeHost.stop`\n",
-                "to stop the host service."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 5,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "await host.stop()\n",
-                "\n",
-                "# To keep the host service running until a termination signal (e.g., SIGTERM)\n",
-                "# await host.stop_when_signal()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Next Steps\n",
-                "To see complete examples of using distributed runtime, please take a look at the following samples:\n",
-                "\n",
-                "- [Distributed Workers](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-core/samples/worker)  \n",
-                "- [Distributed Semantic Router](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-core/samples/semantic_router)  \n",
-                "- [Distributed Group Chat](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-core/samples/distributed-group-chat)  \n"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "agnext",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.11.9"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 2
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Distributed Agent Runtime\n",
+    "\n",
+    "```{attention}\n",
+    "The distributed agent runtime is an experimental feature. Expect breaking changes\n",
+    "to the API.\n",
+    "```\n",
+    "\n",
+    "A distributed agent runtime facilitates communication and agent lifecycle management\n",
+    "across process boundaries.\n",
+    "It consists of a host service and at least one worker runtime.\n",
+    "\n",
+    "The host service maintains connections to all active worker runtimes,\n",
+    "facilitates message delivery, and keeps sessions for all direct messages (i.e., RPCs).\n",
+    "A worker runtime processes application code (agents) and connects to the host service.\n",
+    "It also advertises the agents which they support to the host service,\n",
+    "so the host service can deliver messages to the correct worker.\n",
+    "\n",
+    "````{note}\n",
+    "The distributed agent runtime requires extra dependencies, install them using:\n",
+    "```bash\n",
+    "pip install \"autogen-core[grpc]==0.4.0.dev8\"\n",
+    "```\n",
+    "````\n",
+    "\n",
+    "We can start a host service using {py:class}`~autogen_core.application.WorkerAgentRuntimeHost`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen_core.application import WorkerAgentRuntimeHost\n",
+    "\n",
+    "host = WorkerAgentRuntimeHost(address=\"localhost:50051\")\n",
+    "host.start()  # Start a host service in the background."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above code starts the host service in the background and accepts\n",
+    "worker connections on port 50051.\n",
+    "\n",
+    "Before running worker runtimes, let's define our agent.\n",
+    "The agent will publish a new message on every message it receives.\n",
+    "It also keeps track of how many messages it has published, and \n",
+    "stops publishing new messages once it has published 5 messages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import dataclass\n",
+    "\n",
+    "from autogen_core.base import MessageContext\n",
+    "from autogen_core.components import DefaultTopicId, RoutedAgent, default_subscription, message_handler\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class MyMessage:\n",
+    "    content: str\n",
+    "\n",
+    "\n",
+    "@default_subscription\n",
+    "class MyAgent(RoutedAgent):\n",
+    "    def __init__(self, name: str) -> None:\n",
+    "        super().__init__(\"My agent\")\n",
+    "        self._name = name\n",
+    "        self._counter = 0\n",
+    "\n",
+    "    @message_handler\n",
+    "    async def my_message_handler(self, message: MyMessage, ctx: MessageContext) -> None:\n",
+    "        self._counter += 1\n",
+    "        if self._counter > 5:\n",
+    "            return\n",
+    "        content = f\"{self._name}: Hello x {self._counter}\"\n",
+    "        print(content)\n",
+    "        await self.publish_message(MyMessage(content=content), DefaultTopicId())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can set up the worker agent runtimes.\n",
+    "We use {py:class}`~autogen_core.application.WorkerAgentRuntime`.\n",
+    "We set up two worker runtimes. Each runtime hosts one agent.\n",
+    "All agents publish and subscribe to the default topic, so they can see all\n",
+    "messages being published.\n",
+    "\n",
+    "To run the agents, we publishes a message from a worker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "from autogen_core.application import WorkerAgentRuntime\n",
+    "\n",
+    "worker1 = WorkerAgentRuntime(host_address=\"localhost:50051\")\n",
+    "worker1.start()\n",
+    "await MyAgent.register(worker1, \"worker1\", lambda: MyAgent(\"worker1\"))\n",
+    "\n",
+    "worker2 = WorkerAgentRuntime(host_address=\"localhost:50051\")\n",
+    "worker2.start()\n",
+    "await MyAgent.register(worker2, \"worker2\", lambda: MyAgent(\"worker2\"))\n",
+    "\n",
+    "await worker2.publish_message(MyMessage(content=\"Hello!\"), DefaultTopicId())\n",
+    "\n",
+    "# Let the agents run for a while.\n",
+    "await asyncio.sleep(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see each agent published exactly 5 messages.\n",
+    "\n",
+    "To stop the worker runtimes, we can call {py:meth}`~autogen_core.application.WorkerAgentRuntime.stop`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await worker1.stop()\n",
+    "await worker2.stop()\n",
+    "\n",
+    "# To keep the worker running until a termination signal is received (e.g., SIGTERM).\n",
+    "# await worker1.stop_when_signal()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can call {py:meth}`~autogen_core.application.WorkerAgentRuntimeHost.stop`\n",
+    "to stop the host service."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await host.stop()\n",
+    "\n",
+    "# To keep the host service running until a termination signal (e.g., SIGTERM)\n",
+    "# await host.stop_when_signal()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Next Steps\n",
+    "To see complete examples of using distributed runtime, please take a look at the following samples:\n",
+    "\n",
+    "- [Distributed Workers](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-core/samples/worker)  \n",
+    "- [Distributed Semantic Router](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-core/samples/semantic_router)  \n",
+    "- [Distributed Group Chat](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-core/samples/distributed-group-chat)  \n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "agnext",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/python/packages/autogen-core/src/autogen_core/application/_constants.py
+++ b/python/packages/autogen-core/src/autogen_core/application/_constants.py
@@ -1,5 +1,5 @@
 GRPC_IMPORT_ERROR_STR = (
-    "Distributed runtime features require additional dependencies. Install them with: pip install autogen-core[grpc]"
+    "Distributed runtime features require additional dependencies. Install them with: pip install \"autogen-core[grpc]\""
 )
 
 DATA_CONTENT_TYPE_ATTR = "datacontenttype"

--- a/python/packages/autogen-ext/src/autogen_ext/models/_openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/_openai/_openai_client.py
@@ -908,7 +908,7 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient):
 
         .. code-block:: bash
 
-            pip install 'autogen-ext[openai]==0.4.0.dev8'
+            pip install "autogen-ext[openai]==0.4.0.dev8"
 
     The following code snippet shows how to use the client with an OpenAI model:
 
@@ -988,7 +988,7 @@ class AzureOpenAIChatCompletionClient(BaseOpenAIChatCompletionClient):
 
         .. code-block:: bash
 
-            pip install 'autogen-ext[openai,azure]==0.4.0.dev8'
+            pip install "autogen-ext[openai,azure]==0.4.0.dev8"
 
     To use the client, you need to provide your deployment id, Azure Cognitive Services endpoint,
     api version, and model capabilities.


### PR DESCRIPTION
pip install command with single quotes results in the following error:

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
because it results in a pip syntax error

pip install command with single quotes results in the following error:

```
(venv) C:\work\microsoft\autogen>pip install 'autogen-agentchat==0.4.0.dev8' 'autogen-ext[openai]==0.4.0.dev8'

ERROR: Invalid requirement: "'autogen-agentchat==0.4.0.dev8'": Expected package name at the start of dependency specifier
    'autogen-agentchat==0.4.0.dev8'
    ^

```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
as this is a trivial change, i did not create a separate issue
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
