### PR TITLE
[Bug]: Bedrock client uses incorrect environment variables for authentication

### DIFF
--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -94,13 +94,13 @@ class AnthropicClient:
             self._api_key = os.getenv("ANTHROPIC_API_KEY")
 
         if not self._aws_access_key:
-            self._aws_access_key = os.getenv("AWS_ACCESS_KEY")
+            self._aws_access_key = os.getenv("AWS_ACCESS_KEY_ID")
 
         if not self._aws_secret_key:
-            self._aws_secret_key = os.getenv("AWS_SECRET_KEY")
+            self._aws_secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
 
         if not self._aws_region:
-            self._aws_region = os.getenv("AWS_REGION")
+            self._aws_region = os.getenv("AWS_DEFAULT_REGION")
 
         if self._api_key is None and (
             self._aws_access_key is None or self._aws_secret_key is None or self._aws_region is None

--- a/autogen/oai/bedrock.py
+++ b/autogen/oai/bedrock.py
@@ -58,16 +58,16 @@ class BedrockClient:
         self._aws_profile_name = kwargs.get("aws_profile_name", None)
 
         if not self._aws_access_key:
-            self._aws_access_key = os.getenv("AWS_ACCESS_KEY")
+            self._aws_access_key = os.getenv("AWS_ACCESS_KEY_ID")
 
         if not self._aws_secret_key:
-            self._aws_secret_key = os.getenv("AWS_SECRET_KEY")
+            self._aws_secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
 
         if not self._aws_session_token:
             self._aws_session_token = os.getenv("AWS_SESSION_TOKEN")
 
         if not self._aws_region:
-            self._aws_region = os.getenv("AWS_REGION")
+            self._aws_region = os.getenv("AWS_DEFAULT_REGION")
 
         if self._aws_region is None:
             raise ValueError("Region is required to use the Amazon Bedrock API.")

--- a/test/oai/test_anthropic.py
+++ b/test/oai/test_anthropic.py
@@ -50,10 +50,10 @@ def anthropic_client():
 @pytest.mark.skipif(skip, reason=reason)
 def test_initialization_missing_api_key():
     os.environ.pop("ANTHROPIC_API_KEY", None)
-    os.environ.pop("AWS_ACCESS_KEY", None)
-    os.environ.pop("AWS_SECRET_KEY", None)
+    os.environ.pop("AWS_ACCESS_KEY_ID", None)
+    os.environ.pop("AWS_SECRET_ACCESS_KEY", None)
     os.environ.pop("AWS_SESSION_TOKEN", None)
-    os.environ.pop("AWS_REGION", None)
+    os.environ.pop("AWS_DEFAULT_REGION", None)
     with pytest.raises(ValueError, match="API key or AWS credentials are required to use the Anthropic API."):
         AnthropicClient()
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The AWS Bedrock client uses AWS_ACCESS_KEY and AWS_SECRET_KEY as environment variables., the names of which has been updated. in ref: [here](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html) these changes are to update the code base to keep in line with the same.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #3500 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
