### PR TITLE
[FIX] DockerCommandLineCodeExecutor multi event loop aware

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
@@ -244,7 +244,6 @@ $functions"""
 
         self._container: Container | None = None
         self._running = False
-        self._cancellation_tasks: List[asyncio.Task[None]] = []
 
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._cancellation_futures: List[ConcurrentFuture[None]] = []
@@ -567,13 +566,9 @@ $functions"""
             logs_str = self._container.logs().decode("utf-8")
             raise ValueError(f"Failed to start container from image {self._image}. Logs: {logs_str}")
 
-        # --- 추가된 부분 ---
-        # 현재 이벤트 루프 저장
         self._loop = asyncio.get_running_loop()
-        # 퓨처 리스트 초기화
         self._cancellation_futures = []
         logging.debug(f"Executor started, associated with event loop: {self._loop!r}")
-        # -----------------
 
         self._running = True
 

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
@@ -368,7 +368,7 @@ async def test_docker_commandline_code_executor_with_multiple_tasks() -> None:
     if not docker_tests_enabled():
         pytest.skip("Docker tests are disabled")
 
-    async def run_cancellation_scenario(executor: DockerCommandLineCodeExecutor):
+    async def run_cancellation_scenario(executor: DockerCommandLineCodeExecutor) -> None:
         token = CancellationToken()
         code_block = CodeBlock(language="bash", code="sleep 10")
         exec_task = asyncio.create_task(executor.execute_code_blocks([code_block], cancellation_token=token))
@@ -379,7 +379,7 @@ async def test_docker_commandline_code_executor_with_multiple_tasks() -> None:
         except asyncio.CancelledError:
             pass
 
-    def run_scenario_in_new_loop(executor_instance: DockerCommandLineCodeExecutor):
+    def run_scenario_in_new_loop(executor_instance: DockerCommandLineCodeExecutor) -> None:
         asyncio.run(run_cancellation_scenario(executor_instance))
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
@@ -361,3 +361,27 @@ async def test_delete_tmp_files() -> None:
             assert result.code_file is not None
             # Verify file is deleted even after error
             assert not Path(result.code_file).exists()
+
+
+@pytest.mark.asyncio
+async def test_docker_commandline_code_executor_with_multiple_tasks() -> None:
+    if not docker_tests_enabled():
+        pytest.skip("Docker tests are disabled")
+
+    async def run_cancellation_scenario(executor: DockerCommandLineCodeExecutor):
+        token = CancellationToken()
+        code_block = CodeBlock(language="bash", code="sleep 10")
+        exec_task = asyncio.create_task(executor.execute_code_blocks([code_block], cancellation_token=token))
+        await asyncio.sleep(1)
+        token.cancel()
+        try:
+            await exec_task
+        except asyncio.CancelledError:
+            pass
+
+    def run_scenario_in_new_loop(executor_instance: DockerCommandLineCodeExecutor):
+        asyncio.run(run_cancellation_scenario(executor_instance))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        async with DockerCommandLineCodeExecutor(work_dir=temp_dir) as executor:
+            await asyncio.get_running_loop().run_in_executor(None, run_scenario_in_new_loop, executor)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
*Problem*

Previously, in `DockerCommandLineCodeExecutor`, cancellation tasks were added directly to `self._cancellation_tasks` using `asyncio.create_task()`:
```python
self._cancellation_tasks.append(asyncio.create_task(self._kill_running_command(command)))
```
This caused issues when cancellation tasks were created from multiple event loops, leading to loop mismatch errors during executor shutdown.

*Solution*
This PR fixes the issue by introducing a dedicated internal event loop for managing cancellation tasks.
Cancellation tasks are now scheduled in a fixed event loop using `asyncio.run_coroutine_threadsafe()`:
```python
                    future: ConcurrentFuture[None] = asyncio.run_coroutine_threadsafe(
                        self._kill_running_command(command), self._loop
                    )
                    self._cancellation_futures.append(future)
```

*Additional Changes*
- Added detailed logging for easier debugging.
- Ensured clean shutdown of the internal event loop and associated thread.


*Note*
This change ensures that all cancellation tasks are handled consistently in a single loop, preventing cross-loop conflicts and improving executor stability in multi-threaded environments.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #6395 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
