### PR TITLE
Make termination condition config declarative 

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/__init__.py
@@ -2,7 +2,7 @@ from ._chat_agent import ChatAgent, Response
 from ._handoff import Handoff
 from ._task import TaskResult, TaskRunner
 from ._team import Team
-from ._termination import TerminatedException, TerminationCondition, AndTerminationCondition, OrTerminationCondition
+from ._termination import AndTerminationCondition, OrTerminationCondition, TerminatedException, TerminationCondition
 
 __all__ = [
     "ChatAgent",

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/__init__.py
@@ -2,7 +2,7 @@ from ._chat_agent import ChatAgent, Response
 from ._handoff import Handoff
 from ._task import TaskResult, TaskRunner
 from ._team import Team
-from ._termination import TerminatedException, TerminationCondition
+from ._termination import TerminatedException, TerminationCondition, AndTerminationCondition, OrTerminationCondition
 
 __all__ = [
     "ChatAgent",
@@ -10,6 +10,8 @@ __all__ = [
     "Team",
     "TerminatedException",
     "TerminationCondition",
+    "AndTerminationCondition",
+    "OrTerminationCondition",
     "TaskResult",
     "TaskRunner",
     "Handoff",

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_termination.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_termination.py
@@ -1,8 +1,8 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Any, List, Sequence
+from typing import List, Sequence
 
-from autogen_core import Component, ComponentModel
+from autogen_core import Component, ComponentBase, ComponentModel
 from pydantic import BaseModel
 from typing_extensions import Self
 
@@ -12,7 +12,7 @@ from ..messages import AgentEvent, ChatMessage, StopMessage
 class TerminatedException(BaseException): ...
 
 
-class TerminationCondition(ABC, Component[Any]):
+class TerminationCondition(ABC, ComponentBase[BaseModel]):
     """A stateful condition that determines when a conversation should be terminated.
 
     A termination condition is a callable that takes a sequence of ChatMessage objects

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_termination.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_termination.py
@@ -1,14 +1,19 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import List, Sequence
+from typing import Any, List, Sequence
+from typing_extensions import Self
+
+from pydantic import BaseModel
 
 from ..messages import AgentEvent, ChatMessage, StopMessage
+from autogen_core import Component, ComponentModel, ComponentLoader
 
 
-class TerminatedException(BaseException): ...
+class TerminatedException(BaseException):
+    ...
 
 
-class TerminationCondition(ABC):
+class TerminationCondition(ABC, Component[Any]):
     """A stateful condition that determines when a conversation should be terminated.
 
     A termination condition is a callable that takes a sequence of ChatMessage objects
@@ -42,6 +47,8 @@ class TerminationCondition(ABC):
 
             asyncio.run(main())
     """
+
+    component_type = "termination"
 
     @property
     @abstractmethod
@@ -79,7 +86,15 @@ class TerminationCondition(ABC):
         return _OrTerminationCondition(self, other)
 
 
-class _AndTerminationCondition(TerminationCondition):
+class AndTerminationConditionConfig(BaseModel):
+    conditions:  List[ComponentModel]
+
+
+class _AndTerminationCondition(TerminationCondition, Component[AndTerminationConditionConfig]):
+
+    component_config_schema = AndTerminationConditionConfig
+    component_type = "termination"
+
     def __init__(self, *conditions: TerminationCondition) -> None:
         self._conditions = conditions
         self._stop_messages: List[StopMessage] = []
@@ -90,7 +105,8 @@ class _AndTerminationCondition(TerminationCondition):
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self.terminated:
-            raise TerminatedException("Termination condition has already been reached.")
+            raise TerminatedException(
+                "Termination condition has already been reached.")
         # Check all remaining conditions.
         stop_messages = await asyncio.gather(
             *[condition(messages) for condition in self._conditions if not condition.terminated]
@@ -102,8 +118,10 @@ class _AndTerminationCondition(TerminationCondition):
         if any(stop_message is None for stop_message in stop_messages):
             # If any remaining condition has not reached termination, it is not terminated.
             return None
-        content = ", ".join(stop_message.content for stop_message in self._stop_messages)
-        source = ", ".join(stop_message.source for stop_message in self._stop_messages)
+        content = ", ".join(
+            stop_message.content for stop_message in self._stop_messages)
+        source = ", ".join(
+            stop_message.source for stop_message in self._stop_messages)
         return StopMessage(content=content, source=source)
 
     async def reset(self) -> None:
@@ -111,8 +129,33 @@ class _AndTerminationCondition(TerminationCondition):
             await condition.reset()
         self._stop_messages.clear()
 
+    def _to_config(self) -> AndTerminationConditionConfig:
+        """Convert the AND termination condition to a config."""
+        return AndTerminationConditionConfig(
+            conditions=[condition.dump_component()
+                        for condition in self._conditions]
+        )
 
-class _OrTerminationCondition(TerminationCondition):
+    @classmethod
+    def _from_config(cls, config: AndTerminationConditionConfig) -> Self:
+        """Create an AND termination condition from a config."""
+        conditions = [
+            ComponentLoader.load_component(
+                condition_model, TerminationCondition)
+            for condition_model in config.conditions
+        ]
+        return cls(*conditions)
+
+
+class OrTerminationConditionConfig(BaseModel):
+    conditions: List[ComponentModel]
+    """List of termination conditions where any one being satisfied is sufficient."""
+
+
+class _OrTerminationCondition(TerminationCondition, Component[OrTerminationConditionConfig]):
+    component_config_schema = OrTerminationConditionConfig
+    component_type = "termination"
+
     def __init__(self, *conditions: TerminationCondition) -> None:
         self._conditions = conditions
 
@@ -122,14 +165,34 @@ class _OrTerminationCondition(TerminationCondition):
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self.terminated:
-            raise RuntimeError("Termination condition has already been reached")
+            raise RuntimeError(
+                "Termination condition has already been reached")
         stop_messages = await asyncio.gather(*[condition(messages) for condition in self._conditions])
         if any(stop_message is not None for stop_message in stop_messages):
-            content = ", ".join(stop_message.content for stop_message in stop_messages if stop_message is not None)
-            source = ", ".join(stop_message.source for stop_message in stop_messages if stop_message is not None)
+            content = ", ".join(
+                stop_message.content for stop_message in stop_messages if stop_message is not None)
+            source = ", ".join(
+                stop_message.source for stop_message in stop_messages if stop_message is not None)
             return StopMessage(content=content, source=source)
         return None
 
     async def reset(self) -> None:
         for condition in self._conditions:
             await condition.reset()
+
+    def _to_config(self) -> OrTerminationConditionConfig:
+        """Convert the OR termination condition to a config."""
+        return OrTerminationConditionConfig(
+            conditions=[condition.dump_component()
+                        for condition in self._conditions]
+        )
+
+    @classmethod
+    def _from_config(cls, config: OrTerminationConditionConfig) -> Self:
+        """Create an OR termination condition from a config."""
+        conditions = [
+            ComponentLoader.load_component(
+                condition_model, TerminationCondition)
+            for condition_model in config.conditions
+        ]
+        return cls(*conditions)

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_termination.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_termination.py
@@ -1,12 +1,12 @@
 import asyncio
 from abc import ABC, abstractmethod
 from typing import Any, List, Sequence
+
+from autogen_core import Component, ComponentModel
+from pydantic import BaseModel
 from typing_extensions import Self
 
-from pydantic import BaseModel
-
 from ..messages import AgentEvent, ChatMessage, StopMessage
-from autogen_core import Component, ComponentModel
 
 
 class TerminatedException(BaseException): ...

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -1,12 +1,12 @@
 import time
 from typing import List, Sequence
 
+from autogen_core import Component
 from pydantic import BaseModel
+from typing_extensions import Self
 
 from ..base import TerminatedException, TerminationCondition
 from ..messages import AgentEvent, ChatMessage, HandoffMessage, MultiModalMessage, StopMessage
-from autogen_core import Component
-from typing_extensions import Self
 
 
 class StopMessageTerminationConfig(BaseModel):

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -29,8 +29,7 @@ class StopMessageTermination(TerminationCondition, Component[StopMessageTerminat
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self._terminated:
-            raise TerminatedException(
-                "Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
         for message in messages:
             if isinstance(message, StopMessage):
                 self._terminated = True
@@ -73,8 +72,7 @@ class MaxMessageTermination(TerminationCondition, Component[MaxMessageTerminatio
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self.terminated:
-            raise TerminatedException(
-                "Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
         self._message_count += len(messages)
         if self._message_count >= self._max_messages:
             return StopMessage(
@@ -120,8 +118,7 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self._terminated:
-            raise TerminatedException(
-                "Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
         for message in messages:
             if isinstance(message.content, str) and self._text in message.content:
                 self._terminated = True
@@ -186,22 +183,19 @@ class TokenUsageTermination(TerminationCondition, Component[TokenUsageTerminatio
     @property
     def terminated(self) -> bool:
         return (
-            (self._max_total_token is not None and self._total_token_count >=
-             self._max_total_token)
+            (self._max_total_token is not None and self._total_token_count >= self._max_total_token)
             or (self._max_prompt_token is not None and self._prompt_token_count >= self._max_prompt_token)
             or (self._max_completion_token is not None and self._completion_token_count >= self._max_completion_token)
         )
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self.terminated:
-            raise TerminatedException(
-                "Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
         for message in messages:
             if message.models_usage is not None:
                 self._prompt_token_count += message.models_usage.prompt_tokens
                 self._completion_token_count += message.models_usage.completion_tokens
-                self._total_token_count += message.models_usage.prompt_tokens + \
-                    message.models_usage.completion_tokens
+                self._total_token_count += message.models_usage.prompt_tokens + message.models_usage.completion_tokens
         if self.terminated:
             content = f"Token usage limit reached, total token count: {self._total_token_count}, prompt token count: {self._prompt_token_count}, completion token count: {self._completion_token_count}."
             return StopMessage(content=content, source="TokenUsageTermination")
@@ -216,7 +210,7 @@ class TokenUsageTermination(TerminationCondition, Component[TokenUsageTerminatio
         return TokenUsageTerminationConfig(
             max_total_token=self._max_total_token,
             max_prompt_token=self._max_prompt_token,
-            max_completion_token=self._max_completion_token
+            max_completion_token=self._max_completion_token,
         )
 
     @classmethod
@@ -224,7 +218,7 @@ class TokenUsageTermination(TerminationCondition, Component[TokenUsageTerminatio
         return cls(
             max_total_token=config.max_total_token,
             max_prompt_token=config.max_prompt_token,
-            max_completion_token=config.max_completion_token
+            max_completion_token=config.max_completion_token,
         )
 
 
@@ -254,8 +248,7 @@ class HandoffTermination(TerminationCondition, Component[HandoffTerminationConfi
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self._terminated:
-            raise TerminatedException(
-                "Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
         for message in messages:
             if isinstance(message, HandoffMessage) and message.target == self._target:
                 self._terminated = True
@@ -301,8 +294,7 @@ class TimeoutTermination(TerminationCondition, Component[TimeoutTerminationConfi
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self._terminated:
-            raise TerminatedException(
-                "Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
 
         if (time.monotonic() - self._start_time) >= self._timeout_seconds:
             self._terminated = True
@@ -365,8 +357,7 @@ class ExternalTermination(TerminationCondition, Component[ExternalTerminationCon
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self._terminated:
-            raise TerminatedException(
-                "Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
         if self._setted:
             self._terminated = True
             return StopMessage(content="External termination requested", source="ExternalTermination")
@@ -412,8 +403,7 @@ class SourceMatchTermination(TerminationCondition, Component[SourceMatchTerminat
 
     async def __call__(self, messages: Sequence[AgentEvent | ChatMessage]) -> StopMessage | None:
         if self._terminated:
-            raise TerminatedException(
-                "Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
         if not messages:
             return None
         for message in messages:

--- a/python/packages/autogen-agentchat/tests/test_declarative_components.py
+++ b/python/packages/autogen-agentchat/tests/test_declarative_components.py
@@ -1,0 +1,34 @@
+import pytest
+from autogen_agentchat.conditions import StopMessageTermination, MaxMessageTermination
+from autogen_agentchat.messages import StopMessage, TextMessage
+from autogen_core import ComponentLoader
+
+
+@pytest.mark.asyncio
+async def test_termination_declarative() -> None:
+    """Test that termination conditions can be declared and serialized properly."""
+    # Create basic termination conditions
+    max_term = MaxMessageTermination(5)
+    stop_term = StopMessageTermination()
+
+    # Test basic serialization/deserialization
+    max_config = max_term.dump_component()
+    assert max_config.provider == "autogen_agentchat.conditions.MaxMessageTermination"
+    assert max_config.config["max_messages"] == 5
+    loaded_max = ComponentLoader.load_component(max_config)
+    assert isinstance(loaded_max, MaxMessageTermination)
+    assert loaded_max._max_messages == 5
+
+    # Test composition and complex serialization
+    or_term = max_term | stop_term
+    or_config = or_term.dump_component()
+    assert or_config.provider == "autogen_agentchat.base.OrTerminationCondition"
+    assert len(or_config.config["conditions"]) == 2
+
+    # Test behavior after deserialization
+    loaded_or = ComponentLoader.load_component(or_config)
+    messages = [StopMessage(content="stop", source="test")]
+    result = await loaded_or(messages)
+    assert isinstance(result, StopMessage)
+    await loaded_or.reset()
+    assert not loaded_or.terminated

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/index.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/index.md
@@ -91,6 +91,7 @@ tutorial/human-in-the-loop
 tutorial/termination
 tutorial/custom-agents
 tutorial/state
+tutorial/declarative
 ```
 
 ```{toctree}

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/declarative.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/declarative.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Declarative Components \n",
     "\n",
-    "AutoGen provides a declarative component configuration class that defines behaviours for being able to export and import components in a declarative format. This is useful for debugging, visualizing, and even for sharing your work with others. In this notebook, we will demonstrate how to export a declarative representation of a multiagent team in the form of a JSON file.  \n",
+    "AutoGen provides a declarative  {py:class}`~autogen_core.Component` configuration class that defines behaviours for declarative import/export. This is useful for debugging, visualizing, and even for sharing your work with others. In this notebook, we will demonstrate how to export a declarative representation of a multiagent team in the form of a JSON file.  \n",
     "\n",
     "\n",
     "```{note}\n",
@@ -31,15 +31,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<frozen abc>:106: UserWarning: Class variable 'component_config_schema' must be defined in TerminationCondition to be a valid component\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from autogen_agentchat.conditions import MaxMessageTermination, StopMessageTermination\n",
     "\n",

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/declarative.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/declarative.ipynb
@@ -15,10 +15,10 @@
     "\n",
     "We will be implementing declarative support for the following components:\n",
     "\n",
-    "- [X] Termination conditions \n",
-    "- [ ] Tools \n",
-    "- [ ] Agents \n",
-    "- [ ] Teams \n",
+    "- Termination conditions ✔️\n",
+    "- Tools \n",
+    "- Agents \n",
+    "- Teams \n",
     "\n",
     "\n",
     "### Termination Condition Example \n",
@@ -31,12 +31,20 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<frozen abc>:106: UserWarning: Class variable 'component_config_schema' must be defined in TerminationCondition to be a valid component\n"
+     ]
+    }
+   ],
    "source": [
-    "from autogen_agentchat.conditions import StopMessageTermination, MaxMessageTermination \n",
+    "from autogen_agentchat.conditions import MaxMessageTermination, StopMessageTermination\n",
     "\n",
     "max_termination = MaxMessageTermination(5)\n",
-    "stop_termination = StopMessageTermination() "
+    "stop_termination = StopMessageTermination()"
    ]
   },
   {
@@ -79,17 +87,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/wg/hgs_dt8n5lbd3gx3pq7k6lym0000gn/T/ipykernel_86784/1252547633.py:2: UserWarning: Internal module name used in provider string. This is not recommended and may cause issues in the future. Silence this warning by setting component_provider_override to this value.\n",
-      "  or_termination.dump_component()\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "ComponentModel(provider='autogen_agentchat.base._termination._OrTerminationCondition', component_type='termination', version=1, component_version=1, description=None, config={'conditions': [{'provider': 'autogen_agentchat.conditions.MaxMessageTermination', 'component_type': 'termination', 'version': 1, 'component_version': 1, 'config': {'max_messages': 5}}, {'provider': 'autogen_agentchat.conditions.StopMessageTermination', 'component_type': 'termination', 'version': 1, 'component_version': 1, 'config': {}}]})"
+       "ComponentModel(provider='autogen_agentchat.base.OrTerminationCondition', component_type='termination', version=1, component_version=1, description=None, config={'conditions': [{'provider': 'autogen_agentchat.conditions.MaxMessageTermination', 'component_type': 'termination', 'version': 1, 'component_version': 1, 'config': {'max_messages': 5}}, {'provider': 'autogen_agentchat.conditions.StopMessageTermination', 'component_type': 'termination', 'version': 1, 'component_version': 1, 'config': {}}]})"
       ]
      },
      "execution_count": 4,
@@ -99,7 +99,7 @@
    ],
    "source": [
     "or_termination = max_termination | stop_termination\n",
-    "or_termination.dump_component() "
+    "or_termination.dump_component()"
    ]
   }
  ],

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/declarative.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/declarative.ipynb
@@ -1,0 +1,127 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Declarative Components \n",
+    "\n",
+    "AutoGen provides a declarative component configuration class that defines behaviours for being able to export and import components in a declarative format. This is useful for debugging, visualizing, and even for sharing your work with others. In this notebook, we will demonstrate how to export a declarative representation of a multiagent team in the form of a JSON file.  \n",
+    "\n",
+    "\n",
+    "```{note}\n",
+    "This is work in progress\n",
+    "``` \n",
+    "\n",
+    "We will be implementing declarative support for the following components:\n",
+    "\n",
+    "- [X] Termination conditions \n",
+    "- [ ] Tools \n",
+    "- [ ] Agents \n",
+    "- [ ] Teams \n",
+    "\n",
+    "\n",
+    "### Termination Condition Example \n",
+    "\n",
+    "In the example below, we will define termination conditions (a part of an agent team) in python, export this to a dictionary/json and also demonstrate how the termination condition object can be loaded from the dictionary/json. \n",
+    " "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen_agentchat.conditions import StopMessageTermination, MaxMessageTermination \n",
+    "\n",
+    "max_termination = MaxMessageTermination(5)\n",
+    "stop_termination = StopMessageTermination() "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "provider='autogen_agentchat.conditions.MaxMessageTermination' component_type='termination' version=1 component_version=1 description=None config={'max_messages': 5}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(max_termination.dump_component())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'provider': 'autogen_agentchat.conditions.MaxMessageTermination', 'component_type': 'termination', 'version': 1, 'component_version': 1, 'description': None, 'config': {'max_messages': 5}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(max_termination.dump_component().model_dump())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/wg/hgs_dt8n5lbd3gx3pq7k6lym0000gn/T/ipykernel_86784/1252547633.py:2: UserWarning: Internal module name used in provider string. This is not recommended and may cause issues in the future. Silence this warning by setting component_provider_override to this value.\n",
+      "  or_termination.dump_component()\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "ComponentModel(provider='autogen_agentchat.base._termination._OrTerminationCondition', component_type='termination', version=1, component_version=1, description=None, config={'conditions': [{'provider': 'autogen_agentchat.conditions.MaxMessageTermination', 'component_type': 'termination', 'version': 1, 'component_version': 1, 'config': {'max_messages': 5}}, {'provider': 'autogen_agentchat.conditions.StopMessageTermination', 'component_type': 'termination', 'version': 1, 'component_version': 1, 'config': {}}]})"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "or_termination = max_termination | stop_termination\n",
+    "or_termination.dump_component() "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->




## Why are these changes needed?

Step 1 in making components in agentchat natively declarative. 

```python

from autogen_agentchat.conditions import StopMessageTermination, MaxMessageTermination 

max_term = MaxMessageTermination(5)
stop_term = StopMessageTermination() 

or_term = max_term | stop_term
print(or_term.dump_component() )
 
print(max_term.dump_component())

```

Results 

```python
ComponentModel(provider='autogen_agentchat.base._termination._OrTerminationCondition', 
component_type='termination', version=1, component_version=1, description=None, 
config={'conditions': [{'provider': 'autogen_agentchat.conditions.MaxMessageTermination', '
component_type': 'termination', 'version': 1, 'component_version': 1, 
'config': {'max_messages': 5}}, {'provider': 'autogen_agentchat.conditions.StopMessageTermination', 
'component_type': 'termination', 'version': 1, 'component_version': 1, 'config': {}}]})
```

```python
ComponentModel(provider='autogen_agentchat.conditions.MaxMessageTermination', 
component_type='termination', version=1, component_version=1, 
description=None, config={'max_messages': 5})
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #4983 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
