### PR TITLE
Typo in teams.ipynb

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/teams.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/teams.ipynb
@@ -83,7 +83,7 @@
             "source": [
                 "## Running a Team\n",
                 "\n",
-                "Let's calls the {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` method\n",
+                "Let's call the {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` method\n",
                 "to start the team with a task."
             ]
         },


### PR DESCRIPTION
Minor typo,
Let’s calls the run() method to start the team with a task. 

Fixed as,
Let’s call the run() method to start the team with a task.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
