### PR TITLE
Display message type in Console output

### DIFF
--- a/dotnet/src/AutoGen.Core/Extension/MessageExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/MessageExtension.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// MessageExtension.cs
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,17 +11,18 @@ public static class MessageExtension
 
     public static string FormatMessage(this IMessage message)
     {
+        var messageType = message.GetMessageType();
         return message switch
         {
 #pragma warning disable CS0618 // deprecated
-            Message msg => msg.FormatMessage(),
+            Message msg => $"{messageType} {msg.FormatMessage()}",
 #pragma warning restore CS0618 // deprecated
-            TextMessage textMessage => textMessage.FormatMessage(),
-            ImageMessage imageMessage => imageMessage.FormatMessage(),
-            ToolCallMessage toolCallMessage => toolCallMessage.FormatMessage(),
-            ToolCallResultMessage toolCallResultMessage => toolCallResultMessage.FormatMessage(),
-            AggregateMessage<ToolCallMessage, ToolCallResultMessage> aggregateMessage => aggregateMessage.FormatMessage(),
-            _ => message.ToString(),
+            TextMessage textMessage => $"{messageType} {textMessage.FormatMessage()}",
+            ImageMessage imageMessage => $"{messageType} {imageMessage.FormatMessage()}",
+            ToolCallMessage toolCallMessage => $"{messageType} {toolCallMessage.FormatMessage()}",
+            ToolCallResultMessage toolCallResultMessage => $"{messageType} {toolCallResultMessage.FormatMessage()}",
+            AggregateMessage<ToolCallMessage, ToolCallResultMessage> aggregateMessage => $"{messageType} {aggregateMessage.FormatMessage()}",
+            _ => $"{messageType} {message.ToString()}",
         } ?? string.Empty;
     }
 
@@ -218,6 +216,22 @@ public static class MessageExtension
 #pragma warning restore CS0618 // deprecated
             AggregateMessage<ToolCallMessage, ToolCallResultMessage> aggregateMessage => aggregateMessage.Message1.ToolCalls,
             _ => null,
+        };
+    }
+
+    public static string GetMessageType(this IMessage message)
+    {
+        return message switch
+        {
+#pragma warning disable CS0618 // deprecated
+            Message => "Message",
+#pragma warning restore CS0618 // deprecated
+            TextMessage => "TextMessage",
+            ImageMessage => "ImageMessage",
+            ToolCallMessage => "ToolCallMessage",
+            ToolCallResultMessage => "ToolCallResultMessage",
+            AggregateMessage<ToolCallMessage, ToolCallResultMessage> => "AggregateMessage",
+            _ => "UnknownMessageType",
         };
     }
 }

--- a/dotnet/src/AutoGen.Core/Middleware/PrintMessageMiddleware.cs
+++ b/dotnet/src/AutoGen.Core/Middleware/PrintMessageMiddleware.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// PrintMessageMiddleware.cs
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -9,9 +6,6 @@ using System.Threading.Tasks;
 
 namespace AutoGen.Core;
 
-/// <summary>
-/// The middleware that prints the reply from agent to the console.
-/// </summary>
 public class PrintMessageMiddleware : IStreamingMiddleware
 {
     public string? Name => nameof(PrintMessageMiddleware);
@@ -57,7 +51,6 @@ public class PrintMessageMiddleware : IStreamingMiddleware
             {
                 if (recentUpdate is null)
                 {
-                    // Print from: xxx
                     Console.WriteLine($"from: {textMessageUpdate.From}");
                     recentUpdate = new TextMessage(textMessageUpdate);
                     Console.Write(textMessageUpdate.Content);
@@ -66,7 +59,6 @@ public class PrintMessageMiddleware : IStreamingMiddleware
                 }
                 else if (recentUpdate is TextMessage recentTextMessage)
                 {
-                    // Print the content of the message
                     Console.Write(textMessageUpdate.Content);
                     recentTextMessage.Update(textMessageUpdate);
 

--- a/dotnet/src/Microsoft.AutoGen/Agents/IOAgent/ConsoleAgent/IHandleConsole.cs
+++ b/dotnet/src/Microsoft.AutoGen/Agents/IOAgent/ConsoleAgent/IHandleConsole.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// IHandleConsole.cs
 using Microsoft.AutoGen.Contracts;
 
 namespace Microsoft.AutoGen.Agents;
@@ -30,7 +28,10 @@ public interface IHandleConsole : IHandle<Output>, IHandle<Input>, IProcessIO
     async ValueTask IHandle<Output>.HandleAsync(Output item, MessageContext messageContext)
     {
         // Assuming item has a property `Message` that we want to write to the console
+        var messageType = item.GetType().Name;
+        Console.WriteLine($"--------- {messageType} -----------");
         Console.WriteLine(item.Message);
+        Console.WriteLine($"--------- End of {messageType} -----------");
         await ProcessOutputAsync(item.Message);
 
         var evt = new OutputWritten
@@ -52,7 +53,10 @@ public interface IHandleConsole : IHandle<Output>, IHandle<Input>, IProcessIO
         Console.WriteLine("Please enter input:");
         string content = Console.ReadLine() ?? string.Empty;
 
+        var messageType = item.GetType().Name;
+        Console.WriteLine($"--------- {messageType} -----------");
         await ProcessInputAsync(content);
+        Console.WriteLine($"--------- End of {messageType} -----------");
 
         var evt = new InputProcessed
         {


### PR DESCRIPTION
Fixes #6270

Update the `Console` output to display the type of messages.

* Modify `dotnet/src/AutoGen.Core/Extension/MessageExtension.cs` to include the message type in the output for each message type and add a new method `GetMessageType` to return the type of message.
* Update `dotnet/src/AutoGen.Core/Middleware/PrintMessageMiddleware.cs` to include the message type in the console output.
* Modify `dotnet/src/Microsoft.AutoGen/Agents/IOAgent/ConsoleAgent/IHandleConsole.cs` to include the message type in the console output for both `Output` and `Input` handling.

