### PR TITLE
Auto Hashing ID for VectorDB Classes

### DIFF
--- a/autogen/agentchat/contrib/vectordb/qdrant.py
+++ b/autogen/agentchat/contrib/vectordb/qdrant.py
@@ -1,6 +1,7 @@
 import abc
+import hashlib
 import logging
-import os
+import uuid
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 from .base import Document, ItemID, QueryResults, VectorDB
@@ -154,6 +155,18 @@ class QdrantVectorDB(VectorDB):
             Any
         """
         return self.client.delete_collection(collection_name)
+
+    def generate_chunk_ids(chunks: List[str]) -> List[ItemID]:
+        """
+        Generate chunk IDs to ensure non-duplicate uploads.
+
+        Args:
+            chunks (list): A list of chunks (strings) to hash.
+
+        Returns:
+            list: A list of generated chunk IDs.
+        """
+        return [str(uuid.UUID(hex=hashlib.md5(chunk.encode("utf-8")).hexdigest())) for chunk in chunks]
 
     def insert_docs(self, docs: List[Document], collection_name: str = None, upsert: bool = False) -> None:
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These changes allow for users to use the MongoDBAtlas class with more modifiability. This includes enabling users to pass in embeddings, without need to create in the class (note this functionality can be extended to other VectorDB), and make use of MongoDB auto ID assignment, removing the need to insert ID at upload.

## Related issue number

Closes #4728 

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
