### PR TITLE
word wrap prev/next links on autodocs

### DIFF
--- a/python/packages/autogen-core/docs/src/_static/custom.css
+++ b/python/packages/autogen-core/docs/src/_static/custom.css
@@ -128,3 +128,9 @@ html[data-theme="light"] .bd-header {
     opacity: 1;
     visibility: visible;
 }
+
+/* Long autodoc module names wrap on prev/next links */
+/* TODO: Should we extend this to the entire site? */
+.prev-next-title {
+  word-break: break-word;
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Long module names get cut off in autodocs. Fixes (3). I would love to break the words on dots and underscores, but it doesn't look like theres a CSS option for that

before:
![image](https://github.com/user-attachments/assets/c2e425db-a197-4174-9af8-1f7a805df307)

after:
![image](https://github.com/user-attachments/assets/dcfc261a-61ca-4072-a28f-3b51e428ef7f)


## Related issue number

#5634 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
