### PR TITLE
Fix: Ensure UTF-8 encoding in all 'open()' statements

### DIFF
--- a/python/fixup_generated_files.py
+++ b/python/fixup_generated_files.py
@@ -24,12 +24,12 @@ substitutions: Dict[str, str] = {
 
 def main():
     for file in files:
-        with open(file, "r") as f:
+        with open(file, "r",encoding='utf-8') as f:
             content = f.read()
 
         print("Fixing imports in file:", file)
         for old, new in substitutions.items():
             content = content.replace(old, new)
 
-        with open(file, "w") as f:
+        with open(file, "w",encoding='utf-8') as f:
             f.write(content)

--- a/python/packages/agbench/benchmarks/GAIA/Scripts/custom_tabulate.py
+++ b/python/packages/agbench/benchmarks/GAIA/Scripts/custom_tabulate.py
@@ -131,7 +131,7 @@ def scorer(instance_dir):
         return None
 
     expected_answer = None
-    with open(expected_answer_file, "rt") as fh:
+    with open(expected_answer_file, "rt",encoding='utf-8') as fh:
         expected_answer = fh.read().strip()
 
     # Read the console
@@ -140,7 +140,7 @@ def scorer(instance_dir):
         return None
 
     console_log = ""
-    with open(console_log_file, "rt") as fh:
+    with open(console_log_file, "rt",encoding='utf-8') as fh:
         console_log = fh.read()
 
         final_answer = None 

--- a/python/packages/agbench/benchmarks/GAIA/Scripts/init_tasks.py
+++ b/python/packages/agbench/benchmarks/GAIA/Scripts/init_tasks.py
@@ -42,7 +42,7 @@ def create_jsonl(name, tasks, files_dir, template):
     if not os.path.isdir(TASKS_DIR):
         os.mkdir(TASKS_DIR)
 
-    with open(os.path.join(TASKS_DIR, name + ".jsonl"), "wt") as fh:
+    with open(os.path.join(TASKS_DIR, name + ".jsonl"), "wt",encoding='utf-8') as fh:
         for task in tasks:
             print(f"Converting: [{name}] {task['task_id']}")
 
@@ -85,13 +85,13 @@ def main():
 
     # Load the GAIA data
     gaia_validation_tasks = [[], [], []]
-    with open(os.path.join(gaia_validation_files, "metadata.jsonl")) as fh:
+    with open(os.path.join(gaia_validation_files, "metadata.jsonl"),encoding='utf-8') as fh:
         for line in fh:
             data = json.loads(line)
             gaia_validation_tasks[data["Level"] - 1].append(data)
 
     gaia_test_tasks = [[], [], []]
-    with open(os.path.join(gaia_test_files, "metadata.jsonl")) as fh:
+    with open(os.path.join(gaia_test_files, "metadata.jsonl"),encoding='utf-8') as fh:
         for line in fh:
             data = json.loads(line)
 

--- a/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
@@ -20,7 +20,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r",encoding='utf-8') as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])
@@ -30,7 +30,7 @@ async def main() -> None:
     
     # Read the prompt
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt",encoding='utf-8') as fh:
         prompt = fh.read().strip()
     filename = "__FILE_NAME__".strip()
 

--- a/python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py
@@ -25,7 +25,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r",encoding='utf-8') as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])
@@ -35,7 +35,7 @@ async def main() -> None:
     
     # Read the prompt
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt",encoding='utf-8') as fh:
         prompt = fh.read().strip()
     filename = "__FILE_NAME__".strip()
 

--- a/python/packages/agbench/benchmarks/HumanEval/Scripts/init_tasks.py
+++ b/python/packages/agbench/benchmarks/HumanEval/Scripts/init_tasks.py
@@ -85,7 +85,7 @@ def create_jsonl(name, tasks, template):
         os.mkdir(TASKS_DIR)
 
     # Create the jsonl file
-    with open(os.path.join(TASKS_DIR, name + ".jsonl"), "wt") as fh:
+    with open(os.path.join(TASKS_DIR, name + ".jsonl"), "wt",encoding='utf-8') as fh:
         for task in tasks:
             print(f"Converting: [{name}] {task['task_id']}")
 

--- a/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/custom_code_executor.py
+++ b/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/custom_code_executor.py
@@ -17,7 +17,7 @@ class CustomCodeExecutorAgent(CodeExecutorAgent):
     ) -> None:
         super().__init__(name=name, description=description, code_executor=code_executor, sources=sources)
         self._test_code = ""
