### PR TITLE
Refine types in agentchat

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Mapping,
     Sequence,
+    Tuple,
 )
 
 from autogen_core import CancellationToken, FunctionCall
@@ -294,14 +295,14 @@ class AssistantAgent(BaseChatAgent):
         self._is_running = False
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
         """The types of messages that the assistant agent produces."""
         message_types: List[type[ChatMessage]] = [TextMessage]
         if self._handoffs:
             message_types.append(HandoffMessage)
         if self._tools:
             message_types.append(ToolCallSummaryMessage)
-        return message_types
+        return tuple(message_types)
 
     async def on_messages(self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken) -> Response:
         async for message in self.on_messages_stream(messages, cancellation_token):

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Sequence
+from typing import List, Sequence, Tuple
 
 from autogen_core import CancellationToken
 from autogen_core.code_executor import CodeBlock, CodeExecutor
@@ -80,9 +80,9 @@ class CodeExecutorAgent(BaseChatAgent):
         self._code_executor = code_executor
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
         """The types of messages that the code executor agent produces."""
-        return [TextMessage]
+        return (TextMessage,)
 
     async def on_messages(self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken) -> Response:
         # Extract code blocks from the messages.

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_society_of_mind_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_society_of_mind_agent.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncGenerator, List, Mapping, Sequence
+from typing import Any, AsyncGenerator, List, Mapping, Sequence, Tuple
 
 from autogen_core import CancellationToken
 from autogen_core.models import ChatCompletionClient, LLMMessage, SystemMessage, UserMessage
@@ -9,10 +9,8 @@ from autogen_agentchat.state import SocietyOfMindAgentState
 from ..base import TaskResult, Team
 from ..messages import (
     AgentEvent,
+    BaseChatMessage,
     ChatMessage,
-    HandoffMessage,
-    MultiModalMessage,
-    StopMessage,
     TextMessage,
 )
 from ._base_chat_agent import BaseChatAgent
@@ -105,8 +103,8 @@ class SocietyOfMindAgent(BaseChatAgent):
         self._response_prompt = response_prompt
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
-        return [TextMessage]
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
+        return (TextMessage,)
 
     async def on_messages(self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken) -> Response:
         # Call the stream method and collect the messages.
@@ -150,7 +148,7 @@ class SocietyOfMindAgent(BaseChatAgent):
                 [
                     UserMessage(content=message.content, source=message.source)
                     for message in inner_messages
-                    if isinstance(message, TextMessage | MultiModalMessage | StopMessage | HandoffMessage)
+                    if isinstance(message, BaseChatMessage)
                 ]
             )
             llm_messages.append(SystemMessage(content=self._response_prompt))

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py
@@ -1,6 +1,6 @@
 import asyncio
 from inspect import iscoroutinefunction
-from typing import Awaitable, Callable, List, Optional, Sequence, Union, cast
+from typing import Awaitable, Callable, Optional, Sequence, Tuple, Union, cast
 
 from aioconsole import ainput  # type: ignore
 from autogen_core import CancellationToken
@@ -122,9 +122,9 @@ class UserProxyAgent(BaseChatAgent):
         self._is_async = iscoroutinefunction(self.input_func)
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
         """Message types this agent can produce."""
-        return [TextMessage, HandoffMessage]
+        return (TextMessage, HandoffMessage)
 
     def _get_latest_handoff(self, messages: Sequence[ChatMessage]) -> Optional[HandoffMessage]:
         """Find the HandoffMessage in the message sequence that addresses this agent."""

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_chat_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_chat_agent.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, AsyncGenerator, List, Mapping, Protocol, Sequence, runtime_checkable
+from typing import Any, AsyncGenerator, Mapping, Protocol, Sequence, Tuple, runtime_checkable
 
 from autogen_core import CancellationToken
 
@@ -14,8 +14,9 @@ class Response:
     chat_message: ChatMessage
     """A chat message produced by the agent as the response."""
 
-    inner_messages: List[AgentEvent | ChatMessage] | None = None
-    """Inner messages produced by the agent."""
+    inner_messages: Sequence[AgentEvent | ChatMessage] | None = None
+    """Inner messages produced by the agent, they can be :class:`AgentEvent`
+    or :class:`ChatMessage`."""
 
 
 @runtime_checkable
@@ -36,8 +37,9 @@ class ChatAgent(TaskRunner, Protocol):
         ...
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
-        """The types of messages that the agent produces."""
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
+        """The types of messages that the agent produces in the
+        :attr:`Response.chat_message` field. They must be :class:`ChatMessage` types."""
         ...
 
     async def on_messages(self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken) -> Response:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_task.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_task.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import AsyncGenerator, List, Protocol, Sequence
