### PR TITLE
Fixes an error that can occur when listing the contents of a directory.

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_markdown_file_browser.py
@@ -245,7 +245,13 @@ class MarkdownFileBrowser:
         for entry in os.listdir(local_path):
             size = ""
             full_path = os.path.join(local_path, entry)
-            mtime = datetime.datetime.fromtimestamp(os.path.getmtime(full_path)).strftime("%Y-%m-%d %H:%M")
+
+            mtime = ""
+            try
+                mtime = datetime.datetime.fromtimestamp(os.path.getmtime(full_path)).strftime("%Y-%m-%d %H:%M")
+            except Exception as e:
+                # Handles PermissionError, etc.
+                mtime = f"N/A: {type(e).__name__}"
 
             if os.path.isdir(full_path):
                 entry = entry + os.path.sep


### PR DESCRIPTION
Fixes issues like the following trace:

```
packages/autogen_ext/agents/file_surfer/_markdown_file_browser.py", line 39, in __init__
    self.set_path(self._base_path)
  File "/home/hmozannar/webby/.venv/lib/python3.12/site-packages/autogen_ext/agents/file_surfer/_markdown_file_browser.py", line 67, in set_path
    self._open_path(path)
  File "/home/hmozannar/webby/.venv/lib/python3.12/site-packages/autogen_ext/agents/file_surfer/_markdown_file_browser.py", line 210, in _open_path
    io.StringIO(self._fetch_local_dir(path)), file_extension=".txt"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hmozannar/webby/.venv/lib/python3.12/site-packages/autogen_ext/agents/file_surfer/_markdown_file_browser.py", line 248, in _fetch_local_dir
    mtime = datetime.datetime.fromtimestamp(os.path.getmtime(full_path)).strftime("%Y-%m-%d %H:%M")
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen genericpath>", line 67, in getmtime
PermissionError: [Errno 13] Permission denied: '/home/hmozannar/webby/autogen-studio/frontend/readme.txt'
```