### PR TITLE
Add get thread method to BaseGroupChat

### DIFF
--- a/dotnet/src/Microsoft.AutoGen/AgentChat/GroupChat/GroupChatBase.cs
+++ b/dotnet/src/Microsoft.AutoGen/AgentChat/GroupChat/GroupChatBase.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// GroupChatBase.cs
-
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -346,5 +343,15 @@ public abstract class GroupChatBase<TManager> : ITeam where TManager : GroupChat
 
             await this.Runtime!.StopAsync();
         }
+    }
+
+    public async ValueTask<List<AgentMessage>> GetCurrentThread(CancellationToken cancellationToken = default)
+    {
+        GroupChatGetThread getThreadMessage = new GroupChatGetThread();
+
+        AgentId chatManagerId = new AgentId(GroupChatManagerTopicType, this.TeamId);
+        GroupChatThreadResponse response = await this.Runtime!.SendMessageAsync<GroupChatThreadResponse>(getThreadMessage, chatManagerId, cancellationToken: cancellationToken);
+
+        return response.Messages;
     }
 }

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -17,6 +17,7 @@ from ._events import (
     GroupChatStart,
     GroupChatTermination,
     SerializableException,
+    GroupChatGetThread,  # P75dd
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
 
@@ -249,6 +250,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
     async def handle_resume(self, message: GroupChatResume, ctx: MessageContext) -> None:
         """Resume the group chat manager. This is a no-op in the base class."""
         pass
+
+    @rpc  # P9fce
+    async def handle_get_thread(self, message: GroupChatGetThread, ctx: MessageContext) -> List[BaseAgentEvent | BaseChatMessage]:  # P9fce
+        """Handle a request to get the current message thread."""  # P9fce
+        return self._message_thread  # P9fce
 
     @abstractmethod
     async def validate_group_state(self, messages: List[BaseChatMessage] | None) -> None:


### PR DESCRIPTION
Fixes #6085

Add a public method to retrieve the current message thread in `BaseGroupChat` and handle the new RPC event type in `BaseGroupChatManager`.

* **BaseGroupChat**:
  - Add a new public method `GetCurrentThread` to retrieve the current message thread.
  - Use an async `send_message` to the group chat manager agent to get the current thread.

* **BaseGroupChatManager**:
  - Introduce a new `GroupChatGetThread` RPC event type.
  - Handle the `GroupChatGetThread` event to return the current message thread.

