### PR TITLE
Fix/mcp tool adapter connects to the mcp server in a stateless mode

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/__init__.py
@@ -1,5 +1,6 @@
 from ._config import McpServerParams, SseServerParams, StdioServerParams
 from ._factory import mcp_server_tools
+from ._session import McpSessionActor
 from ._sse import SseMcpToolAdapter
 from ._stdio import StdioMcpToolAdapter
 
@@ -10,4 +11,5 @@ __all__ = [
     "SseServerParams",
     "McpServerParams",
     "mcp_server_tools",
+    "McpSessionActor",
 ]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -65,9 +65,7 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
         try:
             if cancellation_token.is_cancelled():
                 raise Exception("Operation cancelled")
-            print("BBBBB0")
             result_future = await self.actor.call(name=self._tool.name, kwargs=kwargs)
-            print("BBBBB1")
             cancellation_token.link_future(result_future)
             result = await result_future
 
@@ -120,3 +118,7 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
         else:
             error_message += f"{str(error)}\n"
         return error_message
+
+    async def close(self) -> None:
+        """Close the adapter and release resources."""
+        await self.actor.close()

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_factory.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_factory.py
@@ -1,5 +1,5 @@
 from ._config import McpServerParams, SseServerParams, StdioServerParams
-from ._session import create_mcp_server_session
+from ._session import McpSessionActor, create_mcp_server_session
 from ._sse import SseMcpToolAdapter
 from ._stdio import StdioMcpToolAdapter
 
@@ -136,7 +136,11 @@ async def mcp_server_tools(
         tools = await session.list_tools()
 
     if isinstance(server_params, StdioServerParams):
-        return [StdioMcpToolAdapter(server_params=server_params, tool=tool) for tool in tools.tools]
+        actor = McpSessionActor(server_params)
+        await actor.initialize()
+        return [StdioMcpToolAdapter(actor=actor, tool=tool) for tool in tools.tools]
     elif isinstance(server_params, SseServerParams):
-        return [SseMcpToolAdapter(server_params=server_params, tool=tool) for tool in tools.tools]
+        actor = McpSessionActor(server_params)
+        await actor.initialize()
+        return [SseMcpToolAdapter(actor=actor, tool=tool) for tool in tools.tools]
     raise ValueError(f"Unsupported server params type: {type(server_params)}")

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_session.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_session.py
@@ -69,11 +69,8 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionConfig]):
         if self._actor_task and self._actor_task.done():
             raise RuntimeError("MCP actor task crashed", self._actor_task.exception())
         fut: asyncio.Future[Any] = asyncio.Future()
-        print("CCCCC1")
         await self._command_queue.put({"type": "call", "name": name, "args": kwargs, "future": fut})
-        print("CCCCC2")
         res = await fut
-        print("CCCCC3")
         return res
 
     async def close(self) -> None:
@@ -88,9 +85,7 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionConfig]):
     async def _run_actor(self) -> None:
         try:
             async with create_mcp_server_session(self.server_params) as session:
-                print("[MCP] session created")
                 await session.initialize()
-                print("[MCP] session initialized")
                 while True:
                     cmd = await self._command_queue.get()
                     if cmd["type"] == "shutdown":

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_session.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_session.py
@@ -1,10 +1,15 @@
+import asyncio
+import atexit
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator, Dict
 
+from autogen_core import Component, ComponentBase
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
+from pydantic import BaseModel, ConfigDict, PrivateAttr
+from typing_extensions import Self
 
 from ._config import McpServerParams, SseServerParams, StdioServerParams
 
