### PR TITLE
fix - #4501 - #4501 some messages published from python are routed to the agent but result in either Unhandled Message or Unknown Payload.

### DIFF
--- a/python/packages/autogen-core/samples/xlang/hello_python_agent/user_input.py
+++ b/python/packages/autogen-core/samples/xlang/hello_python_agent/user_input.py
@@ -32,6 +32,10 @@ class UserProxy(RoutedAgent):
             await self.publish_message(NewMessageReceived(message=response), topic_id=DefaultTopicId())
         elif isinstance(message, Output):
             logger.info(message.message)
+        elif isinstance(message, ConversationClosed):
+            logger.info("Conversation closed. Goodbye!")
+        elif isinstance(message, NewMessageReceived):
+            logger.info(f"New message received: {message.message}")
         else:
             pass
 


### PR DESCRIPTION
fixes #4501 some messages published from python are routed to the agent but result in either Unhandled Message or Unknown Payload.