### PR TITLE
Update memory.ipynb - fixed typo chroma_user_memory

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/memory.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/memory.ipynb
@@ -296,13 +296,13 @@
     "        model=\"gpt-4o\",\n",
     "    ),\n",
     "    tools=[get_weather],\n",
-    "    memory=[user_memory],\n",
+    "    memory=[chroma_user_memory],\n",
     ")\n",
     "\n",
     "stream = assistant_agent.run_stream(task=\"What is the weather in New York?\")\n",
     "await Console(stream)\n",
     "\n",
-    "await user_memory.close()"
+    "await chroma_user_memory.close()"
    ]
   },
   {


### PR DESCRIPTION
Fixed a typo, chroma_user_memory instead of user_memory

## Why are these changes needed?

There's a confusing typo in the documentation.

## Related issue number

None

## Checks

- [x ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x ] I've made sure all auto checks have passed.
