### PR TITLE
feat: add emit_team_events to BaseGroupChatManager to expose internal events via run_stream

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/messages.py
@@ -347,6 +347,22 @@ class ThoughtEvent(BaseAgentEvent):
         return self.content
 
 
+"""adding SelectSpeakerEvent"""
+
+
+class SelectSpeakerEvent(BaseAgentEvent):
+    """An event signaling the selection of a speaker"""
+
+    content: str
+
+    """The selected speaker's name."""
+
+    type: Literal["SelectSpeakerEvent"] = "SelectSpeakerEvent"
+
+    def to_text(self) -> str:
+        return self.content
+
+
 class MessageFactory:
     """:meta private:
 
@@ -369,6 +385,7 @@ class MessageFactory:
         self._message_types[UserInputRequestedEvent.__name__] = UserInputRequestedEvent
         self._message_types[ModelClientStreamingChunkEvent.__name__] = ModelClientStreamingChunkEvent
         self._message_types[ThoughtEvent.__name__] = ThoughtEvent
+        self._message_types[SelectSpeakerEvent.__name__] = SelectSpeakerEvent
 
     def is_registered(self, message_type: type[BaseAgentEvent | BaseChatMessage]) -> bool:
         """Check if a message type is registered with the factory."""
@@ -420,7 +437,8 @@ AgentEvent = Annotated[
     | MemoryQueryEvent
     | UserInputRequestedEvent
     | ModelClientStreamingChunkEvent
-    | ThoughtEvent,
+    | ThoughtEvent
+    | SelectSpeakerEvent,
     Field(discriminator="type"),
 ]
 """The union type of all built-in concrete subclasses of :class:`BaseAgentEvent`."""

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_magentic_one/_magentic_one_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_magentic_one/_magentic_one_group_chat.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Callable, List
+from typing import Callable, List, Union
 
 from autogen_core import AgentRuntime, Component, ComponentModel
 from autogen_core.models import ChatCompletionClient
@@ -128,10 +128,11 @@ class MagenticOneGroupChat(BaseGroupChat, Component[MagenticOneGroupChatConfig])
         participant_topic_types: List[str],
         participant_names: List[str],
         participant_descriptions: List[str],
-        output_message_queue: asyncio.Queue[BaseAgentEvent | BaseChatMessage | GroupChatTermination],
+        output_message_queue: asyncio.Queue[Union[BaseAgentEvent, BaseChatMessage, GroupChatTermination]],
         termination_condition: TerminationCondition | None,
         max_turns: int | None,
         message_factory: MessageFactory,
+        speaker_name: str | None = None,
     ) -> Callable[[], MagenticOneOrchestrator]:
         return lambda: MagenticOneOrchestrator(
             name,

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_round_robin_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_round_robin_group_chat.py
@@ -1,12 +1,12 @@
 import asyncio
-from typing import Any, Callable, List, Mapping
+from typing import Any, Callable, List, Mapping, Union
 
 from autogen_core import AgentRuntime, Component, ComponentModel
 from pydantic import BaseModel
 from typing_extensions import Self
 
 from ...base import ChatAgent, TerminationCondition
-from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory
+from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory, SelectSpeakerEvent
 from ...state import RoundRobinManagerState
 from ._base_group_chat import BaseGroupChat
 from ._base_group_chat_manager import BaseGroupChatManager
@@ -24,10 +24,13 @@ class RoundRobinGroupChatManager(BaseGroupChatManager):
         participant_topic_types: List[str],
         participant_names: List[str],
         participant_descriptions: List[str],
-        output_message_queue: asyncio.Queue[BaseAgentEvent | BaseChatMessage | GroupChatTermination],
+        output_message_queue: asyncio.Queue[
+            Union[BaseAgentEvent, BaseChatMessage, GroupChatTermination, SelectSpeakerEvent]
+        ],
         termination_condition: TerminationCondition | None,
         max_turns: int | None,
         message_factory: MessageFactory,
+        speaker_name: str | None = None,
     ) -> None:
         super().__init__(
             name,
@@ -40,6 +43,7 @@ class RoundRobinGroupChatManager(BaseGroupChatManager):
             termination_condition,
             max_turns,
             message_factory,
+            speaker_name=speaker_name,
         )
         self._next_speaker_index = 0
 
@@ -186,10 +190,13 @@ class RoundRobinGroupChat(BaseGroupChat, Component[RoundRobinGroupChatConfig]):
         participant_topic_types: List[str],
         participant_names: List[str],
         participant_descriptions: List[str],
-        output_message_queue: asyncio.Queue[BaseAgentEvent | BaseChatMessage | GroupChatTermination],
+        output_message_queue: asyncio.Queue[
+            Union[BaseAgentEvent, BaseChatMessage, GroupChatTermination, SelectSpeakerEvent]
+        ],
         termination_condition: TerminationCondition | None,
         max_turns: int | None,
         message_factory: MessageFactory,
+        speaker_name: str | None = None,
     ) -> Callable[[], RoundRobinGroupChatManager]:
         def _factory() -> RoundRobinGroupChatManager:
             return RoundRobinGroupChatManager(
@@ -203,6 +210,7 @@ class RoundRobinGroupChat(BaseGroupChat, Component[RoundRobinGroupChatConfig]):
                 termination_condition,
                 max_turns,
                 message_factory,
+                speaker_name=speaker_name,
             )
 
         return _factory

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -16,6 +16,7 @@ from ...messages import (
     BaseAgentEvent,
     BaseChatMessage,
     MessageFactory,
+    SelectSpeakerEvent,
 )
 from ...state import SelectorManagerState
 from ._base_group_chat import BaseGroupChat
@@ -45,7 +46,9 @@ class SelectorGroupChatManager(BaseGroupChatManager):
         participant_topic_types: List[str],
         participant_names: List[str],
         participant_descriptions: List[str],
-        output_message_queue: asyncio.Queue[BaseAgentEvent | BaseChatMessage | GroupChatTermination],
+        output_message_queue: asyncio.Queue[
+            Union[BaseAgentEvent, BaseChatMessage, GroupChatTermination, SelectSpeakerEvent]
+        ],
         termination_condition: TerminationCondition | None,
         max_turns: int | None,
         message_factory: MessageFactory,
@@ -55,6 +58,7 @@ class SelectorGroupChatManager(BaseGroupChatManager):
         selector_func: Optional[SelectorFuncType],
         max_selector_attempts: int,
         candidate_func: Optional[CandidateFuncType],
+        speaker_name: str | None = None,
     ) -> None:
         super().__init__(
             name,
@@ -67,6 +71,7 @@ class SelectorGroupChatManager(BaseGroupChatManager):
             termination_condition,
             max_turns,
             message_factory,
+            speaker_name=speaker_name,
         )
         self._model_client = model_client
         self._selector_prompt = selector_prompt
@@ -481,7 +486,8 @@ Read the above conversation. Then select the next role from {participants} to pl
         termination_condition: TerminationCondition | None,
         max_turns: int | None,
         message_factory: MessageFactory,
-    ) -> Callable[[], BaseGroupChatManager]:
+        speaker_name: str | None = None,
+    ) -> Callable[[], SelectorGroupChatManager]:
         return lambda: SelectorGroupChatManager(
             name,
             group_topic_type,
@@ -499,6 +505,7 @@ Read the above conversation. Then select the next role from {participants} to pl
             self._selector_func,
             self._max_selector_attempts,
             self._candidate_func,
+            speaker_name=speaker_name,
         )
 
     def _to_config(self) -> SelectorGroupChatConfig:

--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/llamaindex-agent.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/cookbook/llamaindex-agent.ipynb
@@ -38,7 +38,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from pydantic import BaseModel\n",
     "from typing import List, Optional\n",
     "\n",
     "from autogen_core import AgentId, MessageContext, RoutedAgent, SingleThreadedAgentRuntime, message_handler\n",
@@ -57,7 +56,8 @@
     "from llama_index.embeddings.openai import OpenAIEmbedding\n",
     "from llama_index.llms.azure_openai import AzureOpenAI\n",
     "from llama_index.llms.openai import OpenAI\n",
-    "from llama_index.tools.wikipedia import WikipediaToolSpec"
+    "from llama_index.tools.wikipedia import WikipediaToolSpec\n",
+    "from pydantic import BaseModel"
    ]
   },
   {

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/__init__.py
@@ -1,4 +1,4 @@
-from .memory_controller import MemoryController, MemoryControllerConfig
 from ._memory_bank import MemoryBankConfig
+from .memory_controller import MemoryController, MemoryControllerConfig
 
 __all__ = ["MemoryController", "MemoryControllerConfig", "MemoryBankConfig"]


### PR DESCRIPTION
**Closes #6161 

##** Summary

This PR introduces a new optional parameter `emit_team_events` to `BaseGroupChatManager` (and its subclass `MagenticOneOrchestrator`), enabling internal coordination events like `SelectSpeakerEvent` to be emitted as part of the `run_stream()` output.

This is useful for external consumers (e.g. UIs or logs) to capture progress-related events, such as speaker selection decisions, in real-time.

## Changes

- Added `emit_team_events: bool = False` parameter to `BaseGroupChatManager` and `MagenticOneOrchestrator`
- Emitted `SelectSpeakerEvent` through `GroupChatMessage` when `emit_team_events=True`
- Ensured that published `GroupChatMessage` is sent both to the topic and the `output_message_queue`
- Updated instantiation site in `MagenticOneOrchestrator` to allow proper type propagation for the queue
- Made emission conditional using the new flag to preserve default behavior

## Why this is needed

In `AutoGen 0.2.x`, internal orchestrator events (like ledger status and speaker selection) were surfaced during execution. In 0.4.x, these are hidden unless explicitly captured. This feature brings back that visibility via `run_stream`, which helps explain the team’s reasoning, decision-making, and progress to end users.

## Example Usage

```python
team = MagenticOneGroupChat(
    participants=agents,
    model_client=client,
    emit_team_events=True,
    ...
)

async for log_entry in team.run_stream(task=task):
    display_log_message(log_entry=log_entry)