### PR TITLE
Replace Cerebras Llama 3.1 70b with Llama 3.3 70b

### DIFF
--- a/autogen/oai/cerebras.py
+++ b/autogen/oai/cerebras.py
@@ -35,7 +35,7 @@ from autogen.oai.client_utils import should_hide_tools, validate_parameter
 CEREBRAS_PRICING_1K = {
     # Convert pricing per million to per thousand tokens.
     "llama3.1-8b": (0.10 / 1000, 0.10 / 1000),
-    "llama3.1-70b": (0.60 / 1000, 0.60 / 1000),
+    "llama-3.3-70b": (0.85 / 1000, 1.20 / 1000),
 }
 
 

--- a/test/oai/test_cerebras.py
+++ b/test/oai/test_cerebras.py
@@ -136,7 +136,7 @@ def test_cost_calculation(mock_response):
         choices=[{"message": "Test message 1"}],
         usage={"prompt_tokens": 500, "completion_tokens": 300, "total_tokens": 800},
         cost=None,
-        model="llama3.1-70b",
+        model="llama-3.3-70b",
     )
     calculated_cost = calculate_cerebras_cost(
         response.usage["prompt_tokens"], response.usage["completion_tokens"], response.model
@@ -160,7 +160,7 @@ def test_create_response(mock_chat, cerebras_client):
         MagicMock(finish_reason="stop", message=MagicMock(content="Example Cerebras response", tool_calls=None))
     ]
     mock_cerebras_response.id = "mock_cerebras_response_id"
-    mock_cerebras_response.model = "llama3.1-70b"
+    mock_cerebras_response.model = "llama-3.3-70b"
     mock_cerebras_response.usage = MagicMock(prompt_tokens=10, completion_tokens=20)  # Example token usage
 
     mock_chat.return_value = mock_cerebras_response
@@ -168,7 +168,7 @@ def test_create_response(mock_chat, cerebras_client):
     # Test parameters
     params = {
         "messages": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "World"}],
-        "model": "llama3.1-70b",
+        "model": "llama-3.3-70b",
     }
 
     # Call the create method
@@ -179,7 +179,7 @@ def test_create_response(mock_chat, cerebras_client):
         response.choices[0].message.content == "Example Cerebras response"
     ), "Response content should match expected output"
     assert response.id == "mock_cerebras_response_id", "Response ID should match the mocked response ID"
-    assert response.model == "llama3.1-70b", "Response model should match the mocked response model"
+    assert response.model == "llama-3.3-70b", "Response model should match the mocked response model"
     assert response.usage.prompt_tokens == 10, "Response prompt tokens should match the mocked response usage"
     assert response.usage.completion_tokens == 20, "Response completion tokens should match the mocked response usage"
 
@@ -211,7 +211,7 @@ def test_create_response_with_tool_call(mock_chat, cerebras_client):
             )
         ],
         id="mock_cerebras_response_id",
-        model="llama3.1-70b",
+        model="llama-3.3-70b",
         usage=MagicMock(prompt_tokens=10, completion_tokens=20),
     )
 
@@ -239,7 +239,7 @@ def test_create_response_with_tool_call(mock_chat, cerebras_client):
 
     # Call the create method
     response = cerebras_client.create(
-        {"messages": cerebras_messages, "tools": converted_functions, "model": "llama3.1-70b"}
+        {"messages": cerebras_messages, "tools": converted_functions, "model": "llama-3.3-70b"}
     )
 
     # Assertions to check if the functions and content are included in the response


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cerebras added support for Llama 3.3 70b and will be deprecating Llama 3.1 70b support soon. As a result, I've updated the examples and documentations here to reflect that.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
