### PR TITLE
feat(ollama): Add thought field support and fix LLM control parameters

### DIFF
--- a/python/packages/autogen-ext/tests/models/test_ollama_chat_completion_client.py
+++ b/python/packages/autogen-ext/tests/models/test_ollama_chat_completion_client.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, AsyncGenerator, List, Mapping
+from typing import Any, AsyncGenerator, Dict, List, Mapping
 
 import httpx
 import pytest
@@ -601,3 +601,175 @@ async def test_ollama_create_stream_tools(model: str, ollama_client: OllamaChatC
     assert isinstance(create_result.content, str)
     assert len(create_result.content) > 0
     assert create_result.finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_create_tools_with_thought(monkeypatch: pytest.MonkeyPatch) -> None:
+    def add(x: int, y: int) -> str:
+        return str(x + y)
+
+    add_tool = FunctionTool(add, description="Add two numbers")
+    model = "llama3.2"
+    thought_content = "I'll use the add tool to calculate 2 + 2."
+
+    async def _mock_chat(*args: Any, **kwargs: Any) -> ChatResponse:
+        return ChatResponse(
+            model=model,
+            done=True,
+            done_reason="tool_calls",
+            message=Message(
+                role="assistant",
+                content=thought_content,
+                tool_calls=[
+                    Message.ToolCall(
+                        function=Message.ToolCall.Function(
+                            name=add_tool.name,
+                            arguments={"x": 2, "y": 2},
+                        ),
+                    ),
+                ],
+            ),
+            prompt_eval_count=10,
+            eval_count=12,
+        )
+
+    monkeypatch.setattr(AsyncClient, "chat", _mock_chat)
+    client = OllamaChatCompletionClient(model=model)
+
+    create_result = await client.create(
+        messages=[
+            UserMessage(content="What is 2 + 2?", source="user"),
+        ],
+        tools=[add_tool],
+    )
+
+    assert isinstance(create_result.content, list)
+    assert len(create_result.content) > 0
+    assert isinstance(create_result.content[0], FunctionCall)
+    assert create_result.content[0].name == add_tool.name
+    assert create_result.content[0].arguments == json.dumps({"x": 2, "y": 2})
+
+    assert create_result.thought == thought_content
+
+    assert create_result.finish_reason == "function_calls"
+    assert create_result.usage is not None
+    assert create_result.usage.prompt_tokens == 10
+    assert create_result.usage.completion_tokens == 12
+
+
+@pytest.mark.asyncio
+async def test_create_stream_tools_with_thought(monkeypatch: pytest.MonkeyPatch) -> None:
+    def add(x: int, y: int) -> str:
+        return str(x + y)
+
+    add_tool = FunctionTool(add, description="Add two numbers")
+    model = "llama3.2"
+    thought_content = "I'll use the add tool to calculate 2 + 2."
+
+    async def _mock_chat(*args: Any, **kwargs: Any) -> AsyncGenerator[ChatResponse, None]:
+        assert "stream" in kwargs
+        assert kwargs["stream"] is True
+
+        async def _mock_stream() -> AsyncGenerator[ChatResponse, None]:
+            thought_chunks = [thought_content[i : i + 10] for i in range(0, len(thought_content), 10)]
+            for chunk in thought_chunks:
+                yield ChatResponse(
+                    model=model,
+                    done=False,
+                    message=Message(
+                        role="assistant",
+                        content=chunk,
+                    ),
+                )
+
+            yield ChatResponse(
+                model=model,
+                done=True,
+                done_reason="tool_calls",
+                message=Message(
+                    role="assistant",
+                    tool_calls=[
+                        Message.ToolCall(
+                            function=Message.ToolCall.Function(
+                                name=add_tool.name,
+                                arguments={"x": 2, "y": 2},
+                            ),
+                        ),
+                    ],
+                ),
+                prompt_eval_count=10,
+                eval_count=12,
+            )
+
+        return _mock_stream()
+
+    monkeypatch.setattr(AsyncClient, "chat", _mock_chat)
+    client = OllamaChatCompletionClient(model=model)
+
+    stream = client.create_stream(
+        messages=[
+            UserMessage(content="What is 2 + 2?", source="user"),
+        ],
+        tools=[add_tool],
+    )
+
+    chunks: List[str | CreateResult] = []
+    async for chunk in stream:
+        chunks.append(chunk)
+
+    assert len(chunks) > 0
+
+    create_result = next((c for c in chunks if isinstance(c, CreateResult)), None)
+    assert create_result is not None
+
+    assert isinstance(create_result.content, list)
+    assert len(create_result.content) > 0
+    assert isinstance(create_result.content[0], FunctionCall)
+    assert create_result.content[0].name == add_tool.name
+    assert create_result.content[0].arguments == json.dumps({"x": 2, "y": 2})
+
+    assert create_result.thought == thought_content
+
+    assert create_result.finish_reason == "function_calls"
+    assert create_result.usage is not None
+    assert create_result.usage.prompt_tokens == 10
+    assert create_result.usage.completion_tokens == 12
+
+
+@pytest.mark.asyncio
+async def test_llm_control_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    model_name = "llama3.2"
+
+    # Capture the kwargs passed to chat
+    chat_kwargs_captured: Dict[str, Any] = {}
+
+    async def _mock_chat(*args: Any, **kwargs: Any) -> ChatResponse:
+        nonlocal chat_kwargs_captured
+        chat_kwargs_captured = kwargs
+        return ChatResponse(
+            model=model_name,
+            done=True,
+            done_reason="stop",
+            message=Message(
+                role="assistant",
+                content="Test response",
+            ),
+        )
+
+    monkeypatch.setattr(AsyncClient, "chat", _mock_chat)
+
+    client_params: Dict[str, Any] = {"model": model_name, "temperature": 0.7, "top_p": 0.9, "frequency_penalty": 1.2}
+
+    client = OllamaChatCompletionClient(**client_params)
+
+    await client.create(
+        messages=[
+            UserMessage(content="hi", source="user"),
+        ],
+    )
+
+    assert "options" in chat_kwargs_captured
+    assert isinstance(chat_kwargs_captured["options"], dict)
+    assert chat_kwargs_captured["options"]["temperature"] == 0.7
+    assert chat_kwargs_captured["options"]["top_p"] == 0.9
+    assert chat_kwargs_captured["options"]["frequency_penalty"] == 1.2


### PR DESCRIPTION
## Description
This PR implements two improvements to the OllamaChatCompletionClient:

1. Adds support for the `thought` field in `CreateResult` to capture additional text when a model produces both tool calls and content, similar to PR #5500 for OpenAIChatCompletionClient
2. Fixes parameter handling to properly pass LLM control parameters (like temperature, top_p, etc.) to the Ollama API via the options dictionary

## Why are these changes needed?
1. The thought field support helps preserve important reasoning text provided by models alongside tool calls, ensuring no information is lost
2. Currently users are unable to properly set parameters like temperature in the OllamaChatCompletionClient as these parameters are silently dropped rather than being passed to the Ollama API

## Related issue number

Closes #5651 & #6097

## Checks

- [X] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
