### PR TITLE
fix: Unhandled Messages should not error when no deserializer is found

### DIFF
--- a/dotnet/samples/Hello/HelloAgent/Program.cs
+++ b/dotnet/samples/Hello/HelloAgent/Program.cs
@@ -6,10 +6,43 @@ using Microsoft.AutoGen.Contracts;
 using Microsoft.AutoGen.Core;
 using Microsoft.AutoGen.Core.Grpc;
 using Samples;
+
+string? hostAddress = null;
+bool in_host_address = false;
+bool sendHello = true;
+foreach (string arg in args)
+{
+    switch (arg)
+    {
+        case "--host":
+            in_host_address = true;
+            break;
+        case "--nosend":
+            sendHello = false;
+            break;
+        case "-h":
+        case "--help":
+            PrintHelp();
+            Environment.Exit(0);
+            break;
+        default:
+            if (in_host_address)
+            {
+                hostAddress = arg;
+            }
+            break;
+    }
+}
+
+hostAddress ??= Environment.GetEnvironmentVariable("AGENT_HOST");
 var appBuilder = new AgentsAppBuilder(); // Create app builder
 // if we are using distributed, we need the AGENT_HOST var defined and then we will use the grpc runtime
-if (Environment.GetEnvironmentVariable("AGENT_HOST") is string agentHost)
+
+bool usingGrpc = false;
+if (hostAddress is string agentHost)
 {
+    usingGrpc = true;
+    Console.WriteLine($"connecting to {agentHost}");
     appBuilder.AddGrpcAgentWorker(agentHost)
         .AddAgent<HelloAgent>("HelloAgent");
 }
@@ -19,7 +52,31 @@ else
     appBuilder.UseInProcessRuntime(deliverToSelf: true).AddAgent<HelloAgent>("HelloAgent");
 }
 var app = await appBuilder.BuildAsync(); // Build the app
+await app.StartAsync();
 // Create a custom message type from proto and define message
-var message = new NewMessageReceived { Message = "Hello World!" };
-await app.PublishMessageAsync(message, new TopicId("HelloTopic")).ConfigureAwait(false); // Publish custom message (handler has been set in HelloAgent)
+
+if (sendHello)
+{
+    var message = new NewMessageReceived { Message = "Hello World!" };
+    await app.PublishMessageAsync(message, new TopicId("HelloTopic")).ConfigureAwait(false); // Publish custom message (handler has been set in HelloAgent)
+}
+else if (!usingGrpc)
+{
+    Console.Write("Warning: Using --nosend with the InProcessRuntime will hang. Terminating.");
+    Environment.Exit(-1);
+}
+
 await app.WaitForShutdownAsync().ConfigureAwait(false); // Wait for shutdown from agent
+
+static void PrintHelp()
+{
+    /*
+     HelloAgent [--host <hostAddress>] [--nosend]
+       --host Use gRPC gateway at <hostAddress>; this can also be set using the AGENT_HOST Environment Variable
+       --nosend Do not send the starting message. Note: This means HelloAgent will wait until some other agent will send
+                that message. This will not work when using the InProcessRuntime.
+     */
+    Console.WriteLine("HelloAgent [--host <hostAddress>] [--nosend]");
+    Console.WriteLine("  --host \tUse gRPC gateway at <hostAddress>; this can also be set using the AGENT_HOST Environment Variable");
+    Console.WriteLine("  --nosend \tDo not send the starting message. Note: This means HelloAgent will wait until some other agent will send");
+}


### PR DESCRIPTION
Right now if a remote agent sends a message that local agents do not listen to (and thus will never configure a deserializer for), or if the first agent in the iteration is one such, the runtime will throw an unnecessary exception an come down, even though the deserialized message will never actually be needed before a deserializer is registered.

The fix will downgrade that to a warning.

* Also updates the HelloAgent sample to be more amenable to being used with gRPC directly, without configuring environment variables.
