### PR TITLE
Update AgentChat State Docs (Saving to Disc)

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/state.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/state.ipynb
@@ -26,9 +26,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In Tanganyika's depths so wide and deep,  \n",
-      "Ancient secrets in still waters sleep,  \n",
-      "Ripples tell tales that time longs to keep.  \n"
+      "In Tanganyika's embrace so wide and deep,  \n",
+      "Ancient waters cradle secrets they keep,  \n",
+      "Echoes of time where horizons sleep.  \n"
      ]
     }
    ],
@@ -59,14 +59,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'type': 'AssistantAgentState', 'version': '1.0.0', 'llm_messages': [{'content': 'Write a 3 line poem on lake tangayika', 'source': 'user', 'type': 'UserMessage'}, {'content': \"In Tanganyika's depths so wide and deep,  \\nAncient secrets in still waters sleep,  \\nRipples tell tales that time longs to keep.  \", 'source': 'assistant_agent', 'type': 'AssistantMessage'}]}\n"
+      "{'type': 'AssistantAgentState', 'version': '1.0.0', 'llm_messages': [{'content': 'Write a 3 line poem on lake tangayika', 'source': 'user', 'type': 'UserMessage'}, {'content': \"In Tanganyika's embrace so wide and deep,  \\nAncient waters cradle secrets they keep,  \\nEchoes of time where horizons sleep.  \", 'source': 'assistant_agent', 'type': 'AssistantMessage'}]}\n"
      ]
     }
    ],
@@ -77,15 +77,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The last line of the poem I wrote was:  \n",
-      "\"Ripples tell tales that time longs to keep.\"\n"
+      "The last line of the poem was: \"Echoes of time where horizons sleep.\"\n"
      ]
     }
    ],
@@ -131,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -141,16 +140,16 @@
       "---------- user ----------\n",
       "Write a beautiful poem 3-line about lake tangayika\n",
       "---------- assistant_agent ----------\n",
-      "In Tanganyika's depths, where light gently weaves,  \n",
-      "Silver reflections dance on ancient water's face,  \n",
-      "Whispered stories of time in the rippling leaves.  \n",
-      "[Prompt tokens: 29, Completion tokens: 36]\n",
+      "In Tanganyika's gleam, beneath the azure skies,  \n",
+      "Whispers of ancient waters, in tranquil guise,  \n",
+      "Nature's mirror, where dreams and serenity lie.\n",
+      "[Prompt tokens: 29, Completion tokens: 34]\n",
       "---------- Summary ----------\n",
       "Number of messages: 2\n",
       "Finish reason: Maximum number of messages 2 reached, current message count: 2\n",
       "Total prompt tokens: 29\n",
-      "Total completion tokens: 36\n",
-      "Duration: 1.16 seconds\n"
+      "Total completion tokens: 34\n",
+      "Duration: 0.71 seconds\n"
      ]
     }
    ],
@@ -184,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -194,23 +193,23 @@
       "---------- user ----------\n",
       "What was the last line of the poem you wrote?\n",
       "---------- assistant_agent ----------\n",
-      "I don't write poems on my own, but I can help create one with you or try to recall a specific poem if you have one in mind. Let me know what you'd like to do!\n",
-      "[Prompt tokens: 28, Completion tokens: 39]\n",
+      "I'm sorry, but I am unable to recall or access previous interactions, including any specific poem I may have composed in our past conversations. If you like, I can write a new poem for you.\n",
+      "[Prompt tokens: 28, Completion tokens: 40]\n",
       "---------- Summary ----------\n",
       "Number of messages: 2\n",
       "Finish reason: Maximum number of messages 2 reached, current message count: 2\n",
       "Total prompt tokens: 28\n",
