### PR TITLE
Improve the model mismatch warning msg

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -561,7 +561,8 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             if self._resolved_model != result.model:
                 warnings.warn(
                     f"Resolved model mismatch: {self._resolved_model} != {result.model}. "
-                    "Model mapping in autogen_ext.models.openai may be incorrect.",
+                    "Model mapping in autogen_ext.models.openai may be incorrect. "
+                    f"Set the model to {result.model} to enhance token/cost estimation and suppress this warning.",
                     stacklevel=2,
                 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I see `UserWarning: Resolved model mismatch: gpt-4o-2024-08-06 != gpt-4o-2024-05-13. Model mapping in autogen_ext.models.openai may be incorrect.` when using below client:
```python
client = AzureOpenAIChatCompletionClient(
    azure_deployment="gpt-4o",
    model="gpt-4o",
    api_version="2024-06-01",
)
```

This is caused by the default gpt-4o in my env is different from the one pre-configured in `autogen_ext.models.openai`. The current warning message lacks guidance on why and how to suppress it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