@@ -26,3 +31,110 @@ async def create_mcp_server_session(
         async with sse_client(**server_params.model_dump()) as (read, write):
             async with ClientSession(read_stream=read, write_stream=write) as session:
                 yield session
+
+
+class McpSessionConfig(BaseModel):
+    server_params: McpServerParams
+
+
+class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionConfig]):
+    component_type = "mcp_session_actor"
+    component_config_schema = McpSessionConfig
+    component_provider_override = "autogen_ext.tools.mcp.McpSessionActor"
+
+    server_params: McpServerParams
+    _actor: Any = PrivateAttr(default=None)
+    # actor: Any = PrivateAttr(default=None)
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def __init__(self, server_params: McpServerParams) -> None:
+        self.server_params: McpServerParams = server_params
+        self.name = "mcp_session_actor"
+        self.description = "MCP session actor"
+        self._command_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        self._actor_task: asyncio.Task[Any] | None = None
+        self._shutdown_future: asyncio.Future[Any] | None = None
+        self._active = False
+        atexit.register(self._sync_shutdown)
+
+    async def initialize(self) -> None:
+        if not self._active:
+            self._active = True
+            self._actor_task = asyncio.create_task(self._run_actor())
+
+    async def call(self, name: str, kwargs: Dict[str, Any]) -> Any:
+        if not self._active:
+            raise RuntimeError("MCP Actor not running, call initialize() first")
+        if self._actor_task and self._actor_task.done():
+            raise RuntimeError("MCP actor task crashed", self._actor_task.exception())
+        fut: asyncio.Future[Any] = asyncio.Future()
+        print("CCCCC1")
+        await self._command_queue.put({"type": "call", "name": name, "args": kwargs, "future": fut})
+        print("CCCCC2")
+        res = await fut
+        print("CCCCC3")
+        return res
+
+    async def close(self) -> None:
+        if not self._active or self._actor_task is None:
+            return
+        self._shutdown_future = asyncio.Future()
+        await self._command_queue.put({"type": "shutdown", "future": self._shutdown_future})
+        await self._shutdown_future
+        await self._actor_task
+        self._active = False
+
+    async def _run_actor(self) -> None:
+        try:
+            async with create_mcp_server_session(self.server_params) as session:
+                print("[MCP] session created")
+                await session.initialize()
+                print("[MCP] session initialized")
+                while True:
+                    cmd = await self._command_queue.get()
+                    if cmd["type"] == "shutdown":
+                        cmd["future"].set_result("ok")
+                        break
+                    elif cmd["type"] == "call":
+                        try:
+                            result = session.call_tool(name=cmd["name"], arguments=cmd["args"])
+                            cmd["future"].set_result(result)
+                        except Exception as e:
+                            cmd["future"].set_exception(e)
+        except Exception as e:
+            if self._shutdown_future and not self._shutdown_future.done():
+                self._shutdown_future.set_exception(e)
+
+    def _sync_shutdown(self) -> None:
+        # Attempt to close the actor synchronously
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                loop.create_task(self.close())
+            else:
+                loop.run_until_complete(self.close())
+        except Exception:
+            pass
+
+    def _to_config(self) -> McpSessionConfig:
+        """
+        Convert the adapter to its configuration representation.
+
+        Returns:
+            McpSessionConfig: The configuration of the adapter.
+        """
+        return McpSessionConfig(server_params=self.server_params)
+
+    @classmethod
+    def _from_config(cls, config: McpSessionConfig) -> Self:
+        """
+        Create an instance of McpSessionActor from its configuration.
+
+        Args:
+            config (McpSessionConfig): The configuration of the adapter.
+
+        Returns:
+            McpSessionActor: An instance of SseMcpToolAdapter.
+        """
+        return cls(server_params=config.server_params)

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_sse.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_sse.py
@@ -1,16 +1,17 @@
-from autogen_core import Component
+from autogen_core import Component, ComponentModel
 from mcp import Tool
 from pydantic import BaseModel
 from typing_extensions import Self
 
 from ._base import McpToolAdapter
 from ._config import SseServerParams
+from ._session import McpSessionActor
 
 
 class SseMcpToolAdapterConfig(BaseModel):
     """Configuration for the MCP tool adapter."""
 
-    server_params: SseServerParams
+    actor: ComponentModel
     tool: Tool
 
 
