### PR TITLE
Add Git LFS Note to AGS Readme

### DIFF
--- a/python/packages/autogen-studio/.devcontainer/post-create-command.sh
+++ b/python/packages/autogen-studio/.devcontainer/post-create-command.sh
@@ -6,7 +6,13 @@ mkdir -p frontend/node_modules
 
 # Change ownership of node_modules to vscode user
 # This prevents permission issues when installing packages
-sudo chown vscode frontend/node_modules
+sudo chown vscode frontend/node_modules 
+
+# Initialize git-lfs and fetch/checkout LFS files
+git lfs install
+git lfs fetch --all
+git lfs checkout
+
 
 pip install --upgrade pip gunicorn
 

--- a/python/packages/autogen-studio/README.md
+++ b/python/packages/autogen-studio/README.md
@@ -39,6 +39,14 @@ pip install -U autogenstudio
 
 _Note: This approach requires some familiarity with building interfaces in React._
 
+> Note: The AutoGen repo uses git-lfs. please ensure you have install git lfs and then run `git lfs checkout` in the repo to load all image files and any other large file.
+
+```
+apt-get install git-lfs
+git lfs fetch --all
+git lfs checkout # this command downloads all missing image files to the working dir
+```
+
 You have two options for installing from source: manually or using a dev container.
 
 #### A) Install from source manually

--- a/python/packages/autogen-studio/README.md
+++ b/python/packages/autogen-studio/README.md
@@ -39,43 +39,69 @@ pip install -U autogenstudio
 
 _Note: This approach requires some familiarity with building interfaces in React._
 
-> Note: The AutoGen repo uses git-lfs. please ensure you have install git lfs and then run `git lfs checkout` in the repo to load all image files and any other large file.
+### Important: Git LFS Requirement
 
-```
-apt-get install git-lfs
+AutoGen Studio uses Git Large File Storage (LFS) for managing image and other large files. If you clone the repository without git-lfs, you'll encounter build errors related to image formats.
+
+**Before cloning the repository:**
+
+1. Install git-lfs:
+
+   ```bash
+   # On Debian/Ubuntu
+   apt-get install git-lfs
+
+   # On macOS with Homebrew
+   brew install git-lfs
+
+   # On Windows with Chocolatey
+   choco install git-lfs
+   ```
+
+2. Set up git-lfs:
+   ```bash
+   git lfs install
+   ```
+
+**If you've already cloned the repository:**
+
+```bash
+git lfs install
 git lfs fetch --all
-git lfs checkout # this command downloads all missing image files to the working dir
+git lfs checkout  # downloads all missing image files to the working directory
 ```
+
+This setup is handled automatically if you use the dev container method of installation.
 
 You have two options for installing from source: manually or using a dev container.
 
 #### A) Install from source manually
 
-  1. Ensure you have Python 3.10+ and Node.js (version above 14.15.0) installed.
-  2. Clone the AutoGen Studio repository and install its Python dependencies using `pip install -e .`
-  3. Navigate to the `python/packages/autogen-studio/frontend` directory, install the dependencies, and build the UI:
+1. Ensure you have Python 3.10+ and Node.js (version above 14.15.0) installed.
+2. Clone the AutoGen Studio repository and install its Python dependencies using `pip install -e .`
+3. Navigate to the `python/packages/autogen-studio/frontend` directory, install the dependencies, and build the UI:
 
-      ```bash
-      npm install -g gatsby-cli
-      npm install --global yarn
-      cd frontend
-      yarn install
-      yarn build
-      # Windows users may need alternative commands to build the frontend:
-      gatsby clean && rmdir /s /q ..\\autogenstudio\\web\\ui 2>nul & (set \"PREFIX_PATH_VALUE=\" || ver>nul) && gatsby build --prefix-paths && xcopy /E /I /Y public ..\\autogenstudio\\web\\ui
-      ```
+   ```bash
+   npm install -g gatsby-cli
+   npm install --global yarn
+   cd frontend
+   yarn install
+   yarn build
+   # Windows users may need alternative commands to build the frontend:
+   gatsby clean && rmdir /s /q ..\\autogenstudio\\web\\ui 2>nul & (set \"PREFIX_PATH_VALUE=\" || ver>nul) && gatsby build --prefix-paths && xcopy /E /I /Y public ..\\autogenstudio\\web\\ui
+   ```
 
-#### B)  Install from source using a dev container
+#### B) Install from source using a dev container
 
-  1. Follow the [Dev Containers tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial) to install VS Code, Docker and relevant extensions.
-  2. Clone the AutoGen Studio repository.
-  3. Open `python/packages/autogen-studio/`in VS Code. Click the blue button in bottom the corner or press F1 and select _"Dev Containers: Reopen in Container"_.
-  4. Build the UI:
+1. Follow the [Dev Containers tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial) to install VS Code, Docker and relevant extensions.
+2. Clone the AutoGen Studio repository.
+3. Open `python/packages/autogen-studio/`in VS Code. Click the blue button in bottom the corner or press F1 and select _"Dev Containers: Reopen in Container"_.
+4. Build the UI:
 
-      ```bash
-      cd frontend
-      yarn build
-      ```
+   ```bash
+   cd frontend
+   yarn build
+   ```
 
 ### Running the Application
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->



## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

- AGS contains image files which are required for local build /dev
- These files are stored using git lfs  which needs to be run before the files are downloaded 
- This PR adds a reminder to the AGS readme to run `git lfs checkout` after installing git lfs to download the image files 
- Also adds gitlfs install to devcontainer

## Related issue number

<!-- For example: "Closes #1234" -->

Close #3418

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
