### PR TITLE
Add warning message when NoEligibleSpeaker

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1185,6 +1185,7 @@ class GroupChatManager(ConversableAgent):
                     raise
             except NoEligibleSpeaker:
                 # No eligible speaker, terminate the conversation
+                logger.warning("No eligible speaker found. Terminating the conversation.")
                 break
 
             if reply is None:
@@ -1266,6 +1267,7 @@ class GroupChatManager(ConversableAgent):
                     raise
             except NoEligibleSpeaker:
                 # No eligible speaker, terminate the conversation
+                logger.warning("No eligible speaker found. Terminating the conversation.")
                 break
 
             if reply is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add warning message when `NoEligibleSpeaker` to increase the readability of the outputs and help the user understand why the conversation is being terminated.

## Related issue number

Closes #4422 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
