### PR TITLE
Allow m1 cli to read a configuration from a yaml file.

### DIFF
--- a/python/packages/magentic-one-cli/pyproject.toml
+++ b/python/packages/magentic-one-cli/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=5.1",
+    "types-PyYAML",
     "autogen-agentchat>=0.4.4,<0.5",
     "autogen-ext[openai,magentic-one,rich]>=0.4.4,<0.5",
 ]

--- a/python/packages/magentic-one-cli/pyproject.toml
+++ b/python/packages/magentic-one-cli/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "pyyaml>=5.1",
     "autogen-agentchat>=0.4.4,<0.5",
     "autogen-ext[openai,magentic-one,rich]>=0.4.4,<0.5",
 ]

--- a/python/packages/magentic-one-cli/pyproject.toml
+++ b/python/packages/magentic-one-cli/pyproject.toml
@@ -20,17 +20,13 @@ dependencies = [
     "autogen-ext[openai,magentic-one,rich]>=0.4.4,<0.5",
 ]
 
-[dependency-groups]
-dev = [
-    "types-PyYAML",
-]
-
 [project.scripts]
 m1 = "magentic_one_cli._m1:main"
 
 [dependency-groups]
-dev = []
-
+dev = [
+    "types-PyYAML",
+]
 
 [tool.ruff]
 extend = "../../pyproject.toml"

--- a/python/packages/magentic-one-cli/pyproject.toml
+++ b/python/packages/magentic-one-cli/pyproject.toml
@@ -16,9 +16,13 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=5.1",
-    "types-PyYAML",
     "autogen-agentchat>=0.4.4,<0.5",
     "autogen-ext[openai,magentic-one,rich]>=0.4.4,<0.5",
+]
+
+[dependency-groups]
+dev = [
+    "types-PyYAML",
 ]
 
 [project.scripts]

--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -1,28 +1,30 @@
 import argparse
 import asyncio
-import warnings
-import yaml
 import os
-from typing import Optional, Any, Dict
+import sys
+import warnings
+from typing import Any, Dict, Optional
 
+import yaml
 from autogen_agentchat.ui import Console, UserInputManager
 from autogen_core import CancellationToken
+from autogen_core.models import ChatCompletionClient
 from autogen_ext.teams.magentic_one import MagenticOne
 from autogen_ext.ui import RichConsole
-from autogen_core.models import ChatCompletionClient
 
 # Suppress warnings about the requests.Session() not being closed
 warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
-DEFAULT_CONFIG_FILE="config.yaml"
-DEFAULT_CONFIG_CONTENTS="""# config.yaml
+DEFAULT_CONFIG_FILE = "config.yaml"
+DEFAULT_CONFIG_CONTENTS = """# config.yaml
 #
 
-client: 
+client:
   provider: autogen_ext.models.openai.OpenAIChatCompletionClient
   config:
     model: gpt-4o
 """
+
 
 async def cancellable_input(prompt: str, cancellation_token: Optional[CancellationToken]) -> str:
     task: asyncio.Task[str] = asyncio.create_task(asyncio.to_thread(input, prompt))
@@ -52,13 +54,13 @@ def main() -> None:
     python magentic_one_cli.py --config config.yaml "example task"
 
     Use --sample-config to print a sample configuration file.
-    
+
     Example:
-    python magentic_one_cli.py --sample-config 
-    
-    NOTE: 
+    python magentic_one_cli.py --sample-config
+
+    NOTE:
     If --config is not specified, the configuration is loaded from the
-    file DEFAULT_CONFIG_FILE. If that file does not exist, load from 
+    file DEFAULT_CONFIG_FILE. If that file does not exist, load from
     DEFAULT_CONFIG_CONTENTS.
     """
     parser = argparse.ArgumentParser(
@@ -67,7 +69,7 @@ def main() -> None:
             "For more information, refer to the following paper: https://arxiv.org/abs/2411.04468"
         )
     )
-    parser.add_argument("task", type=str, nargs='?', help="The task to be executed by MagenticOne.")
+    parser.add_argument("task", type=str, nargs="?", help="The task to be executed by MagenticOne.")
     parser.add_argument("--no-hil", action="store_true", help="Disable human-in-the-loop mode.")
     parser.add_argument(
         "--rich",
@@ -78,18 +80,14 @@ def main() -> None:
         "--config",
         type=str,
         nargs=1,
-        help="The model configuration file to use. Leave empty to print a sample configuration."
+        help="The model configuration file to use. Leave empty to print a sample configuration.",
     )
