### PR TITLE
Create a common abstraction for storing message threads in teams

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_memory_message_store.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_memory_message_store.py
@@ -1,0 +1,41 @@
+import asyncio
+import time
+from typing import List, Optional
+
+from ...messages import BaseChatMessage
+from ._message_store import MessageStore
+
+
+class MemoryMessageStore(MessageStore):
+    def __init__(self, ttl: Optional[float] = None):
+        super().__init__()
+        self._ttl = ttl
+        self._lock = asyncio.Lock()
+        self._messages: List[tuple[BaseChatMessage, float]] = []
+
+    async def add_message(self, message: BaseChatMessage) -> None:
+        await self._remove_expired_messages()
+        async with self._lock:
+            self._messages.append((message, time.time()))
+
+    async def get_message_thread(self) -> List[BaseChatMessage]:
+        await self._remove_expired_messages()
+
+        async with self._lock:
+            return [message for message, _ in self._messages]
+
+    async def clear(self) -> None:
+        async with self._lock:
+            self._messages.clear()
+
+    async def _remove_expired_messages(self) -> None:
+        if self._ttl:
+            async with self._lock:
+                time_threshold = time.time() - self._ttl
+                self._messages = [
+                    (message, timestamp) for message, timestamp in self._messages if timestamp > time_threshold
+                ]
+
+    @property
+    def ttl(self) -> Optional[float]:
+        return self._ttl

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_message_store.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_message_store.py
@@ -1,0 +1,44 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from ...messages import BaseChatMessage
+
+
+class MessageStore(ABC):
+    """
+    Abstract base class for storing a message thread
+    """
+
+    @abstractmethod
+    async def add_message(self, message: BaseChatMessage) -> None:
+        """
+        Add a message to the store
+        """
+        pass
+
+    @abstractmethod
+    async def add_messages(self, messages: List[BaseChatMessage]) -> None:
+        """
+        Add multiple messages to the store
+        """
+        pass
+
+    @abstractmethod
+    async def get_message_thread(self) -> List[BaseChatMessage]:
+        """
+        Retrieve the current message thread
+        """
+        pass
+
+    @abstractmethod
+    async def clear(self) -> None:
+        """
+        Clear the message thread storage
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def ttl(self) -> Optional[float]:
+        """Time-To-Live for messages in seconds."""
+        pass

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/_common.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/_common.py
@@ -166,7 +166,7 @@ def lang_to_cmd(lang: str) -> str:
         elif shutil.which("powershell") is not None:
             return "powershell"
         else:
-            raise ValueError(f"Powershell or pwsh is not installed. Please install one of them.")
+            raise ValueError("Powershell or pwsh is not installed. Please install one of them.")
     else:
         raise ValueError(f"Unsupported language: {lang}")
 


### PR DESCRIPTION
Introduce `MessageStore` abstract base class for storing message thread in teams and `MemoryMessageStore` a memory (thread-safe) memory implementation of the abstract class that uses a timestamp-based _time to live_ (_TTL_) to handle message expiration.

To Do to complete this PR:
- [ ] Include such changes in all the group chat teams
- [ ] Add tests for the added classes

## Why are these changes needed?

Define correctly and rigorously how messages should be stored and handled in teams.

## Related issue number

Closes #6227 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
