### PR TITLE
fix: Remove R1 model family from is_openai function

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/models/_model_client.py
+++ b/python/packages/autogen-core/src/autogen_core/models/_model_client.py
@@ -81,7 +81,6 @@ class ModelFamily:
             ModelFamily.O3,
             ModelFamily.GPT_4,
             ModelFamily.GPT_35,
-            ModelFamily.R1,
         )
 
 


### PR DESCRIPTION
Resolves #5598