### PR TITLE
Generalize Continuous SystemMessage merging via model_info[“multiple_system_messages”] instead of `startswith("gemini-")`

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -525,9 +525,9 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         if self.model_info["json_output"] is False and json_output is True:
             raise ValueError("Model does not support JSON output.")
 
-        if create_args.get("model", "unknown").startswith("gemini-"):
-            # Gemini models accept only one system message(else, it will read only the last one)
-            # So, merge system messages into one
+        if not self.model_info.get("multiple_system_messages", False):
+            # Some models accept only one system message(or, it will read only the last one)
+            # So, merge system messages into one (if multiple and continuous)
             system_message_content = ""
             _messages: List[LLMMessage] = []
             _first_system_message_idx = -1
@@ -540,7 +540,9 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                     elif _last_system_message_idx + 1 != idx:
                         # That case, system message is not continuous
                         # Merge system messages only contiues system messages
-                        raise ValueError("Multiple and Not continuous system messages are not supported")
+                        raise ValueError(
+                            "Multiple and Not continuous system messages are not supported if model_info['multiple_system_messages'] is False"
+                        )
                     system_message_content += message.content + "\n"
                     _last_system_message_idx = idx
                 else:

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -2096,7 +2096,7 @@ async def test_muliple_system_message(model: str, openai_client: OpenAIChatCompl
 
 
 @pytest.mark.asyncio
-async def test_system_message_merge_for_gemini_models() -> None:
+async def test_system_message_merge_with_continuous_system_messages_models() -> None:
     """Tests that system messages are merged correctly for Gemini models."""
     # Create a mock client
     mock_client = MagicMock()
@@ -2109,6 +2109,7 @@ async def test_system_message_merge_for_gemini_models() -> None:
             "json_output": False,
             "family": "unknown",
             "structured_output": False,
+            "multiple_system_messages": False,
         },
     )
 
@@ -2157,6 +2158,7 @@ async def test_system_message_merge_with_non_continuous_messages() -> None:
             "json_output": False,
             "family": "unknown",
             "structured_output": False,
+            "multiple_system_messages": False,
         },
     )
 
@@ -2180,7 +2182,7 @@ async def test_system_message_merge_with_non_continuous_messages() -> None:
 
 
 @pytest.mark.asyncio
-async def test_system_message_not_merged_for_non_gemini_models() -> None:
+async def test_system_message_not_merged_for_multiple_system_messages_true() -> None:
     """Tests that system messages aren't modified for non-Gemini models."""
     # Create a mock client
     mock_client = MagicMock()
@@ -2193,6 +2195,7 @@ async def test_system_message_not_merged_for_non_gemini_models() -> None:
             "json_output": False,
             "family": "unknown",
             "structured_output": False,
+            "multiple_system_messages": True,
         },
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current implementation of consecutive `SystemMessage` merging applies only to models where `model_info.family` starts with `"gemini-"`.

Since PR #6327 introduced the `multiple_system_messages` field in `model_info`, we can now generalize this logic by checking whether the field is explicitly set to `False`.

This change replaces the hardcoded family check with a conditional that merges consecutive `SystemMessage` blocks whenever `multiple_system_messages` is set to `False`.

Test cases that previously depended on the `"gemini"` model family have been updated to reflect this configuration flag, and renamed accordingly for clarity.

In addition, for consistency across conditional logic, a follow-up PR is planned to refactor the Claude-specific transformation condition  
(currently implemented via `create_args.get("model", "unknown").startswith("claude-")`)  
to instead use the existing `is_claude()`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
