### PR TITLE
Add getting started page for magentic one

### DIFF
--- a/python/packages/autogen-core/docs/src/images/autogen-magentic-one-agents.png
+++ b/python/packages/autogen-core/docs/src/images/autogen-magentic-one-agents.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25a3a1f79319b89d80b8459af8b522eb9a884dea842b11e3d7dae2bca30add5e
+size 90181

--- a/python/packages/autogen-core/docs/src/images/autogen-magentic-one-example.png
+++ b/python/packages/autogen-core/docs/src/images/autogen-magentic-one-example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc910bda7e5f3b54d6502f26384f7b10b67f0597d7ac4631dfb45801882768fa
+size 201460

--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -69,6 +69,30 @@ pip install "autogen-agentchat==0.4.0.dev13"
 <a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-secondary reference internal" href="user-guide/agentchat-user-guide/migration-guide.html"><span class="doc">Migration Guide (0.2.x to 0.4.x)</span></a>
 
 :::
+
+:::{grid-item-card}
+:shadow: none
+:margin: 2 0 0 0
+:columns: 12 12 12 12
+
+<div class="sd-card-title sd-font-weight-bold docutils">
+
+{fas}`book;pst-color-primary`
+Magentic-One </div>
+Magentic-One is a generalist multi-agent system for solving open-ended web and file-based tasks across a variety of domains.
+
++++
+
+
+```{button-ref} user-guide/agentchat-user-guide/magentic-one
+:color: secondary
+
+Get Started
+```
+
+:::
+
+
 :::{grid-item-card} {fas}`palette;pst-color-primary` Studio
 :shadow: none
 :margin: 2 0 0 0

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/index.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/index.md
@@ -31,6 +31,12 @@ How to install AgentChat
 Build your first agent
 :::
 
+:::{grid-item-card} {fas}`book;pst-color-primary` Magentic-One
+:link: ./magentic-one.html
+
+Get started with Magentic-One
+:::
+
 :::{grid-item-card} {fas}`graduation-cap;pst-color-primary` Tutorial
 :link: ./tutorial/models.html
 
@@ -56,6 +62,7 @@ How to migrate from AutoGen 0.2.x to 0.4.x.
 
 installation
 quickstart
+magentic-one
 migration-guide
 ```
 

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
@@ -23,7 +23,7 @@ The paper and original release of Magentic-One is based on [the implementation u
 
 ![](../../images/autogen-magentic-one-example.png)
 
-**Example**: The figure above illustrates Magentic-One mutli-agent team completing a complex task from the GAIA benchmark. Magentic-One's Orchestrator agent creates a plan, delegates tasks to other agents, and tracks progress towards the goal, dynamically revising the plan as needed. The Orchestrator can delegate tasks to a FileSurfer agent to read and handle files, a WebSurfer agent to operate a web browser, or a Coder or Computer Terminal agent to write or execute code, respectively.
+**Example**: The figure above illustrates Magentic-One multi-agent team completing a complex task from the GAIA benchmark. Magentic-One's Orchestrator agent creates a plan, delegates tasks to other agents, and tracks progress towards the goal, dynamically revising the plan as needed. The Orchestrator can delegate tasks to a FileSurfer agent to read and handle files, a WebSurfer agent to operate a web browser, or a Coder or Computer Terminal agent to write or execute code, respectively.
 
 ```{caution}
 Using Magentic-One involves interacting with a digital world designed for humans, which carries inherent risks. To minimize these risks, consider the following precautions:
@@ -67,7 +67,7 @@ async def main() -> None:
         model_client=model_client,
     )
     team = MagenticOneGroupChat([assistant], model_client=model_client)
