### PR TITLE
Revert Allow Voice Access to find clickable cards commit

### DIFF
--- a/python/packages/autogen-core/docs/src/_static/custom.css
+++ b/python/packages/autogen-core/docs/src/_static/custom.css
@@ -123,21 +123,10 @@ html[data-theme="light"] .bd-header {
 
 /* Copy button */
 .bd-article .docutils .docutils .copybtn:focus-visible:after {
+  /* border: 10px outset var(--pst-color-primary); */
     display: block;
     opacity: 1;
     visibility: visible;
-}
-
-/* Allow voice access to find clickable cards */
-.sd-card a {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1;
-  text-decoration: none;
-  color: inherit;
 }
 
 /* Long autodoc module names wrap on prev/next links */


### PR DESCRIPTION
Reverts https://github.com/microsoft/autogen/pull/5857 due to weird interaction with non-clickable cards