### PR TITLE
Fix `poe check` on Windows

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -396,6 +396,7 @@ $functions"""
             )
             cancellation_token.link_future(task)
 
+            proc = None  # Track the process
             try:
                 proc = await task
                 stdout, stderr = await asyncio.wait_for(proc.communicate(), self._timeout)
@@ -403,10 +404,16 @@ $functions"""
             except asyncio.TimeoutError:
                 logs_all += "\nTimeout"
                 exitcode = 124
+                if proc:
+                    proc.terminate()
+                    await proc.wait()  # Ensure process is fully dead
                 break
             except asyncio.CancelledError:
                 logs_all += "\nCancelled"
                 exitcode = 125
+                if proc:
+                    proc.terminate()
+                    await proc.wait()
                 break
 
             logs_all += stderr.decode()

--- a/python/packages/autogen-ext/tests/cache_store/test_diskcache_store.py
+++ b/python/packages/autogen-ext/tests/cache_store/test_diskcache_store.py
@@ -9,8 +9,7 @@ def test_diskcache_store_basic() -> None:
     from autogen_ext.cache_store.diskcache import DiskCacheStore
     from diskcache import Cache
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        cache = Cache(temp_dir)
+    with tempfile.TemporaryDirectory() as temp_dir, Cache(temp_dir) as cache:
         store = DiskCacheStore[int](cache)
         test_key = "test_key"
         test_value = 42
@@ -30,10 +29,12 @@ def test_diskcache_with_different_instances() -> None:
     from autogen_ext.cache_store.diskcache import DiskCacheStore
     from diskcache import Cache
 
-    with tempfile.TemporaryDirectory() as temp_dir_1, tempfile.TemporaryDirectory() as temp_dir_2:
-        cache_1 = Cache(temp_dir_1)
-        cache_2 = Cache(temp_dir_2)
-
+    with (
+        tempfile.TemporaryDirectory() as temp_dir_1,
+        tempfile.TemporaryDirectory() as temp_dir_2,
+        Cache(temp_dir_1) as cache_1,
+        Cache(temp_dir_2) as cache_2,
+    ):
         store_1 = DiskCacheStore[int](cache_1)
         store_2 = DiskCacheStore[int](cache_2)
 
@@ -47,7 +48,8 @@ def test_diskcache_with_different_instances() -> None:
         store_2.set(test_key, test_value_2)
         assert store_2.get(test_key) == test_value_2
 
-        # test serialization
+        # Test serialization
         store_1_config = store_1.dump_component()
         loaded_store_1: DiskCacheStore[int] = DiskCacheStore.load_component(store_1_config)
         assert loaded_store_1.get(test_key) == test_value_1
+        loaded_store_1.cache.close()

--- a/python/packages/autogen-ext/tests/code_executors/test_user_defined_functions.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_user_defined_functions.py
@@ -72,7 +72,7 @@ print(data['name'][0])"""
             ],
             cancellation_token=cancellation_token,
         )
-        assert result.output == "John\n"
+        assert result.output == f"John{os.linesep}"
         assert result.exit_code == 0
 
 
@@ -121,7 +121,7 @@ print(add_two_numbers(1, 2))"""
             ],
             cancellation_token=cancellation_token,
         )
-        assert result.output == "3\n"
+        assert result.output == f"3{os.linesep}"
         assert result.exit_code == 0
 
 
