### PR TITLE
docs: add note about markdown code block requirement in CodeExecutorA…

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -42,7 +42,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         The code executor only processes code that is properly formatted in markdown code blocks using triple backticks.
         For example:
 
-        .. code-block:: python
+        .. code-block:: text
 
             ```python
             print("Hello World")

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -37,6 +37,23 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         It is recommended that the `CodeExecutorAgent` agent uses a Docker container to execute code. This ensures that model-generated code is executed in an isolated environment. To use Docker, your environment must have Docker installed and running.
         Follow the installation instructions for `Docker <https://docs.docker.com/get-docker/>`_.
 
+    .. note::
+
+        The code executor only processes code that is properly formatted in markdown code blocks using triple backticks.
+        For example:
+
+        .. code-block:: python
+
+            ```python
+            print("Hello World")
+            ```
+
+            # or
+
+            ```sh
+            echo "Hello World"
+            ```
+
     In this example, we show how to set up a `CodeExecutorAgent` agent that uses the
     :py:class:`~autogen_ext.code_executors.docker.DockerCommandLineCodeExecutor`
     to execute code snippets in a Docker container. The `work_dir` parameter indicates where all executed files are first saved locally before being executed in the Docker container.


### PR DESCRIPTION
## Why are these changes needed?

The CodeExecutorAgent documentation needs to be updated to explicitly mention that it only processes code properly formatted in markdown code blocks with triple backticks. This change adds a clear note with examples to help users understand the required format for code execution.

## Related issue number

Closes #5771

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
