### PR TITLE
Ensure SecretStr is cast to str on load for model clients

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -22,7 +22,6 @@ from typing import (
     cast,
 )
 
-from pydantic import SecretStr
 import tiktoken
 from anthropic import AsyncAnthropic, AsyncStream
 from anthropic.types import (
@@ -62,6 +61,7 @@ from autogen_core.models import (
     validate_model_info,
 )
 from autogen_core.tools import Tool, ToolSchema
+from pydantic import SecretStr
 from typing_extensions import Self, Unpack
 
 from . import _model_info
@@ -1003,9 +1003,9 @@ class AnthropicChatCompletionClient(
     @classmethod
     def _from_config(cls, config: AnthropicClientConfigurationConfigModel) -> Self:
         copied_config = config.model_copy().model_dump(exclude_none=True)
-        
+
         # Handle api_key as SecretStr
         if "api_key" in copied_config and isinstance(config.api_key, SecretStr):
             copied_config["api_key"] = config.api_key.get_secret_value()
-            
+
         return cls(**copied_config)

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1298,11 +1298,11 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
     @classmethod
     def _from_config(cls, config: OpenAIClientConfigurationConfigModel) -> Self:
         copied_config = config.model_copy().model_dump(exclude_none=True)
-        
+
         # Handle api_key as SecretStr
         if "api_key" in copied_config and isinstance(config.api_key, SecretStr):
             copied_config["api_key"] = config.api_key.get_secret_value()
-            
+
         return cls(**copied_config)
 
 
@@ -1458,17 +1458,17 @@ class AzureOpenAIChatCompletionClient(
             )
 
         return AzureOpenAIClientConfigurationConfigModel(**copied_config)
- 
+
     @classmethod
     def _from_config(cls, config: AzureOpenAIClientConfigurationConfigModel) -> Self:
         from ...auth.azure import AzureTokenProvider
 
         copied_config = config.model_copy().model_dump(exclude_none=True)
-        
+
         # Handle api_key as SecretStr
         if "api_key" in copied_config and isinstance(config.api_key, SecretStr):
             copied_config["api_key"] = config.api_key.get_secret_value()
-        
+
         if "azure_ad_token_provider" in copied_config:
             copied_config["azure_ad_token_provider"] = AzureTokenProvider.load_component(
                 copied_config["azure_ad_token_provider"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->



## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently we have SecretStr type for model clients to promote security best practices.

- when we dump_component, keys are serialized  as SecreteStr ..
- when we load_component ... SecreteStr type is passed to the client in the api_key field. This i causes the type problems as the clients expect a string type.

This PR updates the from_config method for model clients to ensure we get the value from SecretStr.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #5944 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
