### PR TITLE
Fix ValueError: Dataclass has a union type error

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/llamaindex-agent.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/llamaindex-agent.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from dataclasses import dataclass\n",
+    "from pydantic import BaseModel\n",
     "from typing import List, Optional\n",
     "\n",
     "from autogen_core import AgentId, MessageContext, RoutedAgent, SingleThreadedAgentRuntime, message_handler\n",
@@ -73,15 +73,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@dataclass\n",
-    "class Resource:\n",
+    "class Resource(BaseModel):\n",
     "    content: str\n",
     "    node_id: str\n",
     "    score: Optional[float] = None\n",
     "\n",
     "\n",
-    "@dataclass\n",
-    "class Message:\n",
+    "class Message(BaseModel):\n",
     "    content: str\n",
     "    sources: Optional[List[Resource]] = None"
    ]


### PR DESCRIPTION
Closes #6265

Convert the `Message` and `Resource` dataclasses to Pydantic models in the `llamaindex-agent` cookbook.

* Replace `dataclass` with `BaseModel` for `Message` and `Resource` classes.
* Update imports to use `BaseModel` from `pydantic`