-    await Console(team.run_stream(task="Provide a different proof to Fermat last theorem"))
+    await Console(team.run_stream(task="Provide a different proof for Fermat's Last Theorem"))
 
 
 asyncio.run(main())

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
@@ -1,0 +1,134 @@
+---
+myst:
+  html_meta:
+    "description lang=en": |
+      User Guide for AgentChat, a high-level API for AutoGen
+---
+
+# Magentic-One
+
+Magentic-One is a generalist multi-agent system for solving open-ended web and file-based tasks across a variety of domains. Magentic-One represents a significant step towards developing agents that can complete tasks that people encounter in their work and personal lives.
+
+The Magentic-One orchestrator {py:class}`~autogen_agentchat.teams.MagenticOneGroupChat` is simply an AgentChat team now. Therefore, it supports all standard AgentChat agents and features.
+
+The agents are also available as AgentChat agents: {py:class}`~autogen_ext.agents.web_surfer.MultimodalWebSurfer`, {py:class}`~autogen_ext.agents.file_surfer.FileSurfer`, and {py:class}`~autogen_ext.agents.magentic_one.MagenticOneCoderAgent`.
+
+Lastly, there is a helper class, {py:class}`~autogen_ext.teams.magentic_one.MagenticOne`, which bundles all of this together as it was in the paper with minimal configuration.
+
+Find additional information about Magentic-one in our [blog post](https://aka.ms/magentic-one-blog) and [technical report](https://arxiv.org/abs/2411.04468).
+
+```{note}
+The paper and original release of Magentic-One is based on [the implementation using `autogen-core`](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-magentic-one). We have now ported Magentic-One to use `autogen-agentchat`. The new implementation is more modular and easier to use.
+```
+
+![](../../images/autogen-magentic-one-example.png)
+
+**Example**: The figure above illustrates Magentic-One mutli-agent team completing a complex task from the GAIA benchmark. Magentic-One's Orchestrator agent creates a plan, delegates tasks to other agents, and tracks progress towards the goal, dynamically revising the plan as needed. The Orchestrator can delegate tasks to a FileSurfer agent to read and handle files, a WebSurfer agent to operate a web browser, or a Coder or Computer Terminal agent to write or execute code, respectively.
+
+```{caution}
+Using Magentic-One involves interacting with a digital world designed for humans, which carries inherent risks. To minimize these risks, consider the following precautions:
+
+1. **Use Containers**: Run all tasks in docker containers to isolate the agents and prevent direct system attacks.
+2. **Virtual Environment**: Use a virtual environment to run the agents and prevent them from accessing sensitive data.
+3. **Monitor Logs**: Closely monitor logs during and after execution to detect and mitigate risky behavior.
+4. **Human Oversight**: Run the examples with a human in the loop to supervise the agents and prevent unintended consequences.
+5. **Limit Access**: Restrict the agents' access to the internet and other resources to prevent unauthorized actions.
+6. **Safeguard Data**: Ensure that the agents do not have access to sensitive data or resources that could be compromised. Do not share sensitive information with the agents.
+Be aware that agents may occasionally attempt risky actions, such as recruiting humans for help or accepting cookie agreements without human involvement. Always ensure agents are monitored and operate within a controlled environment to prevent unintended consequences. Moreover, be cautious that Magentic-One may be susceptible to prompt injection attacks from webpages.
+```
+
+## Getting started
+
+Install the required packages:
+```bash
+pip install autogen-agentchat==0.4.0.dev13 autogen-ext[magentic-one]==0.4.0.dev13
+
+# If using the MultimodalWebSurfer, you also need to install playwright dependencies:
+playwright install --with-deps chromium
+```
+
+If you haven't done so already, go through the AgentChat tutorial to learn about the concepts of AgentChat.
+
+Then, you can try swapping out a {py:class}`autogen_agentchat.teams.SelectorGroupChat` with {py:class}`~autogen_agentchat.teams.MagenticOneGroupChat`. For example:
+
+```python
+import asyncio
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import MagenticOneGroupChat
+from autogen_agentchat.ui import Console
+
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+    assistant = AssistantAgent(
+        "Assistant",
+        model_client=model_client,
+    )
+    team = MagenticOneGroupChat([assistant], model_client=model_client)
+    await Console(team.run_stream(task="Provide a different proof to Fermat last theorem"))
+
+
+asyncio.run(main())
+```
+
+Or, use the Magentic-One agents in a team:
+
+```{caution}
+The example code may download files from the internet, execute code, and interact with web pages. Ensure you are in a safe environment before running the example code.
+```
+
+```python
+import asyncio
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_agentchat.teams import MagenticOneGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.agents.web_surfer import MultimodalWebSurfer
+
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+    surfer = MultimodalWebSurfer(
+        "WebSurfer",
+        model_client=model_client,
+    )
+    team = MagenticOneGroupChat([surfer], model_client=model_client)
+    await Console(team.run_stream(task="What is the UV index in Melbourne today?"))
+
+
+asyncio.run(main())
+```
+
+
+## Architecture
+
+![](../../images/autogen-magentic-one-agents.png)
+
+Magentic-One work is based on a multi-agent architecture where a lead Orchestrator agent is responsible for high-level planning, directing other agents and tracking task progress. The Orchestrator begins by creating a plan to tackle the task, gathering needed facts and educated guesses in a Task Ledger that is maintained. At each step of its plan, the Orchestrator creates a Progress Ledger where it self-reflects on task progress and checks whether the task is completed. If the task is not yet completed, it assigns one of Magentic-One other agents a subtask to complete. After the assigned agent completes its subtask, the Orchestrator updates the Progress Ledger and continues in this way until the task is complete. If the Orchestrator finds that progress is not being made for enough steps, it can update the Task Ledger and create a new plan. This is illustrated in the figure above; the Orchestrator work is thus divided into an outer loop where it updates the Task Ledger and an inner loop to update the Progress Ledger.
+
+Overall, Magentic-One consists of the following agents:
+- Orchestrator: the lead agent responsible for task decomposition and planning, directing other agents in executing subtasks, tracking overall progress, and taking corrective actions as needed
+- WebSurfer: This is an LLM-based agent that is proficient in commanding and managing the state of a Chromium-based web browser. With each incoming request, the WebSurfer performs an action on the browser then reports on the new state of the web page   The action space of the WebSurfer includes navigation (e.g. visiting a URL, performing a web search);  web page actions (e.g., clicking and typing); and reading actions (e.g., summarizing or answering questions). The WebSurfer relies on the accessibility tree of the browser and on set-of-marks prompting to perform its actions.
+- FileSurfer: This is an LLM-based agent that commands a markdown-based file preview application to read local files of most types. The FileSurfer can also perform common navigation tasks such as listing the contents of directories and navigating a folder structure.
+- Coder: This is an LLM-based agent specialized through its system prompt for writing code, analyzing information collected from the other agents, or creating new artifacts.
+- ComputerTerminal: Finally, ComputerTerminal provides the team with access to a console shell where the Coder’s programs can be executed, and where new programming libraries can be installed.
+
+Together, Magentic-One’s agents provide the Orchestrator with the tools and capabilities that it needs to solve a broad variety of open-ended problems, as well as the ability to autonomously adapt to, and act in, dynamic and ever-changing web and file-system environments.
+
+While the default multimodal LLM we use for all agents is GPT-4o, Magentic-One is model agnostic and can incorporate heterogonous models to support different capabilities or meet different cost requirements when getting tasks done. For example, it can use different LLMs and SLMs and their specialized versions to power different agents. We recommend a strong reasoning model for the Orchestrator agent such as GPT-4o. In a different configuration of Magentic-One, we also experiment with using OpenAI o1-preview for the outer loop of the Orchestrator and for the Coder, while other agents continue to use GPT-4o.
+
+## Citation
+
+```
+@misc{fourney2024magenticonegeneralistmultiagentsolving,
+      title={Magentic-One: A Generalist Multi-Agent System for Solving Complex Tasks},
+      author={Adam Fourney and Gagan Bansal and Hussein Mozannar and Cheng Tan and Eduardo Salinas and Erkang and Zhu and Friederike Niedtner and Grace Proebsting and Griffin Bassman and Jack Gerrits and Jacob Alber and Peter Chang and Ricky Loynd and Robert West and Victor Dibia and Ahmed Awadallah and Ece Kamar and Rafah Hosn and Saleema Amershi},
+      year={2024},
+      eprint={2411.04468},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2411.04468},
+}
+```

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
@@ -7,19 +7,19 @@ myst:
 
 # Magentic-One
 
-Magentic-One is a generalist multi-agent system for solving open-ended web and file-based tasks across a variety of domains. Magentic-One represents a significant step towards developing agents that can complete tasks that people encounter in their work and personal lives.
+[Magentic-One](https://aka.ms/magentic-one-blog) is a generalist multi-agent system for solving open-ended web and file-based tasks across a variety of domains. It represents a significant step forward for multi-agent systems, achieving competitive performance on a number of agentic benchmarks (see the [technical report](https://arxiv.org/abs/2411.04468) for full details).
 
-The Magentic-One orchestrator {py:class}`~autogen_agentchat.teams.MagenticOneGroupChat` is simply an AgentChat team now. Therefore, it supports all standard AgentChat agents and features.
 
-The agents are also available as AgentChat agents: {py:class}`~autogen_ext.agents.web_surfer.MultimodalWebSurfer`, {py:class}`~autogen_ext.agents.file_surfer.FileSurfer`, and {py:class}`~autogen_ext.agents.magentic_one.MagenticOneCoderAgent`.
+When originally released in [November 2024](https://aka.ms/magentic-one-blog) Magentic-One was [implemented directly on the `autogen-core` library](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-magentic-one). We have now ported Magentic-One to use `autogen-agentchat`, providing a more modular and easier to use interface.
+
+
+To this end, the Magentic-One orchestrator {py:class}`~autogen_agentchat.teams.MagenticOneGroupChat` is now simply an AgentChat team, supporting all standard AgentChat agents and features. Likewise, Magentic-One's {py:class}`~autogen_ext.agents.web_surfer.MultimodalWebSurfer`, {py:class}`~autogen_ext.agents.file_surfer.FileSurfer`, and {py:class}`~autogen_ext.agents.magentic_one.MagenticOneCoderAgent` agents are now broadly available as AgentChat agents, to be used in any AgentChat workflows.
+
 
 Lastly, there is a helper class, {py:class}`~autogen_ext.teams.magentic_one.MagenticOne`, which bundles all of this together as it was in the paper with minimal configuration.
 
-Find additional information about Magentic-one in our [blog post](https://aka.ms/magentic-one-blog) and [technical report](https://arxiv.org/abs/2411.04468).
 
-```{note}
-The paper and original release of Magentic-One is based on [the implementation using `autogen-core`](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-magentic-one). We have now ported Magentic-One to use `autogen-agentchat`. The new implementation is more modular and easier to use.
-```
+Find additional information about Magentic-one in our [blog post](https://aka.ms/magentic-one-blog) and [technical report](https://arxiv.org/abs/2411.04468).
 
 ![](../../images/autogen-magentic-one-example.png)
 

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -6,10 +6,12 @@ The `v0.4` version contains breaking changes. Please read this guide carefully.
 We still maintain the `v0.2` version in the `0.2` branch; however,
 we highly recommend you upgrade to the `v0.4` version.
 
-> **Note**: We no longer have admin access to the `pyautogen` PyPI package, and
-> the releases from that package are no longer from Microsoft since version 0.2.34.
-> To continue use the `v0.2` version of AutoGen, install it using `autogen-agentchat~=0.2`.
-> Please read our [clarification statement](https://github.com/microsoft/autogen/discussions/4217) regarding forks.
+```{note}
+We no longer have admin access to the `pyautogen` PyPI package, and
+the releases from that package are no longer from Microsoft since version 0.2.34.
+To continue use the `v0.2` version of AutoGen, install it using `autogen-agentchat~=0.2`.
+Please read our [clarification statement](https://github.com/microsoft/autogen/discussions/4217) regarding forks.
+```
 
 ## What is `v0.4`?
 
@@ -571,8 +573,8 @@ asyncio.run(main())
 ```
 
 When using tool-equipped agents inside a group chat such as
-{py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`, 
-you simply do the same as above to add tools to the agents, and create a 
+{py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`,
+you simply do the same as above to add tools to the agents, and create a
 group chat with the agents.
 
 ## Chat Result


### PR DESCRIPTION
This adds a page under agentchat for magentic one, based heavily on all other docs that already existed.

Not necessarily complete but wanted to get the ball rolling on a central location to learn more