### PR TITLE
feat!: Add message context to signature of intervention handler, add more to docs

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/termination-with-intervention.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/termination-with-intervention.ipynb
@@ -23,7 +23,6 @@
     "from typing import Any\n",
     "\n",
     "from autogen_core import (\n",
-    "    AgentId,\n",
     "    DefaultInterventionHandler,\n",
     "    DefaultTopicId,\n",
     "    MessageContext,\n",
@@ -100,7 +99,7 @@
     "    def __init__(self) -> None:\n",
     "        self._termination_value: Termination | None = None\n",
     "\n",
-    "    async def on_publish(self, message: Any, *, sender: AgentId | None) -> Any:\n",
+    "    async def on_publish(self, message: Any, *, message_context: MessageContext) -> Any:\n",
     "        if isinstance(message, Termination):\n",
     "            self._termination_value = message\n",
     "        return message\n",
@@ -171,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/tool-use-with-intervention.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/tool-use-with-intervention.ipynb
@@ -131,7 +131,9 @@
    "outputs": [],
    "source": [
     "class ToolInterventionHandler(DefaultInterventionHandler):\n",
-    "    async def on_send(self, message: Any, *, sender: AgentId | None, recipient: AgentId) -> Any | type[DropMessage]:\n",
+    "    async def on_send(\n",
+    "        self, message: Any, *, message_context: MessageContext, recipient: AgentId\n",
+    "    ) -> Any | type[DropMessage]:\n",
     "        if isinstance(message, FunctionCall):\n",
     "            # Request user prompt for tool execution.\n",
     "            user_input = input(\n",

--- a/python/packages/autogen-core/samples/slow_human_in_loop.py
+++ b/python/packages/autogen-core/samples/slow_human_in_loop.py
@@ -31,7 +31,6 @@ from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 
 from autogen_core import (
-    AgentId,
     CancellationToken,
     DefaultInterventionHandler,
     DefaultTopicId,
@@ -211,7 +210,7 @@ class NeedsUserInputHandler(DefaultInterventionHandler):
     def __init__(self):
         self.question_for_user: GetSlowUserMessage | None = None
 
-    async def on_publish(self, message: Any, *, sender: AgentId | None) -> Any:
+    async def on_publish(self, message: Any, *, message_context: MessageContext) -> Any:
         if isinstance(message, GetSlowUserMessage):
             self.question_for_user = message
         return message
@@ -231,7 +230,7 @@ class TerminationHandler(DefaultInterventionHandler):
     def __init__(self):
         self.terminateMessage: TerminateMessage | None = None
 
-    async def on_publish(self, message: Any, *, sender: AgentId | None) -> Any:
+    async def on_publish(self, message: Any, *, message_context: MessageContext) -> Any:
         if isinstance(message, TerminateMessage):
             self.terminateMessage = message
         return message

--- a/python/packages/autogen-core/src/autogen_core/_intervention.py
+++ b/python/packages/autogen-core/src/autogen_core/_intervention.py
@@ -32,6 +32,7 @@ class InterventionHandler(Protocol):
 
         from autogen_core import DefaultInterventionHandler, MessageContext, AgentId, SingleThreadedAgentRuntime
         from dataclasses import dataclass
+        from typing import Any
 
 
         @dataclass

--- a/python/packages/autogen-core/src/autogen_core/_intervention.py
+++ b/python/packages/autogen-core/src/autogen_core/_intervention.py
@@ -1,6 +1,7 @@
 from typing import Any, Protocol, final
 
 from ._agent_id import AgentId
+from ._message_context import MessageContext
 
 __all__ = [
     "DropMessage",
@@ -10,20 +11,58 @@ __all__ = [
 
 
 @final
-class DropMessage: ...
+class DropMessage:
+    """Marker type for signalling that a message should be dropped by an intervention handler. The type itself should be returned from the handler."""
+
+    ...
 
 
 class InterventionHandler(Protocol):
     """An intervention handler is a class that can be used to modify, log or drop messages that are being processed by the :class:`autogen_core.base.AgentRuntime`.
 
+    The handler is called when the message is submitted to the runtime.
+
+    Currently the only runtime which supports this is the :class:`autogen_core.base.SingleThreadedAgentRuntime`.
+
     Note: Returning None from any of the intervention handler methods will result in a warning being issued and treated as "no change". If you intend to drop a message, you should return :class:`DropMessage` explicitly.
+
+    Example:
+
+    .. code-block:: python
+
+        from autogen_core import DefaultInterventionHandler, MessageContext, AgentId, SingleThreadedAgentRuntime
+        from dataclasses import dataclass
+
+
+        @dataclass
+        class MyMessage:
+            content: str
+
+
+        class MyInterventionHandler(DefaultInterventionHandler):
+            async def on_send(self, message: Any, *, message_context: MessageContext, recipient: AgentId) -> MyMessage:
+                if isinstance(message, MyMessage):
+                    message.content = message.content.upper()
+                return message
+
+
+        runtime = SingleThreadedAgentRuntime(intervention_handlers=[MyInterventionHandler()])
+
     """
 
-    async def on_send(self, message: Any, *, sender: AgentId | None, recipient: AgentId) -> Any | type[DropMessage]: ...
-    async def on_publish(self, message: Any, *, sender: AgentId | None) -> Any | type[DropMessage]: ...
-    async def on_response(
-        self, message: Any, *, sender: AgentId, recipient: AgentId | None
-    ) -> Any | type[DropMessage]: ...
+    async def on_send(
+        self, message: Any, *, message_context: MessageContext, recipient: AgentId
+    ) -> Any | type[DropMessage]:
+        """Called when a message is submitted to the AgentRuntime using :meth:`autogen_core.base.AgentRuntime.send_message`."""
+        ...
+
+    async def on_publish(self, message: Any, *, message_context: MessageContext) -> Any | type[DropMessage]:
+        """Called when a message is published to the AgentRuntime using :meth:`autogen_core.base.AgentRuntime.publish_message`."""
+        ...
+
+    async def on_response(self, message: Any, *, sender: AgentId, recipient: AgentId | None) -> Any | type[DropMessage]:
+        """Called when a response is received by the AgentRuntime from an Agent's message handler returning a value."""
+        ...
 
 
 class DefaultInterventionHandler(InterventionHandler):
@@ -31,10 +70,12 @@ class DefaultInterventionHandler(InterventionHandler):
     handler methods, that simply returns the message unchanged. Allows for easy
     subclassing to override only the desired methods."""
 
-    async def on_send(self, message: Any, *, sender: AgentId | None, recipient: AgentId) -> Any | type[DropMessage]:
+    async def on_send(
+        self, message: Any, *, message_context: MessageContext, recipient: AgentId
+    ) -> Any | type[DropMessage]:
         return message
 
-    async def on_publish(self, message: Any, *, sender: AgentId | None) -> Any | type[DropMessage]:
+    async def on_publish(self, message: Any, *, message_context: MessageContext) -> Any | type[DropMessage]:
         return message
 
     async def on_response(self, message: Any, *, sender: AgentId, recipient: AgentId | None) -> Any | type[DropMessage]:

--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -474,7 +474,16 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                             "intercept", handler.__class__.__name__, parent=message_envelope.metadata
                         ):
                             try:
-                                temp_message = await handler.on_send(message, sender=sender, recipient=recipient)
+                                message_context = MessageContext(
+                                    sender=sender,
+                                    topic_id=None,
+                                    is_rpc=True,
+                                    cancellation_token=message_envelope.cancellation_token,
+                                    message_id=message_envelope.message_id,
+                                )
+                                temp_message = await handler.on_send(
+                                    message, message_context=message_context, recipient=recipient
+                                )
                                 _warn_if_none(temp_message, "on_send")
                             except BaseException as e:
                                 future.set_exception(e)
@@ -506,7 +515,14 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                             "intercept", handler.__class__.__name__, parent=message_envelope.metadata
                         ):
                             try:
-                                temp_message = await handler.on_publish(message, sender=sender)
+                                message_context = MessageContext(
+                                    sender=sender,
+                                    topic_id=topic_id,
+                                    is_rpc=False,
+                                    cancellation_token=message_envelope.cancellation_token,
+                                    message_id=message_envelope.message_id,
+                                )
+                                temp_message = await handler.on_publish(message, message_context=message_context)
                                 _warn_if_none(temp_message, "on_publish")
                             except BaseException as e:
                                 # TODO: we should raise the intervention exception to the publisher.

--- a/python/packages/autogen-core/tests/test_intervention.py
+++ b/python/packages/autogen-core/tests/test_intervention.py
@@ -52,7 +52,7 @@ async def test_intervention_count_messages() -> None:
     runtime.start()
     await runtime.add_subscription(DefaultSubscription(agent_type="name"))
 
-    _response = await runtime.publish_message(MessageType(), topic_id=DefaultTopicId())
+    await runtime.publish_message(MessageType(), topic_id=DefaultTopicId())
 
     await runtime.stop_when_idle()
     assert loopback_agent.num_calls == 2

--- a/python/packages/autogen-core/tests/test_intervention.py
+++ b/python/packages/autogen-core/tests/test_intervention.py
@@ -1,5 +1,5 @@
 import pytest
-from autogen_core import AgentId, DefaultInterventionHandler, DropMessage, SingleThreadedAgentRuntime
+from autogen_core import AgentId, DefaultInterventionHandler, DropMessage, MessageContext, SingleThreadedAgentRuntime
 from autogen_core.exceptions import MessageDroppedException
 from autogen_test_utils import LoopbackAgent, MessageType
 
@@ -10,7 +10,9 @@ async def test_intervention_count_messages() -> None:
         def __init__(self) -> None:
             self.num_messages = 0
 
-        async def on_send(self, message: MessageType, *, sender: AgentId | None, recipient: AgentId) -> MessageType:
+        async def on_send(
+            self, message: MessageType, *, message_context: MessageContext, recipient: AgentId
+        ) -> MessageType:
             self.num_messages += 1
             return message
 
@@ -33,7 +35,7 @@ async def test_intervention_count_messages() -> None:
 async def test_intervention_drop_send() -> None:
     class DropSendInterventionHandler(DefaultInterventionHandler):
         async def on_send(
-            self, message: MessageType, *, sender: AgentId | None, recipient: AgentId
+            self, message: MessageType, *, message_context: MessageContext, recipient: AgentId
         ) -> MessageType | type[DropMessage]:
             return DropMessage
 
@@ -81,7 +83,7 @@ async def test_intervention_raise_exception_on_send() -> None:
 
     class ExceptionInterventionHandler(DefaultInterventionHandler):  # type: ignore
         async def on_send(
-            self, message: MessageType, *, sender: AgentId | None, recipient: AgentId
+            self, message: MessageType, *, message_context: MessageContext, recipient: AgentId
         ) -> MessageType | type[DropMessage]:  # type: ignore
             raise InterventionException
 

--- a/python/packages/autogen-core/tests/test_intervention.py
+++ b/python/packages/autogen-core/tests/test_intervention.py
@@ -1,10 +1,15 @@
 from typing import Any
 
 import pytest
-from autogen_core import AgentId, DefaultInterventionHandler, DropMessage, MessageContext, SingleThreadedAgentRuntime
-from autogen_core._default_subscription import DefaultSubscription
-from autogen_core._default_topic import DefaultTopicId
-from autogen_core._type_subscription import TypeSubscription
+from autogen_core import (
+    AgentId,
+    DefaultInterventionHandler,
+    DefaultSubscription,
+    DefaultTopicId,
+    DropMessage,
+    MessageContext,
+    SingleThreadedAgentRuntime,
+)
 from autogen_core.exceptions import MessageDroppedException
 from autogen_test_utils import LoopbackAgent, MessageType
 
@@ -13,20 +18,20 @@ from autogen_test_utils import LoopbackAgent, MessageType
 async def test_intervention_count_messages() -> None:
     class DebugInterventionHandler(DefaultInterventionHandler):
         def __init__(self) -> None:
-            self._num_send_messages = 0
-            self._num_publish_messages = 0
-            self._num_response_messages = 0
+            self.num_send_messages = 0
+            self.num_publish_messages = 0
+            self.num_response_messages = 0
 
         async def on_send(self, message: Any, *, message_context: MessageContext, recipient: AgentId) -> Any:
-            self._num_send_messages += 1
+            self.num_send_messages += 1
             return message
 
         async def on_publish(self, message: Any, *, message_context: MessageContext) -> Any:
-            self._num_publish_messages += 1
+            self.num_publish_messages += 1
             return message
 
         async def on_response(self, message: Any, *, sender: AgentId, recipient: AgentId | None) -> Any:
-            self._num_response_messages += 1
+            self.num_response_messages += 1
             return message
 
     handler = DebugInterventionHandler()
@@ -39,8 +44,8 @@ async def test_intervention_count_messages() -> None:
 
     await runtime.stop_when_idle()
 
-    assert handler._num_send_messages == 1
-    assert handler._num_response_messages == 1
+    assert handler.num_send_messages == 1
+    assert handler.num_response_messages == 1
     loopback_agent = await runtime.try_get_underlying_agent_instance(loopback, type=LoopbackAgent)
     assert loopback_agent.num_calls == 1
 
@@ -51,7 +56,7 @@ async def test_intervention_count_messages() -> None:
 
     await runtime.stop_when_idle()
     assert loopback_agent.num_calls == 2
-    assert handler._num_publish_messages == 1
+    assert handler.num_publish_messages == 1
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-test-utils/src/autogen_test_utils/telemetry_test_utils.py
+++ b/python/packages/autogen-test-utils/src/autogen_test_utils/telemetry_test_utils.py
@@ -1,6 +1,5 @@
 from typing import List, Sequence
 
-import pytest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
 


### PR DESCRIPTION
Breaking:
- This changes the signature of the `on_publish` and `on_send` method in the `InterventionHandler` class to include a `message_context` parameter instead of an `AgentId` parameter.

Closes #4003
Related #4349