### PR TITLE
Update: override return_value_as_string for McpToolAdapter

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -7,6 +7,7 @@ from autogen_core import CancellationToken
 from autogen_core.tools import BaseTool
 from autogen_core.utils import schema_to_pydantic_model
 from mcp import ClientSession, Tool
+from mcp.types import EmbeddedResource, ImageContent, TextContent
 from pydantic import BaseModel
 
 from ._config import McpServerParams
@@ -114,6 +115,17 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
                 )
 
         return cls(server_params=server_params, tool=matching_tool)
+
+    def return_value_as_string(self, value: Any) -> str:
+        if isinstance(value, list):
+            valid_types = (TextContent, ImageContent, EmbeddedResource)
+            return list(
+                map(
+                    lambda t: (t.model_dump_json() if isinstance(t, valid_types) else str(t)),
+                    value,
+                )
+            )
+        return str(value)
 
     def _format_errors(self, error: Exception) -> str:
         """Recursively format errors into a string."""

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -129,6 +129,8 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
                 for key, val in item.resource.model_dump().items():
                     if isinstance(val, AnyUrl):
                         resource[key] = str(val)
+                    else:
+                        resource[key] = val
                 annotations = item.annotations.model_dump() if item.annotations else None
                 return {"type": type, "resource": resource, "annotations": annotations}
             else:

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -7,8 +7,9 @@ from autogen_core import CancellationToken
 from autogen_core.tools import BaseTool
 from autogen_core.utils import schema_to_pydantic_model
 from mcp import ClientSession, Tool
-from mcp.types import EmbeddedResource, ImageContent, TextContent
+from mcp.types import AnyUrl, EmbeddedResource, ImageContent, TextContent
 from pydantic import BaseModel
+import json
 
 from ._config import McpServerParams
 from ._session import create_mcp_server_session
@@ -116,16 +117,23 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
 
         return cls(server_params=server_params, tool=matching_tool)
 
-    def return_value_as_string(self, value: Any) -> str:
-        if isinstance(value, list):
-            valid_types = (TextContent, ImageContent, EmbeddedResource)
-            return list(
-                map(
-                    lambda t: (t.model_dump_json() if isinstance(t, valid_types) else str(t)),
-                    value,
-                )
-            )
-        return str(value)
+    def return_value_as_string(self, value: list) -> str:
+        """Return a string representation of the result."""
+
+        def serialize_item(item):
+            if isinstance(item, (TextContent, ImageContent)):
+                return item.model_dump()
+            elif isinstance(item, EmbeddedResource):
+                type = item.type
+                resource = {}
+                for key, val in item.resource.model_dump().items():
+                    if isinstance(val, AnyUrl):
+                        resource[key] = str(val)
+                annotations = item.annotations.model_dump() if item.annotations else None
+                return {"type": type, "resource": resource, "annotations": annotations}
+            else:
+                return str(item)
+        return json.dumps([serialize_item(item) for item in value])
 
     def _format_errors(self, error: Exception) -> str:
         """Recursively format errors into a string."""

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -135,6 +135,7 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
                 return {"type": type, "resource": resource, "annotations": annotations}
             else:
                 return str(item)
+
         return json.dumps([serialize_item(item) for item in value])
 
     def _format_errors(self, error: Exception) -> str:

--- a/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
@@ -15,7 +15,14 @@ from autogen_ext.tools.mcp import (
     mcp_server_tools,
 )
 from mcp import ClientSession, Tool
-from mcp.types import EmbeddedResource, ImageContent, TextContent, TextResourceContents
+from mcp.types import (
+    AnyUrl,
+    Annotations,
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+    TextResourceContents,
+)
 
 
 @pytest.fixture
@@ -201,29 +208,29 @@ async def test_adapter_from_server_params_with_return_value_as_string(
 
     adapter = await StdioMcpToolAdapter.from_server_params(sample_server_params, "test_tool")
 
-    assert (
-        adapter.return_value_as_string(
+    assert adapter.return_value_as_string(
             [
-                TextContent(text="this is a sample text", type="text"),
+                TextContent(
+                    text="this is a sample text",
+                    type="text",
+                    annotations=Annotations(audience=["user", "assistant"], priority=0.7),
+                ),
                 ImageContent(
                     data="this is a sample base64 encoded image",
                     mimeType="image/png",
                     type="image",
+                    annotations=None,
                 ),
                 EmbeddedResource(
                     type="resource",
                     resource=TextResourceContents(
                         text="this is a sample text",
-                        uri="http://example.com/test",
+                        uri=AnyUrl(url="http://example.com/test"),
                     ),
+                    annotations=Annotations(audience=["user"], priority=0.3),
                 ),
             ]
-        )
-    ) == [
-        '{"type":"text","text":"this is a sample text","annotations":null}',
-        '{"type":"image","data":"this is a sample base64 encoded image","mimeType":"image/png","annotations":null}',
-        '{"type":"resource","resource":{"uri":"http://example.com/test","mimeType":null,"text":"this is a sample text"},"annotations":null}',
-    ]
+    ) == '[{"type": "text", "text": "this is a sample text", "annotations": {"audience": ["user", "assistant"], "priority": 0.7}}, {"type": "image", "data": "this is a sample base64 encoded image", "mimeType": "image/png", "annotations": null}, {"type": "resource", "resource": {"uri": "http://example.com/test"}, "annotations": {"audience": ["user"], "priority": 0.3}}]'
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
@@ -230,7 +230,7 @@ async def test_adapter_from_server_params_with_return_value_as_string(
                     annotations=Annotations(audience=["user"], priority=0.3),
                 ),
             ]
