### PR TITLE
Doc/moudulor transform oai

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_message_transform.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_message_transform.py
@@ -1,3 +1,141 @@
+"""
+# `_message_transform.py` Module-Level Documentation
+
+This document is a markdown-formatted version of the module-level docstring inserted into `_message_transform.py` as part of [PR #6063](https://github.com/microsoft/autogen/pull/6063).
+
+---
+
+## AutoGen Modular Transformer Pipeline
+
+This module implements a modular and extensible message transformation pipeline
+for converting `LLMMessage` instances into SDK-specific message formats
+(e.g., OpenAI-style `ChatCompletionMessageParam`).
+
+---
+
+### 📌 Background
+
+In previous versions of AutoGen, message adaptation was handled in ad-hoc ways,
+scattered across model clients. This led to compatibility bugs and code duplication,
+especially when supporting diverse models such as Gemini, Claude, or Anthropic SDKs.
+
+To address this, PR #6063 introduced a unified, composable transformer pipeline
+that decouples message transformation logic from model SDK constructors.
+
+---
+
+### 🎯 Key Concepts
+
+- **Transformer Function**:  
+  Transforms a field (e.g., `content`, `name`, `role`) of an `LLMMessage` into a keyword argument.
+
+- **Transformer Pipeline**:  
+  A sequence of transformer functions composed using `build_transformer_func`.
+
+- **Transformer Map**:  
+  A dictionary mapping `LLMMessage` types (System, User, Assistant) to transformers for a specific model.
+
+- **Conditional Transformer**:  
+  Chooses a pipeline dynamically based on message content or runtime conditions.
+
+---
+
+### 🧪 Example: Basic Flow
+
+```python
+from autogen_ext.models.openai._message_transform import get_transformer
+from autogen.types import AssistantMessage
+
+llm_message = AssistantMessage(name="a", thought="Let's go!")
+transformer = get_transformer("openai", "gpt-4", type(llm_message))
+sdk_message = transformer(llm_message, context={})
+print(sdk_message)
+```
+
+---
+
+### 🧰 Example: Define Transformer Functions
+
+```python
+def _set_role(role: str):
+    def fn(message, context):
+        return {"role": role}
+    return fn
+
+def _set_content_from_thought(message, context):
+    return {"content": message.thought or " "}
+
+base_user_transformer_funcs = [
+    _set_role("user"),
+    _set_content_from_thought
+]
+```
+
+---
+
+### 🛠️ Example: Build and Register Transformer Map
+
+```python
+from autogen_ext.models.utils import build_transformer_func, register_transformer
+from openai.types.chat import ChatCompletionUserMessageParam
+from autogen.types import UserMessage, SystemMessage, AssistantMessage
+
+user_transformer = build_transformer_func(
+    funcs=base_user_transformer_funcs,
+    message_param_func=ChatCompletionUserMessageParam
+)
+
+MY_TRANSFORMER_MAP = {
+    UserMessage: user_transformer,
+    SystemMessage: ...,
+    AssistantMessage: ...
+}
+
+register_transformer("openai", "mistral-7b", MY_TRANSFORMER_MAP)
+```
+
+---
+
+### 🔁 Conditional Transformer Example
+
+```python
+from autogen_ext.models.utils import build_conditional_transformer_func
+
+def condition_func(message, context):
+    return "multimodal" if isinstance(message.content, dict) else "text"
+
+user_transformers = {
+    "text": [_set_content_from_thought],
+    "multimodal": [_set_content_from_thought]  # could be different logic
+}
+
+message_param_funcs = {
+    "text": ChatCompletionUserMessageParam,
+    "multimodal": ChatCompletionUserMessageParam,
+}
+
+conditional_user_transformer = build_conditional_transformer_func(
+    funcs_map=user_transformers,
+    message_param_func_map=message_param_funcs,
+    condition_func=condition_func,
+)
+```
+
+---
+
+### 📦 Design Principles
+
+- ✅ DRY and Composable
+- ✅ Model-specific overrides without forking entire clients
+- ✅ Explicit separation between transformation logic and SDK builders
+- ✅ Future extensibility (e.g., Claude, Gemini, Alibaba)
+
+---
+
+### 📎 Reference
+
+- Introduced in: [PR #6063](https://github.com/microsoft/autogen/pull/6063)  
+"""
 from typing import Any, Callable, Dict, List, cast, get_args
 
 from autogen_core import (

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_message_transform.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_message_transform.py
@@ -26,16 +26,16 @@ that decouples message transformation logic from model SDK constructors.
 
 ### 🎯 Key Concepts
 
-- **Transformer Function**:  
+- **Transformer Function**:
   Transforms a field (e.g., `content`, `name`, `role`) of an `LLMMessage` into a keyword argument.
 
-- **Transformer Pipeline**:  
+- **Transformer Pipeline**:
   A sequence of transformer functions composed using `build_transformer_func`.
 
-- **Transformer Map**:  
+- **Transformer Map**:
   A dictionary mapping `LLMMessage` types (System, User, Assistant) to transformers for a specific model.
 
-- **Conditional Transformer**:  
+- **Conditional Transformer**:
   Chooses a pipeline dynamically based on message content or runtime conditions.
 
 ---
@@ -60,15 +60,15 @@ print(sdk_message)
 def _set_role(role: str):
     def fn(message, context):
         return {"role": role}
+
     return fn
+
 
 def _set_content_from_thought(message, context):
     return {"content": message.thought or " "}
 
-base_user_transformer_funcs = [
-    _set_role("user"),
-    _set_content_from_thought
-]
+
+base_user_transformer_funcs = [_set_role("user"), _set_content_from_thought]
 ```
 
 ---
@@ -81,15 +81,10 @@ from openai.types.chat import ChatCompletionUserMessageParam
 from autogen.types import UserMessage, SystemMessage, AssistantMessage
 
 user_transformer = build_transformer_func(
-    funcs=base_user_transformer_funcs,
-    message_param_func=ChatCompletionUserMessageParam
+    funcs=base_user_transformer_funcs, message_param_func=ChatCompletionUserMessageParam
 )
 
-MY_TRANSFORMER_MAP = {
-    UserMessage: user_transformer,
-    SystemMessage: ...,
-    AssistantMessage: ...
-}
+MY_TRANSFORMER_MAP = {UserMessage: user_transformer, SystemMessage: ..., AssistantMessage: ...}
 
 register_transformer("openai", "mistral-7b", MY_TRANSFORMER_MAP)
 ```
@@ -101,12 +96,14 @@ register_transformer("openai", "mistral-7b", MY_TRANSFORMER_MAP)
 ```python
 from autogen_ext.models.utils import build_conditional_transformer_func
 
+
 def condition_func(message, context):
     return "multimodal" if isinstance(message.content, dict) else "text"
 
+
 user_transformers = {
     "text": [_set_content_from_thought],
-    "multimodal": [_set_content_from_thought]  # could be different logic
+    "multimodal": [_set_content_from_thought],  # could be different logic
 }
 
 message_param_funcs = {
@@ -134,8 +131,9 @@ conditional_user_transformer = build_conditional_transformer_func(
 
 ### 📎 Reference
 
-- Introduced in: [PR #6063](https://github.com/microsoft/autogen/pull/6063)  
+- Introduced in: [PR #6063](https://github.com/microsoft/autogen/pull/6063)
 """
+
 from typing import Any, Callable, Dict, List, cast, get_args
 
 from autogen_core import (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a module-level docstring to `_message_transform.py`, as requested in the review for [PR #6063](https://github.com/microsoft/autogen/pull/6063).

The documentation includes:
- Background and motivation behind the modular transformer design
- Key concepts such as transformer functions, pipelines, and maps
- Examples of how to define, register, and use transformers
- Design principles to guide future contributions and extensions

By embedding this explanation directly into the module, contributors and maintainers can more easily understand the structure, purpose, and usage of the transformer pipeline without needing to refer to external documents.

## Related issue number

Follow-up to [PR #6063](https://github.com/microsoft/autogen/pull/6063)

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.