### PR TITLE
feat: Enable queueing and step mode in InProcessRuntime

### DIFF
--- a/dotnet/samples/getting-started/Program.cs
+++ b/dotnet/samples/getting-started/Program.cs
@@ -21,6 +21,7 @@ appBuilder.Services.TryAddSingleton(runUntilFunc);
 appBuilder.AddAgent<Checker>("Checker");
 appBuilder.AddAgent<Modifier>("Modifier");
 var app = await appBuilder.BuildAsync();
+await app.StartAsync();
 
 // Send the initial count to the agents app, running on the `local` runtime, and pass through the registered services via the application `builder`
 await app.PublishMessageAsync(new CountMessage

--- a/dotnet/src/Microsoft.AutoGen/Contracts/AgentProxy.cs
+++ b/dotnet/src/Microsoft.AutoGen/Contracts/AgentProxy.cs
@@ -45,7 +45,7 @@ public class AgentProxy(AgentId agentId, IAgentRuntime runtime)
     /// A token used to cancel an in-progress operation. Defaults to <c>null</c>.
     /// </param>
     /// <returns>A task representing the asynchronous operation, returning the response from the agent.</returns>
-    public ValueTask<object?> SendMessageAsync(object message, AgentId sender, string? messageId = null, CancellationToken? cancellationToken = default)
+    public ValueTask<object?> SendMessageAsync(object message, AgentId sender, string? messageId = null, CancellationToken cancellationToken = default)
     {
         return this.runtime.SendMessageAsync(message, this.Id, sender, messageId, cancellationToken);
     }

--- a/dotnet/src/Microsoft.AutoGen/Contracts/IAgentRuntime.cs
+++ b/dotnet/src/Microsoft.AutoGen/Contracts/IAgentRuntime.cs
@@ -22,7 +22,7 @@ public interface IAgentRuntime : ISaveState<IAgentRuntime>
     /// <returns>A task representing the asynchronous operation, returning the response from the agent.</returns>
     /// <exception cref="CantHandleException">Thrown if the recipient cannot handle the message.</exception>
     /// <exception cref="UndeliverableException">Thrown if the message cannot be delivered.</exception>
-    public ValueTask<object?> SendMessageAsync(object message, AgentId recepient, AgentId? sender = null, string? messageId = null, CancellationToken? cancellationToken = default);
+    public ValueTask<object?> SendMessageAsync(object message, AgentId recepient, AgentId? sender = null, string? messageId = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publishes a message to all agents subscribed to the given topic.
@@ -35,7 +35,7 @@ public interface IAgentRuntime : ISaveState<IAgentRuntime>
     /// <param name="cancellationToken">A token to cancel the operation if needed.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <exception cref="UndeliverableException">Thrown if the message cannot be delivered.</exception>
-    public ValueTask PublishMessageAsync(object message, TopicId topic, AgentId? sender = null, string? messageId = null, CancellationToken? cancellationToken = default);
+    public ValueTask PublishMessageAsync(object message, TopicId topic, AgentId? sender = null, string? messageId = null, CancellationToken cancellationToken = default);
 
     // TODO: Can we call this Resolve?
     /// <summary>

--- a/dotnet/src/Microsoft.AutoGen/Core/BaseAgent.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/BaseAgent.cs
@@ -100,13 +100,13 @@ public abstract class BaseAgent : IAgent, IHostableAgent
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask<object?> SendMessageAsync(object message, AgentId recepient, string? messageId = null, CancellationToken? cancellationToken = default)
+    public ValueTask<object?> SendMessageAsync(object message, AgentId recepient, string? messageId = null, CancellationToken cancellationToken = default)
     {
         return this.Runtime.SendMessageAsync(message, recepient, sender: this.Id, messageId: messageId, cancellationToken: cancellationToken);
 
     }
 
-    public ValueTask PublishMessageAsync(object message, TopicId topic, string? messageId = null, CancellationToken? cancellationToken = default)
+    public ValueTask PublishMessageAsync(object message, TopicId topic, string? messageId = null, CancellationToken cancellationToken = default)
     {
         return this.Runtime.PublishMessageAsync(message, topic, sender: this.Id, messageId: messageId, cancellationToken: cancellationToken);
     }

--- a/dotnet/src/Microsoft.AutoGen/Core/MessageDelivery.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/MessageDelivery.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// MessageDelivery.cs
+
+using Microsoft.AutoGen.Contracts;
+
+namespace Microsoft.AutoGen.Core;
+
+internal sealed class MessageDelivery(MessageEnvelope message, Func<MessageEnvelope, CancellationToken, ValueTask> servicer, IResultSink<object?>? resultSink = null)
+{
+    public MessageEnvelope Message { get; } = message;
+    public Func<MessageEnvelope, CancellationToken, ValueTask> Servicer { get; } = servicer;
+    public IResultSink<object?>? ResultSink { get; } = resultSink;
+
+    public ValueTask<object?> Future => this.ResultSink != null ? this.ResultSink.Future : ValueTask.FromResult((object?)null);
+
+    public ValueTask InvokeAsync(CancellationToken cancellation)
+    {
+        return this.Servicer(this.Message, cancellation);
+    }
+}
+
+internal sealed class MessageEnvelope
+{
+    public object Message { get; }
+    public string MessageId { get; }
+    public TopicId? Topic { get; private set; }
+    public AgentId? Sender { get; private set; }
+    public AgentId? Receiver { get; private set; }
+    public CancellationToken Cancellation { get; }
+
+    public MessageEnvelope(object message, string? messageId = null, CancellationToken cancellation = default)
+    {
+        this.Message = message;
+        this.MessageId = messageId ?? Guid.NewGuid().ToString();
+        this.Cancellation = cancellation;
+    }
+
+    public MessageEnvelope WithSender(AgentId? sender)
+    {
+        this.Sender = sender;
+        return this;
+    }
+
+    public MessageDelivery ForSend(AgentId receiver, Func<MessageEnvelope, CancellationToken, ValueTask<object?>> servicer)
+    {
+        this.Receiver = receiver;
+
+        ResultSink<object?> resultSink = new ResultSink<object?>();
+        Func<MessageEnvelope, CancellationToken, ValueTask> boundServicer = async (envelope, cancellation) =>
+        {
+            object? result = await servicer(envelope, cancellation);
+            resultSink.SetResult(result);
+        };
+
+        return new MessageDelivery(this, boundServicer, resultSink);
+    }
+
+    public MessageDelivery ForPublish(TopicId topic, Func<MessageEnvelope, CancellationToken, ValueTask> servicer)
+    {
+        this.Topic = topic;
+
+        return new MessageDelivery(this, servicer);
+    }
+}

--- a/dotnet/src/Microsoft.AutoGen/Core/ResultSink.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/ResultSink.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ResultSink.cs
+
+using System.Threading.Tasks.Sources;
+
+namespace Microsoft.AutoGen.Core;
+
+internal interface IResultSink<TResult> : IValueTaskSource<TResult>
+{
+    void SetResult(TResult result);
+    void SetException(Exception exception);
+    void SetCancelled();
+
+    ValueTask<TResult> Future { get; }
+}
+
+internal sealed class ResultSink<TResult> : IResultSink<TResult>
+{
+    private ManualResetValueTaskSourceCore<TResult> core;
+
+    public TResult GetResult(short token)
+    {
+        return this.core.GetResult(token);
+    }
+
+    public ValueTaskSourceStatus GetStatus(short token)
+    {
+        return this.core.GetStatus(token);
+    }
+
+    public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+    {
+        this.core.OnCompleted(continuation, state, token, flags);
+    }
+
+    public bool IsCancelled { get; private set; }
+    public void SetCancelled()
+    {
+        this.IsCancelled = true;
+        this.core.SetException(new OperationCanceledException());
+    }
+
+    public void SetException(Exception exception)
+    {
+        this.core.SetException(exception);
+    }
+
+    public void SetResult(TResult result)
+    {
+        this.core.SetResult(result);
+    }
+
+    public ValueTask<TResult> Future => new(this, this.core.Version);
+}


### PR DESCRIPTION
Moves the semantics of message delivery in .NET to be closer to Python (up to vagaries of differences in Threading)

* Creates a message delivery queue in InProcessRuntime
* Creates Start/Stop/WaitForIdle APIs on InProcessRuntime
* Creates API to step individual messages
* Updates InProcessRuntime to play well with IHost as an IHostedService