### PR TITLE
fix "keep_first_message" to make sure messages are in correct order,

### DIFF
--- a/autogen/agentchat/contrib/capabilities/transforms.py
+++ b/autogen/agentchat/contrib/capabilities/transforms.py
@@ -96,7 +96,7 @@ class MessageHistoryLimiter:
             if remaining_count == 1:
                 # If there's only 1 slot left and it's a 'tools' message, ignore it.
                 if messages[i].get("role") != "tool":
-                    truncated_messages.insert(1, messages[i])
+                    truncated_messages.insert(1 if self._keep_first_message else 0, messages[i])
 
             remaining_count -= 1
             if remaining_count == 0:


### PR DESCRIPTION
## Why are these changes needed?

When "keep_first_message" is false, sometimes the truncated message list is in wrong order.
This fix inserts messages are in correct order,

## Related issue number

https://github.com/microsoft/autogen/pull/3178#issuecomment-2530740564

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [y ] I've made sure all auto checks have passed.
