### PR TITLE
fix: NuGet icon is broken when building in ADO

### DIFF
--- a/.azure/pipelines/templates/build.yaml
+++ b/.azure/pipelines/templates/build.yaml
@@ -79,6 +79,7 @@ jobs:
           allowPackageConflicts: true
   steps:
   - checkout: self
+    lfs: true
   - task: UseDotNet@2
     displayName: 'Use .NET Core sdk'
     inputs:


### PR DESCRIPTION
We use git-lfs for storing the icon, and cannot publish with a broken icon