### PR TITLE
Make sure thought content is included in handoff context

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -1111,6 +1111,14 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
                     )
                 )
                 handoff_context.append(FunctionExecutionResultMessage(content=tool_call_results))
+            elif model_result.thought:
+                # If no tool calls, but a thought exists, include it in the context
+                handoff_context.append(
+                    AssistantMessage(
+                        content=model_result.thought,
+                        source=agent_name,
+                    )
+                )
 
             # Return response for the first handoff
             return Response(


### PR DESCRIPTION
Resolves #6295

Ensure the thought content gets included in handoff message conetxt, when the only tool call was handoff tool call. 