### PR TITLE
feat: select errors that will be caught when raised within a tool

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -37,6 +37,9 @@ class Tool(Protocol):
     @property
     def schema(self) -> ToolSchema: ...
 
+    @property
+    def returned_errors(self) -> tuple[type[Exception], ...]: ...
+
     def args_type(self) -> Type[BaseModel]: ...
 
     def return_type(self) -> Type[Any]: ...
@@ -66,12 +69,14 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
         return_type: Type[ReturnT],
         name: str,
         description: str,
+        returned_errors: tuple[type[Exception], ...] = (Exception,),
     ) -> None:
         self._args_type = args_type
         # Normalize Annotated to the base type.
         self._return_type = normalize_annotated_type(return_type)
         self._name = name
         self._description = description
+        self._returned_errors = returned_errors
 
     @property
     def schema(self) -> ToolSchema:
@@ -102,6 +107,10 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
     @property
     def description(self) -> str:
         return self._description
+
+    @property
+    def returned_errors(self) -> tuple[type[Exception], ...]:
+        return self._returned_errors
 
     def args_type(self) -> Type[BaseModel]:
         return self._args_type

--- a/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
@@ -83,7 +83,12 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
     component_config_schema = FunctionToolConfig
 
     def __init__(
-        self, func: Callable[..., Any], description: str, name: str | None = None, global_imports: Sequence[Import] = []
+        self,
+        func: Callable[..., Any],
+        description: str,
+        name: str | None = None,
+        global_imports: Sequence[Import] = [],
+        return_errors: tuple[type[Exception], ...] = (Exception,),
     ) -> None:
         self._func = func
         self._global_imports = global_imports
@@ -92,6 +97,7 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
         args_model = args_base_model_from_signature(func_name + "args", signature)
         return_type = signature.return_annotation
         self._has_cancellation_support = "cancellation_token" in signature.parameters
+        self._return_errors = return_errors
 
         super().__init__(args_model, return_type, func_name, description)
 


### PR DESCRIPTION
Conversation starter to agree on the implementation. When we are aligned, I'll add tests.

## Why are these changes needed?
Not every tool error should be returned to the agent. This change allows to cherry-pick which exceptions we want to share with the agent.

## Related issue number
Closes: #5274 

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
