### PR TITLE
ci: Remove --locked from uv sync in Integration test project

### DIFF
--- a/dotnet/test/Microsoft.AutoGen.Integration.Tests/Microsoft.AutoGen.Integration.Tests.csproj
+++ b/dotnet/test/Microsoft.AutoGen.Integration.Tests/Microsoft.AutoGen.Integration.Tests.csproj
@@ -59,7 +59,7 @@
     </PropertyGroup>
     <Message Importance="Normal" Text="Initializing virtual environment for $(PythonVenvRoot)" />
 
-    <Exec Command="$(UvPath) sync --locked --all-extras --no-install-package llama-cpp-python" WorkingDirectory="$(PythonRoot)" Condition=" '$(CreateVenv)' == 'True' " />
+    <Exec Command="$(UvPath) sync --all-extras --no-install-package llama-cpp-python" WorkingDirectory="$(PythonRoot)" Condition=" '$(CreateVenv)' == 'True' " />
       <!--Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
     <Message Importance="Normal" Text="$(OutputOfExec)" />-->


### PR DESCRIPTION
For some reason --locked is causing the CI to fall over in the codesign pipeline. 

Unclear why it is not happening on the GitHub Actions side - though it may be an artifact of the way we have the uv cache set up (and the uv install version does not match between the two). Getting to a building state, then will investigate further.