### PR TITLE
Fix/use model pointers to resolve model names

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -226,7 +226,7 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
     "claude-3-5-haiku-20241022": {
         "vision": True,
         "function_calling": True,
-        "json_output": False,  # Update this when Anthropic supports structured output
+        "json_output": True,  # Update this when Anthropic supports structured output
         "family": ModelFamily.CLAUDE_3_5_HAIKU,
         "structured_output": False,
     },

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -64,6 +64,7 @@ class BaseOpenAIClientConfiguration(CreateArguments, total=False):
     add_name_prefixes: bool
     """What functionality the model supports, determined by default from model name but is overriden if value passed."""
     default_headers: Dict[str, str] | None
+    resolve_model_alias: bool
 
 
 # See OpenAI docs for explanation of these parameters
@@ -106,6 +107,7 @@ class BaseOpenAIClientConfigurationConfigModel(CreateArgumentsConfigModel):
     model_info: ModelInfo | None = None
     add_name_prefixes: bool | None = None
     default_headers: Dict[str, str] | None = None
+    resolve_model_alias: bool = True
 
 
 # See OpenAI docs for explanation of these parameters

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -1620,7 +1620,7 @@ def openai_client(request: pytest.FixtureRequest) -> OpenAIChatCompletionClient:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "model",
-    ["gpt-4o-mini", "gemini-1.5-flash", "claude-3-5-haiku-20241022"],
+    ["gpt-4o-mini", "gemini-1.5-flash", "claude-3-5-haiku"],
 )
 async def test_model_client_basic_completion(model: str, openai_client: OpenAIChatCompletionClient) -> None:
     # Test basic completion
@@ -1637,7 +1637,7 @@ async def test_model_client_basic_completion(model: str, openai_client: OpenAICh
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "model",
-    ["gpt-4o-mini", "gemini-1.5-flash", "claude-3-5-haiku-20241022"],
+    ["gpt-4o-mini", "gemini-1.5-flash", "claude-3-5-haiku"],
 )
 async def test_model_client_with_function_calling(model: str, openai_client: OpenAIChatCompletionClient) -> None:
     # Test tool calling
@@ -2069,7 +2069,7 @@ async def test_add_name_prefixes(monkeypatch: pytest.MonkeyPatch) -> None:
     [
         "gpt-4o-mini",
         "gemini-1.5-flash",
-        "claude-3-5-haiku-20241022",
+        "claude-3-5-haiku",
     ],
 )
 async def test_muliple_system_message(model: str, openai_client: OpenAIChatCompletionClient) -> None:
@@ -2349,7 +2349,7 @@ async def test_empty_assistant_content_with_gemini(model: str, openai_client: Op
     [
         "gpt-4o-mini",
         "gemini-1.5-flash",
-        "claude-3-5-haiku-20241022",
+        "claude-3-5-haiku",
     ],
 )
 async def test_empty_assistant_content_string_with_some_model(

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -1643,7 +1643,9 @@ async def test_model_client_with_function_calling(model: str, openai_client: Ope
     # Test tool calling
     pass_tool = FunctionTool(_pass_function, name="pass_tool", description="pass session.")
     fail_tool = FunctionTool(_fail_function, name="fail_tool", description="fail session.")
-    messages: List[LLMMessage] = [UserMessage(content="Call the pass tool with input 'task'", source="user")]
+    messages: List[LLMMessage] = [
+        UserMessage(content="Call the pass tool with input 'task' and talk result", source="user")
+    ]
     create_result = await openai_client.create(messages=messages, tools=[pass_tool, fail_tool])
     assert isinstance(create_result.content, list)
     assert len(create_result.content) == 1
@@ -1674,7 +1676,8 @@ async def test_model_client_with_function_calling(model: str, openai_client: Ope
     # Test parallel tool calling
     messages = [
         UserMessage(
-            content="Call both the pass tool with input 'task' and the fail tool also with input 'task'", source="user"
+            content="Call both the pass tool with input 'task' and the fail tool also with input 'task' and talk result",
+            source="user",
         )
     ]
     create_result = await openai_client.create(messages=messages, tools=[pass_tool, fail_tool])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a model resolution issue when using model aliases such as `claude-3-5-haiku`. These aliases are defined in `MODEL_POINTERS` and should be resolved into actual model names (e.g., `claude-3-haiku-20240307`). 

Currently, `create_args["model"]` is passed directly to the OpenAI client without resolving through `MODEL_POINTERS`, which results in an error if the alias is not an officially recognized model ID.

Even though `self._resolved_model` is computed using `_model_info.resolve_model(...)`, the actual request still uses the unresolved value in `create_args`.

This PR ensures that `create_args["model"]` is updated accordingly so that model aliases are consistently resolved throughout the code path.

## Related issue number

Related to feedback from @ekzhu:
> Use MODEL_POINTERS to map model names for Claude models. Right now, if using claude-3-5-haiku here it will result in error

## What does this change do?

- Updates `create_args["model"]` in `__init__` if `model` is provided
- Ensures that downstream requests use resolved model names (e.g., Claude, Mistral, etc.)
- Prevents runtime errors when using model aliases defined in `MODEL_POINTERS`

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
