### PR TITLE
typo fix in llm_configuration.ipynb

### DIFF
--- a/notebook/agentchat_nested_chats_chess_altmodels.ipynb
+++ b/notebook/agentchat_nested_chats_chess_altmodels.ipynb
@@ -130,7 +130,7 @@
     "    move: Annotated[\n",
     "        str,\n",
     "        \"Call this tool to make a move after you have the list of legal moves and want to make a move. Takes UCI format, e.g. e2e4 or e7e5 or e7e8q.\",\n",
-    "    ]\n",
+    "    ],\n",
     ") -> Annotated[str, \"Result of the move.\"]:\n",
     "    move = chess.Move.from_uci(move)\n",
     "    board.push_uci(str(move))\n",

--- a/website/docs/topics/llm_configuration.ipynb
+++ b/website/docs/topics/llm_configuration.ipynb
@@ -244,7 +244,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then when filtering the `config_list` you can can specify the desired tags. A config is selected if it has at least one of the tags specified in the filter. For example, to just get the `llama` model, you can use the following filter:"
+    "Then when filtering the `config_list` you can specify the desired tags. A config is selected if it has at least one of the tags specified in the filter. For example, to just get the `llama` model, you can use the following filter:"
    ]
   },
   {


### PR DESCRIPTION
There is double 'can can' in the documentation.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

typo-fix in the documentation.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
