### PR TITLE
Handle GroupChatMessage concurrently.

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -51,7 +51,6 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
             sequential_message_types=[
                 GroupChatStart,
                 GroupChatAgentResponse,
-                GroupChatMessage,
                 GroupChatReset,
             ],
         )


### PR DESCRIPTION
Make sure `GroupChatMessage` is handled concurrently. 