### PR TITLE
Fix typo in `Multi-Agent Design Patterns -> Intro` docs

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/design-patterns/intro.md
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/design-patterns/intro.md
@@ -9,7 +9,7 @@ like software development.
 
 A multi-agent design pattern is a structure that emerges from message protocols:
 it describes how agents interact with each other to solve problems.
-For example, the [tool-equiped agent](../framework/tools.ipynb#tool-equipped-agent) in
+For example, the [tool-equipped agent](../framework/tools.ipynb#tool-equipped-agent) in
 the previous section employs a design pattern called ReAct,
 which involves an agent interacting with tools.
 


### PR DESCRIPTION
## Why are these changes needed?

There's a small typo in the documentation.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
