### PR TITLE
fix: No context vars for async agents replies

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import copy
 import functools
 import inspect
@@ -1486,6 +1487,7 @@ class ConversableAgent(LLMAgent):
     ) -> Tuple[bool, Union[str, Dict, None]]:
         """Generate a reply using autogen.oai asynchronously."""
         iostream = IOStream.get_default()
+        parent_context = contextvars.copy_context()
 
         def _generate_oai_reply(
             self, iostream: IOStream, *args: Any, **kwargs: Any
@@ -1495,7 +1497,7 @@ class ConversableAgent(LLMAgent):
 
         return await asyncio.get_event_loop().run_in_executor(
             None,
-            functools.partial(
+            lambda: parent_context.run(
                 _generate_oai_reply, self=self, iostream=iostream, messages=messages, sender=sender, config=config
             ),
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The Autogen currently utilizes the `asyncio.get_event_loop().run_in_executor()` method for generating async agent replies. However, this approach presents a challenge if the application decorates OpenAI calls (such as `openai.resources.chat.completions.AsyncCompletions.create`) for purposes like call tracing or statistics measurement. The problem is that context variables cannot be accessed in this setup.

To address this issue, suggested to use `contextvars.copy_context().run()` method. This change will allow context variables to be properly propagated and accessed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
