### PR TITLE
Move start() and stop() as interface methods for CodeExecutor

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/code_executor/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/code_executor/_base.py
@@ -7,9 +7,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from types import TracebackType
 from typing import List, Optional, Type
-from typing_extensions import Self
 
 from pydantic import BaseModel
+from typing_extensions import Self
 
 from .._cancellation_token import CancellationToken
 from .._component_config import ComponentBase
@@ -43,7 +43,7 @@ class CodeExecutor(ABC, ComponentBase[BaseModel]):
     It is recommended for subclass to be used as a context manager to ensure
     that resources are cleaned up properly. To do this, implement the
     :meth:`~autogen_core.code_executor.CodeExecutor.start` and
-    :meth:`~autogen_core.code_executor.CodeExecutor.stop` methods 
+    :meth:`~autogen_core.code_executor.CodeExecutor.stop` methods
     that will be called when entering and exiting the context manager.
 
     """
@@ -70,12 +70,12 @@ class CodeExecutor(ABC, ComponentBase[BaseModel]):
             asyncio.CancelledError: CancellationToken evoked during execution
         """
         ...
-    
+
     @abstractmethod
     async def start(self) -> None:
         """Start the code executor."""
         ...
-    
+
     @abstractmethod
     async def stop(self) -> None:
         """Stop the code executor and release any resources."""

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
@@ -458,3 +458,13 @@ import pkg_resources\n[d.project_name for d in pkg_resources.working_set]
         self._access_token = None
         self._available_packages = None
         self._setup_cwd_complete = False
+
+    async def start(self) -> None:
+        """(Experimental) Start the code executor."""
+        # No setup needed for this executor
+        pass
+
+    async def stop(self) -> None:
+        """(Experimental) Stop the code executor."""
+        # No cleanup needed for this executor
+        pass

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
@@ -11,8 +11,7 @@ import uuid
 from collections.abc import Sequence
 from hashlib import sha256
 from pathlib import Path
-from types import TracebackType
-from typing import Any, Callable, ClassVar, Dict, List, Optional, ParamSpec, Tuple, Type, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, ParamSpec, Tuple, Union
 
 from autogen_core import CancellationToken, Component
 from autogen_core.code_executor import (
@@ -428,16 +427,6 @@ $functions"""
             raise ValueError(f"Failed to start container from image {self._image}. Logs: {logs_str}")
 
         self._running = True
-
-    async def __aenter__(self) -> Self:
-        await self.start()
-        return self
-
-    async def __aexit__(
-        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
-    ) -> Optional[bool]:
-        await self.stop()
-        return None
 
     def _to_config(self) -> DockerCommandLineCodeExecutorConfig:
         """(Experimental) Convert the component to a config object."""

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -6,7 +6,6 @@ import sys
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from types import TracebackType
 
 from autogen_core import Component
 from pydantic import BaseModel
@@ -264,18 +263,6 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
     async def stop(self) -> None:
         """Stop the kernel."""
         await self.kernel_context.__aexit__(None, None, None)
-
-    async def __aenter__(self) -> Self:
-        await self.start()
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        await self.stop()
 
     def _to_config(self) -> JupyterCodeExecutorConfig:
         """Convert current instance to config object"""

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -432,6 +432,16 @@ $functions"""
             stacklevel=2,
         )
 
+    async def start(self) -> None:
+        """(Experimental) Start the code executor."""
+        # No action needed for local command line executor
+        pass
+
+    async def stop(self) -> None:
+        """(Experimental) Stop the code executor."""
+        # No action needed for local command line executor
+        pass
+
     def _to_config(self) -> LocalCommandLineCodeExecutorConfig:
         if self._functions:
             logging.info("Functions will not be included in serialized configuration")


### PR DESCRIPTION
Resolves #6015