### PR TITLE
fix: use tool_calls field to detect tool calls in OpenAI client; add integration tests for OpenAI and Gemini

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -539,20 +539,32 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         if self._resolved_model is not None:
             if self._resolved_model != result.model:
                 warnings.warn(
-                    f"Resolved model mismatch: {self._resolved_model} != {result.model}. Model mapping may be incorrect.",
+                    f"Resolved model mismatch: {self._resolved_model} != {result.model}. "
+                    "Model mapping in autogen_ext.models.openai may be incorrect.",
                     stacklevel=2,
                 )
 
         # Limited to a single choice currently.
         choice: Union[ParsedChoice[Any], ParsedChoice[BaseModel], Choice] = result.choices[0]
-        if choice.finish_reason == "function_call":
-            raise ValueError("Function calls are not supported in this context")
 
+        # Detect whether it is a function call or not.
+        # We don't rely on choice.finish_reason as it is not always accurate, depending on the API used.
         content: Union[str, List[FunctionCall]]
-        if choice.finish_reason == "tool_calls":
-            assert choice.message.tool_calls is not None
-            assert choice.message.function_call is None
-
+        if choice.message.function_call is not None:
+            raise ValueError("function_call is deprecated and is not supported by this model client.")
+        elif choice.message.tool_calls is not None:
+            if choice.finish_reason != "tool_calls":
+                warnings.warn(
+                    f"finish reason mismatch: {choice.finish_reason} != tool_calls "
+                    "when tool_calls are present. Finish reason may not be accurate.",
+                    stacklevel=2,
+                )
+            if choice.message.content is not None and choice.message.content != "":
+                warnings.warn(
+                    "Both tool_calls and content are present in the message. "
+                    "This is unexpected. content will be ignored.",
+                    stacklevel=2,
+                )
             # NOTE: If OAI response type changes, this will need to be updated
             content = [
                 FunctionCall(
@@ -566,6 +578,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         else:
             finish_reason = choice.finish_reason
             content = choice.message.content or ""
+
         logprobs: Optional[List[ChatCompletionTokenLogprob]] = None
         if choice.logprobs and choice.logprobs.content:
             logprobs = [

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -555,14 +555,15 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         elif choice.message.tool_calls is not None:
             if choice.finish_reason != "tool_calls":
                 warnings.warn(
-                    f"finish reason mismatch: {choice.finish_reason} != tool_calls "
-                    "when tool_calls are present. Finish reason may not be accurate.",
+                    f"Finish reason mismatch: {choice.finish_reason} != tool_calls "
+                    "when tool_calls are present. Finish reason may not be accurate. "
+                    "This may be due to the API used that is not returning the correct finish reason.",
                     stacklevel=2,
                 )
             if choice.message.content is not None and choice.message.content != "":
                 warnings.warn(
                     "Both tool_calls and content are present in the message. "
-                    "This is unexpected. content will be ignored.",
+                    "This is unexpected. content will be ignored, tool_calls will be used.",
                     stacklevel=2,
                 )
             # NOTE: If OAI response type changes, this will need to be updated
@@ -574,7 +575,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                 )
                 for x in choice.message.tool_calls
             ]
-            finish_reason = "function_calls"
+            finish_reason = "tool_calls"
         else:
             finish_reason = choice.finish_reason
             content = choice.message.content or ""


### PR DESCRIPTION
Resolves: #4878

See comment: https://github.com/microsoft/autogen/issues/4878#issuecomment-2603296182

Also added unit tests for tool calling and integration tests for OpenAI and Gemini.

The integration tests won't run in CI because we haven't set up API keys. 