### PR TITLE
add stream_options to openai model

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1112,6 +1112,7 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
             "this is content" becomes "Reviewer said: this is content."
             This can be useful for models that do not support the `name` field in
             message. Defaults to False.
+        stream_options (optional, dict): Additional options for streaming. Currently only `include_usage` is supported.
 
     Examples:
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -9,6 +9,8 @@ from typing_extensions import Required, TypedDict
 class ResponseFormat(TypedDict):
     type: Literal["text", "json_object"]
 
+class StreamOptions(TypedDict):
+    include_usage: bool
 
 class CreateArguments(TypedDict, total=False):
     frequency_penalty: Optional[float]
@@ -22,6 +24,7 @@ class CreateArguments(TypedDict, total=False):
     temperature: Optional[float]
     top_p: Optional[float]
     user: str
+    stream_options: Optional[StreamOptions]
 
 
 AsyncAzureADTokenProvider = Callable[[], Union[str, Awaitable[str]]]
@@ -67,6 +70,7 @@ class CreateArgumentsConfigModel(BaseModel):
     temperature: float | None = None
     top_p: float | None = None
     user: str | None = None
+    stream_options: StreamOptions | None = None
 
 
 class BaseOpenAIClientConfigurationConfigModel(CreateArgumentsConfigModel):

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -9,8 +9,10 @@ from typing_extensions import Required, TypedDict
 class ResponseFormat(TypedDict):
     type: Literal["text", "json_object"]
 
+
 class StreamOptions(TypedDict):
     include_usage: bool
+
 
 class CreateArguments(TypedDict, total=False):
     frequency_penalty: Optional[float]


### PR DESCRIPTION
## Why are these changes needed?

stream_options are not part of the model classes, so they won't get serialized when calling dump_component. Adding this to the model allows us to store the stream options when the component is serialized.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