-        with open("test.txt", "rt") as fh:
+        with open("test.txt", "rt",encoding='utf-8') as fh:
             self._test_code = fh.read()
 
 

--- a/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py
+++ b/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py
@@ -13,7 +13,7 @@ from autogen_core.models import ChatCompletionClient
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r",encoding='utf-8') as f:
         config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(config["model_config"])
 
@@ -37,7 +37,7 @@ async def main() -> None:
     agent_team = RoundRobinGroupChat([coder_agent, executor], max_turns=12, termination_condition=termination)
 
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt",encoding='utf-8') as fh:
         prompt = fh.read()
 
     task = f"""Complete the following python function. Format your output as Markdown python code block containing the entire function definition:

--- a/python/packages/agbench/benchmarks/process_logs.py
+++ b/python/packages/agbench/benchmarks/process_logs.py
@@ -96,7 +96,7 @@ def scorer(instance_dir, benchmark_name):
         if not os.path.isfile(expected_answer_file):
             return None
 
-        with open(expected_answer_file, "rt") as fh:
+        with open(expected_answer_file, "rt",encoding='utf-8') as fh:
             expected_answer = fh.read().strip()
 
         # Read the console log
@@ -104,7 +104,7 @@ def scorer(instance_dir, benchmark_name):
         if not os.path.isfile(console_log_file):
             return None
 
-        with open(console_log_file, "rt") as fh:
+        with open(console_log_file, "rt",encoding='utf-8') as fh:
             console_log = fh.read()
             final_answer = None
             m = re.search(r"FINAL ANSWER:(.*?)\n", console_log, re.DOTALL)
@@ -125,7 +125,7 @@ def scorer(instance_dir, benchmark_name):
         if not os.path.isfile(console_log_file):
             return None
 
-        with open(console_log_file, "rt") as fh:
+        with open(console_log_file, "rt",encoding='utf-8') as fh:
             console_log = fh.read()
             final_score = None
             m = re.search(r"FINAL SCORE:(.*?)\n", console_log, re.DOTALL)
@@ -145,7 +145,7 @@ def get_number_of_chat_messages(chat_messages_dir):
     # Count the number of chat messages in the chat_messages_dir
     result = 0
     for file in glob.glob(f"{chat_messages_dir}/*_messages.json"):
-        with open(file, "r") as f:
+        with open(file, "r",encoding='utf-8') as f:
             content = json.load(f)
             for agent, messages in content.items():
                 result += len(messages)
@@ -158,7 +158,7 @@ def did_agent_stall(instance_dir):
     if not os.path.isfile(log_file_path):
         return None
     # Stalled.... Replanning...
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r",encoding='utf-8') as f:
         for line in f:
             if "Stalled.... Replanning..." in line:
                 return True
@@ -172,7 +172,7 @@ def get_message_logs(instance_dir):
         return None
     messages = []
     # for each line, convert to dict, check if it has a message and source key, and append to messages
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r",encoding='utf-8') as f:
         for line in f:
             line_dict = json.loads(line)
             if "message" in line_dict and "source" in line_dict:
@@ -186,13 +186,13 @@ def get_task_information(instance_dir, benchmark_name):
         prompt_file = os.path.join(instance_dir, "prompt.txt")
         if not os.path.isfile(prompt_file):
             return None
-        with open(prompt_file, "r") as f:
+        with open(prompt_file, "r",encoding='utf-8') as f:
             return f.read().strip()
     elif benchmark_name == "webarena":
         task_prompt_file = os.path.join(instance_dir, "task_prompt.json")
         if not os.path.isfile(task_prompt_file):
             return None
-        with open(task_prompt_file, "r") as f:
+        with open(task_prompt_file, "r",encoding='utf-8') as f:
             return json.load(f)["intent"]
     else:
         raise ValueError(f"Unsupported benchmark_name: {benchmark_name}")
@@ -204,7 +204,7 @@ def is_progress_not_being_made(instance_dir):
     log_file_path = os.path.join(instance_dir, "log.jsonl")
     if not os.path.isfile(log_file_path):
         return None
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r",encoding='utf-8') as f:
         for line in f:
             line_dict = json.loads(line)
             if (

--- a/python/packages/agbench/src/agbench/remove_missing_cmd.py
+++ b/python/packages/agbench/src/agbench/remove_missing_cmd.py
@@ -11,7 +11,7 @@ def default_scorer(instance_dir: str) -> bool:
     """
     console_log = os.path.join(instance_dir, "console_log.txt")
     if os.path.isfile(console_log):
