### PR TITLE
Fix "extensions" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Currently, there are three main APIs your application can target:
 
 - [Core](https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/index.html)
 - [AgentChat](https://microsoft.github.io/autogen/dev/user-guide/agentchat-user-guide/index.html)
-- [Extensions](https://microsoft.github.io/autogen/dev/reference/python/autogen_ext/autogen_ext.html)
+- [Extensions](https://microsoft.github.io/autogen/dev/user-guide/extensions-user-guide/index.html)
 
 ## Core
 


### PR DESCRIPTION
## Why are these changes needed?

"Extentions" link fix - broken link

## Related issue number
Closes #4716

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
