### PR TITLE
Add missing C# and F# kernels

### DIFF
--- a/dotnet/src/AutoGen.DotnetInteractive/DotnetInteractiveKernelBuilder.cs
+++ b/dotnet/src/AutoGen.DotnetInteractive/DotnetInteractiveKernelBuilder.cs
@@ -14,7 +14,9 @@ public static class DotnetInteractiveKernelBuilder
 
     public static InProccessDotnetInteractiveKernelBuilder CreateDefaultInProcessKernelBuilder()
     {
-        return new InProccessDotnetInteractiveKernelBuilder();
+        return new InProccessDotnetInteractiveKernelBuilder()
+            .AddCSharpKernel()
+            .AddFSharpKernel();
     }
 #endif
 


### PR DESCRIPTION
Add missing C# and F# kernels.
These are needed to create a default kernel else it will return an empty kernel.
