### PR TITLE
docs: Add Link (and redirect) to .NET docs

### DIFF
--- a/python/packages/autogen-core/docs/redirects/redirect_urls.txt
+++ b/python/packages/autogen-core/docs/redirects/redirect_urls.txt
@@ -351,3 +351,4 @@
 /autogen/docs/reference/agentchat/contrib/vectordb/utils,/autogen/0.2/docs/reference/agentchat/contrib/vectordb/utils
 /autogen/0.4.0dev0/,/autogen/0.4.0.dev0/
 /autogen/0.4.0dev1/,/autogen/0.4.0.dev1/
+/autogen/dotnet/,/autogen/dotnet/dev/

--- a/python/packages/autogen-core/docs/src/conf.py
+++ b/python/packages/autogen-core/docs/src/conf.py
@@ -131,6 +131,7 @@ html_theme_options = {
     },
     "show_version_warning_banner": True,
     "external_links": [
+      {"name": ".NET", "url": "https://microsoft.github.io/autogen/dotnet/"},
       {"name": "0.2 Docs", "url": "https://microsoft.github.io/autogen/0.2/"},
     ]
 }


### PR DESCRIPTION
Pulls the .NET Docs a bit more into the documentation website proper:

* Add a link from the 0.4-series Python docs to 
* Adds a transient redirect from /dotnet/ to /dotnet/dev/ to forward to the dev docs until we do a non "-dev" release