+from typing import AsyncGenerator, Protocol, Sequence
 
 from autogen_core import CancellationToken
 
@@ -23,10 +23,12 @@ class TaskRunner(Protocol):
     async def run(
         self,
         *,
-        task: str | ChatMessage | List[ChatMessage] | None = None,
+        task: str | ChatMessage | Sequence[ChatMessage] | None = None,
         cancellation_token: CancellationToken | None = None,
     ) -> TaskResult:
         """Run the task and return the result.
+
+        The task can be a string, a single message, or a sequence of messages.
 
         The runner is stateful and a subsequent call to this method will continue
         from where the previous call left off. If the task is not specified,
@@ -36,11 +38,13 @@ class TaskRunner(Protocol):
     def run_stream(
         self,
         *,
-        task: str | ChatMessage | List[ChatMessage] | None = None,
+        task: str | ChatMessage | Sequence[ChatMessage] | None = None,
         cancellation_token: CancellationToken | None = None,
     ) -> AsyncGenerator[AgentEvent | ChatMessage | TaskResult, None]:
         """Run the task and produces a stream of messages and the final result
         :class:`TaskResult` as the last item in the stream.
+
+        The task can be a string, a single message, or a sequence of messages.
 
         The runner is stateful and a subsequent call to this method will continue
         from where the previous call left off. If the task is not specified,

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -77,7 +77,7 @@ class TextMentionTermination(TerminationCondition):
         if self._terminated:
             raise TerminatedException("Termination condition has already been reached")
         for message in messages:
-            if isinstance(message, TextMessage | StopMessage) and self._text in message.content:
+            if isinstance(message.content, str) and self._text in message.content:
                 self._terminated = True
                 return StopMessage(content=f"Text '{self._text}' mentioned", source="TextMentionTermination")
             elif isinstance(message, MultiModalMessage):

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
@@ -1,9 +1,10 @@
 """
 This module defines various message types used for agent-to-agent communication.
-Each message type inherits from the BaseMessage class and includes specific fields
-relevant to the type of message being sent.
+Each message type inherits either from the BaseChatMessage class or BaseAgentEvent
+class and includes specific fields relevant to the type of message being sent.
 """
 
+from abc import ABC
 from typing import List, Literal
 
 from autogen_core import FunctionCall, Image
@@ -12,8 +13,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated, deprecated
 
 
-class BaseMessage(BaseModel):
-    """A base message."""
+class BaseMessage(BaseModel, ABC):
+    """Base class for all message types."""
 
     source: str
     """The name of the agent that sent this message."""
