### PR TITLE
Fix bytes in markdown converter playwright

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/playwright_controller.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/playwright_controller.py
@@ -565,8 +565,11 @@ class PlaywrightController:
         assert page is not None
         if self._markdown_converter is None and markitdown is not None:
             self._markdown_converter = markitdown.MarkItDown()
+            assert self._markdown_converter is not None
             html = await page.evaluate("document.documentElement.outerHTML;")
-            res = self._markdown_converter.convert_stream(io.StringIO(html), file_extension=".html", url=page.url)  # type: ignore
+            res = self._markdown_converter.convert_stream(
+                io.BytesIO(html.encode("utf-8")), file_extension=".html", url=page.url
+            )
             assert hasattr(res, "text_content") and isinstance(res.text_content, str)
             return res.text_content
         else:


### PR DESCRIPTION
Fix error:

TypeError: Input stream must be opened in bytes mode, not in text mode.

Markdown converter takes binary stream