### PR TITLE
[BUGFIX] Add LLMCallEventMessage to resolve instantiation error in AgentStudio

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/datamodel/types.py
+++ b/python/packages/autogen-studio/autogenstudio/datamodel/types.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Literal, Optional
 from autogen_agentchat.base import TaskResult
 from autogen_agentchat.messages import BaseChatMessage
 from autogen_core import ComponentModel
+from autogen_core.models import UserMessage
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from pydantic import BaseModel, ConfigDict, SecretStr
 
@@ -24,6 +25,15 @@ class TeamResult(BaseModel):
 class LLMCallEventMessage(BaseChatMessage):
     source: str = "llm_call_event"
     content: str
+
+    def to_text(self) -> str:
+        return self.content
+
+    def to_model_text(self) -> str:
+        return self.content
+
+    def to_model_message(self) -> UserMessage:
+        raise NotImplementedError("This message type is not supported.")
 
 
 class MessageMeta(BaseModel):

--- a/python/packages/autogen-studio/tests/test_datamodel_types.py
+++ b/python/packages/autogen-studio/tests/test_datamodel_types.py
@@ -1,0 +1,16 @@
+import pytest
+
+from autogenstudio.datamodel.types import LLMCallEventMessage
+
+def test_LLMCallEventMessage_inner_funcs():
+    """Test the inner functions of LLMCallEventMessage"""
+    # Create a mock LLMCallEventMessage
+    message = LLMCallEventMessage(
+        content="Test message"
+    )
+
+    # Test the inner functions
+    assert message.to_text() == "Test message"
+    assert message.to_model_text() == "Test message"
+    with pytest.raises(NotImplementedError, match="This message type is not supported."):
+        message.to_model_message()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR defines the missing `LLMCallEventMessage` class to resolve an instantiation error that occurs when using custom messages (e.g., via AgentStudio).

> **Discord Report**  
> சravanaன் — 오후 6:40  
> _“i updated agentchat and agentcore and tried running the config from agentstudio and it is now not running the agent and is throwing error `TypeError: Can't instantiate abstract class LLMCallEventMessage with abstract methods to_model_message, to_model_text, to_text`”_

The issue stems from `LLMCallEventMessage` being an abstract class that lacks required methods from `BaseChatMessage`.  
This PR implements the missing methods.

Since `LLMCallEventMessage` is intended for **logging/UI use only**, and not to be sent to LLMs, the `to_model_message()` method raises `NotImplementedError` by design.


## Related issue number

Reported in Discord 
Closes #6206

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
