### PR TITLE
Add MagenticOne CLI

### DIFF
--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "autogen-core==0.4.0.dev11",
 ]
 
+[project.scripts]
+m1 = "autogen_ext.teams.magentic_one_cli:main"
 
 [project.optional-dependencies]
 langchain = ["langchain_core~= 0.3.3"]
@@ -58,7 +60,6 @@ packages = ["src/autogen_ext"]
 dev-dependencies = [
     "autogen_test_utils"
 ]
-
 
 [tool.ruff]
 extend = "../../pyproject.toml"

--- a/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
+++ b/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
@@ -6,6 +6,21 @@ from autogen_ext.teams.magentic_one import MagenticOne
 from autogen_agentchat.ui import Console
 
 def main():
+    """
+    Command-line interface for running a complex task using MagenticOne.
+
+    This script accepts a single task string and an optional flag to disable
+    human-in-the-loop mode. It initializes the necessary clients and runs the
+    task using the MagenticOne class.
+
+    Arguments:
+    task (str): The task to be executed by MagenticOne.
+    --no-hil: Optional flag to disable human-in-the-loop mode.
+
+    Example usage:
+    python magentic_one_cli.py "example task"
+    python magentic_one_cli.py "example task" --no-hil
+    """
     parser = argparse.ArgumentParser(
         description=(
             "Run a complex task using MagenticOne.\n\n"

--- a/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
+++ b/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
@@ -1,0 +1,28 @@
+import asyncio
+import argparse
+import shlex
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.teams.magentic_one import MagenticOne
+from autogen_agentchat.ui import Console
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a complex task using MagenticOne.\n\n"
+            "For more information, refer to the following paper: https://arxiv.org/abs/2411.04468"
+        )
+    )
+    parser.add_argument('task', type=str, nargs='*', help='The task to be executed by MagenticOne.')
+    parser.add_argument('--no-hil', action='store_true', help='Disable human-in-the-loop mode.')
+    args = parser.parse_args()
+
+    async def run_task(task, hil_mode):
+        client = OpenAIChatCompletionClient(model="gpt-4o")
+        m1 = MagenticOne(client=client, hil_mode=hil_mode)
+        await Console(m1.run_stream(task=task))
+
+    task = ' '.join(shlex.split(' '.join(args.task)))
+    asyncio.run(run_task(task, not args.no_hil))
+
+if __name__ == "__main__":
+    main()

--- a/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
+++ b/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
@@ -12,7 +12,7 @@ def main():
             "For more information, refer to the following paper: https://arxiv.org/abs/2411.04468"
         )
     )
-    parser.add_argument('task', type=str, nargs='*', help='The task to be executed by MagenticOne.')
+    parser.add_argument('task', type=str, nargs=1, help='The task to be executed by MagenticOne.')
     parser.add_argument('--no-hil', action='store_true', help='Disable human-in-the-loop mode.')
     args = parser.parse_args()
 
@@ -21,7 +21,7 @@ def main():
         m1 = MagenticOne(client=client, hil_mode=hil_mode)
         await Console(m1.run_stream(task=task))
 
-    task = ' '.join(shlex.split(' '.join(args.task)))
+    task = args.task[0]
     asyncio.run(run_task(task, not args.no_hil))
 
 if __name__ == "__main__":

--- a/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
+++ b/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
@@ -19,7 +19,7 @@ def main():
 
     Example usage:
     python magentic_one_cli.py "example task"
-    python magentic_one_cli.py "example task" --no-hil
+    python magentic_one_cli.py --no-hil "example task" 
     """
     parser = argparse.ArgumentParser(
         description=(

--- a/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
+++ b/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py
@@ -1,9 +1,11 @@
-import asyncio
 import argparse
-import shlex
+import asyncio
+
+from autogen_agentchat.ui import Console
+
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from autogen_ext.teams.magentic_one import MagenticOne
-from autogen_agentchat.ui import Console
+
 
 def main():
     """
@@ -19,7 +21,7 @@ def main():
 
     Example usage:
     python magentic_one_cli.py "example task"
-    python magentic_one_cli.py --no-hil "example task" 
+    python magentic_one_cli.py --no-hil "example task"
     """
     parser = argparse.ArgumentParser(
         description=(
@@ -27,8 +29,8 @@ def main():
             "For more information, refer to the following paper: https://arxiv.org/abs/2411.04468"
         )
     )
-    parser.add_argument('task', type=str, nargs=1, help='The task to be executed by MagenticOne.')
-    parser.add_argument('--no-hil', action='store_true', help='Disable human-in-the-loop mode.')
+    parser.add_argument("task", type=str, nargs=1, help="The task to be executed by MagenticOne.")
+    parser.add_argument("--no-hil", action="store_true", help="Disable human-in-the-loop mode.")
     args = parser.parse_args()
 
     async def run_task(task, hil_mode):
@@ -38,6 +40,7 @@ def main():
 
     task = args.task[0]
     asyncio.run(run_task(task, not args.no_hil))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Extends #4782 

This pull request introduces a new CLI tool for running tasks using the MagenticOne model and updates the project configuration to include this new script. The most important changes include adding the script entry point to the project configuration and implementing the CLI tool itself.

### Usage:
```bash
pip install autogen_ext
m1 "How many people are there in MSR HAX group"
```

### Project Configuration Updates:
* [`python/packages/autogen-ext/pyproject.toml`](diffhunk://#diff-095119d4420ff09059557bd25681211d1772c2be0fbe0ff2d551a3726eff1b4bR21-R22): Added a new script entry point `m1` for the `autogen_ext.teams.magentic_one_cli:main` function.

### New CLI Tool Implementation:
* [`python/packages/autogen-ext/src/autogen_ext/teams/magentic_one_cli.py`](diffhunk://#diff-07da23716f39f5d3f6f0f9d8869638db2e5034fad2fb8a544e54828270f44c5bR1-R28): Implemented a new CLI tool that allows users to run complex tasks using the MagenticOne model, with optional human-in-the-loop mode.


https://github.com/user-attachments/assets/88d7225c-e9a7-4ffc-ba09-331ab70a69f6

