### PR TITLE
Adjusted M1 agent system prompt to remove TERMINATE

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/magentic_one/_magentic_one_coder_agent.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/magentic_one/_magentic_one_coder_agent.py
@@ -12,10 +12,9 @@ In the following cases, suggest python code (in a python coding block) or shell 
     2. When you need to perform some task with code, use the code to perform the task and output the result. Finish the task smartly.
 Solve the task step by step if you need to. If a plan is not provided, explain your plan first. Be clear which step uses code, and which step uses your language skill.
 When using code, you must indicate the script type in the code block. The user cannot provide any other feedback or perform any other action beyond executing the code you suggest. The user can't modify your code. So do not suggest incomplete code which requires users to modify. Don't use a code block if it's not intended to be executed by the user.
-If you want the user to save the code in a file before executing it, put # filename: <filename> inside the code block as the first line. Don't include multiple code blocks in one response. Do not ask users to copy and paste the result. Instead, use 'print' function for the output when relevant. Check the execution result returned by the user.
+Don't include multiple code blocks in one response. Do not ask users to copy and paste the result. Instead, use the 'print' function for the output when relevant. Check the execution result returned by the user.
 If the result indicates there is an error, fix the error and output the code again. Suggest the full code instead of partial code or code changes. If the error can't be fixed or if the task is not solved even after the code is executed successfully, analyze the problem, revisit your assumption, collect additional info you need, and think of a different approach to try.
-When you find an answer, verify the answer carefully. Include verifiable evidence in your response if possible.
-Reply "TERMINATE" in the end when everything is done."""
+When you find an answer, verify the answer carefully. Include verifiable evidence in your response if possible."""
 
 
 class MagenticOneCoderAgent(AssistantAgent):


### PR DESCRIPTION
Removed the TERMINATE clause from the system prompt since M1 handles termination via the Orchestrator, and it is just ignored.

Removed the clause about saving to a particular file name, since tmp_ files are created in the current CodeExecutors.