### PR TITLE
[Accessibility] fix screen reader is not announcing 'Copied' information

### DIFF
--- a/python/packages/autogen-core/docs/src/_static/custom.js
+++ b/python/packages/autogen-core/docs/src/_static/custom.js
@@ -1,16 +1,16 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   document.querySelectorAll('.copybtn').forEach(button => {
-      // Return focus to copy button after activation
-      button.addEventListener('click', async function(event) {
-          // Save the current focus
-          const focusedElement = document.activeElement;
+    // Return focus to copy button after activation
+    button.addEventListener('click', async function (event) {
+      // Save the current focus
+      const focusedElement = document.activeElement;
 
-          // Perform the copy action
-          await copyToClipboard(this);
+      // Perform the copy action
+      await copyToClipboard(this);
 
-          // Restore the focus
-          focusedElement.focus();
-      });
+      // Restore the focus
+      focusedElement.focus();
+    });
   });
 
   document.querySelectorAll('.search-button-field').forEach(button => {
@@ -33,8 +33,30 @@ async function copyToClipboard(button) {
   const targetSelector = button.getAttribute('data-clipboard-target');
   const codeBlock = document.querySelector(targetSelector);
   try {
-      await navigator.clipboard.writeText(codeBlock.textContent);
+    await navigator.clipboard.writeText(codeBlock.textContent);
+
+    // Add a visually hidden element for screen readers to announce
+    const srAnnouncement = document.createElement('div');
+    srAnnouncement.textContent = 'Copied to clipboard';
+    srAnnouncement.setAttribute('role', 'status');
+    srAnnouncement.setAttribute('aria-live', 'polite');
+    srAnnouncement.style.position = 'absolute';
+    srAnnouncement.style.width = '1px';
+    srAnnouncement.style.height = '1px';
+    srAnnouncement.style.padding = '0';
+    srAnnouncement.style.margin = '-1px';
+    srAnnouncement.style.overflow = 'hidden';
+    srAnnouncement.style.clipPath = 'inset(50%)';
+    srAnnouncement.style.whiteSpace = 'nowrap';
+    srAnnouncement.style.border = '0';
+
+    document.body.appendChild(srAnnouncement);
+
+    // Remove the announcement element after it's been read
+    setTimeout(() => {
+      document.body.removeChild(srAnnouncement);
+    }, 3000);
   } catch (err) {
-      console.error('Failed to copy text: ', err);
+    console.error('Failed to copy text: ', err);
   }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
If user tab to a code block copy button then hit enter, screen reader doesn't announce "Copied". This PR fixed this bug.


## Related issue number
#5631 (8)
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
