### PR TITLE
fix: ensure serialized messages are passed to LLMStreamStartEvent

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -766,6 +766,7 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
         stop_reason: Optional[str] = None
 
         first_chunk = True
+        serialized_messages: List[Dict[str, Any]] = [self._serialize_message(msg) for msg in anthropic_messages]
 
         # Process the stream
         async for chunk in stream:
@@ -774,7 +775,7 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
                 # Emit the start event.
                 logger.info(
                     LLMStreamStartEvent(
-                        messages=cast(List[Dict[str, Any]], anthropic_messages),
+                        messages=serialized_messages,
                     )
                 )
             # Handle different event types


### PR DESCRIPTION
## Why are these changes needed?


I was getting the following exception when doing tool calls with anthropic - the exception was coming form the `__str__` in `LLMStreamStartEvent`. 

```
('Object of type ToolUseBlock is not JSON serializable',)
```

The issue is that when creating the LLMStreamStartevent in the `create_stream`, the messages weren't being serialized first.
## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
