### PR TITLE
Rysweet fix integration tests and xlang

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -132,6 +132,10 @@ jobs:
     - name: Prepare python venv
       run: |
         source ${{ github.workspace }}/python/.venv/bin/activate
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
     - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v4
       with:

--- a/dotnet/samples/Hello/Hello.AppHost/Program.cs
+++ b/dotnet/samples/Hello/Hello.AppHost/Program.cs
@@ -12,7 +12,7 @@ var client = builder.AddProject<Projects.HelloAgent>("HelloAgentsDotNET")
     .WaitFor(backend);
 #pragma warning disable ASPIREHOSTINGPYTHON001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 // xlang is over http for now - in prod use TLS between containers
-builder.AddPythonApp("HelloAgentsPython", "../../../../python/samples/core_xlang_hello_python_agent", "hello_python_agent.py", "../../.venv")    .WithReference(backend)
+builder.AddPythonApp("HelloAgentsPython", "../../../../python/samples/core_xlang_hello_python_agent", "hello_python_agent.py", "../../.venv").WithReference(backend)
     .WithEnvironment("AGENT_HOST", backend.GetEndpoint("http"))
     .WithEnvironment("STAY_ALIVE_ON_GOODBYE", "true")
     .WithEnvironment("GRPC_DNS_RESOLVER", "native")

--- a/dotnet/samples/Hello/Hello.AppHost/Program.cs
+++ b/dotnet/samples/Hello/Hello.AppHost/Program.cs
@@ -12,8 +12,7 @@ var client = builder.AddProject<Projects.HelloAgent>("HelloAgentsDotNET")
     .WaitFor(backend);
 #pragma warning disable ASPIREHOSTINGPYTHON001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 // xlang is over http for now - in prod use TLS between containers
-builder.AddPythonApp("HelloAgentsPython", "../../../../python/packages/autogen-core/samples/xlang/hello_python_agent", "hello_python_agent.py", "../../../../../.venv")
-    .WithReference(backend)
+builder.AddPythonApp("HelloAgentsPython", "../../../../python/samples/core_xlang_hello_python_agent", "hello_python_agent.py", "../../.venv")    .WithReference(backend)
     .WithEnvironment("AGENT_HOST", backend.GetEndpoint("http"))
     .WithEnvironment("STAY_ALIVE_ON_GOODBYE", "true")
     .WithEnvironment("GRPC_DNS_RESOLVER", "native")

--- a/dotnet/samples/Hello/HelloAIAgents/Program.cs
+++ b/dotnet/samples/Hello/HelloAIAgents/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.AutoGen.Contracts;
 using Microsoft.AutoGen.Core;
 
 // send a message to the agent
-var builder = WebApplication.CreateBuilder();
+var builder = new HostApplicationBuilder();
 // put these in your environment or appsettings.json
 builder.Configuration["HelloAIAgents:ModelType"] = "azureopenai";
 builder.Configuration["HelloAIAgents:LlmModelName"] = "gpt-3.5-turbo";

--- a/dotnet/samples/Hello/HelloAgent/HelloAgent.csproj
+++ b/dotnet/samples/Hello/HelloAgent/HelloAgent.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../../src/Microsoft.AutoGen/Core.Grpc/Microsoft.AutoGen.Core.Grpc.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.AutoGen\Agents\Microsoft.AutoGen.Agents.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.AutoGen\Contracts\Microsoft.AutoGen.Contracts.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.AutoGen\Core\Microsoft.AutoGen.Core.csproj" />

--- a/dotnet/samples/Hello/HelloAgent/Program.cs
+++ b/dotnet/samples/Hello/HelloAgent/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Hosting;
 
 var local = true;
 if (Environment.GetEnvironmentVariable("AGENT_HOST") != null) { local = false; }
