### PR TITLE
Add component config support

### DIFF
--- a/python/packages/autogen-core/docs/src/reference/index.md
+++ b/python/packages/autogen-core/docs/src/reference/index.md
@@ -25,7 +25,7 @@ python/autogen_agentchat.state
 :hidden:
 :caption: AutoGen Core
 
-autogen_core <python/autogen_core>
+python/autogen_core
 python/autogen_core.code_executor
 python/autogen_core.models
 python/autogen_core.model_context

--- a/python/packages/autogen-core/docs/src/reference/index.md
+++ b/python/packages/autogen-core/docs/src/reference/index.md
@@ -25,7 +25,7 @@ python/autogen_agentchat.state
 :hidden:
 :caption: AutoGen Core
 
-python/autogen_core
+autogen_core <python/autogen_core>
 python/autogen_core.code_executor
 python/autogen_core.models
 python/autogen_core.model_context

--- a/python/packages/autogen-core/docs/src/reference/python/autogen_core.rst
+++ b/python/packages/autogen-core/docs/src/reference/python/autogen_core.rst
@@ -1,8 +1,11 @@
 autogen\_core
 =============
 
-
 .. automodule:: autogen_core
    :members:
    :undoc-members:
    :show-inheritance:
+   :member-order: bysource
+
+.. For some reason the following isn't picked up by automodule above
+.. autoclass:: autogen_core.ComponentType

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/component-config.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/component-config.ipynb
@@ -29,16 +29,29 @@
     "1. Add a call to {py:meth}`~autogen_core.Component` in the class inheritance list.\n",
     "2. Implment the {py:meth}`~autogen_core.ComponentConfigImpl._to_config` and {py:meth}`~autogen_core.ComponentConfigImpl._from_config` methods\n",
     "\n",
-    "For example:\n",
+    "For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
     "\n",
-    "```python\n",
-    "from pydantic import BaseModel\n",
     "from autogen_core import Component\n",
+    "from pydantic import BaseModel\n",
+    "\n",
     "\n",
     "class Config(BaseModel):\n",
     "    value: str\n",
     "\n",
-    "class MyComponent(Component(\"custom\", Config)):\n",
+    "\n",
+    "class MyComponent(Component[Config]):\n",
+    "    component_type = \"custom\"\n",
+    "    config_schema = Config\n",
+    "\n",
     "    def __init__(self, value: str):\n",
     "        self.value = value\n",
     "\n",
@@ -47,14 +60,53 @@
     "\n",
     "    @classmethod\n",
     "    def _from_config(cls, config: Config) -> MyComponent:\n",
-    "        return cls(value=config.value)\n",
-    "```\n"
+    "        return cls(value=config.value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Secrets\n",
+    "\n",
+    "If a field of a config object is a secret value, it should be marked using [`SecretStr`](https://docs.pydantic.dev/latest/api/types/#pydantic.types.SecretStr), this will ensure that the value will not be dumped to the config object.\n",
+    "\n",
+    "For example:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel, SecretStr\n",
+    "\n",
+    "\n",
+    "class ClientConfig(BaseModel):\n",
+    "    endpoint: str\n",
+    "    api_key: SecretStr"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/component-config.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/component-config.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Component config\n",
+    "\n",
+    "AutoGen components are able to be declaratively configured in a generic fashion. This is to support configuration based experiences, such as AutoGen studio, but it is also useful for many other scenarios.\n",
+    "\n",
+    "The system that provides this is called \"component configuration\". In AutoGen, a component is simply something that can be created from a config object and itself can be dumped to a config object. In this way, you can define a component in code and then get the config object from it.\n",
+    "\n",
+    "This system is generic and allows for components defined outside of AutoGen itself (such as extensions) to be configured in the same way.\n",
+    "\n",
+    "## How does this differ from state?\n",
+    "\n",
+    "This is a very important point to clarify. When we talk about serializing an object, we must include *all* data that makes that object itself. Including things like message history etc. When deserializing from serialized state, you must get back the *exact* same object. This is not the case with component configuration.\n",
+    "\n",
+    "Component configuration should be thought of as the blueprint for an object, and can be stamped out many times to create many instances of the same configured object.\n",
+    "\n",
+    "## Usage\n",
+    "\n",
+    "If you have a component in Python ad want to get the config for it, simply call {py:meth}`~autogen_core.ComponentConfig.dump_component` on it. The resulting object can be passed back into {py:meth}`~autogen_core.ComponentLoader.load_component` to get the component back.\n",
+    "\n",
+    "## Creating a component\n",
+    "\n",
+    "To add component functionality to a given class:\n",
+    "\n",
+    "1. Add a call to {py:meth}`~autogen_core.Component` in the class inheritance list.\n",
+    "2. Implment the {py:meth}`~autogen_core.ComponentConfigImpl._to_config` and {py:meth}`~autogen_core.ComponentConfigImpl._from_config` methods\n",
+    "\n",
+    "For example:\n",
+    "\n",
+    "```python\n",
+    "from pydantic import BaseModel\n",
+    "from autogen_core import Component\n",
+    "\n",
+    "class Config(BaseModel):\n",
+    "    value: str\n",
+    "\n",
+    "class MyComponent(Component(\"custom\", Config)):\n",
+    "    def __init__(self, value: str):\n",
+    "        self.value = value\n",
+    "\n",
+    "    def _to_config(self) -> Config:\n",
+    "        return Config(value=self.value)\n",
+    "\n",
+    "    @classmethod\n",
+    "    def _from_config(cls, config: Config) -> MyComponent:\n",
+    "        return cls(value=config.value)\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/index.md
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/index.md
@@ -27,4 +27,5 @@ logging
 telemetry
 command-line-code-executors
 distributed-agent-runtime
