### PR TITLE
WIP: Fix SingleThreadedAgentRuntime Examples Not Working

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -178,6 +178,9 @@ class SingleThreadedAgentRuntime(AgentRuntime):
 
 
             class MyAgent(RoutedAgent):
+                def __init__(self):
+                    super().__init__("MyAgent")
+
                 @message_handler
                 async def handle_my_message(self, message: MyMessage, ctx: MessageContext) -> None:
                     print(f"Received message: {message.content}")
@@ -221,6 +224,9 @@ class SingleThreadedAgentRuntime(AgentRuntime):
             # The agent is subscribed to the default topic.
             @default_subscription
             class MyAgent(RoutedAgent):
+                def __init__(self):
+                    super().__init__("MyAgent")
+
                 @message_handler
                 async def handle_my_message(self, message: MyMessage, ctx: MessageContext) -> None:
                     print(f"Received message: {message.content}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The original examples in `SingleThreadedAgentRuntime` were not functioning as expected. It appears that the `RoutedAgent` constructor interface may have changed, leading to the following error:  

```plaintext
TypeError: RoutedAgent.__init__() missing 1 required positional argument: 'description'
```  

This PR updates the examples to resolve the issue.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
