### PR TITLE
WebSurfer: print viewport text

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/_multimodal_web_surfer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/_multimodal_web_surfer.py
@@ -264,8 +264,6 @@ class MultimodalWebSurfer(BaseChatAgent, Component[MultimodalWebSurferConfig]):
             TOOL_SLEEP,
             TOOL_HOVER,
         ]
-        # Number of lines of text to extract from the page in the absence of OCR
-        self.n_lines_page_text = 50
         self.did_lazy_init = False  # flag to check if we have initialized the browser
 
     async def _lazy_init(
@@ -743,7 +741,7 @@ class MultimodalWebSurfer(BaseChatAgent, Component[MultimodalWebSurferConfig]):
         ocr_text = (
             await self._get_ocr_text(new_screenshot, cancellation_token=cancellation_token)
             if self.use_ocr is True
-            else await self._playwright_controller.get_webpage_text(self._page, n_lines=self.n_lines_page_text)
+            else await self._playwright_controller.get_visible_text(self._page)
         )
 
         # Return the complete observation
@@ -752,7 +750,7 @@ class MultimodalWebSurfer(BaseChatAgent, Component[MultimodalWebSurferConfig]):
         if self.use_ocr:
             message_content += f"Automatic OCR of the page screenshot has detected the following text:\n\n{ocr_text}"
         else:
-            message_content += f"The first {self.n_lines_page_text} lines of the page text is:\n\n{ocr_text}"
+            message_content += f"The following text is visible in the viewport:\n\n{ocr_text}"
 
         return [
             message_content,

--- a/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/playwright_controller.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/playwright_controller.py
@@ -527,6 +527,25 @@ class PlaywrightController:
         except Exception:
             return ""
 
+    async def get_visible_text(self, page: Page) -> str:
+        """
+        Retrieve the text content of the browser viewport (approximately).
+
+        Args:
+            page (Page): The Playwright page object.
+
+        Returns:
+            str: The text content of the page.
+        """
+        assert page is not None
+        try:
+            await page.evaluate(self._page_script)
+        except Exception:
+            pass
+        result = await page.evaluate("MultimodalWebSurfer.getVisibleText();")
+        assert isinstance(result, str)
+        return result
+
     async def get_page_markdown(self, page: Page) -> str:
         """
         Retrieve the markdown content of the web page.


### PR DESCRIPTION
This PR adds a method that approximately extracts the text visible in the viewport of the web browser (as opposed to always printing the first 50 lines, or relying entirely on OCR).