+component-config
 ```

--- a/python/packages/autogen-core/src/autogen_core/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/__init__.py
@@ -14,7 +14,6 @@ from ._cancellation_token import CancellationToken
 from ._closure_agent import ClosureAgent, ClosureContext
 from ._component_config import (
     Component,
-    ComponentConfig,
     ComponentConfigImpl,
     ComponentLoader,
     ComponentModel,
@@ -108,7 +107,6 @@ __all__ = [
     "EVENT_LOGGER_NAME",
     "TRACE_LOGGER_NAME",
     "Component",
-    "ComponentConfig",
     "ComponentLoader",
     "ComponentConfigImpl",
     "ComponentModel",

--- a/python/packages/autogen-core/src/autogen_core/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/__init__.py
@@ -12,6 +12,14 @@ from ._agent_type import AgentType
 from ._base_agent import BaseAgent
 from ._cancellation_token import CancellationToken
 from ._closure_agent import ClosureAgent, ClosureContext
+from ._component_config import (
+    Component,
+    ComponentConfig,
+    ComponentConfigImpl,
+    ComponentLoader,
+    ComponentModel,
+    ComponentType,
+)
 from ._constants import (
     EVENT_LOGGER_NAME as EVENT_LOGGER_NAME_ALIAS,
 )
@@ -99,4 +107,10 @@ __all__ = [
     "ROOT_LOGGER_NAME",
     "EVENT_LOGGER_NAME",
     "TRACE_LOGGER_NAME",
+    "Component",
+    "ComponentConfig",
+    "ComponentLoader",
+    "ComponentConfigImpl",
+    "ComponentModel",
+    "ComponentType",
 ]

--- a/python/packages/autogen-core/src/autogen_core/_component_config.py
+++ b/python/packages/autogen-core/src/autogen_core/_component_config.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+import importlib
+import types
+from typing import Generic, Literal, Protocol, Type, cast, overload, runtime_checkable
+
+from pydantic import BaseModel
+from typing_extensions import Self, TypeVar
+
+
+ComponentType = Literal["model", "agent", "tool", "termination", "token_provider"] | str
+ConfigT = TypeVar("ConfigT", bound=BaseModel)
+
+T = TypeVar("T", bound=BaseModel, covariant=True)
+
+class ComponentModel(BaseModel):
+    """Model class for a component. Contains all information required to instantiate a component."""
+
+    provider: str
+    """Describes how the component can be instantiated."""
+    component_type: ComponentType
+    """Logical type of the component."""
+    version: int
+    """Version of the component specification."""
+    description: str | None
+    """Description of the component."""
+
+    config: BaseModel
+    """The config field is passed to a given class's implmentation of :py:meth:`autogen_core.ComponentConfigImpl._from_config` to create a new instance of the component class."""
+
+
+def _type_to_provider_str(t: type) -> str:
+    return f"{t.__module__}.{t.__qualname__}"
+
+@runtime_checkable
+class ComponentConfigImpl(Protocol[ConfigT]):
+    """The two methods a class must implement to be a component.
+
+    Args:
+        Protocol (ConfigT): Type which derives from :py:class:`pydantic.BaseModel`.
+    """
+
+    def _to_config(self) -> ConfigT:
+        """Dump the configuration that would be requite to create a new instance of a component matching the configuration of this instance.
+
+        Returns:
+            T: The configuration of the component.
+
+        :meta public:
+        """
+        ...
+
+    @classmethod
+    def _from_config(cls, config: ConfigT) -> Self:
+        """Create a new instance of the component from a configuration object.
+
+        Args:
+            config (T): The configuration object.
+
+        Returns:
+            Self: The new instance of the component.
+
+        :meta public:
+        """
+        ...
+
+
+ExpectedType = TypeVar("ExpectedType")
+class ComponentLoader():
+
+    @overload
+    @classmethod
+    def load_component(cls, model: ComponentModel, expected: None = None) -> Self:
+        ...
+
+    @overload
+    @classmethod
+    def load_component(cls, model: ComponentModel, expected: Type[ExpectedType]) -> ExpectedType:
+        ...
+
+    @classmethod
+    def load_component(cls, model: ComponentModel, expected: Type[ExpectedType] | None = None) -> Self | ExpectedType:
+        """Load a component from a model. Intended to be used with the return type of :py:meth:`autogen_core.ComponentConfig.dump_component`.
+
+        Example:
+
+            .. code-block:: python
+
+                from autogen_core import ComponentModel
+                from autogen_core.models import ChatCompletionClient
+
+                component: ComponentModel = ... # type: ignore
+
+                model_client = ChatCompletionClient.load_component(component)
+
+        Args:
+            model (ComponentModel): The model to load the component from.
+
+        Returns:
+            Self: The loaded component.
+
+        Args:
+            model (ComponentModel): _description_
+            expected (Type[ExpectedType] | None, optional): Explicit type only if used directly on ComponentLoader. Defaults to None.
+
+        Raises:
+            ValueError: If the provider string is invalid.
+            TypeError: Provider is not a subclass of ComponentConfigImpl, or the expected type does not match.
+
+        Returns:
+            Self | ExpectedType: The loaded component.
+        """
+
+        # Use global and add further type checks
+
+        output = model.provider.rsplit(".", maxsplit=1)
+        if len(output) != 2:
+            raise ValueError("Invalid")
+
+        module_path, class_name = output
+        module = importlib.import_module(module_path)
+        component_class = cast(ComponentConfigImpl[BaseModel], module.__getattribute__(class_name))
+
+        if not isinstance(component_class, ComponentConfigImpl):
+            raise TypeError("Invalid component class")
+
+        # We're allowed to use the private method here
+        instance = component_class._from_config(model.config) # type: ignore
+
+        if expected is None and not isinstance(instance, cls):
+            raise TypeError("Expected type does not match")
+        elif expected is None:
+            return cast(Self, instance)
+        elif not isinstance(instance, expected):
+            raise TypeError("Expected type does not match")
+        else:
+            return cast(ExpectedType, instance)
+
+
+class ComponentConfig(ComponentConfigImpl[ConfigT], ComponentLoader, Generic[ConfigT]):
+    _config_schema: Type[ConfigT]
+    _component_type: ComponentType
+    _description: str | None
+
+    def dump_component(self) -> ComponentModel:
+        """Dump the component to a model that can be loaded back in.
+
+        Raises:
+            TypeError: If the component is a local class.
+
+        Returns:
+            ComponentModel: The model representing the component.
+        """
+        provider = _type_to_provider_str(self.__class__)
+
+        if "<locals>" in provider:
+            raise TypeError("Cannot dump component with local class")
+
+        return ComponentModel(
+            provider=provider,
+            component_type=self._component_type,
+            version=1,
+            description=self._description,
+            config=self._to_config(),
+        )
+
+    @classmethod
+    def component_config_schema(cls) -> Type[ConfigT]:
+        """Get the configuration schema for the component.
+
+        Returns:
+            Type[ConfigT]: The configuration schema for the component.
+        """
+        return cls._config_schema
+
+    @classmethod
+    def component_type(cls) -> ComponentType:
+        """Logical type of the component.
+
+        Returns:
+            ComponentType: The logical type of the component.
+        """
+        return cls._component_type
+
+
+def Component(
+    component_type: ComponentType, config_schema: type[T], description: str | None = None
+) -> type[ComponentConfig[T]]:
+    """This enables easy creation of Component classes. It provides a type to inherit from to provide the necessary methods to be a component.
+
+    Example:
+
+    .. code-block:: python
+
+        from pydantic import BaseModel
+        from autogen_core import Component
+
+        class Config(BaseModel):
+            value: str
+
+        class MyComponent(Component("custom", Config)):
+            def __init__(self, value: str):
+                self.value = value
+
+            def _to_config(self) -> Config:
+                return Config(value=self.value)
+
+            @classmethod
+            def _from_config(cls, config: Config) -> MyComponent:
+                return cls(value=config.value)
+
+
+    Args:
+        component_type (ComponentType): What is the logical type of the component.
+        config_schema (type[T]): Pydantic model class which represents the configuration of the component.
+        description (str | None, optional): Helpful description of the component. Defaults to None.
+
+    Returns:
+        type[ComponentConfig[T]]: A class to be directly inherited from.
+    """
+    return types.new_class(
+        "Component",
+        (ComponentConfig[T],),
+        exec_body=lambda ns: ns.update(
+            {"_config_schema": config_schema, "_component_type": component_type, "_description": description}
+        ),
+    )

--- a/python/packages/autogen-core/src/autogen_core/models/_model_client.py
+++ b/python/packages/autogen-core/src/autogen_core/models/_model_client.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-from typing import Mapping, Optional, Sequence, runtime_checkable
+from abc import ABC, abstractmethod
+from typing import Mapping, Optional, Sequence
 
 from typing_extensions import (
     Any,
     AsyncGenerator,
-    Protocol,
     Required,
     TypedDict,
     Union,
 )
 
 from .. import CancellationToken
+from .._component_config import ComponentLoader
 from ..tools import Tool, ToolSchema
 from ._types import CreateResult, LLMMessage, RequestUsage
 
@@ -22,9 +23,9 @@ class ModelCapabilities(TypedDict, total=False):
     json_output: Required[bool]
 
 
-@runtime_checkable
-class ChatCompletionClient(Protocol):
+class ChatCompletionClient(ABC, ComponentLoader):
     # Caching has to be handled internally as they can depend on the create args that were stored in the constructor
+    @abstractmethod
     async def create(
         self,
         messages: Sequence[LLMMessage],
@@ -36,6 +37,7 @@ class ChatCompletionClient(Protocol):
         cancellation_token: Optional[CancellationToken] = None,
     ) -> CreateResult: ...
 
+    @abstractmethod
     def create_stream(
         self,
         messages: Sequence[LLMMessage],
@@ -47,13 +49,18 @@ class ChatCompletionClient(Protocol):
         cancellation_token: Optional[CancellationToken] = None,
     ) -> AsyncGenerator[Union[str, CreateResult], None]: ...
 
+    @abstractmethod
     def actual_usage(self) -> RequestUsage: ...
 
+    @abstractmethod
     def total_usage(self) -> RequestUsage: ...
 
+    @abstractmethod
     def count_tokens(self, messages: Sequence[LLMMessage], tools: Sequence[Tool | ToolSchema] = []) -> int: ...
 
+    @abstractmethod
     def remaining_tokens(self, messages: Sequence[LLMMessage], tools: Sequence[Tool | ToolSchema] = []) -> int: ...
 
     @property
+    @abstractmethod
     def capabilities(self) -> ModelCapabilities: ...

--- a/python/packages/autogen-core/test.py
+++ b/python/packages/autogen-core/test.py
@@ -1,0 +1,19 @@
+from autogen_ext.models.openai import AzureOpenAIChatCompletionClient
+from autogen_ext.models.openai._azure_token_provider import AzureTokenProvider
+from azure.identity import DefaultAzureCredential
+
+from autogen_core.models import ChatCompletionClient
+
+
+az_model_client = AzureOpenAIChatCompletionClient(
+    azure_deployment="{your-azure-deployment}",
+    model="gpt-4o",
+    api_version="2024-06-01",
+    azure_endpoint="https://{your-custom-endpoint}.openai.azure.com/",
+    azure_ad_token_provider=AzureTokenProvider(DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"),
+)
+
+comp = az_model_client.dump_component()
+loaded = ChatCompletionClient.load_component(comp)
+
+print(loaded.__class__.__name__)

--- a/python/packages/autogen-core/tests/test_component_config.py
+++ b/python/packages/autogen-core/tests/test_component_config.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
-from typing_extensions import Self
-
 import pytest
-from autogen_core import Component
-from autogen_core._component_config import ComponentLoader
-from autogen_core.models._model_client import ChatCompletionClient
+from autogen_core import Component, ComponentLoader, ComponentModel
+from autogen_core._component_config import _type_to_provider_str  # type: ignore
+from autogen_core.models import ChatCompletionClient
 from autogen_test_utils import MyInnerComponent, MyOuterComponent
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
+from typing_extensions import Self
 
 
 class MyConfig(BaseModel):
     info: str
 
 
-class MyComponent(Component("custom", MyConfig)): # type: ignore
-    def __init__(self, info: str):
+class MyComponent(Component[MyConfig]):
+    config_schema = MyConfig
+    component_type = "custom"
+
+    def __init__(self, info: str) -> None:
         self.info = info
 
     def _to_config(self) -> MyConfig:
@@ -26,28 +28,28 @@ class MyComponent(Component("custom", MyConfig)): # type: ignore
         return cls(info=config.info)
 
 
-def test_custom_component():
+def test_custom_component() -> None:
     comp = MyComponent("test")
     comp2 = MyComponent.load_component(comp.dump_component())
     assert comp.info == comp2.info
     assert comp.__class__ == comp2.__class__
 
 
-def test_custom_component_generic_loader():
+def test_custom_component_generic_loader() -> None:
     comp = MyComponent("test")
     comp2 = ComponentLoader.load_component(comp.dump_component(), MyComponent)
     assert comp.info == comp2.info
     assert comp.__class__ == comp2.__class__
 
 
-def test_custom_component_incorrect_class():
+def test_custom_component_incorrect_class() -> None:
     comp = MyComponent("test")
 
     with pytest.raises(TypeError):
         _ = ComponentLoader.load_component(comp.dump_component(), str)
 
 
-def test_nested_component_diff_module():
+def test_nested_component_diff_module() -> None:
     inner_class = MyInnerComponent("inner")
     comp = MyOuterComponent("test", inner_class)
     dumped = comp.dump_component()
@@ -58,11 +60,14 @@ def test_nested_component_diff_module():
     assert comp.inner_class.__class__ == comp2.inner_class.__class__
 
 
-def test_cannot_import_locals():
+def test_cannot_import_locals() -> None:
     class InvalidModelClientConfig(BaseModel):
         info: str
 
-    class MyInvalidModelClient(Component("model", InvalidModelClientConfig)):
+    class MyInvalidModelClient(Component[InvalidModelClientConfig]):
+        config_schema = InvalidModelClientConfig
+        component_type = "model"
+
         def __init__(self, info: str):
             self.info = info
 
@@ -83,8 +88,11 @@ class InvalidModelClientConfig(BaseModel):
     info: str
 
 
-class MyInvalidModelClient(Component("model", InvalidModelClientConfig)):
-    def __init__(self, info: str):
+class MyInvalidModelClient(Component[InvalidModelClientConfig]):
+    config_schema = InvalidModelClientConfig
+    component_type = "model"
+
+    def __init__(self, info: str) -> None:
         self.info = info
 
     def _to_config(self) -> InvalidModelClientConfig:
@@ -95,8 +103,44 @@ class MyInvalidModelClient(Component("model", InvalidModelClientConfig)):
         return cls(info=config.info)
 
 
-def test_type_error_on_creation():
+def test_type_error_on_creation() -> None:
     comp = MyInvalidModelClient("test")
-    # Fails due to MyInvalidModelClient not being a
+    # Fails due to MyInvalidModelClient not being a model client
     with pytest.raises(TypeError):
         ChatCompletionClient.load_component(comp.dump_component())
+
+
+with pytest.warns(UserWarning):
+
+    class MyInvalidMissingAttrs(Component[InvalidModelClientConfig]):
+        def __init__(self, info: str):
+            self.info = info
+
+        def _to_config(self) -> InvalidModelClientConfig:
+            return InvalidModelClientConfig(info=self.info)
+
+        @classmethod
+        def _from_config(cls, config: InvalidModelClientConfig) -> Self:
+            return cls(info=config.info)
+
+
+def test_fails_to_save_on_missing_attributes() -> None:
+    comp = MyInvalidMissingAttrs("test")  # type: ignore
+    with pytest.raises(AttributeError):
+        comp.dump_component()
+
+
+def test_schema_validation_fails_on_bad_config() -> None:
+    class OtherConfig(BaseModel):
+        other: str
+
+    config = OtherConfig(other="test")
+    model = ComponentModel(
+        provider=_type_to_provider_str(MyComponent),
+        component_type=MyComponent.component_type,
+        version=1,
+        description=None,
+        config=config,
+    )
+    with pytest.raises(ValidationError):
+        _ = MyComponent.load_component(model)

--- a/python/packages/autogen-core/tests/test_component_config.py
+++ b/python/packages/autogen-core/tests/test_component_config.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing_extensions import Self
+
+import pytest
+from autogen_core import Component
+from autogen_core._component_config import ComponentLoader
+from autogen_core.models._model_client import ChatCompletionClient
+from autogen_test_utils import MyInnerComponent, MyOuterComponent
+from pydantic import BaseModel
+
+
+class MyConfig(BaseModel):
+    info: str
+
+
+class MyComponent(Component("custom", MyConfig)): # type: ignore
+    def __init__(self, info: str):
+        self.info = info
+
+    def _to_config(self) -> MyConfig:
+        return MyConfig(info=self.info)
+
+    @classmethod
+    def _from_config(cls, config: MyConfig) -> MyComponent:
+        return cls(info=config.info)
+
+
+def test_custom_component():
+    comp = MyComponent("test")
+    comp2 = MyComponent.load_component(comp.dump_component())
+    assert comp.info == comp2.info
+    assert comp.__class__ == comp2.__class__
+
+
+def test_custom_component_generic_loader():
+    comp = MyComponent("test")
+    comp2 = ComponentLoader.load_component(comp.dump_component(), MyComponent)
+    assert comp.info == comp2.info
+    assert comp.__class__ == comp2.__class__
+
+
+def test_custom_component_incorrect_class():
+    comp = MyComponent("test")
+
+    with pytest.raises(TypeError):
+        _ = ComponentLoader.load_component(comp.dump_component(), str)
+
+
+def test_nested_component_diff_module():
+    inner_class = MyInnerComponent("inner")
+    comp = MyOuterComponent("test", inner_class)
+    dumped = comp.dump_component()
+    comp2 = MyOuterComponent.load_component(dumped)
+    assert comp.__class__ == comp2.__class__
+    assert comp.outer_message == comp2.outer_message
+    assert comp.inner_class.inner_message == comp2.inner_class.inner_message
+    assert comp.inner_class.__class__ == comp2.inner_class.__class__
+
+
+def test_cannot_import_locals():
+    class InvalidModelClientConfig(BaseModel):
+        info: str
+
+    class MyInvalidModelClient(Component("model", InvalidModelClientConfig)):
+        def __init__(self, info: str):
+            self.info = info
+
+        def _to_config(self) -> InvalidModelClientConfig:
+            return InvalidModelClientConfig(info=self.info)
+
+        @classmethod
+        def _from_config(cls, config: InvalidModelClientConfig) -> Self:
+            return cls(info=config.info)
+
+    comp = MyInvalidModelClient("test")
+    with pytest.raises(TypeError):
+        # Fails due to the class not being importable
+        ChatCompletionClient.load_component(comp.dump_component())
+
+
+class InvalidModelClientConfig(BaseModel):
+    info: str
+
+
+class MyInvalidModelClient(Component("model", InvalidModelClientConfig)):
+    def __init__(self, info: str):
+        self.info = info
+
+    def _to_config(self) -> InvalidModelClientConfig:
+        return InvalidModelClientConfig(info=self.info)
+
+    @classmethod
+    def _from_config(cls, config: InvalidModelClientConfig) -> Self:
+        return cls(info=config.info)
+
+
+def test_type_error_on_creation():
+    comp = MyInvalidModelClient("test")
+    # Fails due to MyInvalidModelClient not being a
+    with pytest.raises(TypeError):
+        ChatCompletionClient.load_component(comp.dump_component())

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_azure_token_provider.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_azure_token_provider.py
@@ -1,0 +1,50 @@
+from typing import List, Self
+from azure.core.credentials import TokenProvider
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from autogen_core import Component
+from pydantic import BaseModel
+
+class TokenProviderConfig(BaseModel):
+    provider_kind: str
+    scopes: List[str]
+
+class AzureTokenProvider(Component("token", TokenProviderConfig)):
+    def __init__(self, credential: TokenProvider, *scopes: str):
+        self.credential = credential
+        self.scopes = list(scopes)
+        self.provider = get_bearer_token_provider(self.credential, *self.scopes)
+
+    def __call__(self) -> str:
+        return self.provider()
+
+    def _to_config(self) -> TokenProviderConfig:
+        """Dump the configuration that would be requite to create a new instance of a component matching the configuration of this instance.
+
+        Returns:
+            T: The configuration of the component.
+        """
+
+        if isinstance(self.credential, DefaultAzureCredential):
+            # we are not currently inspecting the chained credentials
+            return TokenProviderConfig(provider_kind="DefaultAzureCredential", scopes=self.scopes)
+        else:
+            raise ValueError("Only DefaultAzureCredential is supported")
+
+
+    @classmethod
+    def _from_config(cls, config: TokenProviderConfig) -> Self:
+        """Create a new instance of the component from a configuration object.
+
+        Args:
+            config (T): The configuration object.
+
+        Returns:
+            Self: The new instance of the component.
+        """
+
+        if config.provider_kind == "DefaultAzureCredential":
+            return cls(DefaultAzureCredential(), *config.scopes)
+        else:
+            raise ValueError("Only DefaultAzureCredential is supported")
+
+

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -3,6 +3,8 @@ from typing import Awaitable, Callable, Dict, List, Literal, Optional, Union
 from autogen_core.models import ModelCapabilities
 from typing_extensions import Required, TypedDict
 
+from autogen_ext.models.openai._azure_token_provider import AzureTokenProvider
+
 
 class ResponseFormat(TypedDict):
     type: Literal["text", "json_object"]
@@ -46,7 +48,7 @@ class AzureOpenAIClientConfiguration(BaseOpenAIClientConfiguration, total=False)
     azure_deployment: str
     api_version: Required[str]
     azure_ad_token: str
-    azure_ad_token_provider: AsyncAzureADTokenProvider
+    azure_ad_token_provider: AsyncAzureADTokenProvider | AzureTokenProvider
 
 
 __all__ = ["AzureOpenAIClientConfiguration", "OpenAIClientConfiguration"]

--- a/python/packages/autogen-ext/src/autogen_ext/models/replay/_replay_chat_completion_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/replay/_replay_chat_completion_client.py
@@ -16,7 +16,7 @@ from autogen_core.tools import Tool, ToolSchema
 logger = logging.getLogger(EVENT_LOGGER_NAME)
 
 
-class ReplayChatCompletionClient:
+class ReplayChatCompletionClient(ChatCompletionClient):
     """
     A mock chat completion client that replays predefined responses using an index-based approach.
 

--- a/python/packages/autogen-test-utils/src/autogen_test_utils/__init__.py
+++ b/python/packages/autogen-test-utils/src/autogen_test_utils/__init__.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from autogen_core import BaseAgent, DefaultTopicId, MessageContext, RoutedAgent, default_subscription, message_handler
-
+from autogen_core._component_config import ComponentConfig, ComponentLoader, ComponentModel
+from pydantic import BaseModel
+from autogen_core import Component
 
 @dataclass
 class MessageType: ...
@@ -58,3 +61,39 @@ class NoopAgent(BaseAgent):
 
     async def on_message_impl(self, message: Any, ctx: MessageContext) -> Any:
         raise NotImplementedError
+
+
+
+class MyInnerConfig(BaseModel):
+    inner_message: str
+
+
+class MyInnerComponent(Component("custom", MyInnerConfig)):
+    def __init__(self, inner_message: str):
+        self.inner_message = inner_message
+
+    def _to_config(self) -> MyInnerConfig:
+        return MyInnerConfig(inner_message=self.inner_message)
+
+    @classmethod
+    def _from_config(cls, config: MyInnerConfig) -> MyInnerComponent:
+        return cls(inner_message=config.inner_message)
+
+class MyOuterConfig(BaseModel):
+    outer_message: str
+    inner_class: ComponentModel
+
+
+class MyOuterComponent(Component("custom", MyOuterConfig)):
+    def __init__(self, outer_message: str, inner_class: MyInnerComponent):
+        self.outer_message = outer_message
+        self.inner_class = inner_class
+
+    def _to_config(self) -> MyOuterConfig:
+        inner_component_config = self.inner_class.dump_component()
+        return MyOuterConfig(outer_message=self.outer_message, inner_class=inner_component_config)
+
+    @classmethod
+    def _from_config(cls, config: MyOuterConfig) -> MyOuterComponent:
+        inner = MyInnerComponent.load_component(config.inner_class)
+        return cls(outer_message=config.outer_message, inner_class=inner)

--- a/python/packages/autogen-test-utils/src/autogen_test_utils/__init__.py
+++ b/python/packages/autogen-test-utils/src/autogen_test_utils/__init__.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import Any, Literal
 
-from autogen_core import BaseAgent, DefaultTopicId, MessageContext, RoutedAgent, default_subscription, message_handler
-from autogen_core._component_config import ComponentConfig, ComponentLoader, ComponentModel
+from dataclasses import dataclass
+from typing import Any
+
+from autogen_core import (
+    BaseAgent,
+    Component,
+    DefaultTopicId,
+    MessageContext,
+    RoutedAgent,
+    default_subscription,
+    message_handler,
+)
+from autogen_core._component_config import ComponentModel
 from pydantic import BaseModel
-from autogen_core import Component
+
 
 @dataclass
 class MessageType: ...
@@ -63,12 +72,14 @@ class NoopAgent(BaseAgent):
         raise NotImplementedError
 
 
-
 class MyInnerConfig(BaseModel):
     inner_message: str
 
 
-class MyInnerComponent(Component("custom", MyInnerConfig)):
+class MyInnerComponent(Component[MyInnerConfig]):
+    config_schema = MyInnerConfig
+    component_type = "custom"
+
     def __init__(self, inner_message: str):
         self.inner_message = inner_message
 
@@ -79,12 +90,16 @@ class MyInnerComponent(Component("custom", MyInnerConfig)):
     def _from_config(cls, config: MyInnerConfig) -> MyInnerComponent:
         return cls(inner_message=config.inner_message)
 
+
 class MyOuterConfig(BaseModel):
     outer_message: str
     inner_class: ComponentModel
 
 
-class MyOuterComponent(Component("custom", MyOuterConfig)):
+class MyOuterComponent(Component[MyOuterConfig]):
+    config_schema = MyOuterConfig
+    component_type = "custom"
+
     def __init__(self, outer_message: str, inner_class: MyInnerComponent):
         self.outer_message = outer_message
         self.inner_class = inner_class


### PR DESCRIPTION
Component config adds a generic way for classes to opt in to being declaratively specified.

For example:
```python
from __future__ import annotations

from autogen_core import Component
from pydantic import BaseModel


class Config(BaseModel):
    value: str


class MyComponent(Component[Config]):
    component_type = "custom"
    config_schema = Config

    def __init__(self, value: str):
        self.value = value

    def _to_config(self) -> Config:
        return Config(value=self.value)

    @classmethod
    def _from_config(cls, config: Config) -> MyComponent:
        return cls(value=config.value)
```