### PR TITLE
Add sources field to TextMentionTermination

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -106,7 +106,7 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
     component_config_schema = TextMentionTerminationConfig
     component_provider_override = "autogen_agentchat.conditions.TextMentionTermination"
 
-    def __init__(self, text: str, sources: list[str] | None = None) -> None:
+    def __init__(self, text: str, sources: Sequence[str] | None = None) -> None:
         self._text = text
         self._terminated = False
         self._sources = sources

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -100,14 +100,16 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
 
     Args:
         text: The text to look for in the messages.
+        sources: Check only messages of the specified agents for the text to look for.
     """
 
     component_config_schema = TextMentionTerminationConfig
     component_provider_override = "autogen_agentchat.conditions.TextMentionTermination"
 
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, sources: list[str] | None = None) -> None:
         self._text = text
         self._terminated = False
+        self._sources = sources
 
     @property
     def terminated(self) -> bool:
@@ -117,6 +119,9 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
         if self._terminated:
             raise TerminatedException("Termination condition has already been reached")
         for message in messages:
+            if self._sources is not None and message.source not in self._sources:
+                continue
+
             if isinstance(message.content, str) and self._text in message.content:
                 self._terminated = True
                 return StopMessage(content=f"Text '{self._text}' mentioned", source="TextMentionTermination")

--- a/python/packages/autogen-agentchat/tests/test_termination_condition.py
+++ b/python/packages/autogen-agentchat/tests/test_termination_condition.py
@@ -88,6 +88,13 @@ async def test_mention_termination() -> None:
         await termination([TextMessage(content="Hello", source="user"), TextMessage(content="stop", source="user")])
         is not None
     )
+    termination = TextMentionTermination("stop", sources=["agent"])
+    assert await termination([TextMessage(content="stop", source="user")]) is None
+    await termination.reset()
+    assert (
+        await termination([TextMessage(content="stop", source="user"), TextMessage(content="stop", source="agent")])
+        is not None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See #4807. In many practical scenarios, we only want to stop a dialog, when a specific agent says something e.g. not stop when the keyword is part of the prompt for instance. This PR allows this by adding a list of sources, where a user can specify the agent names.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes  #4807

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
