### PR TITLE
fix: Improve PublishMessageAsync resilience

### DIFF
--- a/dotnet/src/Microsoft.AutoGen/AgentChat/GroupChat/OutputCollectorAgent.cs
+++ b/dotnet/src/Microsoft.AutoGen/AgentChat/GroupChat/OutputCollectorAgent.cs
@@ -26,7 +26,7 @@ internal sealed class OutputSink : IOutputCollectionSink
     }
 
     private readonly object sync = new();
-    private SemaphoreSlim semapohre = new SemaphoreSlim(1, 1);
+    private SemaphoreSlim semapohre = new SemaphoreSlim(0, 1);
 
     private SinkFrame? receivingSinkFrame;
 
@@ -43,7 +43,12 @@ internal sealed class OutputSink : IOutputCollectionSink
             frameAction(this.receivingSinkFrame);
         }
 
-        semapohre.Release();
+        // TODO: Replace the Semaphore with a TaskSource approach
+        try
+        {
+            semapohre.Release();
+        }
+        catch (SemaphoreFullException) { }
     }
 
     public void CollectMessage(AgentMessage message)

--- a/dotnet/src/Microsoft.AutoGen/Core/MessageDelivery.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/MessageDelivery.cs
@@ -13,6 +13,7 @@ internal sealed class MessageDelivery(MessageEnvelope message, Func<MessageEnvel
     public IResultSink<object?> ResultSink { get; } = resultSink;
 
     public ValueTask<object?> Future => this.ResultSink.Future;
+    public ValueTask FutureNoResult => this.ResultSink.FutureNoResult;
 
     public ValueTask InvokeAsync(CancellationToken cancellation)
     {
@@ -79,12 +80,12 @@ internal sealed class MessageEnvelope
                 await servicer(envelope, cancellation);
                 waitForPublish.SetResult(null);
             }
-            catch (Exception ex)
+            catch (Exception ex) // Do we want to special-case cancellation, and hoist the exception type like above?
             {
                 waitForPublish.SetException(ex);
             }
         };
 
-        return new MessageDelivery(this, servicer, waitForPublish);
+        return new MessageDelivery(this, boundServicer, waitForPublish);
     }
 }

--- a/dotnet/src/Microsoft.AutoGen/Core/ResultSink.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/ResultSink.cs
@@ -5,13 +5,14 @@ using System.Threading.Tasks.Sources;
 
 namespace Microsoft.AutoGen.Core;
 
-internal interface IResultSink<TResult> : IValueTaskSource<TResult>
+internal interface IResultSink<TResult> : IValueTaskSource<TResult>, IValueTaskSource
 {
     public void SetResult(TResult result);
     public void SetException(Exception exception);
     public void SetCancelled(OperationCanceledException? ocEx = null);
 
     public ValueTask<TResult> Future { get; }
+    public ValueTask FutureNoResult { get; }
 }
 
 public sealed class ResultSink<TResult> : IResultSink<TResult>
@@ -50,5 +51,9 @@ public sealed class ResultSink<TResult> : IResultSink<TResult>
         this.core.SetResult(result);
     }
 
+    void IValueTaskSource.GetResult(short token) => _ = this.GetResult(token);
+
     public ValueTask<TResult> Future => new(this, this.core.Version);
+    public ValueTask FutureNoResult => new(this, this.core.Version);
 }
+

