### PR TITLE
Update magentic-one.md

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
@@ -41,7 +41,7 @@ Be aware that agents may occasionally attempt risky actions, such as recruiting 
 
 Install the required packages:
 ```bash
-pip install autogen-agentchat==0.4.0.dev13 autogen-ext[magentic-one]==0.4.0.dev13 autogen-ext[openai]==0.4.0.dev13
+pip install autogen-agentchat==0.4.0.dev13 autogen-ext[magentic-one,openai]==0.4.0.dev13
 
 # If using the MultimodalWebSurfer, you also need to install playwright dependencies:
 playwright install --with-deps chromium

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/magentic-one.md
@@ -41,7 +41,7 @@ Be aware that agents may occasionally attempt risky actions, such as recruiting 
 
 Install the required packages:
 ```bash
-pip install autogen-agentchat==0.4.0.dev13 autogen-ext[magentic-one]==0.4.0.dev13
+pip install autogen-agentchat==0.4.0.dev13 autogen-ext[magentic-one]==0.4.0.dev13 autogen-ext[openai]==0.4.0.dev13
 
 # If using the MultimodalWebSurfer, you also need to install playwright dependencies:
 playwright install --with-deps chromium


### PR DESCRIPTION
 Add openai extra to the installation instructions

## Why are these changes needed?

@ekzhu suggested a quick fix by adding openai extra in the installation instructions

## Related issue number

No module named 'azure' -- installation instruction of magentic one needs to be updated #4899

