### PR TITLE
Make CodeExecutor Serializable/Declarative

### DIFF
--- a/dotnet/test/Microsoft.AutoGen.Integration.Tests/Microsoft.AutoGen.Integration.Tests.csproj
+++ b/dotnet/test/Microsoft.AutoGen.Integration.Tests/Microsoft.AutoGen.Integration.Tests.csproj
@@ -51,10 +51,10 @@
     </PropertyGroup>  
     <Message Importance="Normal" Text="Initializing virtual environment for $(PythonVenvRoot)" />
 
-    <Exec Command="$(UvPath) sync --all-extras" WorkingDirectory="$(PythonRoot)" Condition=" '$(CreateVenv)' == 'True' " ConsoleToMsBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    <Exec Command="$(UvPath) sync --all-extras" WorkingDirectory="$(PythonRoot)" Condition=" '$(CreateVenv)' == 'True' " />
+      <!--Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
-    <!--Message Importance="Normal" Text="$(OutputOfExec)" />-->
+    <Message Importance="Normal" Text="$(OutputOfExec)" />-->
   </Target>
 
 

--- a/python/packages/autogen-core/src/autogen_core/code_executor/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/code_executor/_base.py
@@ -3,10 +3,14 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Protocol, runtime_checkable
+from typing import List
+
+from pydantic import BaseModel
 
 from .._cancellation_token import CancellationToken
+from .._component_config import ComponentBase
 
 
 @dataclass
@@ -25,10 +29,12 @@ class CodeResult:
     output: str
 
 
-@runtime_checkable
-class CodeExecutor(Protocol):
+class CodeExecutor(ABC, ComponentBase[BaseModel]):
     """Executes code blocks and returns the result."""
 
+    component_type = "code_executor"
+
+    @abstractmethod
     async def execute_code_blocks(
         self, code_blocks: List[CodeBlock], cancellation_token: CancellationToken
     ) -> CodeResult:
@@ -49,6 +55,7 @@ class CodeExecutor(Protocol):
         """
         ...
 
+    @abstractmethod
     async def restart(self) -> None:
         """Restart the code executor.
 

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, ClassVar, List, Optional, Sequence, Union
 from autogen_core import CancellationToken, Component
 from autogen_core.code_executor import CodeBlock, CodeExecutor, FunctionWithRequirements, FunctionWithRequirementsStr
 from pydantic import BaseModel
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, Self
 
 from .._common import (
     PYTHON_VARIANTS,
@@ -383,7 +383,7 @@ $functions"""
         )
 
     @classmethod
-    def _from_config(cls, config: LocalCommandLineCodeExecutorConfig) -> "LocalCommandLineCodeExecutor":
+    def _from_config(cls, config: LocalCommandLineCodeExecutorConfig) -> Self:
         return cls(
             timeout=config.timeout,
             work_dir=Path(config.work_dir),

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -12,8 +12,9 @@ from string import Template
 from types import SimpleNamespace
 from typing import Any, Callable, ClassVar, List, Optional, Sequence, Union
 
-from autogen_core import CancellationToken
+from autogen_core import CancellationToken, Component
 from autogen_core.code_executor import CodeBlock, CodeExecutor, FunctionWithRequirements, FunctionWithRequirementsStr
+from pydantic import BaseModel
 from typing_extensions import ParamSpec
 
 from .._common import (
@@ -31,7 +32,15 @@ __all__ = ("LocalCommandLineCodeExecutor",)
 A = ParamSpec("A")
 
 
-class LocalCommandLineCodeExecutor(CodeExecutor):
+class LocalCommandLineCodeExecutorConfig(BaseModel):
+    """Configuration for LocalCommandLineCodeExecutor"""
+
+    timeout: int = 60
+    work_dir: str = "."  # Stored as string, converted to Path in _from_config
+    functions_module: str = "functions"
+
+
+class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeExecutorConfig]):
     """A code executor class that executes code through a local command line
     environment.
 
@@ -96,6 +105,9 @@ class LocalCommandLineCodeExecutor(CodeExecutor):
             asyncio.run(example())
 
     """
+
+    component_config_schema = LocalCommandLineCodeExecutorConfig
+    component_provider_override = "autogen_ext.code_executors.local.LocalCommandLineCodeExecutor"
 
     SUPPORTED_LANGUAGES: ClassVar[List[str]] = [
         "bash",
@@ -356,4 +368,24 @@ $functions"""
         warnings.warn(
             "Restarting local command line code executor is not supported. No action is taken.",
             stacklevel=2,
+        )
+
+    def _to_config(self) -> LocalCommandLineCodeExecutorConfig:
+        if self._functions:
+            logging.info("Functions will not be included in serialized configuration")
+        if self._virtual_env_context:
+            logging.info("Virtual environment context will not be included in serialized configuration")
+
+        return LocalCommandLineCodeExecutorConfig(
+            timeout=self._timeout,
+            work_dir=str(self._work_dir),
+            functions_module=self._functions_module,
+        )
+
+    @classmethod
+    def _from_config(cls, config: LocalCommandLineCodeExecutorConfig) -> "LocalCommandLineCodeExecutor":
+        return cls(
+            timeout=config.timeout,
+            work_dir=Path(config.work_dir),
+            functions_module=config.functions_module,
         )

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -195,3 +195,11 @@ async def test_local_executor_with_custom_venv_in_local_relative_path() -> None:
     finally:
         if os.path.isdir(relative_folder_path):
             shutil.rmtree(relative_folder_path)
+
+
+def test_serialize_deserialize() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir)
+        executor_config = executor.dump_component()
+        loaded_executor = LocalCommandLineCodeExecutor.load_component(executor_config)
+        assert executor.work_dir == loaded_executor.work_dir

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
@@ -209,3 +209,12 @@ async def test_docker_commandline_code_executor_extra_args() -> None:
             code_result = await executor.execute_code_blocks(code_blocks, cancellation_token)
             assert code_result.exit_code == 0
             assert "This is a test file." in code_result.output
