### PR TITLE
Initialize BaseGroupChat before reset

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -494,7 +494,7 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
         """
 
         if not self._initialized:
-            raise RuntimeError("The group chat has not been initialized. It must be run before it can be reset.")
+            self._init(self._runtime)
 
         if self._is_running:
             raise RuntimeError("The group chat is currently running. It must be stopped before it can be reset.")

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -494,7 +494,7 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
         """
 
         if not self._initialized:
-            self._init(self._runtime)
+            await self._init(self._runtime)
 
         if self._is_running:
             raise RuntimeError("The group chat is currently running. It must be stopped before it can be reset.")


### PR DESCRIPTION
Fixes #5366 

Solution: Instead of raising an error called `_init()`