@@ -86,8 +87,8 @@ class SseMcpToolAdapter(
     component_config_schema = SseMcpToolAdapterConfig
     component_provider_override = "autogen_ext.tools.mcp.SseMcpToolAdapter"
 
-    def __init__(self, server_params: SseServerParams, tool: Tool) -> None:
-        super().__init__(server_params=server_params, tool=tool)
+    def __init__(self, actor: McpSessionActor, tool: Tool) -> None:
+        super().__init__(actor=actor, tool=tool)
 
     def _to_config(self) -> SseMcpToolAdapterConfig:
         """
@@ -96,7 +97,7 @@ class SseMcpToolAdapter(
         Returns:
             SseMcpToolAdapterConfig: The configuration of the adapter.
         """
-        return SseMcpToolAdapterConfig(server_params=self._server_params, tool=self._tool)
+        return SseMcpToolAdapterConfig(actor=self.actor.dump_component(), tool=self._tool)
 
     @classmethod
     def _from_config(cls, config: SseMcpToolAdapterConfig) -> Self:
@@ -109,4 +110,4 @@ class SseMcpToolAdapter(
         Returns:
             SseMcpToolAdapter: An instance of SseMcpToolAdapter.
         """
-        return cls(server_params=config.server_params, tool=config.tool)
+        return cls(actor=McpSessionActor.load_component(config.actor), tool=config.tool)

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_stdio.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_stdio.py
@@ -1,16 +1,17 @@
-from autogen_core import Component
+from autogen_core import Component, ComponentModel
 from mcp import Tool
 from pydantic import BaseModel
 from typing_extensions import Self
 
 from ._base import McpToolAdapter
 from ._config import StdioServerParams
+from ._session import McpSessionActor
 
 
 class StdioMcpToolAdapterConfig(BaseModel):
     """Configuration for the MCP tool adapter."""
 
-    server_params: StdioServerParams
+    actor: ComponentModel
     tool: Tool
 
 
@@ -44,8 +45,8 @@ class StdioMcpToolAdapter(
     component_config_schema = StdioMcpToolAdapterConfig
     component_provider_override = "autogen_ext.tools.mcp.StdioMcpToolAdapter"
 
-    def __init__(self, server_params: StdioServerParams, tool: Tool) -> None:
-        super().__init__(server_params=server_params, tool=tool)
+    def __init__(self, actor: McpSessionActor, tool: Tool) -> None:
+        super().__init__(actor=actor, tool=tool)
 
     def _to_config(self) -> StdioMcpToolAdapterConfig:
         """
@@ -54,7 +55,7 @@ class StdioMcpToolAdapter(
         Returns:
             StdioMcpToolAdapterConfig: The configuration of the adapter.
         """
-        return StdioMcpToolAdapterConfig(server_params=self._server_params, tool=self._tool)
+        return StdioMcpToolAdapterConfig(actor=self.actor.dump_component(), tool=self._tool)
 
     @classmethod
     def _from_config(cls, config: StdioMcpToolAdapterConfig) -> Self:
@@ -67,4 +68,4 @@ class StdioMcpToolAdapter(
         Returns:
             StdioMcpToolAdapter: An instance of StdioMcpToolAdapter.
         """
-        return cls(server_params=config.server_params, tool=config.tool)
+        return cls(actor=McpSessionActor.load_component(config.actor), tool=config.tool)

--- a/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
@@ -121,12 +121,12 @@ async def test_mcp_tool_execution(
 ) -> None:
     """Test that adapter properly executes tools through ClientSession."""
     @asynccontextmanager
-    async def fake_create_session(*args, **kwargs):
+    async def fake_create_session(*args, **kwargs):  # type: ignore
         yield mock_session
 
     monkeypatch.setattr(
         "autogen_ext.tools.mcp._session.create_mcp_server_session",
-        fake_create_session,
+        fake_create_session,  # type: ignore
     )
 
     mock_session.call_tool.return_value = mock_tool_response
@@ -163,7 +163,7 @@ async def test_adapter_from_server_params(
         lambda *args, **kwargs: mock_context,  # type: ignore
     )
     @asynccontextmanager
-    async def fake_create_session(*args, **kwargs):
+    async def fake_create_session(*args, **kwargs):  # type: ignore
         try:
             yield mock_session
         finally:
@@ -172,7 +172,7 @@ async def test_adapter_from_server_params(
 
     monkeypatch.setattr(
         "autogen_ext.tools.mcp._session.create_mcp_server_session",
-        fake_create_session,
+        fake_create_session,  # type: ignore
     )
 
     mock_session.list_tools.return_value.tools = [sample_tool]
@@ -246,12 +246,12 @@ async def test_sse_tool_execution(
     mock_sse_session.call_tool.return_value = mock_result
 
     @asynccontextmanager
-    async def fake_create_session(*args, **kwargs):
+    async def fake_create_session(*args, **kwargs):  # type: ignore
         yield mock_sse_session
 
     monkeypatch.setattr(
         "autogen_ext.tools.mcp._session.create_mcp_server_session",
-        fake_create_session,
+        fake_create_session,  # type: ignore
     )
 
     with caplog.at_level(logging.INFO):
@@ -291,12 +291,12 @@ async def test_sse_adapter_from_server_params(
     )
 
     @asynccontextmanager
-    async def fake_create_session(*args, **kwargs):
+    async def fake_create_session(*args, **kwargs):  # type: ignore
         yield mock_sse_session
 
     monkeypatch.setattr(
         "autogen_ext.tools.mcp._session.create_mcp_server_session",
-        fake_create_session,
+        fake_create_session,  # type: ignore
     )
 
     adapter = await SseMcpToolAdapter.from_server_params(params, "test_sse_tool")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR introduces a reusable, event-driven McpSessionActor component for AutoGen’s MCP tool adapters.
Previously, each tool instance created its own isolated ClientSession, making it difficult to share a single session context across tools. This change solves that by:
 - Introducing a McpSessionActor that manages a single session via an async task with a queue.
 - Allowing safe concurrent usage of the same session by multiple tools.
 - Supporting serialization/deserialization of the session actor for config-based workflows.
 - Ensuring graceful shutdown of the session, even in atexit or test teardown scenarios.

This addresses hanging issues during test teardown and resolves RuntimeError: Attempted to exit cancel scope in a different task errors in anyio.

## Related issue number

Closes #6198

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
