### PR TITLE
Add an optional base path to FileSurfer

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py
@@ -1,4 +1,5 @@
 import json
+import os
 import traceback
 from typing import List, Sequence, Tuple
 
@@ -75,11 +76,12 @@ class FileSurfer(BaseChatAgent, Component[FileSurferConfig]):
         name: str,
         model_client: ChatCompletionClient,
         description: str = DEFAULT_DESCRIPTION,
+        work_dir: str = os.getcwd(),
     ) -> None:
         super().__init__(name, description)
         self._model_client = model_client
         self._chat_history: List[LLMMessage] = []
-        self._browser = MarkdownFileBrowser(viewport_size=1024 * 5)
+        self._browser = MarkdownFileBrowser(viewport_size=1024 * 5, base_path=work_dir)
 
     @property
     def produced_message_types(self) -> Sequence[type[ChatMessage]]:

--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py
@@ -55,6 +55,7 @@ class FileSurfer(BaseChatAgent, Component[FileSurferConfig]):
         name (str): The agent's name
         model_client (ChatCompletionClient): The model to use (must be tool-use enabled)
         description (str): The agent's description used by the team. Defaults to DEFAULT_DESCRIPTION
+        base_path (str): The base path to use for the file browser. Defaults to the current working directory.
 
     """
 
@@ -76,12 +77,12 @@ class FileSurfer(BaseChatAgent, Component[FileSurferConfig]):
         name: str,
         model_client: ChatCompletionClient,
         description: str = DEFAULT_DESCRIPTION,
-        work_dir: str = os.getcwd(),
+        base_path: str = os.getcwd(),
     ) -> None:
         super().__init__(name, description)
         self._model_client = model_client
         self._chat_history: List[LLMMessage] = []
-        self._browser = MarkdownFileBrowser(viewport_size=1024 * 5, base_path=work_dir)
+        self._browser = MarkdownFileBrowser(viewport_size=1024 * 5, base_path=base_path)
 
     @property
     def produced_message_types(self) -> Sequence[type[ChatMessage]]:

--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py
@@ -17,7 +17,7 @@ class MarkdownFileBrowser:
 
     # TODO: Fix unfollowed import
     def __init__(  # type: ignore
-        self, viewport_size: Union[int, None] = 1024 * 8
+        self, viewport_size: Union[int, None] = 1024 * 8, base_path: Union[str, None] = None
     ):
         """
         Instantiate a new MarkdownFileBrowser.
@@ -31,16 +31,17 @@ class MarkdownFileBrowser:
         self.viewport_current_page = 0
         self.viewport_pages: List[Tuple[int, int]] = list()
         self._markdown_converter = MarkItDown()
-        self.set_path(os.getcwd())
+        self._base_path = base_path or os.getcwd()
         self._page_content: str = ""
         self._find_on_page_query: Union[str, None] = None
         self._find_on_page_last_result: Union[int, None] = None  # Location of the last result
+        self.set_path(self._base_path)
 
     @property
     def path(self) -> str:
         """Return the path of the current page."""
         if len(self.history) == 0:
-            return os.getcwd()
+            return self._base_path
         else:
             return self.history[-1][0]
 

--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py
@@ -17,7 +17,7 @@ class MarkdownFileBrowser:
 
     # TODO: Fix unfollowed import
     def __init__(  # type: ignore
-        self, viewport_size: Union[int, None] = 1024 * 8, base_path: Union[str, None] = None
+        self, viewport_size: Union[int, None] = 1024 * 8, base_path: str = os.getcwd()
     ):
         """
         Instantiate a new MarkdownFileBrowser.
@@ -32,7 +32,7 @@ class MarkdownFileBrowser:
         self.viewport_current_page = 0
         self.viewport_pages: List[Tuple[int, int]] = list()
         self._markdown_converter = MarkItDown()
-        self._base_path = base_path or os.getcwd()
+        self._base_path = base_path
         self._page_content: str = ""
         self._find_on_page_query: Union[str, None] = None
         self._find_on_page_last_result: Union[int, None] = None  # Location of the last result

--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py
@@ -24,6 +24,7 @@ class MarkdownFileBrowser:
 
         Arguments:
             viewport_size: Approximately how many *characters* fit in the viewport. Viewport dimensions are adjusted dynamically to avoid cutting off words (default: 8192).
+            base_path: The base path to use for the file browser. Defaults to the current working directory.
         """
         self.viewport_size = viewport_size  # Applies only to the standard uri types
         self.history: List[Tuple[str, float]] = list()


### PR DESCRIPTION
This pull request introduces a new feature to the `FileSurfer` agent and `MarkdownFileBrowser` by adding support for specifying a base path for file browsing. 

* `python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py`: 
  * Added `base_path` parameter to `FileSurfer` class and its initialization method, with a default value of the current working directory (`os.getcwd()`). [[1]](diffhunk://#diff-084847b5e64c659c9aff0bd2d05bbcd0fff2c819a4b91bbe65fa0566054c0972R58) [[2]](diffhunk://#diff-084847b5e64c659c9aff0bd2d05bbcd0fff2c819a4b91bbe65fa0566054c0972R80-R85)
  * Updated `MarkdownFileBrowser` initialization within `FileSurfer` to use the `base_path` parameter.

* `python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py`:
  * Added `base_path` parameter to `MarkdownFileBrowser` class and its initialization method, with a default value of the current working directory (`os.getcwd()`).
  * Updated `MarkdownFileBrowser` to use the `base_path` for setting the initial path and returning the current page path.