### PR TITLE
Assistant agent drop images when not provided with a vision-capable model.

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -42,7 +42,6 @@ from ..messages import (
     HandoffMessage,
     MemoryQueryEvent,
     ModelClientStreamingChunkEvent,
-    MultiModalMessage,
     TextMessage,
     ToolCallExecutionEvent,
     ToolCallRequestEvent,
@@ -376,8 +375,6 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
     ) -> AsyncGenerator[AgentEvent | ChatMessage | Response, None]:
         # Add messages to the model context.
         for msg in messages:
-            if isinstance(msg, MultiModalMessage) and self._model_client.model_info["vision"] is False:
-                raise ValueError("The model does not support vision.")
             if isinstance(msg, HandoffMessage):
                 # Add handoff context to the model context.
                 for context_msg in msg.context:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/utils/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/utils/__init__.py
@@ -1,0 +1,7 @@
+"""
+This module implements various utilities common to AgentChat agents and teams.
+"""
+
+from ._utils import remove_images
+
+__all__ = ["remove_images"]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/utils/_utils.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/utils/_utils.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from autogen_core import Image
+from autogen_core.models import LLMMessage, UserMessage
+
+
+def _image_content_to_str(content: str | List[str | Image]) -> str:
+    """Convert the content of an LLMMessageto a string."""
+    if isinstance(content, str):
+        return content
+    else:
+        result: List[str] = []
+        for c in content:
+            if isinstance(c, str):
+                result.append(c)
+            elif isinstance(c, Image):
+                result.append("<image>")
+            else:
+                raise AssertionError("Received unexpected content type.")
+
+    return "\n".join(result)
+
+
+def remove_images(messages: List[LLMMessage]) -> List[LLMMessage]:
+    """Remove images from a list of LLMMessages"""
+    str_messages: List[LLMMessage] = []
+    for message in messages:
+        if isinstance(message, UserMessage) and isinstance(message.content, list):
+            str_messages.append(UserMessage(content=_image_content_to_str(message.content), source=message.source))
+        else:
+            str_messages.append(message)
+    return str_messages

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -541,11 +541,13 @@ async def test_invalid_model_capabilities() -> None:
                 FunctionTool(_echo_function, description="Echo"),
             ],
         )
+        await agent.run(task=TextMessage(source="user", content="Test"))
 
     with pytest.raises(ValueError):
         agent = AssistantAgent(name="assistant", model_client=model_client, handoffs=["agent2"])
+        await agent.run(task=TextMessage(source="user", content="Test"))
 
