### PR TITLE
Remove WIP banner from landing

### DIFF
--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -49,11 +49,6 @@ A framework for building AI agents and multi-agent applications
 :shadow: none
 :margin: 2 0 0 0
 
-<div class="wip-card">
-
-{fas}`triangle-exclamation` Work in progress
-</div>
-
 <div class="sd-card-title sd-font-weight-bold docutils">
 
 {fas}`people-group;pst-color-primary`
@@ -64,7 +59,7 @@ High-level API that includes preset agents and teams for building multi-agent sy
 pip install 'autogen-agentchat==0.4.0.dev8'
 ```
 
-💡 *Start here if you are looking for an API similar to AutoGen 0.2*
+💡 *Start here if you are looking for an API similar to AutoGen 0.2.*
 
 +++
 


### PR DESCRIPTION
This pull request makes a few small changes to the documentation of the `autogen-core` package. The changes involve removing a "work in progress" card and fixing punctuation in a note.

Documentation updates:

* [`python/packages/autogen-core/docs/src/index.md`](diffhunk://#diff-7a7a9f0c399abae4e1402a1099f5fec1fbd3bee5c19a837e7317459eb7a1c05eL52-L56): Removed the "work in progress" card.
* [`python/packages/autogen-core/docs/src/index.md`](diffhunk://#diff-7a7a9f0c399abae4e1402a1099f5fec1fbd3bee5c19a837e7317459eb7a1c05eL67-R62): Fixed punctuation in a note by adding a period.