### PR TITLE
Expose TCM TypedDict classes for apps to use

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/__init__.py
@@ -1,3 +1,4 @@
-from .memory_controller import MemoryController
+from .memory_controller import MemoryController, MemoryControllerConfig
+from ._memory_bank import MemoryBankConfig
 
-__all__ = ["MemoryController"]
+__all__ = ["MemoryController", "MemoryControllerConfig", "MemoryBankConfig"]

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/__init__.py
@@ -1,7 +1,7 @@
-from .apprentice import Apprentice
+from .apprentice import Apprentice, ApprenticeConfig
 from .chat_completion_client_recorder import ChatCompletionClientRecorder
 from .grader import Grader
-from .page_logger import PageLogger
+from .page_logger import PageLogger, PageLoggerConfig
 from .teachability import Teachability
 
-__all__ = ["Apprentice", "ChatCompletionClientRecorder", "Grader", "PageLogger", "Teachability"]
+__all__ = ["Apprentice", "ChatCompletionClientRecorder", "Grader", "PageLogger", "Teachability", "ApprenticeConfig", "PageLoggerConfig"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

An app can pass untyped dicts to set configuration options of various Task-Centric Memory classes. But tools like pyright can complain about the loose typing. This PR exposes 4 TypedDict classes that apps can optionally use.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
