### PR TITLE
Fix token limited model context

### DIFF
--- a/python/packages/autogen-agentchat/tests/test_declarative_components.py
+++ b/python/packages/autogen-agentchat/tests/test_declarative_components.py
@@ -106,7 +106,7 @@ async def test_chat_completion_context_declarative() -> None:
     unbounded_context = UnboundedChatCompletionContext()
     buffered_context = BufferedChatCompletionContext(buffer_size=5)
     head_tail_context = HeadAndTailChatCompletionContext(head_size=3, tail_size=2)
-    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test_key")
     token_limited_context = TokenLimitedChatCompletionContext(model_client=model_client, token_limit=5)
 
     # Test serialization

--- a/python/packages/autogen-agentchat/tests/test_declarative_components.py
+++ b/python/packages/autogen-agentchat/tests/test_declarative_components.py
@@ -14,9 +14,10 @@ from autogen_core import ComponentLoader, ComponentModel
 from autogen_core.model_context import (
     BufferedChatCompletionContext,
     HeadAndTailChatCompletionContext,
-    UnboundedChatCompletionContext,
     TokenLimitedChatCompletionContext,
+    UnboundedChatCompletionContext,
 )
+from autogen_ext.models.openai import OpenAIChatCompletionClient
 
 
 @pytest.mark.asyncio
@@ -105,7 +106,8 @@ async def test_chat_completion_context_declarative() -> None:
     unbounded_context = UnboundedChatCompletionContext()
     buffered_context = BufferedChatCompletionContext(buffer_size=5)
     head_tail_context = HeadAndTailChatCompletionContext(head_size=3, tail_size=2)
-    token_limited_context = TokenLimitedChatCompletionContext(token_limit=5, model="gpt-4o")
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+    token_limited_context = TokenLimitedChatCompletionContext(model_client=model_client, token_limit=5)
 
     # Test serialization
     unbounded_config = unbounded_context.dump_component()
@@ -123,7 +125,10 @@ async def test_chat_completion_context_declarative() -> None:
     token_limited_config = token_limited_context.dump_component()
     assert token_limited_config.provider == "autogen_core.model_context.TokenLimitedChatCompletionContext"
     assert token_limited_config.config["token_limit"] == 5
-    assert token_limited_config.config["model"] == "gpt-4o"
+    assert (
+        token_limited_config.config["model_client"]["provider"]
+        == "autogen_ext.models.openai.OpenAIChatCompletionClient"
+    )
 
     # Test deserialization
     loaded_unbounded = ComponentLoader.load_component(unbounded_config, UnboundedChatCompletionContext)

--- a/python/packages/autogen-core/src/autogen_core/model_context/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/__init__.py
@@ -1,7 +1,7 @@
 from ._buffered_chat_completion_context import BufferedChatCompletionContext
-from ._token_limited_chat_completion_context import TokenLimitedChatCompletionContext
 from ._chat_completion_context import ChatCompletionContext, ChatCompletionContextState
 from ._head_and_tail_chat_completion_context import HeadAndTailChatCompletionContext
+from ._token_limited_chat_completion_context import TokenLimitedChatCompletionContext
 from ._unbounded_chat_completion_context import (
     UnboundedChatCompletionContext,
 )

