### PR TITLE
fix: gRPC Agent Runtime Serialization Registration

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -169,7 +169,7 @@ jobs:
         dotnet-version: '9.0.x'
     - name: Install Temp Global.JSON
       run: |
-        echo "{\"sdk\": {\"version\": \"9.0.101\"}}" > global.json
+        echo "{\"sdk\": {\"version\": \"9.0\"}}" > global.json
     - name: Install .NET Aspire workload
       run: dotnet workload install aspire
     - name: Install dev certs

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/AgentExtensions.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/AgentExtensions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// AgentExtensions.cs
+
+using System.Reflection;
+using Google.Protobuf;
+using Microsoft.AutoGen.Contracts;
+using Microsoft.AutoGen.Core.Grpc;
+
+namespace Microsoft.AutoGen.Core;
+
+internal static partial class AgentExtensions
+{
+    private static readonly Type ProtobufIMessage = typeof(IMessage<>);
+    private static bool IsProtobufType(this Type type)
+    {
+        // TODO: Support the non-generic IMessage as well
+        Type specializedIMessageType = ProtobufIMessage.MakeGenericType(type);
+
+        // type T needs to derive from IMessage<T>
+        return specializedIMessageType.IsAssignableFrom(type);
+    }
+
+    public static void RegisterHandledMessageTypes(this IHostableAgent agent, IProtoSerializationRegistry registry)
+    {
+        Type agentRuntimeType = agent.GetType();
+
+        MethodInfo[] messageHandlers = agentRuntimeType.GetHandlers();
+
+        foreach (MethodInfo handler in messageHandlers)
+        {
+            Type messageType = handler.GetParameters().First().ParameterType;
+            if (messageType.IsProtobufType() && registry.GetSerializer(messageType) == null)
+            {
+                registry.RegisterSerializer(messageType);
+            }
+        }
+    }
+}


### PR DESCRIPTION
We were registering the serializers when we already had a concrete type on the way into Publish or Send on the .NET side. However, in a xLang scenario, messages could originate from e.g. Python before being sent/published from .NET, resulting in no serializer being found.

This change adds a second-change registration and lookup when the agent is instantiated based on the IHandle<T> implementations.