### PR TITLE
Update Model Client Docs to Mention API Key from Environment Variables

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/components/model-clients.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/components/model-clients.ipynb
@@ -885,6 +885,8 @@
     "- For OpenAI, you can set the `OPENAI_API_KEY` environment variable.  \n",
     "- For Azure OpenAI, you can set the `AZURE_OPENAI_API_KEY` environment variable. \n",
     "\n",
+    "In addition, for Gemini (Beta), you can set the `GEMINI_API_KEY` environment variable.\n",
+    "\n",
     "This is a good practice to explore, as it avoids including sensitive api keys in your code. \n",
     "\n"
    ]

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/components/model-clients.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/components/model-clients.ipynb
@@ -736,7 +736,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Build Agent using Model Client\n",
+    "## Build an Agent with a Model Client\n",
     "\n",
     "Let's create a simple AI agent that can respond to messages using the ChatCompletion API."
    ]
@@ -872,6 +872,21 @@
     "We can use model context classes from {py:mod}`autogen_core.model_context`\n",
     "to make the agent \"remember\" previous conversations.\n",
     "See the [Model Context](./model-context.ipynb) page for more details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API Keys From Environment Variables\n",
+    "\n",
+    "In the examples above, we show that you can provide the API key through the `api_key` argument. Importantly, the OpenAI and Azure OpenAI clients use the [openai package](https://github.com/openai/openai-python/blob/3f8d8205ae41c389541e125336b0ae0c5e437661/src/openai/__init__.py#L260), which will automatically read an api key from the environment variable if one is not provided.\n",
+    "\n",
+    "- For OpenAI, you can set the `OPENAI_API_KEY` environment variable.  \n",
+    "- For Azure OpenAI, you can set the `AZURE_OPENAI_API_KEY` environment variable. \n",
+    "\n",
+    "This is a good practice to explore, as it avoids including sensitive api keys in your code. \n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Adds the following blurb to the model clients docs

## API Keys From Environment Variables

In the examples above, we show that you can provide the API key through the `api_key` argument. Importantly, the OpenAI and Azure OpenAI clients use the [openai package](https://github.com/openai/openai-python/blob/3f8d8205ae41c389541e125336b0ae0c5e437661/src/openai/__init__.py#L260), which will automatically read an api key from the environment variable if one is not provided.

- For OpenAI, you can set the `OPENAI_API_KEY` environment variable.  
- For Azure OpenAI, you can set the `AZURE_OPENAI_API_KEY` environment variable. 

This is a good practice to explore, as it avoids including sensitive api keys in your code. 



## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