@@ -181,7 +181,7 @@ print(add_two_numbers(1, 2))"""
             ],
             cancellation_token=cancellation_token,
         )
-        assert result.output == "3\n"
+        assert result.output == f"3{os.linesep}"
         assert result.exit_code == 0
 
 

--- a/python/packages/autogen-test-utils/pyproject.toml
+++ b/python/packages/autogen-test-utils/pyproject.toml
@@ -1,29 +1,25 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+build-backend="hatchling.build"
+requires     =[ "hatchling" ]
 
 [project]
-name = "autogen-test-utils"
-version = "0.0.0"
-license = {file = "LICENSE-CODE"}
-requires-python = ">=3.10"
-dependencies = [
-    "autogen-core",
-    "pytest",
-    "opentelemetry-sdk>=1.27.0",
-]
+dependencies   =[ "autogen-core", "opentelemetry-sdk>=1.27.0", "pytest" ]
+license        ={ file="LICENSE-CODE" }
+name           ="autogen-test-utils"
+requires-python=">=3.10"
+version        ="0.0.0"
 
 [tool.ruff]
-extend = "../../pyproject.toml"
-include = ["src/**"]
+extend ="../../pyproject.toml"
+include=[ "src/**" ]
 
 [tool.pyright]
-extends = "../../pyproject.toml"
-include = ["src"]
+extends="../../pyproject.toml"
+include=[ "src" ]
 
 [tool.poe]
-include = "../../shared_tasks.toml"
+include="../../shared_tasks.toml"
 
 [tool.poe.tasks]
-mypy = "mypy --config-file $POE_ROOT/../../pyproject.toml src"
-test = "true"
+mypy="mypy --config-file $POE_ROOT/../../pyproject.toml src"
+test="python -c \"import sys; sys.exit(0)\""

--- a/python/packages/component-schema-gen/pyproject.toml
+++ b/python/packages/component-schema-gen/pyproject.toml
@@ -1,41 +1,38 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+build-backend="hatchling.build"
+requires     =[ "hatchling" ]
 
 [project]
-name = "component-schema-gen"
-version = "0.1.0"
-license = {file = "LICENSE-CODE"}
-description = "Generates a JSON schema for component config"
-readme = "README.md"
-requires-python = ">=3.10"
-classifiers = [
-    "Programming Language :: Python :: 3",
+classifiers=[
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
 ]
-dependencies = [
-    "autogen-core",
-    "autogen-ext",
-]
+dependencies=[ "autogen-core", "autogen-ext" ]
+description="Generates a JSON schema for component config"
+license={ file="LICENSE-CODE" }
+name="component-schema-gen"
+readme="README.md"
+requires-python=">=3.10"
+version="0.1.0"
 
 [project.scripts]
-gen-component-schema = "component_schema_gen.__main__:main"
+gen-component-schema="component_schema_gen.__main__:main"
 
 [tool.ruff]
-extend = "../../pyproject.toml"
-include = ["src/**"]
+extend ="../../pyproject.toml"
+include=[ "src/**" ]
 
 [tool.ruff.lint]
-ignore = ["T201"]
+ignore=[ "T201" ]
 
 [tool.pyright]
-extends = "../../pyproject.toml"
-include = ["src"]
+extends="../../pyproject.toml"
+include=[ "src" ]
 
 [tool.poe]
-include = "../../shared_tasks.toml"
+include="../../shared_tasks.toml"
 
 [tool.poe.tasks]
-mypy = "mypy --config-file $POE_ROOT/../../pyproject.toml src"
-test = "true"
+mypy="mypy --config-file $POE_ROOT/../../pyproject.toml src"
+test="python -c \"import sys; sys.exit(0)\""

--- a/python/packages/magentic-one-cli/pyproject.toml
+++ b/python/packages/magentic-one-cli/pyproject.toml
@@ -1,48 +1,46 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+build-backend="hatchling.build"
+requires     =[ "hatchling" ]
 
 [project]
-name = "magentic-one-cli"
-version = "0.2.3"
-license = {file = "LICENSE-CODE"}
-description = "Magentic-One is a generalist multi-agent system, built on `AutoGen-AgentChat`, for solving complex web and file-based tasks. This package installs the `m1` command-line utility to quickly get started with Magentic-One."
-readme = "README.md"
-requires-python = ">=3.10"
-classifiers = [
-    "Programming Language :: Python :: 3",
+classifiers=[
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
 ]
-dependencies = [
-    "pyyaml>=5.1",
+dependencies=[
     "autogen-agentchat>=0.4.4,<0.5",
     "autogen-ext[docker,openai,magentic-one,rich]>=0.4.4,<0.5",
+    "pyyaml>=5.1",
 ]
+description="Magentic-One is a generalist multi-agent system, built on `AutoGen-AgentChat`, for solving complex web and file-based tasks. This package installs the `m1` command-line utility to quickly get started with Magentic-One."
+license={ file="LICENSE-CODE" }
+name="magentic-one-cli"
+readme="README.md"
+requires-python=">=3.10"
+version="0.2.3"
 
 [project.scripts]
-m1 = "magentic_one_cli._m1:main"
+m1="magentic_one_cli._m1:main"
 
 [dependency-groups]
-dev = [
-    "types-PyYAML",
-]
+dev=[ "types-PyYAML" ]
 
 [tool.ruff]
-extend = "../../pyproject.toml"
-include = ["src/**", "tests/*.py"]
+extend ="../../pyproject.toml"
+include=[ "src/**", "tests/*.py" ]
 
 [tool.pyright]
-extends = "../../pyproject.toml"
-include = ["src"]
+extends="../../pyproject.toml"
+include=[ "src" ]
 
 [tool.pytest.ini_options]
-minversion = "6.0"
-testpaths = ["tests"]
+minversion="6.0"
+testpaths =[ "tests" ]
 
 [tool.poe]
-include = "../../shared_tasks.toml"
+include="../../shared_tasks.toml"
 
 [tool.poe.tasks]
-mypy = "mypy --config-file $POE_ROOT/../../pyproject.toml src"
-test = "true"
+mypy="mypy --config-file $POE_ROOT/../../pyproject.toml src"
+test="python -c \"import sys; sys.exit(0)\""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`poe check` fails on main on Windows due to a combination line ending mismatches, Unix-specific commands, and Windows-specific `asyncio` behavior. This PR attempts to fix this (so that `poe check` on a freshly-pulled `main` passes on Windows 11.)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [X] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
 - None needed,
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
 - No new tests needed, PR fixes existing tests to run properly on Windows.
- [X] I've made sure all auto checks have passed.
 - `poe check` passes
