### PR TITLE
Fix issue #5946: changed code for ACASessionsExecutor _ensure_access_token to be https:/ /dynamicsessions.io/.default 

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
@@ -131,7 +131,7 @@ $functions"""
     # TODO: expiration?
     def _ensure_access_token(self) -> None:
         if not self._access_token:
-            scope = "https://dynamicsessions.io"
+            scope = "https://dynamicsessions.io/.default"
             self._access_token = self._credential.get_token(scope).token
 
     def format_functions_for_prompt(self, prompt_template: str = FUNCTION_PROMPT_TEMPLATE) -> str:


### PR DESCRIPTION
## Why are these changes needed?

when I want to create a ACASessionsExecutor instance and execute some code, the default library imported does not work. It always returns: "ClientAuthenticationError: Authentication failed: AADSTS70011: The provided request must include a 'scope' input parameter. The provided value for the input parameter 'scope' is not valid. The scope https://dynamicsessions.io/ is not valid. Trace ID: d75efa58-8be7-44ef-8839-aacfdc850600 Correlation ID: a8e4d859-92da-4fbe-a8e0-05116323ab55 Timestamp: 2025-03-14 14:15:09Z"

After changing the scope in _ensure_access_token to be "https://dynamicsessions.io/.default" rather than ""https://dynamicsessions.io/" and it worked.

## Related issue number

 issue #5946

## Checks

- [Y ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ Y] I've made sure all auto checks have passed.