-    ) == '[{"type": "text", "text": "this is a sample text", "annotations": {"audience": ["user", "assistant"], "priority": 0.7}}, {"type": "image", "data": "this is a sample base64 encoded image", "mimeType": "image/png", "annotations": null}, {"type": "resource", "resource": {"uri": "http://example.com/test"}, "annotations": {"audience": ["user"], "priority": 0.3}}]'
+    ) == '[{"type": "text", "text": "this is a sample text", "annotations": {"audience": ["user", "assistant"], "priority": 0.7}}, {"type": "image", "data": "this is a sample base64 encoded image", "mimeType": "image/png", "annotations": null}, {"type": "resource", "resource": {"uri": "http://example.com/test", "mimeType": null, "text": "this is a sample text"}, "annotations": {"audience": ["user"], "priority": 0.3}}]'
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
@@ -208,7 +208,8 @@ async def test_adapter_from_server_params_with_return_value_as_string(
 
     adapter = await StdioMcpToolAdapter.from_server_params(sample_server_params, "test_tool")
 
-    assert adapter.return_value_as_string(
+    assert (
+        adapter.return_value_as_string(
             [
                 TextContent(
                     text="this is a sample text",
@@ -230,7 +231,9 @@ async def test_adapter_from_server_params_with_return_value_as_string(
                     annotations=Annotations(audience=["user"], priority=0.3),
                 ),
             ]
-    ) == '[{"type": "text", "text": "this is a sample text", "annotations": {"audience": ["user", "assistant"], "priority": 0.7}}, {"type": "image", "data": "this is a sample base64 encoded image", "mimeType": "image/png", "annotations": null}, {"type": "resource", "resource": {"uri": "http://example.com/test", "mimeType": null, "text": "this is a sample text"}, "annotations": {"audience": ["user"], "priority": 0.3}}]'
+        )
+        == '[{"type": "text", "text": "this is a sample text", "annotations": {"audience": ["user", "assistant"], "priority": 0.7}}, {"type": "image", "data": "this is a sample base64 encoded image", "mimeType": "image/png", "annotations": null}, {"type": "resource", "resource": {"uri": "http://example.com/test", "mimeType": null, "text": "this is a sample text"}, "annotations": {"audience": ["user"], "priority": 0.3}}]'
+    )
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
@@ -15,6 +15,7 @@ from autogen_ext.tools.mcp import (
     mcp_server_tools,
 )
 from mcp import ClientSession, Tool
+from mcp.types import EmbeddedResource, ImageContent, TextContent, TextResourceContents
 
 
 @pytest.fixture
@@ -179,6 +180,50 @@ async def test_adapter_from_server_params(
     assert (
         params_schema["properties"]["test_param"]["type"] == sample_tool.inputSchema["properties"]["test_param"]["type"]
     )
+
+
+@pytest.mark.asyncio
+async def test_adapter_from_server_params_with_return_value_as_string(
+    sample_tool: Tool,
+    sample_server_params: StdioServerParams,
+    mock_session: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that adapter can be created from server parameters."""
+    mock_context = AsyncMock()
+    mock_context.__aenter__.return_value = mock_session
+    monkeypatch.setattr(
+        "autogen_ext.tools.mcp._base.create_mcp_server_session",
+        lambda *args, **kwargs: mock_context,  # type: ignore
+    )
+
+    mock_session.list_tools.return_value.tools = [sample_tool]
+
+    adapter = await StdioMcpToolAdapter.from_server_params(sample_server_params, "test_tool")
+
+    assert (
+        adapter.return_value_as_string(
+            [
+                TextContent(text="this is a sample text", type="text"),
+                ImageContent(
+                    data="this is a sample base64 encoded image",
+                    mimeType="image/png",
+                    type="image",
+                ),
+                EmbeddedResource(
+                    type="resource",
+                    resource=TextResourceContents(
+                        text="this is a sample text",
+                        uri="http://example.com/test",
+                    ),
+                ),
+            ]
+        )
+    ) == [
+        '{"type":"text","text":"this is a sample text","annotations":null}',
+        '{"type":"image","data":"this is a sample base64 encoded image","mimeType":"image/png","annotations":null}',
+        '{"type":"resource","resource":{"uri":"http://example.com/test","mimeType":null,"text":"this is a sample text"},"annotations":null}',
+    ]
 
 
 @pytest.mark.asyncio
@@ -420,7 +465,8 @@ async def test_mcp_server_github() -> None:
     assert len(tools) == 1
     tool = tools[0]
     result = await tool.run_json(
-        {"owner": "microsoft", "repo": "autogen", "path": "python", "branch": "main"}, CancellationToken()
+        {"owner": "microsoft", "repo": "autogen", "path": "python", "branch": "main"},
+        CancellationToken(),
     )
     assert result is not None
 


### PR DESCRIPTION
## Why are these changes needed?
- Add return_value_as_string for formating result from MCP tool

## Related issue number
- Opened Issue on #6368 

## Checks
- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
