### PR TITLE
[autogen-studio] return messages when getting a run

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/datamodel/types.py
+++ b/python/packages/autogen-studio/autogenstudio/datamodel/types.py
@@ -23,7 +23,10 @@ class TeamResult(BaseModel):
 
 class LLMCallEventMessage(BaseChatMessage):
     source: str = "llm_call_event"
+
     content: str
+
+    type: Literal["LLMCallEventMessage"] = "LLMCallEventMessage"
 
 
 class MessageMeta(BaseModel):

--- a/python/packages/autogen-studio/autogenstudio/web/routes/runs.py
+++ b/python/packages/autogen-studio/autogenstudio/web/routes/runs.py
@@ -3,6 +3,7 @@ from typing import Dict
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, HTTPException
+from loguru import logger
 from pydantic import BaseModel
 
 from ...datamodel import Message, MessageConfig, Run, RunStatus, Session, Team
@@ -54,6 +55,12 @@ async def get_run(run_id: UUID, db=Depends(get_db)) -> Dict:
     run = db.get(Run, filters={"id": run_id}, return_json=False)
     if not run.status or not run.data:
         raise HTTPException(status_code=404, detail="Run not found")
+    messages = db.get(Message, filters={"run_id": run_id}, order="asc", return_json=False)
+    if not messages.status:
+        logger.error(f"Failed to fetch messages for run {run_id}")
+        # Set empty list to avoid errors
+        messages.data = []
+    run.data[0].messages = messages.data
 
     return {"status": True, "data": run.data[0]}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

@victordibia 

## Why are these changes needed?

When getting a particular run it's useful to have the list of messages, given that there's no REST endpoint to get messages this feels like the best way. Alternatively we can add endpoints for getting messages by `run_id`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
