### PR TITLE
Dev/fix agent registration consistency

### DIFF
--- a/dotnet/src/Microsoft.AutoGen/RuntimeGateway.Grpc/Services/AgentWorkerHostingExtensions.cs
+++ b/dotnet/src/Microsoft.AutoGen/RuntimeGateway.Grpc/Services/AgentWorkerHostingExtensions.cs
@@ -6,13 +6,31 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AutoGen.RuntimeGateway.Grpc;
 public static class AgentWorkerHostingExtensions
 {
-    public static WebApplicationBuilder AddAgentService(this WebApplicationBuilder builder)
+    /// <summary>
+    /// Adds the Agent Runtime Gateway Service to the web application.
+    /// </summary>
+    /// <param name="builder">The builder for the application.</param>
+    /// <param name="supportAgentTypeMultiplexing">
+    /// Whether the gateway should be configured to support multiple runtime clients registering a new agent. The behaviour
+    /// defaults to <c>false</c> which is consistent with the Python Agent Runtime Gateway. This flag should be thought of
+    /// as experimental and possibly obsolete capability.
+    /// </param>
+    /// <returns>The builder for the application</returns>
+    public static WebApplicationBuilder AddAgentService(this WebApplicationBuilder builder, bool supportAgentTypeMultiplexing = false)
     {
         builder.AddOrleans();
+
+        OptionsBuilder<GrpcGatewayOptions> optionsBuilder = builder.Services.AddOptions<GrpcGatewayOptions>();
+
+        if (supportAgentTypeMultiplexing)
+        {
+            optionsBuilder.Configure(options => options.SupportAgentTypeMultiplexing = supportAgentTypeMultiplexing );
+        }
 
         builder.Services.TryAddSingleton(DistributedContextPropagator.Current);
 

--- a/dotnet/src/Microsoft.AutoGen/RuntimeGateway.Grpc/Services/Grpc/GrpcWorkerConnection.cs
+++ b/dotnet/src/Microsoft.AutoGen/RuntimeGateway.Grpc/Services/Grpc/GrpcWorkerConnection.cs
@@ -6,6 +6,15 @@ using Microsoft.AutoGen.Protobuf;
 
 namespace Microsoft.AutoGen.RuntimeGateway.Grpc;
 
+public static class ServerCallContextExtensions
+{
+    public static string GetClientId(this ServerCallContext context)
+    {
+        return context.RequestHeaders.Get("client-id")?.Value ??
+               throw new RpcException(new Status(StatusCode.InvalidArgument, "Grpc Client ID is required."));
+    }
+}
+
 public sealed class GrpcWorkerConnection : IAsyncDisposable
 {
     private static long s_nextConnectionId;
@@ -25,6 +34,9 @@ public sealed class GrpcWorkerConnection : IAsyncDisposable
         ServerCallContext = context;
         _outboundMessages = Channel.CreateUnbounded<Message>(new UnboundedChannelOptions { AllowSynchronousContinuations = true, SingleReader = true, SingleWriter = false });
     }
+
+    public string ClientId => this.ServerCallContext.GetClientId();
+
     public Task Connect()
     {
         var didSuppress = false;

--- a/python/packages/autogen-ext/tests/test_worker_runtime.py
+++ b/python/packages/autogen-ext/tests/test_worker_runtime.py
@@ -36,7 +36,7 @@ from .protos.serialization_test_pb2 import ProtoMessage
 
 @pytest.mark.grpc
 @pytest.mark.asyncio
-async def test_agent_types_must_be_unique_single_worker() -> None:
+async def test_agent_types_uniqueness_allows_reregistration() -> None:
     host_address = "localhost:50051"
     host = GrpcWorkerAgentRuntimeHost(address=host_address)
     host.start()
@@ -46,10 +46,8 @@ async def test_agent_types_must_be_unique_single_worker() -> None:
 
     await worker.register_factory(type=AgentType("name1"), agent_factory=lambda: NoopAgent(), expected_class=NoopAgent)
 
-    with pytest.raises(ValueError):
-        await worker.register_factory(
-            type=AgentType("name1"), agent_factory=lambda: NoopAgent(), expected_class=NoopAgent
-        )
+    # re-registration of the same agent type should be allowed (if agent_type and client_id match)
+    await worker.register_factory(type=AgentType("name1"), agent_factory=lambda: NoopAgent(), expected_class=NoopAgent)
 
     await worker.register_factory(type=AgentType("name4"), agent_factory=lambda: NoopAgent(), expected_class=NoopAgent)
     await worker.register_factory(type=AgentType("name5"), agent_factory=lambda: NoopAgent())


### PR DESCRIPTION
The behaviour of registration in the .NET Runtime Gateway and the Python Runtime Gateway was inconsistent: .NET allowed arbitrary numbers of clients to register the same agent type, Python did not allow duplicate agent types even in the case of re-registration by the same client.

Per discussion, the decision was to meet in the middle and support re-registration but not multiplexing in the Python, and per further discussion, we decided to allow re-enabling multiplexing mode in .NET.

Closes #5314 