### PR TITLE
Added: Operator overloads for `Request Usage`

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/models/_types.py
+++ b/python/packages/autogen-core/src/autogen_core/models/_types.py
@@ -51,6 +51,25 @@ class RequestUsage:
     prompt_tokens: int
     completion_tokens: int
 
+    def __add__(self, other: "RequestUsage") -> "RequestUsage":
+        # Runtime type check ensures robustness, even though static analysis indicates unreachable code.
+        if not isinstance(other, RequestUsage):
+            raise TypeError(
+                f"Unsupported operand type(s) for +: 'RequestUsage' and '{type(other).__name__}'"
+            )
+        return RequestUsage(
+            prompt_tokens=self.prompt_tokens + other.prompt_tokens,
+            completion_tokens=self.completion_tokens + other.completion_tokens,
+        )
+
+    def __iadd__(self, other: "RequestUsage") -> "RequestUsage":
+        # Runtime type check ensures robustness, even though static analysis indicates unreachable code.
+        if not isinstance(other, RequestUsage):
+            return NotImplemented
+        self.prompt_tokens += other.prompt_tokens
+        self.completion_tokens += other.completion_tokens
+        return self
+
 
 FinishReasons = Literal["stop", "length", "function_calls", "content_filter"]
 


### PR DESCRIPTION
## Why are these changes needed?

This PR adds the operator overloads for `__add__` and `__iadd__`  for the `Request Usage` class. 

Currently we track usage via the `_add_usage` function that is part of the `open_ai` module in `autogen-ext`.  Considering this feature is needed by all model clients adding these methods to the class directly allows for re-use in other classes.

## Related issue number
Extends upon the conversation in #4770

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
