### PR TITLE
fix poe check

### DIFF
--- a/python/packages/autogen-test-utils/pyproject.toml
+++ b/python/packages/autogen-test-utils/pyproject.toml
@@ -27,5 +27,5 @@ include = ["src"]
 include = "../../shared_tasks.toml"
 
 [tool.poe.tasks]
-
+mypy = "mypy --config-file $POE_ROOT/../../pyproject.toml src"
 test = "true"


### PR DESCRIPTION
## Why are these changes needed?

`poe check` fails when running from the `python/` directory

## Related issue number

Closes #4597
