### PR TITLE
fix: update help text for model configuration argument

### DIFF
--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -81,7 +81,7 @@ def main() -> None:
         "--config",
         type=str,
         nargs=1,
-        help="The model configuration file to use. Leave empty to print a sample configuration.",
+        help="The model configuration file to use.",
     )
     parser.add_argument("--sample-config", action="store_true", help="Print a sample configuration to console.")
 


### PR DESCRIPTION
This pull request includes a small change to the `python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py` file. The change modifies the help message for the `--config` argument to remove the part about leaving it empty to print a sample configuration. This is already handled by `--sample-config`. 