-        with open(console_log, "rt") as fh:
+        with open(console_log, "rt",encoding='utf-8') as fh:
             content = fh.read()
             # Use a regular expression to match the expected ending pattern
             has_final_answer = "FINAL ANSWER:" in content

--- a/python/packages/agbench/src/agbench/run_cmd.py
+++ b/python/packages/agbench/src/agbench/run_cmd.py
@@ -240,13 +240,13 @@ def expand_scenario(
     for templated_file in substitutions.keys():  # Keys are relative file paths
         # Read the templated file into memory
         template_contents: List[str] = list()
-        with open(os.path.join(output_dir, templated_file), "rt") as fh:
+        with open(os.path.join(output_dir, templated_file), "rt",encoding='utf-8') as fh:
             for line in fh:
                 template_contents.append(line)
 
         # Rewrite the templated file with substitutions
         values = substitutions[templated_file]
-        with open(os.path.join(output_dir, templated_file), "wt") as fh:
+        with open(os.path.join(output_dir, templated_file), "wt",encoding='utf-8') as fh:
             for line in template_contents:
                 for k, v in values.items():
                     line = line.replace(k, v)
@@ -300,10 +300,10 @@ def get_scenario_env(token_provider: Optional[Callable[[], str]] = None, env_fil
     if env_file is None:
         # Env file was not specified, so read the default, or warn if the default file is missing.
         if os.path.isfile(DEFAULT_ENV_FILE_YAML):
-            with open(DEFAULT_ENV_FILE_YAML, "r") as fh:
+            with open(DEFAULT_ENV_FILE_YAML, "r",encoding='utf-8') as fh:
                 env_file_contents = yaml.safe_load(fh)
         elif os.path.isfile(DEFAULT_ENV_FILE_JSON):
-            with open(DEFAULT_ENV_FILE_JSON, "rt") as fh:
+            with open(DEFAULT_ENV_FILE_JSON, "rt",encoding='utf-8') as fh:
                 env_file_contents = json.loads(fh.read())
             logging.warning(f"JSON environment files are deprecated. Migrate to '{DEFAULT_ENV_FILE_YAML}'")
         else:
@@ -312,7 +312,7 @@ def get_scenario_env(token_provider: Optional[Callable[[], str]] = None, env_fil
             )
     else:
         # Env file was specified. Throw an error if the file can't be read.
-        with open(env_file, "rt") as fh:
+        with open(env_file, "rt",encoding='utf-8') as fh:
             if env_file.endswith(".json"):
                 logging.warning("JSON environment files are deprecated. Migrate to YAML")
                 env_file_contents = json.loads(fh.read())
@@ -401,7 +401,7 @@ def run_scenario_natively(work_dir: str, env: Mapping[str, str], timeout: int = 
     print("\n\n" + os.getcwd() + "\n===================================================================")
 
     # Prepare the run script
-    with open(os.path.join("run.sh"), "wt") as f:
+    with open(os.path.join("run.sh"), "wt",encoding='utf-8') as f:
         f.write(
             f"""#
 echo RUN.SH STARTING !#!#
@@ -464,7 +464,7 @@ echo RUN.SH COMPLETE !#!#
         )
 
     # Run the script and log the output
-    with open("console_log.txt", "wb") as f:
+    with open("console_log.txt", "wb",encoding='utf-8') as f:
         process = subprocess.Popen(
             ["sh", "run.sh"],
             env=full_env,
@@ -521,7 +521,7 @@ def run_scenario_in_docker(
                 print(f"Failed to pull image '{docker_image}'")
 
     # Prepare the run script
-    with open(os.path.join(work_dir, "run.sh"), "wt", newline="\n") as f:
+    with open(os.path.join(work_dir, "run.sh"), "wt", newline="\n",encoding='utf-8') as f:
         f.write(
             f"""#
 echo RUN.SH STARTING !#!#
@@ -715,7 +715,7 @@ def split_jsonl(file_path: str, num_parts: int) -> List[List[Dict[str, Any]]]:
     """
     Split a JSONL file into num_parts approximately equal parts.
     """
-    with open(file_path, "r") as f:
+    with open(file_path, "r",encoding='utf-8') as f:
         data = [json.loads(line) for line in f]
 
     random.shuffle(data)  # Shuffle the data for better distribution
@@ -914,7 +914,7 @@ def run_cli(args: Sequence[str]) -> None:
 
     if parsed_args.config is not None:
         # Make sure the config file is readable, so that we fail early
-        with open(parsed_args.config, "r"):
+        with open(parsed_args.config, "r",encoding='utf-8'):
             pass
 
     # don't support parallel and subsample together

--- a/python/packages/agbench/src/agbench/tabulate_cmd.py
+++ b/python/packages/agbench/src/agbench/tabulate_cmd.py
@@ -65,7 +65,7 @@ def find_tabulate_module(search_dir: str, stop_dir: Optional[str] = None) -> Opt
 def default_scorer(instance_dir: str, success_strings: List[str] = SUCCESS_STRINGS) -> Optional[bool]:
     console_log = os.path.join(instance_dir, "console_log.txt")
     if os.path.isfile(console_log):
-        with open(console_log, "rt") as fh:
+        with open(console_log, "rt",encoding='utf-8') as fh:
             content = fh.read()
 
             # It succeeded

--- a/python/packages/autogen-core/docs/redirects/redirects.py
+++ b/python/packages/autogen-core/docs/redirects/redirects.py
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w",encoding='utf-8') as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r",encoding='utf-8') as f:
         lines = f.readlines()
 
     for line in lines:

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -459,11 +459,11 @@ async def main() -> None:
     state = await assistant.save_state()
 
     # (Optional) Write state to disk.
-    with open("assistant_state.json", "w") as f:
+    with open("assistant_state.json", "w",encoding='utf-8') as f:
         json.dump(state, f)
 
     # (Optional) Load it back from disk.
-    with open("assistant_state.json", "r") as f:
+    with open("assistant_state.json", "r",encoding='utf-8') as f:
         state = json.load(f)
         print(state) # Inspect the state, which contains the chat history.
 
@@ -937,14 +937,14 @@ async def main() -> None:
 
     # Save the state of the group chat and all participants.
     state = await group_chat.save_state()
-    with open("group_chat_state.json", "w") as f:
+    with open("group_chat_state.json", "w",encoding='utf-8') as f:
         json.dump(state, f)
 
     # Create a new team with the same participants configuration.
     group_chat = create_team()
 
     # Load the state of the group chat and all participants.
-    with open("group_chat_state.json", "r") as f:
+    with open("group_chat_state.json", "r",encoding='utf-8') as f:
         state = json.load(f)
     await group_chat.load_state(state)
 

--- a/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/playwright_controller.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/playwright_controller.py
@@ -64,7 +64,7 @@ class PlaywrightController:
         self._markdown_converter: Optional[Any] | None = None
 
         # Read page_script
-        with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "page_script.js"), "rt") as fh:
+        with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "page_script.js"), "rt", encoding='utf-8') as fh:
             self._page_script = fh.read()
 
     async def sleep(self, page: Page, duration: Union[int, float]) -> None:

--- a/python/packages/autogen-studio/autogenstudio/cli.py
+++ b/python/packages/autogen-studio/autogenstudio/cli.py
@@ -62,7 +62,7 @@ def ui(
 
     # Create temporary env file to share configuration with uvicorn workers
     env_file_path = get_env_file_path()
-    with open(env_file_path, "w") as temp_env:
+    with open(env_file_path, "w",encoding='utf-8') as temp_env:
         for key, value in env_vars.items():
             temp_env.write(f"{key}={value}\n")
 

--- a/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
+++ b/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
@@ -75,7 +75,7 @@ class SchemaManager:
 
         # Update alembic.ini
         config_content = self._generate_alembic_ini_content()
-        with open(self.alembic_ini_path, "w") as f:
+        with open(self.alembic_ini_path, "w",encoding='utf-8') as f:
             f.write(config_content)
 
         # Update env.py
@@ -136,7 +136,7 @@ class SchemaManager:
 
             # Create initial config file for alembic init
             config_content = self._generate_alembic_ini_content()
-            with open(self.alembic_ini_path, "w") as f:
+            with open(self.alembic_ini_path, "w",encoding='utf-8') as f:
                 f.write(config_content)
 
             # Use the config we just created
@@ -206,7 +206,7 @@ if context.is_offline_mode():
 else:
     run_migrations_online()"""
 
-        with open(env_path, "w") as f:
+        with open(env_path, "w",encoding='utf-8') as f:
             f.write(content)
 
     def _generate_alembic_ini_content(self) -> str:
@@ -257,7 +257,7 @@ datefmt = %H:%M:%S
         """Update the Alembic script template to include SQLModel."""
         template_path = self.alembic_dir / "script.py.mako"
         try:
-            with open(template_path, "r") as f:
+            with open(template_path, "r",encoding='utf-8') as f:
                 content = f.read()
 
             # Add sqlmodel import to imports section
@@ -266,7 +266,7 @@ datefmt = %H:%M:%S
 
             content = content.replace(import_section, new_imports)
 
-            with open(template_path, "w") as f:
+            with open(template_path, "w",encoding='utf-8') as f:
                 f.write(content)
 
             return True
@@ -283,7 +283,7 @@ datefmt = %H:%M:%S
             self._create_minimal_env_py(env_path)
             return
         try:
-            with open(env_path, "r") as f:
+            with open(env_path, "r",encoding='utf-8') as f:
                 content = f.read()
 
             # Add SQLModel import if not present
@@ -321,7 +321,7 @@ datefmt = %H:%M:%S
             )""",
             )
 