--- a/python/packages/autogen-core/src/autogen_core/model_context/_buffered_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_buffered_chat_completion_context.py
@@ -41,7 +41,9 @@ class BufferedChatCompletionContext(ChatCompletionContext, Component[BufferedCha
         return messages
 
     def _to_config(self) -> BufferedChatCompletionContextConfig:
-        return BufferedChatCompletionContextConfig(buffer_size=self._buffer_size, initial_messages=self._messages)
+        return BufferedChatCompletionContextConfig(
+            buffer_size=self._buffer_size, initial_messages=self._initial_messages
+        )
 
     @classmethod
     def _from_config(cls, config: BufferedChatCompletionContextConfig) -> Self:

--- a/python/packages/autogen-core/src/autogen_core/model_context/_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_chat_completion_context.py
@@ -47,7 +47,10 @@ class ChatCompletionContext(ABC, ComponentBase[BaseModel]):
     component_type = "chat_completion_context"
 
     def __init__(self, initial_messages: List[LLMMessage] | None = None) -> None:
-        self._messages: List[LLMMessage] = initial_messages or []
+        self._messages: List[LLMMessage] = []
+        if initial_messages is not None:
+            self._messages.extend(initial_messages)
+        self._initial_messages = initial_messages
 
     async def add_message(self, message: LLMMessage) -> None:
         """Add a message to the context."""

--- a/python/packages/autogen-core/src/autogen_core/model_context/_head_and_tail_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_head_and_tail_chat_completion_context.py
@@ -68,7 +68,7 @@ class HeadAndTailChatCompletionContext(ChatCompletionContext, Component[HeadAndT
 
     def _to_config(self) -> HeadAndTailChatCompletionContextConfig:
         return HeadAndTailChatCompletionContextConfig(
-            head_size=self._head_size, tail_size=self._tail_size, initial_messages=self._messages
+            head_size=self._head_size, tail_size=self._tail_size, initial_messages=self._initial_messages
         )
 
     @classmethod

--- a/python/packages/autogen-core/src/autogen_core/model_context/_unbounded_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_unbounded_chat_completion_context.py
@@ -9,7 +9,7 @@ from ._chat_completion_context import ChatCompletionContext
 
 
 class UnboundedChatCompletionContextConfig(BaseModel):
-    pass
+    initial_messages: List[LLMMessage] | None = None
 
 
 class UnboundedChatCompletionContext(ChatCompletionContext, Component[UnboundedChatCompletionContextConfig]):
@@ -23,8 +23,8 @@ class UnboundedChatCompletionContext(ChatCompletionContext, Component[UnboundedC
         return self._messages
 
     def _to_config(self) -> UnboundedChatCompletionContextConfig:
-        return UnboundedChatCompletionContextConfig()
+        return UnboundedChatCompletionContextConfig(initial_messages=self._initial_messages)
 
     @classmethod
     def _from_config(cls, config: UnboundedChatCompletionContextConfig) -> Self:
-        return cls()
+        return cls(initial_messages=config.initial_messages)

--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -2,7 +2,8 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Any, Dict, Generic, Mapping, Protocol, Type, TypedDict, TypeVar, cast, runtime_checkable
+from typing import Any, Dict, Generic, Mapping, Protocol, Type, TypeVar, cast, runtime_checkable
+from typing_extensions import TypedDict
 
 import jsonref
 from opentelemetry.trace import get_tracer

--- a/python/packages/autogen-core/tests/test_component_config.py
+++ b/python/packages/autogen-core/tests/test_component_config.py
@@ -361,7 +361,6 @@ async def test_function_tool() -> None:
         await loaded_async.run_json({"x": 1.0, "y": 2.0}, cancelled_token)
 
 
-@pytest.mark.asyncio
 def test_component_descriptions() -> None:
     """Test different ways of setting component descriptions."""
     assert MyComponent("test").dump_component().description is None

--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -137,7 +137,7 @@ async def test_token_limited_model_context_with_token_limit(
         await model_context.add_message(msg)
 
     retrieved = await model_context.get_messages()
-    assert len(retrieved) == 1  # Token limit set very low, will remove 1 of the messages
+    assert len(retrieved) == 1  # Token limit set very low, will remove 2 of the messages
     assert retrieved != messages  # Will not be equal to the original messages
 
     await model_context.clear()

--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -119,7 +119,7 @@ async def test_unbounded_model_context() -> None:
 @pytest.mark.parametrize(
     "model_client,token_limit",
     [
-        (OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0), 30),
+        (OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0, api_key="test"), 30),
         (OllamaChatCompletionClient(model="llama3.3"), 20),
     ],
     ids=["openai", "ollama"],
@@ -159,7 +159,7 @@ async def test_token_limited_model_context_with_token_limit(
 @pytest.mark.parametrize(
     "model_client",
     [
-        OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0),
+        OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0, api_key="test_key"),
         OllamaChatCompletionClient(model="llama3.3"),
     ],
     ids=["openai", "ollama"],
@@ -182,7 +182,7 @@ async def test_token_limited_model_context_without_token_limit(model_client: Cha
 @pytest.mark.parametrize(
     "model_client,token_limit",
     [
-        (OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0), 60),
+        (OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0, api_key="test"), 60),
         (OllamaChatCompletionClient(model="llama3.3"), 50),
     ],
     ids=["openai", "ollama"],

--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -4,10 +4,18 @@ import pytest
 from autogen_core.model_context import (
     BufferedChatCompletionContext,
     HeadAndTailChatCompletionContext,
-    UnboundedChatCompletionContext,
     TokenLimitedChatCompletionContext,
+    UnboundedChatCompletionContext,
 )
-from autogen_core.models import AssistantMessage, LLMMessage, UserMessage, FunctionExecutionResultMessage
+from autogen_core.models import (
+    AssistantMessage,
+    ChatCompletionClient,
+    FunctionExecutionResultMessage,
+    LLMMessage,
+    UserMessage,
+)
+from autogen_ext.models.ollama import OllamaChatCompletionClient
+from autogen_ext.models.openai import OpenAIChatCompletionClient
 
 
 @pytest.mark.asyncio
@@ -108,8 +116,18 @@ async def test_unbounded_model_context() -> None:
 
 
 @pytest.mark.asyncio
-async def test_token_limited_model_context_openai() -> None:
-    model_context = TokenLimitedChatCompletionContext(token_limit=20, model="gpt-4o")
+@pytest.mark.parametrize(
+    "model_client,token_limit",
+    [
+        (OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0), 30),
+        (OllamaChatCompletionClient(model="llama3.3"), 20),
+    ],
+    ids=["openai", "ollama"],
+)
+async def test_token_limited_model_context_with_token_limit(
+    model_client: ChatCompletionClient, token_limit: int
+) -> None:
+    model_context = TokenLimitedChatCompletionContext(model_client=model_client, token_limit=token_limit)
     messages: List[LLMMessage] = [
         UserMessage(content="Hello!", source="user"),
         AssistantMessage(content="What can I do for you?", source="assistant"),
@@ -119,37 +137,7 @@ async def test_token_limited_model_context_openai() -> None:
         await model_context.add_message(msg)
 
     retrieved = await model_context.get_messages()
-    assert len(retrieved) == 2  # Token limit set very low, will remove 1 of the messages
-    assert retrieved != messages  # Will not be equal to the original messages
-
-    await model_context.clear()
-    retrieved = await model_context.get_messages()
-    assert len(retrieved) == 0
-
-    # Test saving and loading state.
-    for msg in messages:
-        await model_context.add_message(msg)
-    state = await model_context.save_state()
-    await model_context.clear()
-    await model_context.load_state(state)
-    retrieved = await model_context.get_messages()
-    assert len(retrieved) == 2
-    assert retrieved != messages
-
-
-@pytest.mark.asyncio
-async def test_token_limited_model_context_llama() -> None:
-    model_context = TokenLimitedChatCompletionContext(token_limit=20, model="llama2-7b")
-    messages: List[LLMMessage] = [
-        UserMessage(content="Hello!", source="user"),
-        AssistantMessage(content="What can I do for you?", source="assistant"),
-        UserMessage(content="Tell what are some fun things to do in seattle.", source="user"),
-    ]
-    for msg in messages:
-        await model_context.add_message(msg)
-
-    retrieved = await model_context.get_messages()
-    assert len(retrieved) == 1  # Token limit set very low, will remove two of the messages
+    assert len(retrieved) == 1  # Token limit set very low, will remove 1 of the messages
     assert retrieved != messages  # Will not be equal to the original messages
 
     await model_context.clear()
@@ -168,8 +156,41 @@ async def test_token_limited_model_context_llama() -> None:
 
 
 @pytest.mark.asyncio
-async def test_token_limited_model_context_openai_with_function_result() -> None:
-    model_context = TokenLimitedChatCompletionContext(token_limit=1000, model="gpt-4o")
+@pytest.mark.parametrize(
+    "model_client",
+    [
+        OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0),
+        OllamaChatCompletionClient(model="llama3.3"),
+    ],
+    ids=["openai", "ollama"],
+)
+async def test_token_limited_model_context_without_token_limit(model_client: ChatCompletionClient) -> None:
+    model_context = TokenLimitedChatCompletionContext(model_client=model_client)
+    messages: List[LLMMessage] = [
+        UserMessage(content="Hello!", source="user"),
+        AssistantMessage(content="What can I do for you?", source="assistant"),
+        UserMessage(content="Tell what are some fun things to do in seattle.", source="user"),
+    ]
+    for msg in messages:
+        await model_context.add_message(msg)
+
+    retrieved = await model_context.get_messages()
+    assert len(retrieved) == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_client,token_limit",
+    [
+        (OpenAIChatCompletionClient(model="gpt-4o", temperature=0.0), 60),
+        (OllamaChatCompletionClient(model="llama3.3"), 50),
+    ],
+    ids=["openai", "ollama"],
+)
+async def test_token_limited_model_context_openai_with_function_result(
+    model_client: ChatCompletionClient, token_limit: int
+) -> None:
+    model_context = TokenLimitedChatCompletionContext(model_client=model_client, token_limit=token_limit)
     messages: List[LLMMessage] = [
         FunctionExecutionResultMessage(content=[]),
         UserMessage(content="Hello!", source="user"),


### PR DESCRIPTION
Token limited model context is currently broken because it is importing from extensions.

This fix removed the imports and updated the model context implementation to use model client directly. 

In the future, the model client's token counting should cache results from model API to provide accurate counting. 