### PR TITLE
Auto Hashing ID for VectorDB Classes (#4746)

### DIFF
--- a/autogen/agentchat/contrib/vectordb/qdrant.py
+++ b/autogen/agentchat/contrib/vectordb/qdrant.py
@@ -1,6 +1,7 @@
 import abc
+import hashlib
 import logging
-import os
+import uuid
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 from .base import Document, ItemID, QueryResults, VectorDB
@@ -154,6 +155,18 @@ class QdrantVectorDB(VectorDB):
             Any
         """
         return self.client.delete_collection(collection_name)
+
+    def generate_chunk_ids(chunks: List[str]) -> List[ItemID]:
+        """
+        Generate chunk IDs to ensure non-duplicate uploads.
+
+        Args:
+            chunks (list): A list of chunks (strings) to hash.
+
+        Returns:
+            list: A list of generated chunk IDs.
+        """
+        return [str(uuid.UUID(hex=hashlib.md5(chunk.encode("utf-8")).hexdigest())) for chunk in chunks]
 
     def insert_docs(self, docs: List[Document], collection_name: str = None, upsert: bool = False) -> None:
         """


### PR DESCRIPTION
* MongoDB ID None allow and pre made embeddings allow

* tests for MongoDB change

* Add support for generating hashed IDs for documents in vector databases

* scaled back approach, removed embedding work, updated tests, single focus PR

* Duplicate content search message and error adjustment.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To run openai tests for PR #4746 .  @mattbeardey

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