-            with open(env_path, "w") as f:
+            with open(env_path, "w",encoding='utf-8') as f:
                 f.write(content)
         except Exception as e:
             logger.error(f"Failed to update env.py: {e}")

--- a/python/packages/autogen-studio/autogenstudio/gallery/builder.py
+++ b/python/packages/autogen-studio/autogenstudio/gallery/builder.py
@@ -403,5 +403,5 @@ if __name__ == "__main__":
     gallery = create_default_gallery()
 
     # Save to file
-    with open("gallery_default.json", "w") as f:
+    with open("gallery_default.json", "w",encoding='utf-8') as f:
         f.write(gallery.model_dump_json(indent=2))

--- a/python/packages/autogen-studio/tests/test_team_manager.py
+++ b/python/packages/autogen-studio/tests/test_team_manager.py
@@ -39,7 +39,7 @@ def sample_config():
 def config_file(sample_config, tmp_path):
     """Create a temporary config file"""
     config_path = tmp_path / "test_config.json"
-    with open(config_path, "w") as f:
+    with open(config_path, "w",encoding='utf-8') as f:
         json.dump(sample_config, f)
     return config_path
 
@@ -49,7 +49,7 @@ def config_dir(sample_config, tmp_path):
     """Create a temporary directory with multiple config files"""
     # Create JSON config
     json_path = tmp_path / "team1.json"
-    with open(json_path, "w") as f:
+    with open(json_path, "w",encoding='utf-8') as f:
         json.dump(sample_config, f)
     
     # Create YAML config from the same dict
@@ -58,7 +58,7 @@ def config_dir(sample_config, tmp_path):
     # Create a modified copy to verify we can distinguish between them
     yaml_config = sample_config.copy()
     yaml_config["label"] = "YamlTeam"  # Change a field to identify this as the YAML version
-    with open(yaml_path, "w") as f:
+    with open(yaml_path, "w",encoding='utf-8') as f:
         yaml.dump(yaml_config, f)
     
     return tmp_path

--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -101,12 +101,12 @@ def main() -> None:
 
     if args.config is None:
         if os.path.isfile(DEFAULT_CONFIG_FILE):
-            with open(DEFAULT_CONFIG_FILE, "r") as f:
+            with open(DEFAULT_CONFIG_FILE, "r",encoding='utf-8') as f:
                 config = yaml.safe_load(f)
         else:
             config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)
     else:
