### PR TITLE
Fix pydantic warnings when saving state

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/state/_states.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/state/_states.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, Optional
+from typing import Annotated, Any, List, Mapping, Optional
 
 from pydantic import BaseModel, Field
 
@@ -6,6 +6,9 @@ from ..messages import (
     AgentEvent,
     ChatMessage,
 )
+
+# Ensures pydantic can distinguish between types of events & messages.
+_AgentMessage = Annotated[AgentEvent | ChatMessage, Field(discriminator="type")]
 
 
 class BaseState(BaseModel):
@@ -33,7 +36,7 @@ class TeamState(BaseState):
 class BaseGroupChatManagerState(BaseState):
     """Base state for all group chat managers."""
 
-    message_thread: List[AgentEvent | ChatMessage] = Field(default_factory=list)
+    message_thread: List[_AgentMessage] = Field(default_factory=list)
     current_turn: int = Field(default=0)
     type: str = Field(default="BaseGroupChatManagerState")
 


### PR DESCRIPTION
## Why are these changes needed?

Removes warnings coming from pydantic being unable to determine allowed message classes.

## Related issue number

Closes #4791

## Checks

- Checked that the script from the issue now works as intended
- I am happy to add a test in `autogen-agentchat/tests/test_group_chat.py` to assert that no warnings are generated when state is generated by pydantic, but thought that was a bit overkill.
