### PR TITLE
fix: Add deferral to RegisterAgentType and (Add/Remove)Subscription

### DIFF
--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcMessageRouter.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcMessageRouter.cs
@@ -34,6 +34,8 @@ internal sealed class AutoRestartChannel : IDisposable
         _shutdownCts = CancellationTokenSource.CreateLinkedTokenSource(shutdownCancellation);
     }
 
+    public bool Connected { get => _channel is not null; }
+
     public void EnsureConnected()
     {
         _logger.LogInformation("Connecting to gRPC endpoint " + Environment.GetEnvironmentVariable("AGENT_HOST"));
@@ -286,6 +288,8 @@ internal sealed class GrpcMessageRouter(AgentRpc.AgentRpcClient client,
 
         this._incomingMessageChannel.Dispose();
     }
+
+    public bool IsChannelOpen => this._incomingMessageChannel.Connected;
 
     public void Dispose()
     {

--- a/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/AgentGrpcTests.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/AgentGrpcTests.cs
@@ -10,13 +10,13 @@ using Xunit;
 namespace Microsoft.AutoGen.Core.Grpc.Tests;
 
 [Trait("Category", "GRPC")]
-public class AgentGrpcTests
+public class AgentGrpcTests : TestBase
 {
     [Fact]
     public async Task AgentShouldNotReceiveMessagesWhenNotSubscribedTest()
     {
         var fixture = new GrpcAgentRuntimeFixture();
-        var runtime = (GrpcAgentRuntime)await fixture.Start();
+        var runtime = (GrpcAgentRuntime)await fixture.StartAsync();
 
         Logger<BaseAgent> logger = new(new LoggerFactory());
         TestProtobufAgent agent = null!;
@@ -45,7 +45,7 @@ public class AgentGrpcTests
     public async Task AgentShouldReceiveMessagesWhenSubscribedTest()
     {
         var fixture = new GrpcAgentRuntimeFixture();
-        var runtime = (GrpcAgentRuntime)await fixture.Start();
+        var runtime = (GrpcAgentRuntime)await fixture.StartAsync();
 
         Logger<BaseAgent> logger = new(new LoggerFactory());
         SubscribedProtobufAgent agent = null!;
@@ -80,7 +80,7 @@ public class AgentGrpcTests
     {
         // Arrange
         var fixture = new GrpcAgentRuntimeFixture();
-        var runtime = (GrpcAgentRuntime)await fixture.Start();
+        var runtime = (GrpcAgentRuntime)await fixture.StartAsync();
 
         Logger<BaseAgent> logger = new(new LoggerFactory());
         await runtime.RegisterAgentFactoryAsync("MyAgent", async (id, runtime) => await ValueTask.FromResult(new TestProtobufAgent(id, runtime, logger)));
@@ -114,7 +114,7 @@ public class AgentGrpcTests
     public async Task SubscribeAsyncRemoveSubscriptionAsyncAndGetSubscriptionsTest()
     {
         var fixture = new GrpcAgentRuntimeFixture();
-        var runtime = (GrpcAgentRuntime)await fixture.Start();
+        var runtime = (GrpcAgentRuntime)await fixture.StartAsync();
         ReceiverAgent? agent = null;
         await runtime.RegisterAgentFactoryAsync("MyAgent", async (id, runtime) =>
         {

--- a/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/FreePortManager.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/FreePortManager.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// FreePortManager.cs
+
+using System.Diagnostics;
+
+namespace Microsoft.AutoGen.Core.Grpc.Tests;
+
+internal sealed class FreePortManager
+{
+    private HashSet<int> takenPorts = new();
+    private readonly object mutex = new();
+
+    [DebuggerDisplay($"{{{nameof(Port)}}}")]
+    internal sealed class PortTicket(FreePortManager portManager, int port) : IDisposable
+    {
+        private FreePortManager? portManager = portManager;
+
+        public int Port { get; } = port;
+
+        public void Dispose()
+        {
+            FreePortManager? localPortManager = Interlocked.Exchange(ref this.portManager, null);
+            localPortManager?.takenPorts.Remove(this.Port);
+        }
+
+        public override string ToString()
+        {
+            return this.Port.ToString();
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is PortTicket ticket && ticket.Port == this.Port;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Port.GetHashCode();
+        }
+
+        public static implicit operator int(PortTicket ticket) => ticket.Port;
+        public static implicit operator string(PortTicket ticket) => ticket.ToString();
+    }
+
+    public PortTicket GetAvailablePort()
+    {
+        lock (mutex)
+        {
+            int port;
+            do
+            {
+                using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+                listener.Start();
+                port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+                listener.Stop();
+                listener.Dispose();
+                Thread.Yield(); // Let the listener actually shut down before we try to use the port
+            } while (takenPorts.Contains(port));
+
+            takenPorts.Add(port);
+
+            Console.WriteLine($"FreePortManager: Yielding port {port}");
+            Debug.WriteLine($"FreePortManager: Yielding port {port}");
+            return new PortTicket(this, port);
+        }
+    }
+}

--- a/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/GrpcAgentRuntimeFixture.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/GrpcAgentRuntimeFixture.cs
@@ -7,23 +7,29 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.AutoGen.Core.Grpc.Tests;
+
 /// <summary>
 /// Fixture for setting up the gRPC agent runtime for testing.
 /// </summary>
 public sealed class GrpcAgentRuntimeFixture : IDisposable
 {
     /// the gRPC agent runtime.
-    public AgentsApp? Client { get; private set; }
+    public AgentsApp? AgentsApp { get; private set; }
+
     /// mock server for testing.
-    public WebApplication? Server { get; private set; }
+    public WebApplication? GatewayServer { get; private set; }
+
+    public GrpcAgentServiceCollector GrpcRequestCollector { get; }
 
     public GrpcAgentRuntimeFixture()
     {
+        GrpcRequestCollector = new GrpcAgentServiceCollector();
     }
+
     /// <summary>
     /// Start - gets a new port and starts fresh instances
     /// </summary>
-    public async Task<IAgentRuntime> Start(bool initialize = true)
+    public async Task<IAgentRuntime> Start(bool startRuntime = true, bool registerDefaultAgent = true)
     {
         int port = GetAvailablePort(); // Get a new port per test run
 
@@ -31,30 +37,47 @@ public sealed class GrpcAgentRuntimeFixture : IDisposable
         Environment.SetEnvironmentVariable("ASPNETCORE_HTTPS_PORTS", port.ToString());
         Environment.SetEnvironmentVariable("AGENT_HOST", $"https://localhost:{port}");
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
-        Server = ServerBuilder().Result;
-        await Server.StartAsync().ConfigureAwait(true);
-        Client = ClientBuilder().Result;
-        await Client.StartAsync().ConfigureAwait(true);
 
-        var worker = Client.Services.GetRequiredService<IAgentRuntime>();
+        this.GatewayServer = await this.InitializeGateway();
+        this.AgentsApp = await this.InitializeRuntime(startRuntime, registerDefaultAgent);
+        var runtime = AgentsApp.Services.GetRequiredService<IAgentRuntime>();
 
-        return (worker);
+        return runtime;
     }
-    private static async Task<AgentsApp> ClientBuilder()
+
+    private async Task<AgentsApp> InitializeRuntime(bool callStartAsync, bool registerDefaultAgent)
     {
         var appBuilder = new AgentsAppBuilder();
         appBuilder.AddGrpcAgentWorker();
-        appBuilder.AddAgent<TestProtobufAgent>("TestAgent");
-        return await appBuilder.BuildAsync();
+
+        if (registerDefaultAgent)
+        {
+            appBuilder.AddAgent<TestProtobufAgent>("TestAgent");
+        }
+
+        AgentsApp result = await appBuilder.BuildAsync();
+
+        if (callStartAsync)
+        {
+            await result.StartAsync().ConfigureAwait(true);
+        }
+
+        return result;
     }
-    private static async Task<WebApplication> ServerBuilder()
+
+    private async Task<WebApplication> InitializeGateway()
     {
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddGrpc();
-        var app = builder.Build();
+        builder.Services.AddSingleton(this.GrpcRequestCollector);
+
+        WebApplication app = builder.Build();
         app.MapGrpcService<GrpcAgentServiceFixture>();
+
+        await app.StartAsync().ConfigureAwait(true);
         return app;
     }
+
     private static int GetAvailablePort()
     {
         using var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
@@ -63,13 +86,14 @@ public sealed class GrpcAgentRuntimeFixture : IDisposable
         listener.Stop();
         return port;
     }
+
     /// <summary>
     /// Stop - stops the agent and ensures cleanup
     /// </summary>
     public void Stop()
     {
-        (Client as IHost)?.StopAsync(TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
-        Server?.StopAsync().GetAwaiter().GetResult();
+        (AgentsApp as IHost)?.StopAsync(TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
+        GatewayServer?.StopAsync().GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/GrpcAgentRuntimeTests.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/GrpcAgentRuntimeTests.cs
@@ -9,13 +9,13 @@ using Xunit;
 namespace Microsoft.AutoGen.Core.Grpc.Tests;
 
 [Trait("Category", "GRPC")]
-public class GrpcAgentRuntimeTests
+public class GrpcAgentRuntimeTests : TestBase
 {
     [Fact]
     public async Task GatewayShouldNotReceiveRegistrationsUntilRuntimeStart()
     {
         var fixture = new GrpcAgentRuntimeFixture();
-        var runtime = (GrpcAgentRuntime)await fixture.Start(startRuntime: false, registerDefaultAgent: false);
+        var runtime = (GrpcAgentRuntime)await fixture.StartAsync(startRuntime: false, registerDefaultAgent: false);
 
         Logger<BaseAgent> logger = new(new LoggerFactory());
 

--- a/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/GrpcAgentRuntimeTests.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/GrpcAgentRuntimeTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// GrpcAgentRuntimeTests.cs
+
+using FluentAssertions;
+using Microsoft.AutoGen.Contracts;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.AutoGen.Core.Grpc.Tests;
+
+[Trait("Category", "GRPC")]
+public class GrpcAgentRuntimeTests
+{
+    [Fact]
+    public async Task GatewayShouldNotReceiveRegistrationsUntilRuntimeStart()
+    {
+        var fixture = new GrpcAgentRuntimeFixture();
+        var runtime = (GrpcAgentRuntime)await fixture.Start(startRuntime: false, registerDefaultAgent: false);
+
+        Logger<BaseAgent> logger = new(new LoggerFactory());
+
+        await runtime.RegisterAgentFactoryAsync("MyAgent", async (id, runtime) =>
+        {
+            return await ValueTask.FromResult(new SubscribedProtobufAgent(id, runtime, logger));
+        });
+        await runtime.RegisterImplicitAgentSubscriptionsAsync<SubscribedProtobufAgent>("MyAgent");
+
+        fixture.GrpcRequestCollector.RegisterAgentTypeRequests.Should().BeEmpty();
+        fixture.GrpcRequestCollector.AddSubscriptionRequests.Should().BeEmpty();
+
+        await fixture.AgentsApp!.StartAsync().ConfigureAwait(true);
+
+        fixture.GrpcRequestCollector.RegisterAgentTypeRequests.Should().NotBeEmpty();
+        fixture.GrpcRequestCollector.RegisterAgentTypeRequests.Single().Type.Should().Be("MyAgent");
+        fixture.GrpcRequestCollector.AddSubscriptionRequests.Should().NotBeEmpty();
+
+        fixture.GrpcRequestCollector.Clear();
+
+        await runtime.RegisterAgentFactoryAsync("MyAgent2", async (id, runtime) =>
+        {
+            return await ValueTask.FromResult(new TestProtobufAgent(id, runtime, logger));
+        });
+
+        fixture.GrpcRequestCollector.RegisterAgentTypeRequests.Should().NotBeEmpty();
+        fixture.GrpcRequestCollector.RegisterAgentTypeRequests.Single().Type.Should().Be("MyAgent2");
+        fixture.GrpcRequestCollector.AddSubscriptionRequests.Should().BeEmpty();
+
+        fixture.Dispose();
+    }
+}

--- a/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/GrpcAgentServiceFixture.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/GrpcAgentServiceFixture.cs
@@ -1,14 +1,37 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // GrpcAgentServiceFixture.cs
+
 using Grpc.Core;
 using Microsoft.AutoGen.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Microsoft.AutoGen.Core.Grpc.Tests;
+
+public sealed class GrpcAgentServiceCollector
+{
+    public List<AddSubscriptionRequest> AddSubscriptionRequests { get; } = new();
+    public List<RemoveSubscriptionRequest> RemoveSubscriptionRequests { get; } = new();
+    public List<RegisterAgentTypeRequest> RegisterAgentTypeRequests { get; } = new();
+
+    internal void Clear()
+    {
+        this.AddSubscriptionRequests.Clear();
+        this.RemoveSubscriptionRequests.Clear();
+        this.RegisterAgentTypeRequests.Clear();
+    }
+}
 
 /// <summary>
 /// This fixture is largely just a loopback as we are testing the client side logic of the GrpcAgentRuntime in isolation from the rest of the system.
 /// </summary>
-public sealed class GrpcAgentServiceFixture() : AgentRpc.AgentRpcBase
+public class GrpcAgentServiceFixture : AgentRpc.AgentRpcBase
 {
+    private GrpcAgentServiceCollector requestCollector;
+    public GrpcAgentServiceFixture(IServiceProvider serviceProvider)
+    {
+        this.requestCollector = serviceProvider.GetService<GrpcAgentServiceCollector>() ?? new();
+    }
+
     public override async Task OpenChannel(IAsyncStreamReader<Message> requestStream, IServerStreamWriter<Message> responseStream, ServerCallContext context)
     {
         try
@@ -25,8 +48,27 @@ public sealed class GrpcAgentServiceFixture() : AgentRpc.AgentRpcBase
             throw;
         }
     }
-    public override async Task<AddSubscriptionResponse> AddSubscription(AddSubscriptionRequest request, ServerCallContext context) => new AddSubscriptionResponse { };
-    public override async Task<RemoveSubscriptionResponse> RemoveSubscription(RemoveSubscriptionRequest request, ServerCallContext context) => new RemoveSubscriptionResponse { };
+
+    public List<AddSubscriptionRequest> AddSubscriptionRequests => this.requestCollector.AddSubscriptionRequests;
+    public override async Task<AddSubscriptionResponse> AddSubscription(AddSubscriptionRequest request, ServerCallContext context)
+    {
+        this.AddSubscriptionRequests.Add(request);
+        return new AddSubscriptionResponse();
+    }
+
+    public List<RemoveSubscriptionRequest> RemoveSubscriptionRequests => this.requestCollector.RemoveSubscriptionRequests;
+    public override async Task<RemoveSubscriptionResponse> RemoveSubscription(RemoveSubscriptionRequest request, ServerCallContext context)
+    {
+        this.RemoveSubscriptionRequests.Add(request);
+        return new RemoveSubscriptionResponse();
+    }
+
     public override async Task<GetSubscriptionsResponse> GetSubscriptions(GetSubscriptionsRequest request, ServerCallContext context) => new GetSubscriptionsResponse { };
-    public override async Task<RegisterAgentTypeResponse> RegisterAgent(RegisterAgentTypeRequest request, ServerCallContext context) => new RegisterAgentTypeResponse { };
+
+    public List<RegisterAgentTypeRequest> RegisterAgentTypeRequests => this.requestCollector.RegisterAgentTypeRequests;
+    public override async Task<RegisterAgentTypeResponse> RegisterAgent(RegisterAgentTypeRequest request, ServerCallContext context)
+    {
+        this.RegisterAgentTypeRequests.Add(request);
+        return new RegisterAgentTypeResponse();
+    }
 }

--- a/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/TestBase.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/TestBase.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// TestBase.cs
+
+namespace Microsoft.AutoGen.Core.Grpc.Tests;
+
+public class TestBase
+{
+    public TestBase()
+    {
+        try
+        {
+            // For some reason the first call to StartAsync() throws when these tests
+            // run in parallel, even though the port does not actually collide between
+            // different instances of GrpcAgentRuntimeFixture. This is a workaround.
+            _ = new GrpcAgentRuntimeFixture().StartAsync().Result;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+        }
+    }
+}


### PR DESCRIPTION
Unlike with the InProcessRuntime, there is a two-phase initialization, first when AgentsApp is built (when initial agents are registered) and when it StartAsync()s and connects to the Gateway. Unfortunately, it is possible to attempt to send direct RPC calls to the Gateway before the message channel is opened; in this case, the Gateway has no connected client corresponding to the RPC's clientId, and falls over.

The fix is to defer registering agents and subscriptions with the gateway until after the connection is established after .StartAsync() is called.