### PR TITLE
Fixed example code in doc:Custom Agents

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/custom-agents.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/tutorial/custom-agents.ipynb
@@ -49,7 +49,7 @@
     }
    ],
    "source": [
-    "from typing import AsyncGenerator, List, Sequence, Tuple\n",
+    "from typing import AsyncGenerator, List, Sequence\n",
     "\n",
     "from autogen_agentchat.agents import BaseChatAgent\n",
     "from autogen_agentchat.base import Response\n",


### PR DESCRIPTION
The Tuple class is never used in CountDownAgent class.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