-    #with pytest.raises(ValueError):
+    # with pytest.raises(ValueError):
     #    agent = AssistantAgent(name="assistant", model_client=model_client)
     #    # Generate a random base64 image.
     #    img_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4//8/AAX+Av4N70a4AAAAAElFTkSuQmCC"

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -21,7 +21,15 @@ from autogen_agentchat.messages import (
 from autogen_core import FunctionCall, Image
 from autogen_core.memory import ListMemory, Memory, MemoryContent, MemoryMimeType, MemoryQueryResult
 from autogen_core.model_context import BufferedChatCompletionContext
-from autogen_core.models import CreateResult, FunctionExecutionResult, LLMMessage, RequestUsage
+from autogen_core.models import (
+    AssistantMessage,
+    CreateResult,
+    FunctionExecutionResult,
+    LLMMessage,
+    RequestUsage,
+    SystemMessage,
+    UserMessage,
+)
 from autogen_core.models._model_client import ModelFamily
 from autogen_core.tools import FunctionTool
 from autogen_ext.models.openai import OpenAIChatCompletionClient
@@ -547,11 +555,38 @@ async def test_invalid_model_capabilities() -> None:
         agent = AssistantAgent(name="assistant", model_client=model_client, handoffs=["agent2"])
         await agent.run(task=TextMessage(source="user", content="Test"))
 
-    # with pytest.raises(ValueError):
-    #    agent = AssistantAgent(name="assistant", model_client=model_client)
-    #    # Generate a random base64 image.
-    #    img_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4//8/AAX+Av4N70a4AAAAAElFTkSuQmCC"
-    #    await agent.run(task=MultiModalMessage(source="user", content=["Test", Image.from_base64(img_base64)]))
+
+@pytest.mark.asyncio
+async def test_remove_images(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = "random-model"
+    model_client_1 = OpenAIChatCompletionClient(
+        model=model,
+        api_key="",
+        model_info={"vision": False, "function_calling": False, "json_output": False, "family": ModelFamily.UNKNOWN},
+    )
+    model_client_2 = OpenAIChatCompletionClient(
+        model=model,
+        api_key="",
+        model_info={"vision": True, "function_calling": False, "json_output": False, "family": ModelFamily.UNKNOWN},
+    )
+
+    img_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4//8/AAX+Av4N70a4AAAAAElFTkSuQmCC"
+    messages: List[LLMMessage] = [
+        SystemMessage(content="System.1"),
+        UserMessage(content=["User.1", Image.from_base64(img_base64)], source="user.1"),
+        AssistantMessage(content="Assistant.1", source="assistant.1"),
+        UserMessage(content="User.2", source="assistant.2"),
+    ]
+
+    agent_1 = AssistantAgent(name="assistant_1", model_client=model_client_1)
+    result = agent_1._get_compatible_context(messages)  # type: ignore
+    assert len(result) == 4
+    assert isinstance(result[1].content, str)
+
+    agent_2 = AssistantAgent(name="assistant_2", model_client=model_client_2)
+    result = agent_2._get_compatible_context(messages)  # type: ignore
+    assert len(result) == 4
+    assert isinstance(result[1].content, list)
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -545,11 +545,11 @@ async def test_invalid_model_capabilities() -> None:
     with pytest.raises(ValueError):
         agent = AssistantAgent(name="assistant", model_client=model_client, handoffs=["agent2"])
 
-    with pytest.raises(ValueError):
-        agent = AssistantAgent(name="assistant", model_client=model_client)
-        # Generate a random base64 image.
-        img_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4//8/AAX+Av4N70a4AAAAAElFTkSuQmCC"
-        await agent.run(task=MultiModalMessage(source="user", content=["Test", Image.from_base64(img_base64)]))
+    #with pytest.raises(ValueError):
+    #    agent = AssistantAgent(name="assistant", model_client=model_client)
+    #    # Generate a random base64 image.
+    #    img_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4//8/AAX+Av4N70a4AAAAAElFTkSuQmCC"
+    #    await agent.run(task=MultiModalMessage(source="user", content=["Test", Image.from_base64(img_base64)]))
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-agentchat/tests/test_utils.py
+++ b/python/packages/autogen-agentchat/tests/test_utils.py
@@ -1,0 +1,36 @@
+from typing import List
+
+import pytest
+from autogen_agentchat.utils import remove_images
+from autogen_core import Image
+from autogen_core.models import AssistantMessage, LLMMessage, SystemMessage, UserMessage
+
+
+@pytest.mark.asyncio
+async def test_remove_images() -> None:
+    img_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4//8/AAX+Av4N70a4AAAAAElFTkSuQmCC"
+    messages: List[LLMMessage] = [
+        SystemMessage(content="System.1"),
+        UserMessage(content=["User.1", Image.from_base64(img_base64)], source="user.1"),
+        AssistantMessage(content="Assistant.1", source="assistant.1"),
+        UserMessage(content="User.2", source="assistant.2"),
+    ]
+
+    result = remove_images(messages)
+
+    # Check all the invariants
+    assert len(result) == 4
+    assert isinstance(result[0], SystemMessage)
+    assert isinstance(result[1], UserMessage)
+    assert isinstance(result[2], AssistantMessage)
+    assert isinstance(result[3], UserMessage)
+    assert result[0].content == messages[0].content
+    assert result[2].content == messages[2].content
+    assert result[3].content == messages[3].content
+    assert isinstance(messages[2], AssistantMessage)
+    assert isinstance(messages[3], UserMessage)
+    assert result[2].source == messages[2].source
+    assert result[3].source == messages[3].source
+
+    # Check that the image was removed.
+    assert result[1].content == "User.1\n<image>"


### PR DESCRIPTION
Allow AssistantAgent to drop images when not equipped with a multi-modal model.

Adds a corresponding utility function, which can the be used in autogen-ext and teams, to accomplish the same.