### PR TITLE
Make azure_ad_token_provider customizable.

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -472,11 +472,14 @@ class OpenAIWrapper:
         openai_config["azure_endpoint"] = openai_config.get("azure_endpoint", openai_config.pop("base_url", None))
 
         # Create a default Azure token provider if requested
-        if openai_config.get("azure_ad_token_provider") == "DEFAULT":
+        azure_ad_token_provider = openai_config.get("azure_ad_token_provider")
+        if azure_ad_token_provider is not None:
+            assert type(azure_ad_token_provider) == str, "azure_ad_token_provider must be a string"
             import azure.identity
-
+            if azure_ad_token_provider == "DEFAULT":
+                azure_ad_token_provider = "https://cognitiveservices.azure.com/.default"
             openai_config["azure_ad_token_provider"] = azure.identity.get_bearer_token_provider(
-                azure.identity.DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+                azure.identity.DefaultAzureCredential(), azure_ad_token_provider
             )
 
     def _configure_openai_config_for_bedrock(self, config: Dict[str, Any], openai_config: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Why are these changes needed?

Currently, when using azure openai,  `azure_ad_token_provider` in `OAI_CONFIG_LIST` can only take a value of "DEFAULT" which uses the default token provider "https://cognitiveservices.azure.com/.default". 

This patch would allow users providing custom token providers by setting `azure_ad_token_provider` to other values.


## Checks

- [ x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ x] I've made sure all auto checks have passed.