@@ -24,7 +25,19 @@ class BaseMessage(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class TextMessage(BaseMessage):
+class BaseChatMessage(BaseMessage, ABC):
+    """Base class for chat messages."""
+
+    pass
+
+
+class BaseAgentEvent(BaseMessage, ABC):
+    """Base class for agent events."""
+
+    pass
+
+
+class TextMessage(BaseChatMessage):
     """A text message."""
 
     content: str
@@ -33,7 +46,7 @@ class TextMessage(BaseMessage):
     type: Literal["TextMessage"] = "TextMessage"
 
 
-class MultiModalMessage(BaseMessage):
+class MultiModalMessage(BaseChatMessage):
     """A multimodal message."""
 
     content: List[str | Image]
@@ -42,7 +55,7 @@ class MultiModalMessage(BaseMessage):
     type: Literal["MultiModalMessage"] = "MultiModalMessage"
 
 
-class StopMessage(BaseMessage):
+class StopMessage(BaseChatMessage):
     """A message requesting stop of a conversation."""
 
     content: str
@@ -51,7 +64,7 @@ class StopMessage(BaseMessage):
     type: Literal["StopMessage"] = "StopMessage"
 
 
-class HandoffMessage(BaseMessage):
+class HandoffMessage(BaseChatMessage):
     """A message requesting handoff of a conversation to another agent."""
 
     target: str
@@ -83,7 +96,7 @@ class ToolCallResultMessage(BaseMessage):
     type: Literal["ToolCallResultMessage"] = "ToolCallResultMessage"
 
 
-class ToolCallRequestEvent(BaseMessage):
+class ToolCallRequestEvent(BaseAgentEvent):
     """An event signaling a request to use tools."""
 
     content: List[FunctionCall]
@@ -92,7 +105,7 @@ class ToolCallRequestEvent(BaseMessage):
     type: Literal["ToolCallRequestEvent"] = "ToolCallRequestEvent"
 
 
-class ToolCallExecutionEvent(BaseMessage):
+class ToolCallExecutionEvent(BaseAgentEvent):
     """An event signaling the execution of tool calls."""
 
     content: List[FunctionExecutionResult]
@@ -101,7 +114,7 @@ class ToolCallExecutionEvent(BaseMessage):
     type: Literal["ToolCallExecutionEvent"] = "ToolCallExecutionEvent"
 
 
-class ToolCallSummaryMessage(BaseMessage):
+class ToolCallSummaryMessage(BaseChatMessage):
     """A message signaling the summary of tool call results."""
 
     content: str

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, AsyncGenerator, Callable, List, Mapping, get_args
+from typing import Any, AsyncGenerator, Callable, List, Mapping, Sequence
 
 from autogen_core import (
     AgentId,
@@ -19,7 +19,7 @@ from autogen_core._closure_agent import ClosureContext
 
 from ... import EVENT_LOGGER_NAME
 from ...base import ChatAgent, TaskResult, Team, TerminationCondition
-from ...messages import AgentEvent, ChatMessage, TextMessage
+from ...messages import AgentEvent, BaseChatMessage, ChatMessage, TextMessage
 from ...state import TeamState
 from ._chat_agent_container import ChatAgentContainer
 from ._events import GroupChatMessage, GroupChatReset, GroupChatStart, GroupChatTermination
@@ -172,7 +172,7 @@ class BaseGroupChat(Team, ABC):
     async def run(
         self,
         *,
-        task: str | ChatMessage | List[ChatMessage] | None = None,
+        task: str | ChatMessage | Sequence[ChatMessage] | None = None,
         cancellation_token: CancellationToken | None = None,
     ) -> TaskResult:
         """Run the team and return the result. The base implementation uses
@@ -180,7 +180,7 @@ class BaseGroupChat(Team, ABC):
         Once the team is stopped, the termination condition is reset.
 
         Args:
-            task (str | ChatMessage | List[ChatMessage] | None): The task to run the team with. Can be a string, a single :class:`ChatMessage` , or a list of :class:`ChatMessage`.
+            task (str | ChatMessage | Sequence[ChatMessage] | None): The task to run the team with. Can be a string, a single :class:`ChatMessage` , or a list of :class:`ChatMessage`.
             cancellation_token (CancellationToken | None): The cancellation token to kill the task immediately.
                 Setting the cancellation token potentially put the team in an inconsistent state,
                 and it may not reset the termination condition.
@@ -271,7 +271,7 @@ class BaseGroupChat(Team, ABC):
     async def run_stream(
         self,
         *,
-        task: str | ChatMessage | List[ChatMessage] | None = None,
+        task: str | ChatMessage | Sequence[ChatMessage] | None = None,
         cancellation_token: CancellationToken | None = None,
     ) -> AsyncGenerator[AgentEvent | ChatMessage | TaskResult, None]:
         """Run the team and produces a stream of messages and the final result
@@ -279,7 +279,7 @@ class BaseGroupChat(Team, ABC):
         team is stopped, the termination condition is reset.
 
         Args:
-            task (str | ChatMessage | List[ChatMessage] | None): The task to run the team with. Can be a string, a single :class:`ChatMessage` , or a list of :class:`ChatMessage`.
+            task (str | ChatMessage | Sequence[ChatMessage] | None): The task to run the team with. Can be a string, a single :class:`ChatMessage` , or a list of :class:`ChatMessage`.
             cancellation_token (CancellationToken | None): The cancellation token to kill the task immediately.
                 Setting the cancellation token potentially put the team in an inconsistent state,
                 and it may not reset the termination condition.
@@ -368,14 +368,16 @@ class BaseGroupChat(Team, ABC):
             pass
         elif isinstance(task, str):
             messages = [TextMessage(content=task, source="user")]
-        elif isinstance(task, get_args(ChatMessage)[0]):
-            messages = [task]  # type: ignore
-        elif isinstance(task, list):
+        elif isinstance(task, BaseChatMessage):
+            messages = [task]
+        else:
             if not task:
-                raise ValueError("Task list cannot be empty")
-            if not all(isinstance(msg, get_args(ChatMessage)[0]) for msg in task):
-                raise ValueError("All messages in task list must be valid ChatMessage types")
-            messages = task
+                raise ValueError("Task list cannot be empty.")
+            messages = []
+            for msg in task:
+                if not isinstance(msg, BaseChatMessage):
+                    raise ValueError("All messages in task list must be valid ChatMessage types")
+                messages.append(msg)
 
         if self._is_running:
             raise ValueError("The team is already running, it cannot run again until it is stopped.")

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -8,14 +8,9 @@ from ... import TRACE_LOGGER_NAME
 from ...base import ChatAgent, TerminationCondition
 from ...messages import (
     AgentEvent,
+    BaseAgentEvent,
     ChatMessage,
-    HandoffMessage,
     MultiModalMessage,
-    StopMessage,
-    TextMessage,
-    ToolCallExecutionEvent,
-    ToolCallRequestEvent,
-    ToolCallSummaryMessage,
 )
 from ...state import SelectorManagerState
 from ._base_group_chat import BaseGroupChat
@@ -96,12 +91,12 @@ class SelectorGroupChatManager(BaseGroupChatManager):
         # Construct the history of the conversation.
         history_messages: List[str] = []
         for msg in thread:
-            if isinstance(msg, ToolCallRequestEvent | ToolCallExecutionEvent):
-                # Ignore tool call messages.
+            if isinstance(msg, BaseAgentEvent):
+                # Ignore agent events.
                 continue
             # The agent type must be the same as the topic type, which we use as the agent name.
             message = f"{msg.source}:"
-            if isinstance(msg, TextMessage | StopMessage | HandoffMessage | ToolCallSummaryMessage):
+            if isinstance(msg.content, str):
                 message += f" {msg.content}"
             elif isinstance(msg, MultiModalMessage):
                 for item in msg.content:

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import tempfile
-from typing import Any, AsyncGenerator, List, Sequence
+from typing import Any, AsyncGenerator, List, Sequence, Tuple
 
 import pytest
 from autogen_agentchat import EVENT_LOGGER_NAME
@@ -75,8 +75,8 @@ class _EchoAgent(BaseChatAgent):
         self._total_messages = 0
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
-        return [TextMessage]
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
+        return (TextMessage,)
 
     @property
     def total_messages(self) -> int:
@@ -104,8 +104,8 @@ class _StopAgent(_EchoAgent):
         self._stop_at = stop_at
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
-        return [TextMessage, StopMessage]
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
+        return (TextMessage, StopMessage)
 
     async def on_messages(self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken) -> Response:
         self._count += 1
@@ -797,8 +797,8 @@ class _HandOffAgent(BaseChatAgent):
         self._next_agent = next_agent
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
-        return [HandoffMessage]
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
+        return (HandoffMessage,)
 
     async def on_messages(self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken) -> Response:
         return Response(

--- a/python/packages/autogen-agentchat/tests/test_magentic_one_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_magentic_one_group_chat.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from typing import List, Sequence
+from typing import Sequence, Tuple
 
 import pytest
 from autogen_agentchat import EVENT_LOGGER_NAME
@@ -33,8 +33,8 @@ class _EchoAgent(BaseChatAgent):
         self._total_messages = 0
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
-        return [TextMessage]
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
+        return (TextMessage,)
 
     @property
     def total_messages(self) -> int:

--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py
@@ -63,8 +63,8 @@ class FileSurfer(BaseChatAgent):
         self._browser = MarkdownFileBrowser(viewport_size=1024 * 5)
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
-        return [TextMessage]
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
+        return (TextMessage,)
 
     async def on_messages(self, messages: Sequence[ChatMessage], cancellation_token: CancellationToken) -> Response:
         for chat_message in messages:

--- a/python/packages/autogen-ext/src/autogen_ext/agents/openai/_openai_assistant_agent.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/openai/_openai_assistant_agent.py
@@ -15,6 +15,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     Union,
     cast,
 )
@@ -298,9 +299,9 @@ class OpenAIAssistantAgent(BaseChatAgent):
         self._initial_message_ids = initial_message_ids
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
         """The types of messages that the assistant agent produces."""
-        return [TextMessage]
+        return (TextMessage,)
 
     @property
     def threads(self) -> AsyncThreads:

--- a/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/_multimodal_web_surfer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/_multimodal_web_surfer.py
@@ -15,6 +15,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     cast,
 )
 from urllib.parse import quote_plus
@@ -321,8 +322,8 @@ class MultimodalWebSurfer(BaseChatAgent):
             )
 
     @property
-    def produced_message_types(self) -> List[type[ChatMessage]]:
-        return [MultiModalMessage]
+    def produced_message_types(self) -> Tuple[type[ChatMessage], ...]:
+        return (MultiModalMessage,)
 
     async def on_reset(self, cancellation_token: CancellationToken) -> None:
         if not self.did_lazy_init:


### PR DESCRIPTION
Resolves #4783

Refined types in AgentChat so that now:

- `ChatAgent.produced_message_types` returns `Tuple[type[ChatMessage], ...]`
- `Response.inner_messages` is of type `Sequence[AgentEvent | ChatMessage]`
- `TaskRunner.run` accepts `Sequence[ChatMessage]`
- `TaskRunner.run_stream`, same as above. 