### PR TITLE
Add session_id_param to ACADynamicSessionsCodeExecutor

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
@@ -73,6 +73,7 @@ class ACADynamicSessionsCodeExecutor(CodeExecutor):
             directory is a temporal directory.
         functions (List[Union[FunctionWithRequirements[Any, A], Callable[..., Any]]]): A list of functions that are available to the code executor. Default is an empty list.
         suppress_result_output bool: By default the executor will attach any result info in the execution response to the result outpu. Set this to True to prevent this.
+        session_id (str): The session id for the code execution (passed to Dynamic Sessions). If None, a new session id will be generated. Default is None.
 
     .. note::
         Using the current directory (".") as working directory is deprecated. Using it will raise a deprecation warning.
@@ -102,6 +103,7 @@ $functions"""
         ] = [],
         functions_module: str = "functions",
         suppress_result_output: bool = False,
+        session_id: Optional[str] = None,
     ):
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
@@ -141,7 +143,7 @@ $functions"""
 
         self._pool_management_endpoint = pool_management_endpoint
         self._access_token: str | None = None
-        self._session_id: str = str(uuid4())
+        self._session_id: str = session_id or str(uuid4())
         self._available_packages: set[str] | None = None
         self._credential: TokenProvider = credential
         # cwd needs to be set to /mnt/data to properly read uploaded files and download written files

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
@@ -73,7 +73,7 @@ class ACADynamicSessionsCodeExecutor(CodeExecutor):
             directory is a temporal directory.
         functions (List[Union[FunctionWithRequirements[Any, A], Callable[..., Any]]]): A list of functions that are available to the code executor. Default is an empty list.
         suppress_result_output bool: By default the executor will attach any result info in the execution response to the result outpu. Set this to True to prevent this.
-        session_id (str): The session id for the code execution (passed to Dynamic Sessions). If None, a new session id will be generated. Default is None.
+        session_id (str): The session id for the code execution (passed to Dynamic Sessions). If None, a new session id will be generated. Default is None. Note this value will be reset when calling `restart`
 
     .. note::
         Using the current directory (".") as working directory is deprecated. Using it will raise a deprecation warning.

--- a/python/packages/autogen-ext/tests/code_executors/test_aca_dynamic_sessions.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_aca_dynamic_sessions.py
@@ -22,6 +22,23 @@ ENVIRON_KEY_AZURE_POOL_ENDPOINT = "AZURE_POOL_ENDPOINT"
 POOL_ENDPOINT = os.getenv(ENVIRON_KEY_AZURE_POOL_ENDPOINT)
 
 
+def test_session_id_preserved_if_passed() -> None:
+    executor = ACADynamicSessionsCodeExecutor(
+        pool_management_endpoint=POOL_ENDPOINT, credential=DefaultAzureCredential()
+    )
+    session_id = "test_session_id"
+    executor._session_id = session_id
+    assert executor._session_id == session_id
+
+
+def test_session_id_generated_if_not_passed() -> None:
+    executor = ACADynamicSessionsCodeExecutor(
+        pool_management_endpoint=POOL_ENDPOINT, credential=DefaultAzureCredential()
+    )
+    assert executor._session_id is not None
+    assert len(executor._session_id) > 0
+
+
 @pytest.mark.skipif(
     not POOL_ENDPOINT,
     reason="do not run if pool endpoint is not defined",

--- a/python/packages/autogen-ext/tests/code_executors/test_aca_dynamic_sessions.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_aca_dynamic_sessions.py
@@ -27,16 +27,16 @@ def test_session_id_preserved_if_passed() -> None:
         pool_management_endpoint="fake-endpoint", credential=DefaultAzureCredential()
     )
     session_id = "test_session_id"
-    executor._session_id = session_id
-    assert executor._session_id == session_id
+    executor._session_id = session_id  # type: ignore[reportPrivateUsage]
+    assert executor._session_id == session_id  # type: ignore[reportPrivateUsage]
 
 
 def test_session_id_generated_if_not_passed() -> None:
     executor = ACADynamicSessionsCodeExecutor(
         pool_management_endpoint="fake-endpoint", credential=DefaultAzureCredential()
     )
-    assert executor._session_id is not None
-    assert len(executor._session_id) > 0
+    assert executor._session_id is not None  # type: ignore[reportPrivateUsage]
+    assert len(executor._session_id) > 0  # type: ignore[reportPrivateUsage]
 
 
 @pytest.mark.skipif(

--- a/python/packages/autogen-ext/tests/code_executors/test_aca_dynamic_sessions.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_aca_dynamic_sessions.py
@@ -24,7 +24,7 @@ POOL_ENDPOINT = os.getenv(ENVIRON_KEY_AZURE_POOL_ENDPOINT)
 
 def test_session_id_preserved_if_passed() -> None:
     executor = ACADynamicSessionsCodeExecutor(
-        pool_management_endpoint=POOL_ENDPOINT, credential=DefaultAzureCredential()
+        pool_management_endpoint="fake-endpoint", credential=DefaultAzureCredential()
     )
     session_id = "test_session_id"
     executor._session_id = session_id
@@ -33,7 +33,7 @@ def test_session_id_preserved_if_passed() -> None:
 
 def test_session_id_generated_if_not_passed() -> None:
     executor = ACADynamicSessionsCodeExecutor(
-        pool_management_endpoint=POOL_ENDPOINT, credential=DefaultAzureCredential()
+        pool_management_endpoint="fake-endpoint", credential=DefaultAzureCredential()
     )
     assert executor._session_id is not None
     assert len(executor._session_id) > 0


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The initializer for ACADynamicSessionsCodeExecutor creates a new GUID to use as the session ID for dynamic sessions.

In some scenarios it is desirable to be able to re-create the agent group chat from saved state. In this case, the ACADynamicSessionsCodeExecutor needs to be associated with a previous instance (so that any execution state is still valid)

This PR adds a new argument to the initializer to allow a session ID to be passed in (defaulting to the current behaviour of creating a GUID if absent).

## Related issue number

Closes #6119
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
