### PR TITLE
Pin opentelemetry-proto version

### DIFF
--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -149,6 +149,7 @@ dev = [
     "langchain-experimental",
     "pandas-stubs>=2.2.3.241126",
     "httpx>=0.28.1",
+    "opentelemetry-proto>=1.28.0"
 ]
 
 [tool.ruff]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -717,6 +717,7 @@ dev = [
     { name = "autogen-test-utils" },
     { name = "httpx" },
     { name = "langchain-experimental" },
+    { name = "opentelemetry-proto" },
     { name = "pandas-stubs" },
 ]
 
@@ -786,6 +787,7 @@ dev = [
     { name = "autogen-test-utils", editable = "packages/autogen-test-utils" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "langchain-experimental" },
+    { name = "opentelemetry-proto", specifier = ">=1.28.0" },
     { name = "pandas-stubs", specifier = ">=2.2.3.241126" },
 ]
 


### PR DESCRIPTION
## Description
This PR pins opentelemetry-proto version to >=1.28.0, which uses protobuf > 5.0, < 6.0 to generate protobuf files.

## Related issue number
Closes #6304 
