### PR TITLE
Update index.md for better clarity and relationship between packages

### DIFF
--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -35,7 +35,7 @@ sd_hide_title: true
 AutoGen
 </h1>
 <h3>
-A framework for building AI agents and multi-agent applications
+A framework for building AI agents and applications
 </h3>
 </div>
 </div>

--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -124,7 +124,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-_Migrating from AutoGen 0.2? Read the [guide](./user-guide/agentchat-user-guide/migration-guide.md)._
+_Start here if you are building conversational agents. [Migrating from AutoGen 0.2?](./user-guide/agentchat-user-guide/migration-guide.md)._
 
 +++
 
@@ -146,6 +146,8 @@ An event-driven programming framework for building scalable multi-agent AI syste
 * Deterministic and dynamic agentic workflows for business processes.
 * Research on multi-agent collaboration.
 * Distributed agents for multi-language applications.
+
+_Start here if you are building workflows or distributed agent systems._
 
 +++
 

--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -35,7 +35,7 @@ sd_hide_title: true
 AutoGen
 </h1>
 <h3>
-For AI agents and multi-agent applications
+A framework for building AI agents and multi-agent applications
 </h3>
 </div>
 </div>

--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -49,40 +49,20 @@ A framework for building AI agents and multi-agent applications
 :::{grid-item-card}
 :shadow: none
 :margin: 2 0 0 0
-:columns: 12 12 12 12
-
-<div class="sd-card-title sd-font-weight-bold docutils">
-
-{fas}`people-group;pst-color-primary`
-AgentChat </div>
-High-level API that includes preset agents and teams for building multi-agent systems.
-
-```sh
-pip install "autogen-agentchat==0.4.0.dev13"
-```
-
-💡 *Start here if you are looking for an API similar to AutoGen 0.2.*
-
-+++
-
-<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-secondary reference internal" href="user-guide/agentchat-user-guide/quickstart.html"><span class="doc">Get Started</span></a>
-<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-secondary reference internal" href="user-guide/agentchat-user-guide/migration-guide.html"><span class="doc">Migration Guide (0.2.x to 0.4.x)</span></a>
-
-:::
-
-:::{grid-item-card}
-:shadow: none
-:margin: 2 0 0 0
-:columns: 12 12 12 12
+:columns: 12 12 6 6
 
 <div class="sd-card-title sd-font-weight-bold docutils">
 
 {fas}`book;pst-color-primary`
 Magentic-One </div>
-Magentic-One is a generalist multi-agent system for solving open-ended web and file-based tasks across a variety of domains.
+A multi-agent team for web and file-based tasks.
+Built on top of AgentChat.
+
+```bash
+% m1 "Find flights from Seattle to Paris and format the result in a table"
+```
 
 +++