-    parser.add_argument(
-        "--sample-config",
-        action="store_true",
-        help="Print a sample configuration to console."
-    )
- 
+    parser.add_argument("--sample-config", action="store_true", help="Print a sample configuration to console.")
+
     args = parser.parse_args()
 
     if args.sample_config:
-        print(DEFAULT_CONFIG_CONTENTS)
+        sys.stdout.write(DEFAULT_CONFIG_CONTENTS + "\n")
         return
 
     # We're not printing a sample, so we need a task
@@ -109,7 +107,7 @@ def main() -> None:
     else:
         with open(args.config[0], "r") as f:
             config = yaml.safe_load(f)
-        
+
     client = ChatCompletionClient.load_component(config["client"])
 
     # Run the task

--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -1,17 +1,28 @@
 import argparse
 import asyncio
 import warnings
-from typing import Optional
+import yaml
+import os
+from typing import Optional, Any, Dict
 
 from autogen_agentchat.ui import Console, UserInputManager
 from autogen_core import CancellationToken
-from autogen_ext.models.openai import OpenAIChatCompletionClient
 from autogen_ext.teams.magentic_one import MagenticOne
 from autogen_ext.ui import RichConsole
+from autogen_core.models import ChatCompletionClient
 
 # Suppress warnings about the requests.Session() not being closed
 warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
+DEFAULT_CONFIG_FILE="config.yaml"
+DEFAULT_CONFIG_CONTENTS="""# config.yaml
+#
+
+client: 
+  provider: autogen_ext.models.openai.OpenAIChatCompletionClient
+  config:
+    model: gpt-4o
+"""
 
 async def cancellable_input(prompt: str, cancellation_token: Optional[CancellationToken]) -> str:
     task: asyncio.Task[str] = asyncio.create_task(asyncio.to_thread(input, prompt))
@@ -32,11 +43,23 @@ def main() -> None:
     task (str): The task to be executed by MagenticOne.
     --no-hil: Optional flag to disable human-in-the-loop mode.
     --rich: Optional flag to enable rich console output.
+    --config: Optional flag to specify an alternate model configuration
 
     Example usage:
     python magentic_one_cli.py "example task"
     python magentic_one_cli.py --no-hil "example task"
     python magentic_one_cli.py --rich "example task"
