### PR TITLE
feat: Expose self-delivery for InProcessRuntime in AgentsApp

### DIFF
--- a/dotnet/samples/getting-started/Program.cs
+++ b/dotnet/samples/getting-started/Program.cs
@@ -15,7 +15,7 @@ TerminationF runUntilFunc = (int x) =>
 };
 
 AgentsAppBuilder appBuilder = new AgentsAppBuilder();
-appBuilder.UseInProcessRuntime(); 
+appBuilder.UseInProcessRuntime();
 
 appBuilder.Services.TryAddSingleton(modifyFunc);
 appBuilder.Services.TryAddSingleton(runUntilFunc);

--- a/dotnet/samples/getting-started/Program.cs
+++ b/dotnet/samples/getting-started/Program.cs
@@ -15,11 +15,14 @@ TerminationF runUntilFunc = (int x) =>
 };
 
 AgentsAppBuilder appBuilder = new AgentsAppBuilder();
+appBuilder.UseInProcessRuntime(); 
+
 appBuilder.Services.TryAddSingleton(modifyFunc);
 appBuilder.Services.TryAddSingleton(runUntilFunc);
 
 appBuilder.AddAgent<Checker>("Checker");
 appBuilder.AddAgent<Modifier>("Modifier");
+
 var app = await appBuilder.BuildAsync();
 await app.StartAsync();
 

--- a/dotnet/src/Microsoft.AutoGen/Core/AgentsApp.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/AgentsApp.cs
@@ -18,8 +18,6 @@ public class AgentsAppBuilder
     public AgentsAppBuilder(HostApplicationBuilder? baseBuilder = null)
     {
         this.builder = baseBuilder ?? new HostApplicationBuilder();
-
-        this.AddInProcessRuntime();
     }
 
     public IServiceCollection Services => this.builder.Services;
@@ -29,9 +27,9 @@ public class AgentsAppBuilder
         this.AddAgentsFromAssemblies(AppDomain.CurrentDomain.GetAssemblies());
     }
 
-    public AgentsAppBuilder AddInProcessRuntime()
+    public AgentsAppBuilder UseInProcessRuntime(bool deliverToSelf = false)
     {
-        this.Services.AddSingleton<IAgentRuntime, InProcessRuntime>();
+        this.Services.AddSingleton<IAgentRuntime, InProcessRuntime>(_ => new InProcessRuntime { DeliverToSelf = deliverToSelf });
         this.Services.AddHostedService<InProcessRuntime>(services =>
         {
             return (services.GetRequiredService<IAgentRuntime>() as InProcessRuntime)!;

--- a/dotnet/src/Microsoft.AutoGen/Core/InProcessRuntime.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/InProcessRuntime.cs
@@ -55,7 +55,7 @@ public sealed class InProcessRuntime : IAgentRuntime, IHostedService
             };
 
             AgentId agentId = subscription.MapToAgent(topic);
-            if (this.DeliverToSelf || sender.HasValue && sender == agentId)
+            if (!this.DeliverToSelf && sender.HasValue && sender == agentId)
             {
                 continue;
             }


### PR DESCRIPTION
* Enable configuring SelfDelivery (defaults to false) when using AgentsAppBuilder
* Also fixes the predicate for self-delivery