### PR TITLE
Add suppress_result_output to ACADynamicSessionsCodeExecutor initializer

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
@@ -70,6 +70,7 @@ class ACADynamicSessionsCodeExecutor(CodeExecutor):
             a default working directory will be used. The default working
             directory is the current directory ".".
         functions (List[Union[FunctionWithRequirements[Any, A], Callable[..., Any]]]): A list of functions that are available to the code executor. Default is an empty list.
+        suppress_result_output bool: By default the executor will attach any result info in the execution response to the result outpu. Set this to True to prevent this.
     """
 
     SUPPORTED_LANGUAGES: ClassVar[List[str]] = [
@@ -95,6 +96,7 @@ $functions"""
             ]
         ] = [],
         functions_module: str = "functions",
+        suppress_result_output: bool = False,
     ):
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
@@ -119,6 +121,8 @@ $functions"""
             self._setup_functions_complete = False
         else:
             self._setup_functions_complete = True
+
+        self._suppress_result_output = suppress_result_output
 
         self._pool_management_endpoint = pool_management_endpoint
         self._access_token: str | None = None
@@ -433,7 +437,8 @@ import pkg_resources\n[d.project_name for d in pkg_resources.working_set]
                     data = data["properties"]
                     logs_all += data.get("stderr", "") + data.get("stdout", "")
                     if "Success" in data["status"]:
-                        logs_all += str(data["result"])
+                        if not self._suppress_result_output:
+                            logs_all += str(data["result"])
                     elif "Failure" in data["status"]:
                         exitcode = 1
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->
When using the `ACADynamicSessionsCodeExecutor` it includes the stdout from the execution but also the `results` property from the call to dynamic sessions. In some situations, when the executed code results in a file being saved this is included in the result:

```console
Plot saved as 'results_by_date.png'
{'type': 'image', 'format': 'png', 'base64_data': 'iVBORw0KGgoAAAANSUhEUgAAA90AAAJOCAYAAACqS2TfAAAAOXRFWHRTb2Z0d2FyZQ...
```

In some situations, this additional output is not desirable:
- when displaying the code output to a user - in this case, the stdout content is dwarfed by the base64 encoded file content
- when an LLM agent is going to evaluate the code output to determine next steps - in this case, the base64 content will be included in the message history sent to the LLM increasing the prompt token cost

To handle these cases, this PR adds a new (optional) argument to the `ACADynamicSessionsCodeExecutor` constructor that would allow suppressing the result content (but default to False to preserve the current behaviour in the default case)

(from #6042)

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #6042 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