+    python magentic_one_cli.py --config config.yaml "example task"
+
+    Use --sample-config to print a sample configuration file.
+    
+    Example:
+    python magentic_one_cli.py --sample-config 
+    
+    NOTE: 
+    If --config is not specified, the configuration is loaded from the
+    file DEFAULT_CONFIG_FILE. If that file does not exist, load from 
+    DEFAULT_CONFIG_CONTENTS.
     """
     parser = argparse.ArgumentParser(
         description=(
@@ -44,18 +67,54 @@ def main() -> None:
             "For more information, refer to the following paper: https://arxiv.org/abs/2411.04468"
         )
     )
-    parser.add_argument("task", type=str, nargs=1, help="The task to be executed by MagenticOne.")
+    parser.add_argument("task", type=str, nargs='?', help="The task to be executed by MagenticOne.")
     parser.add_argument("--no-hil", action="store_true", help="Disable human-in-the-loop mode.")
     parser.add_argument(
         "--rich",
         action="store_true",
         help="Enable rich console output",
     )
+    parser.add_argument(
+        "--config",
+        type=str,
+        nargs=1,
+        help="The model configuration file to use. Leave empty to print a sample configuration."
+    )
+    parser.add_argument(
+        "--sample-config",
+        action="store_true",
+        help="Print a sample configuration to console."
+    )
+ 
     args = parser.parse_args()
 
+    if args.sample_config:
+        print(DEFAULT_CONFIG_CONTENTS)
+        return
+
+    # We're not printing a sample, so we need a task
+    if args.task is None:
+        parser.print_usage()
+        return
+
+    # Load the configuration
+    config: Dict[str, Any] = {}
+
+    if args.config is None:
+        if os.path.isfile(DEFAULT_CONFIG_FILE):
+            with open(DEFAULT_CONFIG_FILE, "r") as f:
+                config = yaml.safe_load(f)
+        else:
+            config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)
+    else:
+        with open(args.config[0], "r") as f:
+            config = yaml.safe_load(f)
+        
+    client = ChatCompletionClient.load_component(config["client"])
+
+    # Run the task
     async def run_task(task: str, hil_mode: bool, use_rich_console: bool) -> None:
         input_manager = UserInputManager(callback=cancellable_input)
-        client = OpenAIChatCompletionClient(model="gpt-4o")
         m1 = MagenticOne(client=client, hil_mode=hil_mode, input_func=input_manager.get_wrapped_callback())
 
         if use_rich_console:

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3571,6 +3571,7 @@ dependencies = [
     { name = "autogen-agentchat" },
     { name = "autogen-ext", extra = ["magentic-one", "openai", "rich"] },
     { name = "pyyaml" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -3578,6 +3579,7 @@ requires-dist = [
     { name = "autogen-agentchat", editable = "packages/autogen-agentchat" },
     { name = "autogen-ext", extras = ["openai", "magentic-one", "rich"], editable = "packages/autogen-ext" },
     { name = "pyyaml", specifier = ">=5.1" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata.requires-dev]
@@ -7279,6 +7281,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/26/516311b02b5a215e721155fb65db8a965d061372e388d6125ebce8d674b0/types_pytz-2024.2.0.20241221.tar.gz", hash = "sha256:06d7cde9613e9f7504766a0554a270c369434b50e00975b3a4a0f6eed0f2c1a9", size = 10213 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/db/c92ca6920cccd9c2998b013601542e2ac5e59bc805bcff94c94ad254b7df/types_pytz-2024.2.0.20241221-py3-none-any.whl", hash = "sha256:8fc03195329c43637ed4f593663df721fef919b60a969066e22606edf0b53ad5", size = 10008 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20241230"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/f9/4d566925bcf9396136c0a2e5dc7e230ff08d86fa011a69888dd184469d80/types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c", size = 17078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/c1/48474fbead512b70ccdb4f81ba5eb4a58f69d100ba19f17c92c0c4f50ae6/types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6", size = 20029 },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3571,6 +3571,10 @@ dependencies = [
     { name = "autogen-agentchat" },
     { name = "autogen-ext", extra = ["magentic-one", "openai", "rich"] },
     { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
     { name = "types-pyyaml" },
 ]
 
@@ -3579,11 +3583,10 @@ requires-dist = [
     { name = "autogen-agentchat", editable = "packages/autogen-agentchat" },
     { name = "autogen-ext", extras = ["openai", "magentic-one", "rich"], editable = "packages/autogen-ext" },
     { name = "pyyaml", specifier = ">=5.1" },
-    { name = "types-pyyaml" },
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "types-pyyaml" }]
 
 [[package]]
 name = "mako"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -3570,12 +3570,14 @@ source = { editable = "packages/magentic-one-cli" }
 dependencies = [
     { name = "autogen-agentchat" },
     { name = "autogen-ext", extra = ["magentic-one", "openai", "rich"] },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "autogen-agentchat", editable = "packages/autogen-agentchat" },
     { name = "autogen-ext", extras = ["openai", "magentic-one", "rich"], editable = "packages/autogen-ext" },
+    { name = "pyyaml", specifier = ">=5.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Allow m1 cli to read a configuration from a yaml file.

```
   Command-line interface for running a complex task using MagenticOne.

    This script accepts a single task string and an optional flag to disable
    human-in-the-loop mode and enable rich console output. It initializes the
    necessary clients and runs the task using the MagenticOne class.

    Arguments:
    task (str): The task to be executed by MagenticOne.
    --no-hil: Optional flag to disable human-in-the-loop mode.
    --rich: Optional flag to enable rich console output.
    --config: Optional flag to specify an alternate model configuration

    Example usage:
    python magentic_one_cli.py "example task"
    python magentic_one_cli.py --no-hil "example task"
    python magentic_one_cli.py --rich "example task"
    python magentic_one_cli.py --config config.yaml "example task"

    Use --sample-config to print a sample configuration file.

    Example:
    python magentic_one_cli.py --sample-config

    NOTE:
    If --config is not specified, the configuration is loaded from the
    file DEFAULT_CONFIG_FILE. If that file does not exist, load from
    DEFAULT_CONFIG_CONTENTS.
```