-
 
 ```{button-ref} user-guide/agentchat-user-guide/magentic-one
 :color: secondary
@@ -92,13 +72,17 @@ Get Started
 
 :::
 
-
-:::{grid-item-card} {fas}`palette;pst-color-primary` Studio
+:::{grid-item-card} {fas}`palette;pst-color-primary` Studio [![PyPi autogenstudio](https://img.shields.io/badge/PyPi-autogen--studio-blue?logo=pypi)](https://pypi.org/project/autogenstudio/)
 :shadow: none
 :margin: 2 0 0 0
-:columns: 12 12 12 12
+:columns: 12 12 6 6
 
-No-code platform for authoring and interacting with multi-agent teams.
+Prototyping, testing and managing multi-agent teams without writing code.
+Built on top of AgentChat.
+
+```bash
+% autogenstudio ui --port 8080
+```
 
 +++
 
@@ -110,16 +94,50 @@ Get Started
 
 :::
 
-:::{grid-item-card} {fas}`cube;pst-color-primary` Core
+:::{grid-item-card}
 :shadow: none
 :margin: 2 0 0 0
-:columns: 12 12 6 6
+:columns: 12 12 12 12
 
-Provides building blocks for creating asynchronous, event driven multi-agent systems.
+<div class="sd-card-title sd-font-weight-bold docutils">
 
-```sh
-pip install "autogen-core==0.4.0.dev13"
+{fas}`people-group;pst-color-primary` AgentChat
+[![PyPi autogen-agentchat](https://img.shields.io/badge/PyPi-autogen--agentchat-blue?logo=pypi)](https://pypi.org/project/autogen-agentchat/0.4.0.dev13/)
+
+</div>
+Preset agents and teams for building conversational single and multi-agent applications.
+Built on top of Core.
+
+```python
+from autogen_agentchat import AssistantAgent
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+agent = AssistantAgent("assistant", OpenAIChatCompletionClient(model="gpt-4o"))
 ```
+
+_Migrating from AutoGen 0.2? Read the [guide](./user-guide/agentchat-user-guide/migration-guide.md)._
+
++++
+
+```{button-ref} user-guide/agentchat-user-guide/quickstart
+:color: secondary
+
+Get Started
+```
+
+:::
+
+:::{grid-item-card} {fas}`cube;pst-color-primary` Core [![PyPi autogen-core](https://img.shields.io/badge/PyPi-autogen--core-blue?logo=pypi)](https://pypi.org/project/autogen-core/0.4.0.dev13/)
+:shadow: none
+:margin: 2 0 0 0
+:columns: 12 12 12 12
+
+Foundational building blocks for asynchronous and event driven multi-agent systems. Examples scenarios:
+
+* Deterministic and dynamic agentic workflows for business processes.
+* Research on multi-agent collaboration.
+* Parallel training data generation for agentic models.
+* Distributed agents for multi-language applications.
 
 +++
 
@@ -131,24 +149,23 @@ Get Started
 
 :::
 
-:::{grid-item-card} {fas}`puzzle-piece;pst-color-primary` Extensions
+:::{grid-item-card} {fas}`puzzle-piece;pst-color-primary` Extensions [![PyPi autogen-ext](https://img.shields.io/badge/PyPi-autogen--ext-blue?logo=pypi)](https://pypi.org/project/autogen-ext/0.4.0.dev13/)
 :shadow: none
 :margin: 2 0 0 0
-:columns: 12 12 6 6
+:columns: 12 12 12 12
 
-Implementations of core components that interface with external services, or use extra dependencies. For example, Docker based code execution.
+Implementations of Core and AgentChat components that interface with external services or other libraries.
+You can find and use community extensions or create your own. Examples of built-in extensions:
 
-```sh
-pip install "autogen-ext==0.4.0.dev13"
-```
+* {py:class}`~autogen_ext.tools.langchain.LangChainToolAdapter` for using LangChain tools.
+* {py:class}`~autogen_ext.agents.openai.OpenAIAssistantAgent` for using Assistant API.
+* {py:class}`~autogen_ext.code_executors.docker.DockerCommandLineCodeExecutor` for running model-generated code in a Docker container.
+* {py:class}`~autogen_ext.runtimes.grpc.GrpcWorkerAgentRuntime` for distributed agents.
 
 +++
 
-```{button-ref} user-guide/extensions-user-guide/index
-:color: secondary
-
-Get Started
-```
+<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-secondary reference internal" href="user-guide/extensions-user-guide/discover.html"><span class="doc">Discover Community Extensions</span></a>
+<a class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-secondary reference internal" href="user-guide/extensions-user-guide/create-your-own.html"><span class="doc">Create New Extension</span></a>
 
 :::
 

--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -141,7 +141,7 @@ Get Started
 :margin: 2 0 0 0
 :columns: 12 12 12 12
 
-An event-driven programming framework for building scalable multi-agent AI systems. Examples scenarios:
+An event-driven programming framework for building scalable multi-agent AI systems. Example scenarios:
 
 * Deterministic and dynamic agentic workflows for business processes.
 * Research on multi-agent collaboration.

--- a/python/packages/autogen-core/docs/src/index.md
+++ b/python/packages/autogen-core/docs/src/index.md
@@ -35,7 +35,7 @@ sd_hide_title: true
 AutoGen
 </h1>
 <h3>
-A framework for building AI agents and multi-agent applications
+For AI agents and multi-agent applications
 </h3>
 </div>
 </div>
@@ -55,8 +55,8 @@ A framework for building AI agents and multi-agent applications
 
 {fas}`book;pst-color-primary`
 Magentic-One </div>
-A multi-agent team for web and file-based tasks.
-Built on top of AgentChat.
+A multi-agent assistant for web and file-based tasks.
+Built on AgentChat.
 
 ```bash
 % m1 "Find flights from Seattle to Paris and format the result in a table"
@@ -77,8 +77,8 @@ Get Started
 :margin: 2 0 0 0
 :columns: 12 12 6 6
 
-Prototyping, testing and managing multi-agent teams without writing code.
-Built on top of AgentChat.
+An app for prototyping and managing agents without writing code.
+Built on AgentChat.
 
 ```bash
 % autogenstudio ui --port 8080
@@ -105,14 +105,23 @@ Get Started
 [![PyPi autogen-agentchat](https://img.shields.io/badge/PyPi-autogen--agentchat-blue?logo=pypi)](https://pypi.org/project/autogen-agentchat/0.4.0.dev13/)
 
 </div>
-Preset agents and teams for building conversational single and multi-agent applications.
-Built on top of Core.
+A programming framework for building conversational single and multi-agent applications.
+Built on Core.
 
 ```python
-from autogen_agentchat import AssistantAgent
+# pip install "autogen-agentchat==0.4.0.dev13" "autogen-ext[openai]==0.4.0.dev13" "yfinance" "matplotlib"
+import asyncio
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
 from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.code_executors.local import LocalCommandLineCodeExecutor
+from autogen_ext.tools.code_execution import PythonCodeExecutionTool
 
-agent = AssistantAgent("assistant", OpenAIChatCompletionClient(model="gpt-4o"))
+async def main() -> None:
+    tool = PythonCodeExecutionTool(LocalCommandLineCodeExecutor(work_dir="coding"))
+    agent = AssistantAgent("assistant", OpenAIChatCompletionClient(model="gpt-4o"), tools=[tool], reflect_on_tool_use=True)
+    await Console(agent.run_stream(task="Create a plot of MSFT stock prices in 2024 and save it to a file. Use yfinance and matplotlib."))
+asyncio.run(main())
 ```
 
 _Migrating from AutoGen 0.2? Read the [guide](./user-guide/agentchat-user-guide/migration-guide.md)._
@@ -132,11 +141,10 @@ Get Started
 :margin: 2 0 0 0
 :columns: 12 12 12 12
 
-Foundational building blocks for asynchronous and event driven multi-agent systems. Examples scenarios:
+An event-driven programming framework for building scalable multi-agent AI systems. Examples scenarios:
 
 * Deterministic and dynamic agentic workflows for business processes.
 * Research on multi-agent collaboration.
-* Parallel training data generation for agentic models.
 * Distributed agents for multi-language applications.
 
 +++

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -89,7 +89,7 @@ gen-proto = "python -m grpc_tools.protoc --python_out=./packages/autogen-ext/src
 
 gen-proto-samples = "python -m grpc_tools.protoc --python_out=./packages/autogen-core/samples/protos --grpc_python_out=./packages/autogen-core/samples/protos --mypy_out=./packages/autogen-core/samples/protos --mypy_grpc_out=./packages/autogen-core/samples/protos --proto_path ../protos/ agent_events.proto"
 
-markdown-code-lint = "python check_md_code_blocks.py ../README.md ./packages/autogen-core/docs/src/user-guide/agentchat-user-guide/*.md"
+markdown-code-lint = "python check_md_code_blocks.py ../README.md ./packages/autogen-core/docs/src/user-guide/agentchat-user-guide/*.md ./packages/autogen-core/docs/src/index.md"
 
 [[tool.poe.tasks.gen-test-proto.sequence]]
 cmd = "python -m grpc_tools.protoc --python_out=./packages/autogen-core/tests/protos --grpc_python_out=./packages/autogen-core/tests/protos --mypy_out=./packages/autogen-core/tests/protos --mypy_grpc_out=./packages/autogen-core/tests/protos --proto_path ./packages/autogen-core/tests/protos serialization_test.proto"


### PR DESCRIPTION
- Make the releationship between packages clear.
- Entice users by showing preview of builtin capabilities and API by using runnable code snippet.
- Prominently feature extension discovery and creation.
- Updated description and "Start here if ..." note to help user choose where to start.
- Bring back stock plot using single agent, which works quite well. 

Need help with:
- Float the package badges to the top-right of each box.
- Center each "Get Started" button.

Follow ups:

- Add `autogen-magentic-one` PyPI package for convenient installation of `m1` CLI tool and magentic one Python API. 
- Add top-level tab for Magentic One

Updated look:

<img width="703" alt="Screenshot 2025-01-05 at 10 14 25 PM" src="https://github.com/user-attachments/assets/0d6d6a78-c339-4929-abb6-a8f9fc0d94ee" />


