### PR TITLE
Add author name before their message in Chainlit team sample

### DIFF
--- a/python/samples/agentchat_chainlit/app_team.py
+++ b/python/samples/agentchat_chainlit/app_team.py
@@ -79,7 +79,7 @@ async def chat(message: cl.Message) -> None:
             # Stream the model client response to the user.
             if streaming_response is None:
                 # Start a new streaming response.
-                streaming_response = cl.Message(content="", author=msg.source)
+                streaming_response = cl.Message(content=msg.source + ": ", author=msg.source)
             await streaming_response.stream_token(msg.content)
         elif streaming_response is not None:
             # Done streaming the model client response.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR makes it clear which agent is speaking per message in the Chainlit team sample. Previously, messages would be exchanged without showing who is communicating.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #5609 

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
