### PR TITLE
VideoSurferAgent -> VideoSurfer

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/__init__.py
@@ -1,3 +1,3 @@
-from ._video_surfer import VideoSurferAgent
+from ._video_surfer import VideoSurfer
 
 __all__ = ["VideoSurfer"]

--- a/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/__init__.py
@@ -1,3 +1,3 @@
 from ._video_surfer import VideoSurferAgent
 
-__all__ = ["VideoSurferAgent"]
+__all__ = ["VideoSurfer"]

--- a/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/_video_surfer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/_video_surfer.py
@@ -14,9 +14,9 @@ from .tools import (
 )
 
 
-class VideoSurferAgent(AssistantAgent):
+class VideoSurfer(AssistantAgent):
     """
-    VideoSurferAgent is a specialized agent designed to answer questions about a local video file.
+    VideoSurfer is a specialized agent designed to answer questions about a local video file.
 
     This agent utilizes various tools to extract information from the video, such as its length, screenshots at specific timestamps, and audio transcriptions. It processes these elements to provide detailed answers to user queries.
 
@@ -43,15 +43,15 @@ class VideoSurferAgent(AssistantAgent):
             from autogen_agentchat.conditions import TextMentionTermination
             from autogen_agentchat.teams import RoundRobinGroupChat
             from autogen_ext.models import OpenAIChatCompletionClient
-            from autogen_ext.agents.video_surfer import VideoSurferAgent
+            from autogen_ext.agents.video_surfer import VideoSurfer
 
             async def main() -> None:
                 \"\"\"
                 Main function to run the video agent.
                 \"\"\"
                 # Define an agent
-                video_agent = VideoSurferAgent(
-                    name="VideoSurferAgent",
+                video_agent = VideoSurfer(
+                    name="VideoSurfer",
                     model_client=OpenAIChatCompletionClient(model="gpt-4o-2024-08-06")
                     )
 
@@ -67,7 +67,7 @@ class VideoSurferAgent(AssistantAgent):
 
             asyncio.run(main())
 
-        The following example demonstrates how to create and use a VideoSurferAgent and UserProxyAgent with MagenticOneGroupChat.
+        The following example demonstrates how to create and use a VideoSurfer and UserProxyAgent with MagenticOneGroupChat.
 
         .. code-block:: python
 
@@ -77,7 +77,7 @@ class VideoSurferAgent(AssistantAgent):
             from autogen_agentchat.teams import MagenticOneGroupChat
             from autogen_agentchat.agents import UserProxyAgent
             from autogen_ext.models import OpenAIChatCompletionClient
-            from autogen_ext.agents.video_surfer import VideoSurferAgent
+            from autogen_ext.agents.video_surfer import VideoSurfer
 
             async def main() -> None:
                 \"\"\"
@@ -87,8 +87,8 @@ class VideoSurferAgent(AssistantAgent):
                 model_client = OpenAIChatCompletionClient(model="gpt-4o-2024-08-06")
 
                 # Define an agent
-                video_agent = VideoSurferAgent(
-                    name="VideoSurferAgent",
+                video_agent = VideoSurfer(
+                    name="VideoSurfer",
                     model_client=model_client
                     )
 
@@ -128,7 +128,7 @@ class VideoSurferAgent(AssistantAgent):
         system_message: Optional[str] = None,
     ):
         """
-        Initialize the VideoSurferAgent.
+        Initialize the VideoSurfer.
 
         Args:
             name (str): The name of the agent.


### PR DESCRIPTION
This pull request includes changes to the `python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/_video_surfer.py` file to rename the `VideoSurferAgent` class to `VideoSurfer`. The changes ensure consistency in the naming convention across the file.

Class renaming:

* [`python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/_video_surfer.py`](diffhunk://#diff-f9ce9a97dff9d0dee184ba3a896041374888f1e70e0cc15c8bf4ca8e9c889169L17-R19): Renamed `VideoSurferAgent` class to `VideoSurfer` and updated all references to this class accordingly. [[1]](diffhunk://#diff-f9ce9a97dff9d0dee184ba3a896041374888f1e70e0cc15c8bf4ca8e9c889169L17-R19) [[2]](diffhunk://#diff-f9ce9a97dff9d0dee184ba3a896041374888f1e70e0cc15c8bf4ca8e9c889169L46-R54) [[3]](diffhunk://#diff-f9ce9a97dff9d0dee184ba3a896041374888f1e70e0cc15c8bf4ca8e9c889169L70-R70) [[4]](diffhunk://#diff-f9ce9a97dff9d0dee184ba3a896041374888f1e70e0cc15c8bf4ca8e9c889169L80-R80) [[5]](diffhunk://#diff-f9ce9a97dff9d0dee184ba3a896041374888f1e70e0cc15c8bf4ca8e9c889169L90-R91) [[6]](diffhunk://#diff-f9ce9a97dff9d0dee184ba3a896041374888f1e70e0cc15c8bf4ca8e9c889169L131-R131)