-var app = await AgentsApp.PublishMessageAsync("HelloAgents", new NewMessageReceived
+var app = await Microsoft.AutoGen.Core.Grpc.AgentsApp.PublishMessageAsync("HelloAgents", new NewMessageReceived
 {
     Message = "World"
 }, local: local).ConfigureAwait(false);

--- a/dotnet/samples/Hello/HelloAgent/Program.cs
+++ b/dotnet/samples/Hello/HelloAgent/Program.cs
@@ -16,7 +16,7 @@ await app.WaitForShutdownAsync();
 
 namespace Hello
 {
-    [TopicSubscription("agents")]
+    [TopicSubscription("HelloAgents")]
     public class HelloAgent(
         IAgentWorker worker, IHostApplicationLifetime hostApplicationLifetime,
         [FromKeyedServices("EventTypes")] EventTypes typeRegistry) : Agent(

--- a/dotnet/samples/Hello/HelloAgent/appsettings.json
+++ b/dotnet/samples/Hello/HelloAgent/appsettings.json
@@ -2,7 +2,7 @@
     "Logging": {
       "LogLevel": {
         "Default": "Warning",
-        "Microsoft": "Warning",
+        "Microsoft": "Information",
         "Microsoft.Orleans": "Warning"
       }
     }

--- a/dotnet/src/Microsoft.AutoGen/AgentHost/appsettings.json
+++ b/dotnet/src/Microsoft.AutoGen/AgentHost/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Microsoft": "Warning",
+      "Microsoft": "Information",
       "Microsoft.Orleans": "Warning"
     }
   },

--- a/dotnet/src/Microsoft.AutoGen/AgentHost/appsettings.json
+++ b/dotnet/src/Microsoft.AutoGen/AgentHost/appsettings.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft": "Information",
-      "Microsoft.Orleans": "Warning"
+      "Microsoft.Orleans": "Warning",
+      "Orleans.Runtime": "Error"
     }
   },
   "AllowedHosts": "*",

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/App.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/App.cs
@@ -3,7 +3,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Google.Protobuf;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -13,26 +12,30 @@ namespace Microsoft.AutoGen.Core.Grpc;
 public static class AgentsApp
 {
     // need a variable to store the runtime instance
-    public static WebApplication? Host { get; private set; }
+    public static IHost? Host { get; private set; }
 
     [MemberNotNull(nameof(Host))]
-    public static async ValueTask<WebApplication> StartAsync(WebApplicationBuilder? builder = null, AgentTypes? agentTypes = null, bool local = false)
+    public static async ValueTask<IHost> StartAsync(HostApplicationBuilder? builder = null, AgentTypes? agentTypes = null, bool local = false)
     {
-        builder ??= WebApplication.CreateBuilder();
+        builder ??= new HostApplicationBuilder();
         builder.Services.TryAddSingleton(DistributedContextPropagator.Current);
-        builder.AddAgentWorker()
+        if (! local) 
+        {
+            builder.AddGrpcAgentWorker()
             .AddAgents(agentTypes);
-        builder.AddServiceDefaults();
+        } else {
+            builder.AddAgentWorker()
+            .AddAgents(agentTypes);
+        }
         var app = builder.Build();
-        app.MapDefaultEndpoints();
         Host = app;
         await app.StartAsync().ConfigureAwait(false);
         return Host;
     }
-    public static async ValueTask<WebApplication> PublishMessageAsync(
+    public static async ValueTask<IHost> PublishMessageAsync(
         string topic,
         IMessage message,
-        WebApplicationBuilder? builder = null,
+        HostApplicationBuilder? builder = null,
         AgentTypes? agents = null,
         bool local = false)
     {

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/App.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/App.cs
@@ -19,11 +19,13 @@ public static class AgentsApp
     {
         builder ??= new HostApplicationBuilder();
         builder.Services.TryAddSingleton(DistributedContextPropagator.Current);
-        if (! local) 
+        if (!local)
         {
             builder.AddGrpcAgentWorker()
             .AddAgents(agentTypes);
-        } else {
+        }
+        else
+        {
             builder.AddAgentWorker()
             .AddAgents(agentTypes);
         }

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorker.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorker.cs
@@ -90,12 +90,14 @@ public sealed class GrpcAgentWorker(
 
                             break;
                         case Message.MessageOneofCase.RegisterAgentTypeResponse:
-                            if (!message.RegisterAgentTypeResponse.Success){
+                            if (!message.RegisterAgentTypeResponse.Success)
+                            {
                                 _logger.LogError($"Failed to register agent type '{message.RegisterAgentTypeResponse.Error}'");
                             }
                             break;
                         case Message.MessageOneofCase.AddSubscriptionResponse:
-                            if (!message.AddSubscriptionResponse.Success){
+                            if (!message.AddSubscriptionResponse.Success)
+                            {
                                 _logger.LogError($"Failed to add subscription '{message.AddSubscriptionResponse.Error}'");
                             }
                             break;
@@ -326,7 +328,7 @@ public sealed class GrpcAgentWorker(
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _channel = GetChannel();
-        _logger.LogInformation("Starting GrpcAgentWorker, connecting to gRPC endpoint "+ Environment.GetEnvironmentVariable("AGENT_HOST"));
+        _logger.LogInformation("Starting GrpcAgentWorker, connecting to gRPC endpoint " + Environment.GetEnvironmentVariable("AGENT_HOST"));
 
         StartCore();
 

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorker.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorker.cs
@@ -156,7 +156,7 @@ public sealed class GrpcAgentWorker(
             {
                 // we could not connect to the endpoint - most likely we have the wrong port or failed ssl
                 // we need to let the user know what port we tried to connect to and then do backoff and retry
-                _logger.LogError(ex, "Error connecting to GRPC endpoint {Endpoint}.", channel.ToString());
+                _logger.LogError(ex, "Error connecting to GRPC endpoint {Endpoint}.", Environment.GetEnvironmentVariable("AGENT_HOST"));
                 break;
             }
             catch (Exception ex) when (!_shutdownCts.IsCancellationRequested)
@@ -326,7 +326,7 @@ public sealed class GrpcAgentWorker(
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _channel = GetChannel();
-        _logger.LogInformation("Starting GrpcAgentWorker, connecting to gRPC endpoint "+ _client.ToString());
+        _logger.LogInformation("Starting GrpcAgentWorker, connecting to gRPC endpoint "+ Environment.GetEnvironmentVariable("AGENT_HOST"));
 
         StartCore();
 

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorker.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorker.cs
@@ -89,6 +89,16 @@ public sealed class GrpcAgentWorker(
                             }
 
                             break;
+                        case Message.MessageOneofCase.RegisterAgentTypeResponse:
+                            if (!message.RegisterAgentTypeResponse.Success){
+                                _logger.LogError($"Failed to register agent type '{message.RegisterAgentTypeResponse.Error}'");
+                            }
+                            break;
+                        case Message.MessageOneofCase.AddSubscriptionResponse:
+                            if (!message.AddSubscriptionResponse.Success){
+                                _logger.LogError($"Failed to add subscription '{message.AddSubscriptionResponse.Error}'");
+                            }
+                            break;
                         default:
                             throw new InvalidOperationException($"Unexpected message '{message}'.");
                     }
@@ -316,6 +326,8 @@ public sealed class GrpcAgentWorker(
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _channel = GetChannel();
+        _logger.LogInformation("Starting GrpcAgentWorker, connecting to gRPC endpoint "+ _client.ToString());
+
         StartCore();
 
         var tasks = new List<Task>(_agentTypes.Count);

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorkerHostBuilderExtension.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorkerHostBuilderExtension.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // GrpcAgentWorkerHostBuilderExtension.cs
+using System.Reflection;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using Grpc.Core;
 using Grpc.Net.Client.Configuration;
 using Microsoft.AutoGen.Contracts;
@@ -44,8 +47,80 @@ public static class GrpcAgentWorkerHostBuilderExtensions
             });
         });
         builder.Services.AddSingleton<IAgentWorker, GrpcAgentWorker>();
+                builder.Services.AddKeyedSingleton("EventTypes", (sp, key) =>
+        {
+            var interfaceType = typeof(IMessage);
+            var pairs = AppDomain.CurrentDomain.GetAssemblies()
+                                    .SelectMany(assembly => assembly.GetTypes())
+                                    .Where(type => interfaceType.IsAssignableFrom(type) && type.IsClass && !type.IsAbstract)
+                                    .Select(t => (t, GetMessageDescriptor(t)));
+
+            var descriptors = pairs.Select(t => t.Item2);
+            var typeRegistry = TypeRegistry.FromMessages(descriptors);
+            var types = pairs.ToDictionary(item => item.Item2?.FullName ?? "", item => item.t);
+
+            var eventsMap = AppDomain.CurrentDomain.GetAssemblies()
+                                    .SelectMany(assembly => assembly.GetTypes())
+                                    .Where(type => ReflectionHelper.IsSubclassOfGeneric(type, typeof(Agent)) && !type.IsAbstract)
+                                    .Select(t => (t, t.GetInterfaces()
+                                                  .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IHandle<>))
+                                                  .Select(i => (GetMessageDescriptor(i.GetGenericArguments().First())?.FullName ?? "")).ToHashSet()))
+                                    .ToDictionary(item => item.t, item => item.Item2);
+            // if the assembly contains any interfaces of type IHandler, then add all the methods of the interface to the eventsMap
+            var handlersMap = AppDomain.CurrentDomain.GetAssemblies()
+                                    .SelectMany(assembly => assembly.GetTypes())
+                                    .Where(type => ReflectionHelper.IsSubclassOfGeneric(type, typeof(Agent)) && !type.IsAbstract)
+                                    .Select(t => (t, t.GetMethods()
+                                                  .Where(m => m.Name == "Handle")
+                                                  .Select(m => (GetMessageDescriptor(m.GetParameters().First().ParameterType)?.FullName ?? "")).ToHashSet()))
+                                    .ToDictionary(item => item.t, item => item.Item2);
+            // get interfaces implemented by the agent and get the methods of the interface if they are named Handle
+            var ifaceHandlersMap = AppDomain.CurrentDomain.GetAssemblies()
+                                    .SelectMany(assembly => assembly.GetTypes())
+                                    .Where(type => ReflectionHelper.IsSubclassOfGeneric(type, typeof(Agent)) && !type.IsAbstract)
+                                    .Select(t => t.GetInterfaces()
+                                                  .Select(i => (t, i, i.GetMethods()
+                                                  .Where(m => m.Name == "Handle")
+                                                    .Select(m => (GetMessageDescriptor(m.GetParameters().First().ParameterType)?.FullName ?? ""))
+                                                    //to dictionary of type t and paramter type of the method
+                                                    .ToDictionary(m => m, m => m).Keys.ToHashSet())).ToList());
+            // for each item in ifaceHandlersMap, add the handlers to eventsMap with item as the key 
+            foreach (var item in ifaceHandlersMap)
+            {
+                foreach (var iface in item)
+                {
+                    if (eventsMap.TryGetValue(iface.Item2, out var events))
+                    {
+                        events.UnionWith(iface.Item3);
+                    }
+                    else
+                    {
+                        eventsMap[iface.Item2] = iface.Item3;
+                    }
+                }
+            }
+
+            // merge the handlersMap into the eventsMap
+            foreach (var item in handlersMap)
+            {
+                if (eventsMap.TryGetValue(item.Key, out var events))
+                {
+                    events.UnionWith(item.Value);
+                }
+                else
+                {
+                    eventsMap[item.Key] = item.Value;
+                }
+            }
+            return new EventTypes(typeRegistry, types, eventsMap);
+        });
         builder.Services.AddSingleton<Client>();
 
         return builder;
+    }
+    private static MessageDescriptor? GetMessageDescriptor(Type type)
+    {
+        var property = type.GetProperty("Descriptor", BindingFlags.Static | BindingFlags.Public);
+        return property?.GetValue(null) as MessageDescriptor;
     }
 }

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorkerHostBuilderExtension.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentWorkerHostBuilderExtension.cs
@@ -44,6 +44,8 @@ public static class GrpcAgentWorkerHostBuilderExtensions
             });
         });
         builder.Services.AddSingleton<IAgentWorker, GrpcAgentWorker>();
