### PR TITLE
fix: ollama fails when tools use optional args

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py
@@ -320,7 +320,7 @@ def convert_tools(
                 if prop_type is None and "anyOf" in prop_schema:
                     prop_type = next(
                         (opt.get("type") for opt in prop_schema["anyOf"] if opt.get("type") != "null"),
-                        None # Default to None if no non-null type found in anyOf
+                        None,  # Default to None if no non-null type found in anyOf
                     )
                 prop_type = prop_type or "string"
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py
@@ -315,8 +315,17 @@ def convert_tools(
         if parameters is not None:
             ollama_properties = {}
             for prop_name, prop_schema in parameters["properties"].items():
+                # Determine property type, checking "type" first, then "anyOf", defaulting to "string"
+                prop_type = prop_schema.get("type")
+                if prop_type is None and "anyOf" in prop_schema:
+                    prop_type = next(
+                        (opt.get("type") for opt in prop_schema["anyOf"] if opt.get("type") != "null"),
+                        None # Default to None if no non-null type found in anyOf
+                    )
+                prop_type = prop_type or "string"
+
                 ollama_properties[prop_name] = OllamaTool.Function.Parameters.Property(
-                    type=prop_schema["type"],
+                    type=prop_type,
                     description=prop_schema["description"] if "description" in prop_schema else None,
                 )
         result.append(


### PR DESCRIPTION
## Why are these changes needed?
`convert_tools` failed if Optional args were used in tools (the `type` field doesn't exist in that case and `anyOf` must be used).

This uses the `anyOf` field to pick the first non-null type to use.  

## Related issue number

Fixes #6323

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
