### PR TITLE
Fix accessibility issue 14 for visual accessibility

### DIFF
--- a/python/packages/autogen-core/docs/src/_static/custom.css
+++ b/python/packages/autogen-core/docs/src/_static/custom.css
@@ -4,18 +4,18 @@
 
 html[data-theme="light"] {
   --pst-color-primary: hsl(222.2 47.4% 11.2%);
-  --pst-color-secondary: #007bff;
-  --pst-color-secondary-bg: #007bff;
-  --pst-color-accent: #007bff;
+  --pst-color-secondary: #1774E5;
+  --pst-color-secondary-bg: #1774E5;
+  --pst-color-accent: #1774E5;
   --sd-color-secondary-highlight: #0062cc;
   --pst-color-shadow: rgba(0, 0, 0, 0.0);
 }
 
 html[data-theme="dark"] {
   --pst-color-primary: hsl(213 31% 91%);
-  --pst-color-secondary: #007bff;
-  --pst-color-secondary-bg: #007bff;
-  --pst-color-accent: #007bff;
+  --pst-color-secondary: #017FFF;
+  --pst-color-secondary-bg: #017FFF;
+  --pst-color-accent: #017FFF;
   --sd-color-secondary-highlight: #0062cc;
   --pst-color-shadow: rgba(0, 0, 0, 0.0);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixes `(14) Ensures the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds`

Note: the color values don't output at the exact values on the stylesheet. For example, the value `#1774E5` evaluates to `#2274E0` by the Accessibility Insights app.

## Related issue number

https://github.com/microsoft/autogen/issues/5633

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