+
+
+@pytest.mark.asyncio
+async def test_docker_commandline_code_executor_serialization() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        executor = DockerCommandLineCodeExecutor(work_dir=temp_dir)
+        loaded_executor = DockerCommandLineCodeExecutor.load_component(executor.dump_component())
+        assert executor.bind_dir == loaded_executor.bind_dir
+        assert executor.timeout == loaded_executor.timeout

--- a/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
@@ -167,3 +167,12 @@ async def test_execute_code_with_html_output(tmp_path: Path) -> None:
             output_files=code_result.output_files,
         )
         assert code_result.output_files[0].parent == tmp_path
+
+
+@pytest.mark.asyncio
+async def test_jupyter_code_executor_serialization(tmp_path: Path) -> None:
+    executor = JupyterCodeExecutor(output_dir=tmp_path)
+    serialized = executor.dump_component()
+    loaded_executor = JupyterCodeExecutor.load_component(serialized)
+
+    assert isinstance(loaded_executor, JupyterCodeExecutor)

--- a/python/packages/autogen-ext/tests/tools/test_python_code_executor_tool.py
+++ b/python/packages/autogen-ext/tests/tools/test_python_code_executor_tool.py
@@ -1,0 +1,59 @@
+import tempfile
+
+import pytest
+from autogen_core import CancellationToken
+from autogen_ext.code_executors.local import LocalCommandLineCodeExecutor
+from autogen_ext.tools.code_execution import CodeExecutionInput, PythonCodeExecutionTool
+
+
+@pytest.mark.asyncio
+async def test_python_code_execution_tool() -> None:
+    """Test basic functionality of PythonCodeExecutionTool."""
+    # Create a temporary directory for the executor
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Initialize the executor and tool
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir)
+        tool = PythonCodeExecutionTool(executor=executor)
+
+        # Test simple code execution
+        code = "print('hello world!')"
+        result = await tool.run(args=CodeExecutionInput(code=code), cancellation_token=CancellationToken())
+
+        # Verify successful execution
+        assert result.success is True
+        assert "hello world!" in result.output
+
+        # Test code with computation
+        code = """a = 100 + 200 \nprint(f'Result: {a}')
+        """
+        result = await tool.run(args=CodeExecutionInput(code=code), cancellation_token=CancellationToken())
+
+        # Verify computation result
+        assert result.success is True
+        assert "Result: 300" in result.output
+
+        # Test error handling
+        code = "print(undefined_variable)"
+        result = await tool.run(args=CodeExecutionInput(code=code), cancellation_token=CancellationToken())
+
+        # Verify error handling
+        assert result.success is False
+        assert "NameError" in result.output
+
+
+def test_python_code_execution_tool_serialization() -> None:
+    """Test serialization and deserialization of PythonCodeExecutionTool."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create original tool
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir)
+        original_tool = PythonCodeExecutionTool(executor=executor)
+
+        # Serialize
+        config = original_tool.dump_component()
+        assert config.config.get("executor") is not None
+
+        # Deserialize
+        loaded_tool = PythonCodeExecutionTool.load_component(config)
+
+        # Verify the loaded tool has the same configuration
+        assert isinstance(loaded_tool, PythonCodeExecutionTool)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Make  [PythonCodeExecutionTool](https://github.com/microsoft/autogen/blob/main/python/packages/autogen-ext/src/autogen_ext/tools/code_execution/_code_execution.py) declarative so it can be used in tools like AGS

Summary of changes

- Make CodeExecutor declarative (convert from Protocol to ABC, inherit from ComponentBase)
- Make LocalCommandLineCodeExecutor, JupyterCodeExecutor and DockerCommandLineCodeExecutor declarative , best effort. Not all fields are serialized, warnings are shown where appropriate.
- Make PythonCodeExecutionTool declarative.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #5526 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
