### PR TITLE
Closes #5059

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_magentic_one/_magentic_one_orchestrator.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_magentic_one/_magentic_one_orchestrator.py
@@ -460,7 +460,7 @@ class MagenticOneOrchestrator(BaseGroupChatManager):
                 assert isinstance(m, TextMessage | ToolCallSummaryMessage)
                 context.append(AssistantMessage(content=m.content, source=m.source))
             else:
-                assert isinstance(m, TextMessage) or isinstance(m, MultiModalMessage)
+                assert isinstance(m, (TextMessage, MultiModalMessage, ToolCallSummaryMessage))
                 context.append(UserMessage(content=m.content, source=m.source))
         return context
 


### PR DESCRIPTION
In a Magentic Group Settting, if one of the Assitant Agents uses a tool it gives the following error, note this is under a FALSE reflect_on_tool variable.

Making it true, wont happen, though more tokens will be consumed and it will have a worst output and the philosophy of a tool as an answer is not followed...

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
