### PR TITLE
Fix gallery broken image path issue #4934

### DIFF
--- a/website/src/components/GalleryPage.js
+++ b/website/src/components/GalleryPage.js
@@ -70,8 +70,8 @@ const GalleryPage = (props) => {
           item.image
             ? item.image.includes("http")
               ? item.image
-              : `/autogen/img/gallery/${item.image}`
-            : `/autogen/img/gallery/default.png`
+              : `/autogen/0.2/img/gallery/${item.image}`
+            : `/autogen/0.2/img/gallery/default.png`
         }
         style={{
           height: 150,


### PR DESCRIPTION
This PR updates the image paths in `GalleryPage.js` to use absolute URLs starting with `/autogen/0.2/img/...` so that images correctly load on GitHub Pages in the 0.2 documentation site.

Fixes #4934