+        builder.Services.AddSingleton<Client>();
+
         return builder;
     }
 }

--- a/dotnet/src/Microsoft.AutoGen/Core/App.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/App.cs
@@ -3,7 +3,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Google.Protobuf;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -13,27 +12,25 @@ namespace Microsoft.AutoGen.Core;
 public static class AgentsApp
 {
     // need a variable to store the runtime instance
-    public static WebApplication? Host { get; private set; }
+    public static IHost? Host { get; private set; }
 
     [MemberNotNull(nameof(Host))]
-    public static async ValueTask<WebApplication> StartAsync(WebApplicationBuilder? builder = null, AgentTypes? agentTypes = null)
+    public static async ValueTask<IHost> StartAsync(HostApplicationBuilder? builder = null, AgentTypes? agentTypes = null)
     {
-        builder ??= WebApplication.CreateBuilder();
+        builder ??= new HostApplicationBuilder();
         builder.Services.TryAddSingleton(DistributedContextPropagator.Current);
         builder.AddAgentWorker()
             .AddAgents(agentTypes);
-        builder.AddServiceDefaults();
         var app = builder.Build();
 
-        app.MapDefaultEndpoints();
         Host = app;
         await app.StartAsync().ConfigureAwait(false);
         return Host;
     }
-    public static async ValueTask<WebApplication> PublishMessageAsync(
+    public static async ValueTask<IHost> PublishMessageAsync(
         string topic,
         IMessage message,
-        WebApplicationBuilder? builder = null,
+        HostApplicationBuilder? builder = null,
         AgentTypes? agents = null,
         bool local = false)
     {

--- a/dotnet/src/Microsoft.AutoGen/Runtime.Grpc/Services/Grpc/GrpcGateway.cs
+++ b/dotnet/src/Microsoft.AutoGen/Runtime.Grpc/Services/Grpc/GrpcGateway.cs
@@ -171,8 +171,14 @@ public sealed class GrpcGateway : BackgroundService, IGateway
     {
         // get the event type and then send to all agents that are subscribed to that event type
         var eventType = evt.Type;
+        var source = evt.Source;
+        var agentTypes = new List<string>();
         // ensure that we get agentTypes as an async enumerable list - try to get the value of agentTypes by topic and then cast it to an async enumerable list
-        if (_subscriptionsByTopic.TryGetValue(eventType, out var agentTypes))
+        if (_subscriptionsByTopic.TryGetValue(eventType, out var agentTypesList)) { agentTypes.AddRange(agentTypesList); }
+        if (_subscriptionsByTopic.TryGetValue(source, out var agentTypesList2)) { agentTypes.AddRange(agentTypesList2); }
+        if (_subscriptionsByTopic.TryGetValue(source + "." + eventType, out var agentTypesList3)) { agentTypes.AddRange(agentTypesList3); }
+        agentTypes = agentTypes.Distinct().ToList();
+        if (agentTypes.Count > 0)
         {
             await DispatchEventToAgentsAsync(agentTypes, evt);
         }


### PR DESCRIPTION
## Why are these changes needed?

somewhere after #4674 I broke the integration test in a non-obvious way (it was succeeding but not testing the right things) and after that grpc was broken in subsequent prs. this fixes both. 

* fix path for integration test
* because AddAgentWorker split in a prior check-in, fixing AddGrpcAgentWorker with the necessary DI statements
* WebApplication -> HostApplication for the AgentsApp
* cleaning up some logging

