### PR TITLE
chore: Add powershell path check for code executor

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/_common.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/_common.py
@@ -1,5 +1,6 @@
 import inspect
 import re
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent, indent
@@ -159,7 +160,13 @@ def lang_to_cmd(lang: str) -> str:
     if lang in ["shell"]:
         return "sh"
     if lang in ["pwsh", "powershell", "ps1"]:
-        return "pwsh"
+        # Check if pwsh is available, otherwise fall back to powershell
+        if shutil.which("pwsh") is not None:
+            return "pwsh"
+        elif shutil.which("powershell") is not None:
+            return "powershell"
+        else:
+            raise ValueError(f"Powershell or pwsh is not installed. Please install one of them.")
     else:
         raise ValueError(f"Unsupported language: {lang}")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addresses the follow up error in #5518 ,  it will now check if both `powershell` or `pwsh` are in the path and throw a value error if neither is available.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
