### PR TITLE
Fix function tool naming to avoid overriding the name input

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_function_utils.py
+++ b/python/packages/autogen-core/src/autogen_core/_function_utils.py
@@ -304,18 +304,18 @@ def normalize_annotated_type(type_hint: Type[Any]) -> Type[Any]:
 
 def args_base_model_from_signature(name: str, sig: inspect.Signature) -> Type[BaseModel]:
     fields: Dict[str, tuple[Type[Any], Any]] = {}
-    for name, param in sig.parameters.items():
+    for param_name, param in sig.parameters.items():
         # This is handled externally
-        if name == "cancellation_token":
+        if param_name == "cancellation_token":
             continue
 
         if param.annotation is inspect.Parameter.empty:
             raise ValueError("No annotation")
 
         type = normalize_annotated_type(param.annotation)
-        description = type2description(name, param.annotation)
+        description = type2description(param_name, param.annotation)
         default_value = param.default if param.default is not inspect.Parameter.empty else PydanticUndefined
 
-        fields[name] = (type, Field(default=default_value, description=description))
+        fields[param_name] = (type, Field(default=default_value, description=description))
 
     return cast(BaseModel, create_model(name, **fields))  # type: ignore


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For tools, the transformation from function object to pydantic object (used to  create the string to give the agent to describe the tool) is done with an error were the name of one of the parameters overrides the name of the function.
## Related issue number

Closes #5138

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
