### PR TITLE
Fix tracking SelectorGroupChat tokens with new Message type

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_task.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_task.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import AsyncGenerator, List, Protocol, Sequence
 
 from autogen_core import CancellationToken
+from autogen_core.models._types import RequestUsage
 
 from ..messages import AgentEvent, ChatMessage
 
@@ -15,6 +16,9 @@ class TaskResult:
 
     stop_reason: str | None = None
     """The reason the task stopped."""
+
+    usage: RequestUsage | None = None
+    """The usage of the task."""
 
 
 class TaskRunner(Protocol):

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
@@ -101,11 +101,23 @@ class ToolCallExecutionEvent(BaseMessage):
     type: Literal["ToolCallExecutionEvent"] = "ToolCallExecutionEvent"
 
 
+class UsageEvent(BaseMessage):
+    """An event signaling the usage of a model."""
+
+    content: str = ""
+    """The content of the usage event."""
+
+    models_usage: RequestUsage
+    """The model client usage incurred when producing this message."""
+
+    type: Literal["UsageEvent"] = "UsageEvent"
+
+
 ChatMessage = Annotated[TextMessage | MultiModalMessage | StopMessage | HandoffMessage, Field(discriminator="type")]
 """Messages for agent-to-agent communication only."""
 
 
-AgentEvent = Annotated[ToolCallRequestEvent | ToolCallExecutionEvent, Field(discriminator="type")]
+AgentEvent = Annotated[ToolCallRequestEvent | ToolCallExecutionEvent | UsageEvent, Field(discriminator="type")]
 """Events emitted by agents and teams when they work, not used for agent-to-agent communication."""
 
 

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -2,7 +2,10 @@ import logging
 import re
 from typing import Any, Callable, Dict, List, Mapping, Sequence
 
+from autogen_core._default_topic import DefaultTopicId
 from autogen_core.models import ChatCompletionClient, SystemMessage
+
+from autogen_agentchat.teams._group_chat._events import GroupChatMessage
 
 from ... import TRACE_LOGGER_NAME
 from ...base import ChatAgent, TerminationCondition
@@ -15,6 +18,7 @@ from ...messages import (
     TextMessage,
     ToolCallExecutionEvent,
     ToolCallRequestEvent,
+    UsageEvent,
 )
 from ...state import SelectorManagerState
 from ._base_group_chat import BaseGroupChat
@@ -152,6 +156,12 @@ class SelectorGroupChatManager(BaseGroupChatManager):
             agent_name = participants[0]
         self._previous_speaker = agent_name
         trace_logger.debug(f"Selected speaker: {agent_name}")
+
+        await self.publish_message(
+            GroupChatMessage(message=UsageEvent(source=self._id._type, models_usage=response.usage)),
+            topic_id=DefaultTopicId(type=self._output_topic_type),
+        )
+
         return agent_name
 
     def _mentioned_agents(self, message_content: str, agent_names: List[str]) -> Dict[str, int]:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
@@ -7,7 +7,7 @@ from autogen_core import Image
 from autogen_core.models import RequestUsage
 
 from autogen_agentchat.base import Response, TaskResult
-from autogen_agentchat.messages import AgentEvent, ChatMessage, MultiModalMessage
+from autogen_agentchat.messages import AgentEvent, ChatMessage, MultiModalMessage, UsageEvent
 
 
 def _is_running_in_iterm() -> bool:
@@ -90,7 +90,9 @@ async def Console(
             sys.stdout.flush()
             # mypy ignore
             last_processed = message  # type: ignore
-
+        elif isinstance(message, UsageEvent):
+            total_usage.completion_tokens += message.models_usage.completion_tokens
+            total_usage.prompt_tokens += message.models_usage.prompt_tokens
         else:
             # Cast required for mypy to be happy
             message = cast(AgentEvent | ChatMessage, message)  # type: ignore


### PR DESCRIPTION
The below changes are not meant to be merged but rather are here to open a discussion about how to correctly track the token usage for the calls that occur internally to some agents/teams such as the SelectorGroupChat.


## Why are these changes needed?


## Related issue number

#4719 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
