### PR TITLE
highlight focused code output boxes in jupyter notebook pages

### DIFF
--- a/python/packages/autogen-core/docs/src/_static/custom.css
+++ b/python/packages/autogen-core/docs/src/_static/custom.css
@@ -88,3 +88,8 @@ html[data-theme="light"] .bd-header {
   vertical-align: bottom;
   margin-right: 5px;
 }
+
+/* jupyter notebook output cells */
+.bd-article .docutils .cell_output .output .highlight > pre:focus-visible{
+  border: 2px outset var(--pst-color-secondary);
+}


### PR DESCRIPTION
## Why are these changes needed?

Current webpage theme does not highlight code output boxes. Issues (5) and (29)

## Related issue number

#5630 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