--- a/dotnet/test/Microsoft.AutoGen.Core.Tests/MessagingTestFixture.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Tests/MessagingTestFixture.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// MessagingTestFixture.cs
+
+using Microsoft.AutoGen.Contracts;
+
+namespace Microsoft.AutoGen.Core.Tests;
+
+public sealed class MessagingTestFixture
+{
+    private Dictionary<Type, object> AgentsTypeMap { get; } = new();
+    public InProcessRuntime Runtime { get; private set; } = new();
+
+    public ValueTask<AgentType> RegisterFactoryMapInstances<TAgent>(AgentType type, Func<AgentId, IAgentRuntime, ValueTask<TAgent>> factory)
+        where TAgent : IHostableAgent
+    {
+        Func<AgentId, IAgentRuntime, ValueTask<TAgent>> wrappedFactory = async (id, runtime) =>
+        {
+            TAgent agent = await factory(id, runtime);
+            this.GetAgentInstances<TAgent>()[id] = agent;
+            return agent;
+        };
+
+        return this.Runtime.RegisterAgentFactoryAsync(type, wrappedFactory);
+    }
+
+    public ValueTask RegisterDefaultSubscriptions<TAgentType>(AgentType type) where TAgentType : IHostableAgent
+    {
+        return this.Runtime.RegisterImplicitAgentSubscriptionsAsync<TAgentType>(type);
+    }
+
+    public Dictionary<AgentId, TAgent> GetAgentInstances<TAgent>() where TAgent : IHostableAgent
+    {
+        if (!AgentsTypeMap.TryGetValue(typeof(TAgent), out object? maybeAgentMap) ||
+            maybeAgentMap is not Dictionary<AgentId, TAgent> result)
+        {
+            this.AgentsTypeMap[typeof(TAgent)] = result = new Dictionary<AgentId, TAgent>();
+        }
+
+        return result;
+    }
+
+    public async ValueTask<object?> RunSendTestAsync(AgentId sendTarget, object message, string? messageId = null)
+    {
+        messageId ??= Guid.NewGuid().ToString();
+
+        await this.Runtime.StartAsync();
+
+        object? result = await this.Runtime.SendMessageAsync(message, sendTarget, messageId: messageId);
+
+        await this.Runtime.RunUntilIdleAsync();
+
+        return result;
+    }
+
+    public async ValueTask RunPublishTestAsync(TopicId sendTarget, object message, string? messageId = null)
+    {
+        messageId ??= Guid.NewGuid().ToString();
+
+        await this.Runtime.StartAsync();
+        await this.Runtime.PublishMessageAsync(message, sendTarget, messageId: messageId);
+        await this.Runtime.RunUntilIdleAsync();
+    }
+}

