### PR TITLE
Fix sha256_hash docstring

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/utils/utils.py
+++ b/python/packages/autogen-studio/autogenstudio/utils/utils.py
@@ -15,10 +15,10 @@ from ..version import APP_NAME
 
 def sha256_hash(text: str) -> str:
     """
-    Compute the MD5 hash of a given text.
+    Compute the SHA-256 hash of a given text.
 
     :param text: The string to hash
-    :return: The MD5 hash of the text
+    :return: The SHA-256 hash of the text, hex-encoded.
     """
     return hashlib.sha256(text.encode()).hexdigest()
 


### PR DESCRIPTION
Fixes the sha256_hash docstring to refer to SHA-256 and not MD5.

## Why are these changes needed?

The docstring refers to (presumably) a previous implementation that was using MD5.

## Related issue number

N/A

## Checks

- [X] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [N/A] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [N/A] I've made sure all auto checks have passed.
