### PR TITLE
Avoid httpx breaking change

### DIFF
--- a/notebook/agentchat_microsoft_fabric.ipynb
+++ b/notebook/agentchat_microsoft_fabric.ipynb
@@ -226,7 +226,7 @@
    "outputs": [],
    "source": [
     "# autogen-agentchat>0.1.14 supports openai>=1\n",
-    "%pip install \"autogen-agentchat~=0.2\" \"openai>1\" -q"
+    "%pip install \"autogen-agentchat~=0.2\" \"openai>1\" \"httpx==0.27.2\" -q"
    ]
   },
   {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The latest httpx introduced a breaking change on SSL related issue, which will break the usage of AutoGen in Microsoft Fabric. With this PR, we pin the httpx version to 0.27.2 to avoid the breaking change.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