--- a/dotnet/test/Microsoft.AutoGen.Core.Tests/PublishMessageTests.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Tests/PublishMessageTests.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// PublishMessageTests.cs
+
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AutoGen.Contracts;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.AutoGen.Core.Tests;
+
+public static class PublishTestsExtensions
+{
+    public static async ValueTask RegisterReceiverAgent(this MessagingTestFixture fixture,
+        string? agentNameSuffix = null,
+        params string[] topicTypes)
+    {
+        await fixture.RegisterFactoryMapInstances($"{nameof(ReceiverAgent)}{agentNameSuffix ?? string.Empty}",
+            (id, runtime) => ValueTask.FromResult(new ReceiverAgent(id, runtime, string.Empty)));
+
+        foreach (string topicType in topicTypes)
+        {
+            await fixture.Runtime.AddSubscriptionAsync(new TypeSubscription(topicType, $"{nameof(ReceiverAgent)}{agentNameSuffix ?? string.Empty}"));
+        }
+    }
+
+    public static async ValueTask RegisterErrorAgent(this MessagingTestFixture fixture,
+        string? agentNameSuffix = null,
+        params string[] topicTypes)
+    {
+        await fixture.RegisterFactoryMapInstances($"{nameof(ErrorAgent)}{agentNameSuffix ?? string.Empty}",
+            (id, runtime) => ValueTask.FromResult(new ErrorAgent(id, runtime, string.Empty)));
+
+        foreach (string topicType in topicTypes)
+        {
+            await fixture.Runtime.AddSubscriptionAsync(new TypeSubscription(topicType, $"{nameof(ErrorAgent)}{agentNameSuffix ?? string.Empty}"));
+        }
+    }
+}
+
+[Trait("Category", "UnitV2")]
+public class PublishMessageTests
+{
+    private sealed class PublisherAgent : BaseAgent, IHandle<BasicMessage>
+    {
+        private IList<TopicId> targetTopics;
+
+        public PublisherAgent(AgentId id, IAgentRuntime runtime, string description, IList<TopicId> targetTopics, ILogger<BaseAgent>? logger = null)
+            : base(id, runtime, description, logger)
+        {
+            this.targetTopics = targetTopics;
+        }
+
+        public async ValueTask HandleAsync(BasicMessage item, MessageContext messageContext)
+        {
+            foreach (TopicId targetTopic in targetTopics)
+            {
+                BasicMessage message = new BasicMessage { Content = $"@{targetTopic}: {item.Content}" };
+                await this.Runtime.PublishMessageAsync(message, targetTopic);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Test_PublishMessage_Success()
+    {
+        MessagingTestFixture fixture = new MessagingTestFixture();
+
+        await fixture.RegisterReceiverAgent(topicTypes: "TestTopic");
+        await fixture.RegisterReceiverAgent("2", topicTypes: "TestTopic");
+
+        await fixture.RunPublishTestAsync(new TopicId("TestTopic"), new BasicMessage { Content = "1" });
+
+        fixture.GetAgentInstances<ReceiverAgent>().Values
+            .Should().HaveCount(2, "Two agents should have been created")
+                 .And.AllSatisfy(receiverAgent => receiverAgent.Messages
+                                                               .Should().NotBeNull()
+                                                                    .And.HaveCount(1)
+                                                                    .And.ContainSingle(m => m.Content == "1"));
+    }
+
+    [Fact]
+    public async Task Test_PublishMessage_SingleFailure()
+    {
+        MessagingTestFixture fixture = new MessagingTestFixture();
+
+        await fixture.RegisterErrorAgent(topicTypes: "TestTopic");
+
+        Func<Task> publishTask = async () => await fixture.RunPublishTestAsync(new TopicId("TestTopic"), new BasicMessage { Content = "1" });
+
+        // Test that we wrap single errors appropriately
+        (await publishTask.Should().ThrowAsync<AggregateException>())
+                                   .Which.Should().Match<AggregateException>(
+                                        ex => ex.InnerExceptions.Count == 1 &&
+                                              ex.InnerExceptions.All(
+                                                inEx => inEx is TargetInvocationException &&
+                                                ((TargetInvocationException)inEx).InnerException is TestException));
+
+        fixture.GetAgentInstances<ErrorAgent>().Values.Should().ContainSingle()
+                                                .Which.DidThrow.Should().BeTrue("Agent should have thrown an exception");
+    }
+
+    [Fact]
+    public async Task Test_PublishMessage_MultipleFailures()
+    {
+        MessagingTestFixture fixture = new MessagingTestFixture();
+
+        await fixture.RegisterErrorAgent(topicTypes: "TestTopic");
+        await fixture.RegisterErrorAgent("2", topicTypes: "TestTopic");
+
+        Func<Task> publishTask = async () => await fixture.RunPublishTestAsync(new TopicId("TestTopic"), new BasicMessage { Content = "1" });
+
+        // What we are really testing here is that a single exception does not prevent sending to the remaining agents
+        (await publishTask.Should().ThrowAsync<AggregateException>())
+                                   .Which.Should().Match<AggregateException>(
+                                        ex => ex.InnerExceptions.Count == 2 &&
+                                              ex.InnerExceptions.All(
+                                                inEx => inEx is TargetInvocationException &&
+                                                ((TargetInvocationException)inEx).InnerException is TestException));
+
+        fixture.GetAgentInstances<ErrorAgent>().Values
+            .Should().HaveCount(2)
+                 .And.AllSatisfy(
+                    agent => agent.DidThrow.Should().BeTrue("Agent should have thrown an exception"));
+    }
+
+    [Fact]
+    public async Task Test_PublishMessage_MixedSuccessFailure()
+    {
+        MessagingTestFixture fixture = new MessagingTestFixture();
+
+        await fixture.RegisterReceiverAgent(topicTypes: "TestTopic");
+        await fixture.RegisterReceiverAgent("2", topicTypes: "TestTopic");
+
+        await fixture.RegisterErrorAgent(topicTypes: "TestTopic");
+        await fixture.RegisterErrorAgent("2", topicTypes: "TestTopic");
+
+        Func<Task> publicTask = async () => await fixture.RunPublishTestAsync(new TopicId("TestTopic"), new BasicMessage { Content = "1" });
+
+        // What we are really testing here is that raising exceptions does not prevent sending to the remaining agents
+        (await publicTask.Should().ThrowAsync<AggregateException>())
+                                   .Which.Should().Match<AggregateException>(
+                                        ex => ex.InnerExceptions.Count == 2 &&
+                                              ex.InnerExceptions.All(
+                                                inEx => inEx is TargetInvocationException &&
+                                                ((TargetInvocationException)inEx).InnerException is TestException));
+
+        fixture.GetAgentInstances<ReceiverAgent>().Values
+            .Should().HaveCount(2, "Two ReceiverAgents should have been created")
+                 .And.AllSatisfy(receiverAgent => receiverAgent.Messages
+                                                               .Should().NotBeNull()
+                                                                    .And.HaveCount(1)
+                                                                    .And.ContainSingle(m => m.Content == "1"),
+                                 "ReceiverAgents should get published message regardless of ErrorAgents throwing exception.");
+
+        fixture.GetAgentInstances<ErrorAgent>().Values
+            .Should().HaveCount(2, "Two ErrorAgents should have been created")
+                 .And.AllSatisfy(agent => agent.DidThrow.Should().BeTrue("ErrorAgent should have thrown an exception"));
+    }
+
+    [Fact]
+    public async Task Test_PublishMessage_RecurrentPublishSucceeds()
+    {
+        MessagingTestFixture fixture = new MessagingTestFixture();
+
+        await fixture.RegisterFactoryMapInstances(nameof(PublisherAgent),
+            (id, runtime) => ValueTask.FromResult(new PublisherAgent(id, runtime, string.Empty, new List<TopicId> { new TopicId("TestTopic") })));
+
+        await fixture.Runtime.AddSubscriptionAsync(new TypeSubscription("RunTest", nameof(PublisherAgent)));
+
+        await fixture.RegisterReceiverAgent(topicTypes: "TestTopic");
+        await fixture.RegisterReceiverAgent("2", topicTypes: "TestTopic");
+
+        await fixture.RunPublishTestAsync(new TopicId("RunTest"), new BasicMessage { Content = "1" });
+
+        TopicId testTopicId = new TopicId("TestTopic");
+        fixture.GetAgentInstances<ReceiverAgent>().Values
+            .Should().HaveCount(2, "Two ReceiverAgents should have been created")
+                 .And.AllSatisfy(receiverAgent => receiverAgent.Messages
+                                                               .Should().NotBeNull()
+                                                                    .And.HaveCount(1)
+                                                                    .And.ContainSingle(m => m.Content == $"@{testTopicId}: 1"));
+    }
+}

--- a/dotnet/test/Microsoft.AutoGen.Core.Tests/SendMessageTests.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Tests/SendMessageTests.cs
@@ -11,13 +11,8 @@ using Xunit;
 namespace Microsoft.AutoGen.Core.Tests;
 
 [Trait("Category", "UnitV2")]
-public class SendMessageTests
+public partial class SendMessageTests
 {
-    private sealed class BasicMessage
-    {
-        public string Content { get; set; } = string.Empty;
-    }
-
     private sealed class SendOnAgent : BaseAgent, IHandle<BasicMessage>
     {
         private IList<Guid> targetKeys;
@@ -33,119 +28,9 @@ public class SendMessageTests
             foreach (Guid targetKey in targetKeys)
             {
                 AgentId targetId = new(nameof(ReceiverAgent), targetKey.ToString());
-                BasicMessage message = new BasicMessage { Content = $"@{targetKey}: item.Content" };
+                BasicMessage message = new BasicMessage { Content = $"@{targetKey}: {item.Content}" };
                 await this.Runtime.SendMessageAsync(message, targetId);
             }
-        }
-    }
-
-    private sealed class ReceiverAgent : BaseAgent, IHandle<BasicMessage>
-    {
-        public List<BasicMessage> Messages { get; } = new();
-
-        public ReceiverAgent(AgentId id, IAgentRuntime runtime, string description, ILogger<BaseAgent>? logger = null)
-            : base(id, runtime, description, logger)
-        {
-        }
-
-        public ValueTask HandleAsync(BasicMessage item, MessageContext messageContext)
-        {
-            this.Messages.Add(item);
-
-            return ValueTask.CompletedTask;
-        }
-    }
-
-    private sealed class ProcessorAgent : BaseAgent, IHandle<BasicMessage, BasicMessage>
-    {
-        private Func<string, string> ProcessFunc { get; }
-
-        public ProcessorAgent(AgentId id, IAgentRuntime runtime, Func<string, string> processFunc, string description, ILogger<BaseAgent>? logger = null)
-            : base(id, runtime, description, logger)
-        {
-            this.ProcessFunc = processFunc;
-        }
-
-        public ValueTask<BasicMessage> HandleAsync(BasicMessage item, MessageContext messageContext)
-        {
-            BasicMessage result = new() { Content = this.ProcessFunc(item.Content) };
-
-            return ValueTask.FromResult(result);
-        }
-    }
-
-    private sealed class TestException : Exception
-    { }
-
-    private sealed class CancelAgent : BaseAgent, IHandle<BasicMessage, BasicMessage>
-    {
-        public CancelAgent(AgentId id, IAgentRuntime runtime, string description, ILogger<BaseAgent>? logger = null)
-            : base(id, runtime, description, logger)
-        {
-        }
-
-        public ValueTask<BasicMessage> HandleAsync(BasicMessage item, MessageContext messageContext)
-        {
-            CancellationToken cancelledToken = new CancellationToken(canceled: true);
-            cancelledToken.ThrowIfCancellationRequested();
-
-            return ValueTask.FromResult(item);
-        }
-    }
-
-    private sealed class ErrorAgent : BaseAgent, IHandle<BasicMessage, BasicMessage>
-    {
-        public ErrorAgent(AgentId id, IAgentRuntime runtime, string description, ILogger<BaseAgent>? logger = null)
-            : base(id, runtime, description, logger)
-        {
-        }
-
-        public ValueTask<BasicMessage> HandleAsync(BasicMessage item, MessageContext messageContext)
-        {
-            throw new TestException();
-        }
-    }
-
-    private sealed class SendTestFixture
-    {
-        private Dictionary<Type, object> AgentsTypeMap { get; } = new();
-        public InProcessRuntime Runtime { get; private set; } = new();
-
-        public ValueTask<AgentType> RegisterFactoryMapInstances<TAgent>(AgentType type, Func<AgentId, IAgentRuntime, ValueTask<TAgent>> factory)
-            where TAgent : IHostableAgent
-        {
-            Func<AgentId, IAgentRuntime, ValueTask<TAgent>> wrappedFactory = async (id, runtime) =>
-            {
-                TAgent agent = await factory(id, runtime);
-                this.GetAgentInstances<TAgent>()[id] = agent;
-                return agent;
-            };
-
-            return this.Runtime.RegisterAgentFactoryAsync(type, wrappedFactory);
-        }
-
-        public Dictionary<AgentId, TAgent> GetAgentInstances<TAgent>() where TAgent : IHostableAgent
-        {
-            if (!AgentsTypeMap.TryGetValue(typeof(TAgent), out object? maybeAgentMap) ||
-                maybeAgentMap is not Dictionary<AgentId, TAgent> result)
-            {
-                this.AgentsTypeMap[typeof(TAgent)] = result = new Dictionary<AgentId, TAgent>();
-            }
-
-            return result;
-        }
-
-        public async ValueTask<object?> RunTestAsync(AgentId sendTarget, object message, string? messageId = null)
-        {
-            messageId ??= Guid.NewGuid().ToString();
-
-            await this.Runtime.StartAsync();
-
-            object? result = await this.Runtime.SendMessageAsync(message, sendTarget, messageId: messageId);
-
-            await this.Runtime.RunUntilIdleAsync();
-
-            return result;
         }
     }
 
@@ -154,13 +39,13 @@ public class SendMessageTests
     {
         Func<string, string> ProcessFunc = (s) => $"Processed({s})";
 
-        SendTestFixture fixture = new SendTestFixture();
+        MessagingTestFixture fixture = new MessagingTestFixture();
 
         await fixture.RegisterFactoryMapInstances(nameof(ProcessorAgent),
             (id, runtime) => ValueTask.FromResult(new ProcessorAgent(id, runtime, ProcessFunc, string.Empty)));
 
         AgentId targetAgent = new AgentId(nameof(ProcessorAgent), Guid.NewGuid().ToString());
-        object? maybeResult = await fixture.RunTestAsync(targetAgent, new BasicMessage { Content = "1" });
+        object? maybeResult = await fixture.RunSendTestAsync(targetAgent, new BasicMessage { Content = "1" });
 
         maybeResult.Should().NotBeNull()
                         .And.BeOfType<BasicMessage>()
@@ -170,13 +55,13 @@ public class SendMessageTests
     [Fact]
     public async Task Test_SendMessage_Cancellation()
     {
-        SendTestFixture fixture = new SendTestFixture();
+        MessagingTestFixture fixture = new MessagingTestFixture();
 
         await fixture.RegisterFactoryMapInstances(nameof(CancelAgent),
             (id, runtime) => ValueTask.FromResult(new CancelAgent(id, runtime, string.Empty)));
 
         AgentId targetAgent = new AgentId(nameof(CancelAgent), Guid.NewGuid().ToString());
-        Func<Task> testAction = () => fixture.RunTestAsync(targetAgent, new BasicMessage { Content = "1" }).AsTask();
+        Func<Task> testAction = () => fixture.RunSendTestAsync(targetAgent, new BasicMessage { Content = "1" }).AsTask();
 
         // TODO: Do we want to do the unwrap in this case?
         await testAction.Should().ThrowAsync<OperationCanceledException>();
@@ -185,13 +70,13 @@ public class SendMessageTests
     [Fact]
     public async Task Test_SendMessage_Error()
     {
-        SendTestFixture fixture = new SendTestFixture();
+        MessagingTestFixture fixture = new MessagingTestFixture();
 
         await fixture.RegisterFactoryMapInstances(nameof(ErrorAgent),
             (id, runtime) => ValueTask.FromResult(new ErrorAgent(id, runtime, string.Empty)));
 
         AgentId targetAgent = new AgentId(nameof(ErrorAgent), Guid.NewGuid().ToString());
-        Func<Task> testAction = () => fixture.RunTestAsync(targetAgent, new BasicMessage { Content = "1" }).AsTask();
+        Func<Task> testAction = () => fixture.RunSendTestAsync(targetAgent, new BasicMessage { Content = "1" }).AsTask();
 
         (await testAction.Should().ThrowAsync<TargetInvocationException>())
                                   .WithInnerException<TestException>();
@@ -202,7 +87,7 @@ public class SendMessageTests
     {
         Guid[] targetGuids = [Guid.NewGuid(), Guid.NewGuid()];
 
-        SendTestFixture fixture = new SendTestFixture();
+        MessagingTestFixture fixture = new MessagingTestFixture();
 
         Dictionary<AgentId, SendOnAgent> sendAgents = fixture.GetAgentInstances<SendOnAgent>();
         Dictionary<AgentId, ReceiverAgent> receiverAgents = fixture.GetAgentInstances<ReceiverAgent>();
@@ -213,8 +98,9 @@ public class SendMessageTests
         await fixture.RegisterFactoryMapInstances(nameof(ReceiverAgent),
             (id, runtime) => ValueTask.FromResult(new ReceiverAgent(id, runtime, string.Empty)));
 
+        const string HelloContent = "Hello";
         AgentId targetAgent = new AgentId(nameof(SendOnAgent), Guid.NewGuid().ToString());
-        Task testTask = fixture.RunTestAsync(targetAgent, new BasicMessage { Content = "Hello" }).AsTask();
+        Task testTask = fixture.RunSendTestAsync(targetAgent, new BasicMessage { Content = HelloContent }).AsTask();
 
         // We do not actually expect to wait the timeout here, but it is still better than waiting the 10 min
         // timeout that the tests default to. A failure will fail regardless of what timeout value we set.
@@ -228,7 +114,7 @@ public class SendMessageTests
         foreach (var targetKey in targetGuids)
         {
             var targetId = new AgentId(nameof(ReceiverAgent), targetKey.ToString());
-            receiverAgents[targetId].Messages.Should().ContainSingle(m => m.Content == $"@{targetKey}: item.Content");
+            receiverAgents[targetId].Messages.Should().ContainSingle(m => m.Content == $"@{targetKey}: {HelloContent}");
         }
     }
 }

--- a/dotnet/test/Microsoft.AutoGen.Core.Tests/TestMessages.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Tests/TestMessages.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// TestMessages.cs
+
+namespace Microsoft.AutoGen.Core.Tests;
+
+public class TextMessage
+{
+    public string Source { get; set; } = "";
+    public string Content { get; set; } = "";
+}
+
+public class RpcTextMessage
+{
+    public string Source { get; set; } = "";
+    public string Content { get; set; } = "";
+}
+
+public sealed class BasicMessage
+{
+    public string Content { get; set; } = string.Empty;
+}
+


### PR DESCRIPTION
During the recent fix to SendMessageAsync's recurrence, we added code to ensure blocking on Publish. This adds additional resilience to the Publish delivery, ensuring that every subscribed agents receives the message, regardless of errors in the middle.