### PR TITLE
fix: the installation instruction had a missing step

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/autogenstudio-user-guide/installation.md
+++ b/python/packages/autogen-core/docs/src/user-guide/autogenstudio-user-guide/installation.md
@@ -74,8 +74,9 @@ You have two options for installing from source: manually or using a dev contain
 ### A) Install from source manually
 
 1. Ensure you have Python 3.10+ and Node.js (version above 14.15.0) installed.
-2. Clone the AutoGen Studio repository and install its Python dependencies using `pip install -e .`
-3. Navigate to the `python/packages/autogen-studio/frontend` directory, install the dependencies, and build the UI:
+2. Clone the AutoGen Studio repository.
+3. Navigate to the `python/packages/autogen-studio` and install its Python dependencies using `pip install -e .`
+4. Navigate to the `python/packages/autogen-studio/frontend` directory, install the dependencies, and build the UI:
 
 ```bash
 npm install -g gatsby-cli


### PR DESCRIPTION
## Why are these changes needed?

Following the [guide instructions](https://microsoft.github.io/autogen/stable//user-guide/autogenstudio-user-guide/installation.html#a-install-from-source-manually) the user will execute the commands in the wrong directory.

## Related issue number

Closes #6165
