### PR TITLE
Added type hints existence validation to make error message when miss…

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import warnings
+import typing
 from textwrap import dedent
 from typing import Any, Callable, Sequence
 
@@ -87,6 +88,12 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
     ) -> None:
         self._func = func
         self._global_imports = global_imports
+
+        # Validate type hints exist
+        hints = typing.get_type_hints(func)
+        if not hints:
+            raise TypeError(f"Function '{func.__name__}' has no type hints. All parameters must be annotated.")
+        
         signature = get_typed_signature(func)
         func_name = name or func.__name__
         args_model = args_base_model_from_signature(func_name + "args", signature)


### PR DESCRIPTION
Change: Added type hints existence validation to make error message when missing more explicit.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The FunctionTool class requires type hints on function parameters to generate proper schemas for input validation and LLM interaction. Previously, when type hints were missing, the error message was not explicit enough to help users understand the requirement. This change adds explicit validation to check for type hints existence and provides a clearer error message when they are missing.

I spent sometime trying to figure out the vagye error message, found another person reporting this issue: https://github.com/microsoft/autogen/discussions/5142

## Related issue number

Not an issue, but a discussion here: https://github.com/microsoft/autogen/discussions/5142

## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
