### PR TITLE
Run metadata stage in addition to build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -199,7 +199,7 @@ jobs:
       - run: dotnet tool update -g docfx
       - run: |
           mkdir -p ./build/dotnet/dev/
-          docfx build docfx.json --output ./build/dotnet/dev/
+          docfx docfx.json --output ./build/dotnet/dev/
         working-directory: ./docs/dotnet
       - name: insert clarity snippet to *.html
         working-directory: ./docs/dotnet/build/dotnet/dev/


### PR DESCRIPTION
`build` does not run the api doc generation step. The default command does both.