### PR TITLE
fix(magentic-one): Remove redundant exception raising in update_ledger

### DIFF
--- a/python/packages/autogen-magentic-one/src/autogen_magentic_one/agents/orchestrator.py
+++ b/python/packages/autogen-magentic-one/src/autogen_magentic_one/agents/orchestrator.py
@@ -256,7 +256,6 @@ class LedgerOrchestrator(BaseOrchestrator):
                         f"Failed to parse ledger information: {ledger_str}",
                     )
                 )
-                raise e
 
         raise ValueError("Failed to parse ledger information after multiple retries.")
 

--- a/python/packages/autogen-magentic-one/src/autogen_magentic_one/agents/orchestrator.py
+++ b/python/packages/autogen-magentic-one/src/autogen_magentic_one/agents/orchestrator.py
@@ -249,7 +249,7 @@ class LedgerOrchestrator(BaseOrchestrator):
                 if key_error:
                     continue
                 return ledger_dict
-            except json.JSONDecodeError as e:
+            except json.JSONDecodeError:
                 self.logger.info(
                     OrchestrationEvent(
                         f"{self.metadata['type']} (error)",


### PR DESCRIPTION
magentic-one, ledger orchestrator
update_ledger handles exception, and has a retry mechnism in place to allow up to 10 retries but will fail on the first since its reraising the JSON decoding error.

## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