-        with open(args.config if isinstance(args.config, str) else args.config[0], "r") as f:
+        with open(args.config if isinstance(args.config, str) else args.config[0], "r",encoding='utf-8') as f:
             config = yaml.safe_load(f)
 
     client = ChatCompletionClient.load_component(config["client"])

--- a/python/samples/agentchat_chainlit/app_agent.py
+++ b/python/samples/agentchat_chainlit/app_agent.py
@@ -31,7 +31,7 @@ async def get_weather(city: str) -> str:
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r",encoding='utf-8') as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chainlit/app_team.py
+++ b/python/samples/agentchat_chainlit/app_team.py
@@ -14,7 +14,7 @@ from autogen_core.models import ChatCompletionClient
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r",encoding='utf-8') as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chainlit/app_team_user_proxy.py
+++ b/python/samples/agentchat_chainlit/app_team_user_proxy.py
@@ -47,7 +47,7 @@ async def user_action_func(prompt: str, cancellation_token: CancellationToken | 
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r",encoding='utf-8') as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chess_game/main.py
+++ b/python/samples/agentchat_chess_game/main.py
@@ -12,7 +12,7 @@ from autogen_core.models import ChatCompletionClient
 
 def create_ai_player() -> AssistantAgent:
     # Load the model client from config.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r",encoding='utf-8') as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
     # Create an agent that can use the model client.

--- a/python/samples/agentchat_graphrag/app.py
+++ b/python/samples/agentchat_graphrag/app.py
@@ -56,6 +56,6 @@ if __name__ == "__main__":
         handler = logging.FileHandler("graphrag_search.log")
         logging.getLogger("autogen_core").addHandler(handler)
 
-    with open(args.model_config, "r") as f:
+    with open(args.model_config, "r",encoding='utf-8') as f:
         model_config = yaml.safe_load(f)
     asyncio.run(main(model_config))

--- a/python/samples/agentchat_streamlit/agent.py
+++ b/python/samples/agentchat_streamlit/agent.py
@@ -8,7 +8,7 @@ from autogen_core.models import ChatCompletionClient
 class Agent:
     def __init__(self) -> None:
         # Load the model client from config.
-        with open("model_config.yml", "r") as f:
+        with open("model_config.yml", "r",encoding='utf-8') as f:
             model_config = yaml.safe_load(f)
         model_client = ChatCompletionClient.load_component(model_config)
         self.agent = AssistantAgent(

--- a/python/samples/core_async_human_in_the_loop/main.py
+++ b/python/samples/core_async_human_in_the_loop/main.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
     # if os.path.exists("state.json"):
     #     os.remove("state.json")
 
-    with open("model_config.yml") as f:
+    with open("model_config.yml",encoding='utf-8') as f:
         model_config = yaml.safe_load(f)
 
     def get_user_input(question_for_user: str):

--- a/python/samples/core_chess_game/main.py
+++ b/python/samples/core_chess_game/main.py
@@ -275,6 +275,6 @@ if __name__ == "__main__":
         handler = logging.FileHandler("chess_game.log")
         logging.getLogger("autogen_core").addHandler(handler)
 
-    with open(args.model_config, "r") as f:
+    with open(args.model_config, "r",encoding='utf-8') as f:
         model_config = yaml.safe_load(f)
     asyncio.run(main(model_config))

--- a/python/samples/core_distributed-group-chat/_utils.py
+++ b/python/samples/core_distributed-group-chat/_utils.py
@@ -11,7 +11,7 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 def load_config(file_path: str = os.path.join(os.path.dirname(__file__), "config.yaml")) -> AppConfig:
     model_client = {}
-    with open(file_path, "r") as file:
+    with open(file_path, "r",encoding='utf-8') as file:
         config_data = yaml.safe_load(file)
         model_client = config_data["client_config"]
         del config_data["client_config"]


### PR DESCRIPTION
## **Why are these changes needed?**  

This PR ensures consistent UTF-8 encoding across all file operations by adding `encoding="utf-8"` to all `with open()` statements.  
This prevents potential encoding issues when running the code in different environments.

## **Related issue number**  
Closes #5566

## **Checks**  

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.  
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.  
- [x] I've made sure all auto checks have passed.  