-      "Total completion tokens: 39\n",
-      "Duration: 0.95 seconds\n"
+      "Total completion tokens: 40\n",
+      "Duration: 0.70 seconds\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "TaskResult(messages=[TextMessage(source='user', models_usage=None, type='TextMessage', content='What was the last line of the poem you wrote?'), TextMessage(source='assistant_agent', models_usage=RequestUsage(prompt_tokens=28, completion_tokens=39), type='TextMessage', content=\"I don't write poems on my own, but I can help create one with you or try to recall a specific poem if you have one in mind. Let me know what you'd like to do!\")], stop_reason='Maximum number of messages 2 reached, current message count: 2')"
+       "TaskResult(messages=[TextMessage(source='user', models_usage=None, content='What was the last line of the poem you wrote?', type='TextMessage'), TextMessage(source='assistant_agent', models_usage=RequestUsage(prompt_tokens=28, completion_tokens=40), content=\"I'm sorry, but I am unable to recall or access previous interactions, including any specific poem I may have composed in our past conversations. If you like, I can write a new poem for you.\", type='TextMessage')], stop_reason='Maximum number of messages 2 reached, current message count: 2')"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -225,42 +224,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we load the state of the team and ask the same question. We see that the team is able to accurately return the last line of the poem it wrote.\n",
-    "\n",
-    "Note: You can serialize the state of the team to a file and load it back later."
+    "Next, we load the state of the team and ask the same question. We see that the team is able to accurately return the last line of the poem it wrote."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'type': 'TeamState', 'version': '1.0.0', 'agent_states': {'group_chat_manager/c80054be-efb2-4bc7-ba0d-900962092c44': {'type': 'RoundRobinManagerState', 'version': '1.0.0', 'message_thread': [{'source': 'user', 'models_usage': None, 'type': 'TextMessage', 'content': 'Write a beautiful poem 3-line about lake tangayika'}, {'source': 'assistant_agent', 'models_usage': {'prompt_tokens': 29, 'completion_tokens': 36}, 'type': 'TextMessage', 'content': \"In Tanganyika's depths, where light gently weaves,  \\nSilver reflections dance on ancient water's face,  \\nWhispered stories of time in the rippling leaves.  \"}], 'current_turn': 0, 'next_speaker_index': 0}, 'collect_output_messages/c80054be-efb2-4bc7-ba0d-900962092c44': {}, 'assistant_agent/c80054be-efb2-4bc7-ba0d-900962092c44': {'type': 'ChatAgentContainerState', 'version': '1.0.0', 'agent_state': {'type': 'AssistantAgentState', 'version': '1.0.0', 'llm_messages': [{'content': 'Write a beautiful poem 3-line about lake tangayika', 'source': 'user', 'type': 'UserMessage'}, {'content': \"In Tanganyika's depths, where light gently weaves,  \\nSilver reflections dance on ancient water's face,  \\nWhispered stories of time in the rippling leaves.  \", 'source': 'assistant_agent', 'type': 'AssistantMessage'}]}, 'message_buffer': []}}, 'team_id': 'c80054be-efb2-4bc7-ba0d-900962092c44'}\n",
+      "{'type': 'TeamState', 'version': '1.0.0', 'agent_states': {'group_chat_manager/a55364ad-86fd-46ab-9449-dcb5260b1e06': {'type': 'RoundRobinManagerState', 'version': '1.0.0', 'message_thread': [{'source': 'user', 'models_usage': None, 'content': 'Write a beautiful poem 3-line about lake tangayika', 'type': 'TextMessage'}, {'source': 'assistant_agent', 'models_usage': {'prompt_tokens': 29, 'completion_tokens': 34}, 'content': \"In Tanganyika's gleam, beneath the azure skies,  \\nWhispers of ancient waters, in tranquil guise,  \\nNature's mirror, where dreams and serenity lie.\", 'type': 'TextMessage'}], 'current_turn': 0, 'next_speaker_index': 0}, 'collect_output_messages/a55364ad-86fd-46ab-9449-dcb5260b1e06': {}, 'assistant_agent/a55364ad-86fd-46ab-9449-dcb5260b1e06': {'type': 'ChatAgentContainerState', 'version': '1.0.0', 'agent_state': {'type': 'AssistantAgentState', 'version': '1.0.0', 'llm_messages': [{'content': 'Write a beautiful poem 3-line about lake tangayika', 'source': 'user', 'type': 'UserMessage'}, {'content': \"In Tanganyika's gleam, beneath the azure skies,  \\nWhispers of ancient waters, in tranquil guise,  \\nNature's mirror, where dreams and serenity lie.\", 'source': 'assistant_agent', 'type': 'AssistantMessage'}]}, 'message_buffer': []}}, 'team_id': 'a55364ad-86fd-46ab-9449-dcb5260b1e06'}\n",
       "---------- user ----------\n",
       "What was the last line of the poem you wrote?\n",
       "---------- assistant_agent ----------\n",
-      "The last line of the poem I wrote was:  \n",
-      "\"Whispered stories of time in the rippling leaves.\"\n",
-      "[Prompt tokens: 88, Completion tokens: 24]\n",
+      "The last line of the poem I wrote is:  \n",
+      "\"Nature's mirror, where dreams and serenity lie.\"\n",
+      "[Prompt tokens: 86, Completion tokens: 22]\n",
       "---------- Summary ----------\n",
       "Number of messages: 2\n",
       "Finish reason: Maximum number of messages 2 reached, current message count: 2\n",
-      "Total prompt tokens: 88\n",
-      "Total completion tokens: 24\n",
-      "Duration: 0.79 seconds\n"
+      "Total prompt tokens: 86\n",
+      "Total completion tokens: 22\n",
+      "Duration: 0.96 seconds\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "TaskResult(messages=[TextMessage(source='user', models_usage=None, type='TextMessage', content='What was the last line of the poem you wrote?'), TextMessage(source='assistant_agent', models_usage=RequestUsage(prompt_tokens=88, completion_tokens=24), type='TextMessage', content='The last line of the poem I wrote was:  \\n\"Whispered stories of time in the rippling leaves.\"')], stop_reason='Maximum number of messages 2 reached, current message count: 2')"
+       "TaskResult(messages=[TextMessage(source='user', models_usage=None, content='What was the last line of the poem you wrote?', type='TextMessage'), TextMessage(source='assistant_agent', models_usage=RequestUsage(prompt_tokens=86, completion_tokens=22), content='The last line of the poem I wrote is:  \\n\"Nature\\'s mirror, where dreams and serenity lie.\"', type='TextMessage')], stop_reason='Maximum number of messages 2 reached, current message count: 2')"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,11 +270,71 @@
     "stream = agent_team.run_stream(task=\"What was the last line of the poem you wrote?\")\n",
     "await Console(stream)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Persisting State (File or Database)\n",
+    "\n",
+    "In many cases, we may want to persist the state of the team to disk (or a database) and load it back later. State is a dictionary that can be serialized to a file or written to a database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "---------- user ----------\n",
+      "What was the last line of the poem you wrote?\n",
+      "---------- assistant_agent ----------\n",
+      "The last line of the poem I wrote is:  \n",
+      "\"Nature's mirror, where dreams and serenity lie.\"\n",
+      "[Prompt tokens: 86, Completion tokens: 22]\n",
+      "---------- Summary ----------\n",
+      "Number of messages: 2\n",
+      "Finish reason: Maximum number of messages 2 reached, current message count: 2\n",
+      "Total prompt tokens: 86\n",
+      "Total completion tokens: 22\n",
+      "Duration: 0.72 seconds\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskResult(messages=[TextMessage(source='user', models_usage=None, content='What was the last line of the poem you wrote?', type='TextMessage'), TextMessage(source='assistant_agent', models_usage=RequestUsage(prompt_tokens=86, completion_tokens=22), content='The last line of the poem I wrote is:  \\n\"Nature\\'s mirror, where dreams and serenity lie.\"', type='TextMessage')], stop_reason='Maximum number of messages 2 reached, current message count: 2')"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "## save state to disk \n",
+    "\n",
+    "with open(\"coding/team_state.json\", \"w\") as f:\n",
+    "    json.dump(team_state, f)\n",
+    "\n",
+    "## load state from disk\n",
+    "with open(\"coding/team_state.json\", \"r\") as f:\n",
+    "    team_state = json.load(f)\n",
+    "\n",
+    "new_agent_team = RoundRobinGroupChat([assistant_agent], termination_condition=MaxMessageTermination(max_messages=2)) \n",
+    "await new_agent_team.load_state(team_state)\n",
+    "stream = new_agent_team.run_stream(task=\"What was the last line of the poem you wrote?\") \n",
+    "await Console(stream)\n"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "agnext",
    "language": "python",
    "name": "python3"
   },
@@ -291,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/state.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/state.ipynb
@@ -275,7 +275,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Persisting State (File or Database)\n",
+    "## Persisting State (File or Database)\n",
     "\n",
     "In many cases, we may want to persist the state of the team to disk (or a database) and load it back later. State is a dictionary that can be serialized to a file or written to a database."
    ]

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/state.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/state.ipynb
@@ -316,7 +316,7 @@
    ],
    "source": [
     "import json\n",
-    "## save state to disk \n",
+    "## save state to disk\n",
     "\n",
     "with open(\"coding/team_state.json\", \"w\") as f:\n",
     "    json.dump(team_state, f)\n",
@@ -325,10 +325,10 @@
     "with open(\"coding/team_state.json\", \"r\") as f:\n",
     "    team_state = json.load(f)\n",
     "\n",
-    "new_agent_team = RoundRobinGroupChat([assistant_agent], termination_condition=MaxMessageTermination(max_messages=2)) \n",
+    "new_agent_team = RoundRobinGroupChat([assistant_agent], termination_condition=MaxMessageTermination(max_messages=2))\n",
     "await new_agent_team.load_state(team_state)\n",
-    "stream = new_agent_team.run_stream(task=\"What was the last line of the poem you wrote?\") \n",
-    "await Console(stream)\n"
+    "stream = new_agent_team.run_stream(task=\"What was the last line of the poem you wrote?\")\n",
+    "await Console(stream)"
    ]
   }
  ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. --> 

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Provides explicit example on how to save state to a dict on disc and load it back.  
```python
import json


## save state to disk 
with open("coding/team_state.json", "w") as f:
    json.dump(team_state, f)

## load state from disk
with open("coding/team_state.json", "r") as f:
    team_state = json.load(f)

## create team
new_agent_team = RoundRobinGroupChat([assistant_agent], termination_condition=MaxMessageTermination(max_messages=2)) 

## load state
await new_agent_team.load_state(team_state)
stream = new_agent_team.run_stream(task="What was the last line of the poem you wrote?") 
await Console(stream)

```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4327

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
