### PR TITLE
Track SelectorGroupChat token usage with new Message type

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_task.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_task.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import AsyncGenerator, List, Protocol, Sequence
 
 from autogen_core import CancellationToken
+from autogen_core.models._types import RequestUsage
 
 from ..messages import AgentEvent, ChatMessage
 
@@ -15,6 +16,9 @@ class TaskResult:
 
     stop_reason: str | None = None
     """The reason the task stopped."""
+
+    usage: RequestUsage | None = None
+    """The usage of the task."""
 
 
 class TaskRunner(Protocol):

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
@@ -110,13 +110,25 @@ class ToolCallSummaryMessage(BaseMessage):
     type: Literal["ToolCallSummaryMessage"] = "ToolCallSummaryMessage"
 
 
+class UsageEvent(BaseMessage):
+    """An event signaling the usage of a model."""
+
+    content: str = ""
+    """The content of the usage event."""
+
+    models_usage: RequestUsage
+    """The model client usage incurred when producing this message."""
+
+    type: Literal["UsageEvent"] = "UsageEvent"
+
+
 ChatMessage = Annotated[
     TextMessage | MultiModalMessage | StopMessage | ToolCallSummaryMessage | HandoffMessage, Field(discriminator="type")
 ]
 """Messages for agent-to-agent communication only."""
 
 
-AgentEvent = Annotated[ToolCallRequestEvent | ToolCallExecutionEvent, Field(discriminator="type")]
+AgentEvent = Annotated[ToolCallRequestEvent | ToolCallExecutionEvent | UsageEvent, Field(discriminator="type")]
 """Events emitted by agents and teams when they work, not used for agent-to-agent communication."""
 
 

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
@@ -7,7 +7,7 @@ from autogen_core import Image
 from autogen_core.models import RequestUsage
 
 from autogen_agentchat.base import Response, TaskResult
-from autogen_agentchat.messages import AgentEvent, ChatMessage, MultiModalMessage
+from autogen_agentchat.messages import AgentEvent, ChatMessage, MultiModalMessage, UsageEvent
 
 
 def _is_running_in_iterm() -> bool:
@@ -90,7 +90,9 @@ async def Console(
             sys.stdout.flush()
             # mypy ignore
             last_processed = message  # type: ignore
-
+        elif isinstance(message, UsageEvent):
+            total_usage.completion_tokens += message.models_usage.completion_tokens
+            total_usage.prompt_tokens += message.models_usage.prompt_tokens
         else:
             # Cast required for mypy to be happy
             message = cast(AgentEvent | ChatMessage, message)  # type: ignore


### PR DESCRIPTION
The below changes are not meant to be merged but rather are here to open a discussion about how to correctly track the token usage for the calls that occur internally in some agents/teams such as the SelectorGroupChat.

The problem is how do we pass a message from `SelectorGroupChat.select_speaker()` to somewhere where we are tracking the token usage (specifically we want to also track the tokens used inside `select_speaker`)? I thought about publishing to the `output_topic` a new type of Message, one that tracks only Token Usage, however, in the future it could track other things that are not meant to be consumed by the agents. 

### To consider
**Some tests are failing!**
- The tests for `SelectorGroupChat` are failing because `SelectorGroupChat.run(...)`  is generating more messages than expected, that's because `BaseGroupChat` is additionally yielding the new `UsageEvent` messages. We need to yield them for Console to receive them and account them
- Fix: We can make it so that `BaseGroupChat` only yields messages that are not `UsageEvent`, note that these messages would still be considering when computing the token usage that gets return with the `TaskResult`.
- Problem the above fix: `Console`  would no longer be receiving `UsageEvent` needed for its internal token_usage track.


## Why are these changes needed?



## Related issue number

https://github.com/microsoft/autogen/issues/4719

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
