### PR TITLE
FIX: resolving_workbench_and_tools_conflict_at_desirialize_assistant_agent

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -65,7 +65,6 @@ class AssistantAgentConfig(BaseModel):
 
     name: str
     model_client: ComponentModel
-    tools: List[ComponentModel] | None
     workbench: ComponentModel | None = None
     handoffs: List[HandoffBase | str] | None = None
     model_context: ComponentModel | None = None
@@ -1342,7 +1341,6 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         return AssistantAgentConfig(
             name=self.name,
             model_client=self._model_client.dump_component(),
-            tools=[tool.dump_component() for tool in self._tools],
             workbench=self._workbench.dump_component() if self._workbench else None,
             handoffs=list(self._handoffs.values()) if self._handoffs else None,
             model_context=self._model_context.dump_component(),
@@ -1375,7 +1373,6 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         return cls(
             name=config.name,
             model_client=ChatCompletionClient.load_component(config.model_client),
-            tools=[BaseTool.load_component(tool) for tool in config.tools] if config.tools else None,
             workbench=Workbench.load_component(config.workbench) if config.workbench else None,
             handoffs=config.handoffs,
             model_context=ChatCompletionContext.load_component(config.model_context) if config.model_context else None,

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -65,6 +65,7 @@ class AssistantAgentConfig(BaseModel):
 
     name: str
     model_client: ComponentModel
+    tools: List[ComponentModel] | None = None
     workbench: ComponentModel | None = None
     handoffs: List[HandoffBase | str] | None = None
     model_context: ComponentModel | None = None
@@ -1341,6 +1342,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         return AssistantAgentConfig(
             name=self.name,
             model_client=self._model_client.dump_component(),
+            tools=None,  # versionchanged:: v0.5.5  Now tools are not serialized, Cause they are part of the workbench.
             workbench=self._workbench.dump_component() if self._workbench else None,
             handoffs=list(self._handoffs.values()) if self._handoffs else None,
             model_context=self._model_context.dump_component(),
@@ -1376,6 +1378,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
             workbench=Workbench.load_component(config.workbench) if config.workbench else None,
             handoffs=config.handoffs,
             model_context=ChatCompletionContext.load_component(config.model_context) if config.model_context else None,
+            tools=[BaseTool.load_component(tool) for tool in config.tools] if config.tools else None,
             memory=[Memory.load_component(memory) for memory in config.memory] if config.memory else None,
             description=config.description,
             system_message=config.system_message,

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -1448,3 +1448,90 @@ async def test_workbenchs_serialize_and_deserialize() -> None:
 
     assert deserialize.name == agent.name
     assert deserialize._workbench._to_config() == agent._workbench._to_config()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_tools_deserialize_aware() -> None:
+    client = ReplayChatCompletionClient(
+        chat_completions=[
+            CreateResult(
+                finish_reason="function_calls",
+                content=[FunctionCall(id="hello", arguments="{}", name="hello")],
+                usage=RequestUsage(prompt_tokens=0, completion_tokens=0),
+                cached=False,
+            )
+        ],
+        model_info={
+            "vision": False,
+            "function_calling": True,
+            "json_output": False,
+            "family": "unknown",
+            "structured_output": False,
+        },
+    )
+    # Why does not serialize the client? Ans: Now(0.5.5) the ReplayChatCompletionClient is not deserializable with FunctionCall
+    dump = """
+    {
+        "provider": "autogen_agentchat.agents.AssistantAgent",
+        "component_type": "agent",
+        "version": 1,
+        "component_version": 1,
+        "description": "An agent that provides assistance with tool use.",
+        "label": "AssistantAgent",
+        "config": {
+            "name": "TestAgent",
+            "model_client": {
+            "provider": "autogen_ext.models.openai.OpenAIChatCompletionClient",
+            "component_type": "model",
+            "version": 1,
+            "component_version": 1,
+            "description": "Chat completion client for OpenAI hosted models.",
+            "label": "OpenAIChatCompletionClient",
+            "config": {
+                "model": "gpt-4",
+                "api_key": "**********"
+            }
+            },
+            "tools": [
+            {
+                "provider": "autogen_core.tools.FunctionTool",
+                "component_type": "tool",
+                "version": 1,
+                "component_version": 1,
+                "description": "Create custom tools by wrapping standard Python functions.",
+                "label": "FunctionTool",
+                "config": {
+                "source_code": "def hello():\\n    return 'Hello, World!'\\n",
+                "name": "hello",
+                "description": "",
+                "global_imports": [],
+                "has_cancellation_support": false
+                }
+            }
+            ],
+            "model_context": {
+            "provider": "autogen_core.model_context.UnboundedChatCompletionContext",
+            "component_type": "chat_completion_context",
+            "version": 1,
+            "component_version": 1,
+            "description": "An unbounded chat completion context that keeps a view of the all the messages.",
+            "label": "UnboundedChatCompletionContext",
+            "config": {}
+            },
+            "description": "An agent that provides assistance with ability to use tools.",
+            "system_message": "You are a helpful assistant.",
+            "model_client_stream": false,
+            "reflect_on_tool_use": false,
+            "tool_call_summary_format": "{result}",
+            "metadata": {}
+        }
+    }
+    """
+    agent = AssistantAgent.load_component(json.loads(dump))
+    agent._model_client = client  # type: ignore
+    result = await agent.run(task="hello")
+
+    assert len(result.messages) == 4
+    assert result.messages[-1].content == "Hello, World!"  # type: ignore
+    assert result.messages[-1].type == "ToolCallSummaryMessage"  # type: ignore
+    assert isinstance(result.messages[-1], ToolCallSummaryMessage)  # type: ignore


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Starting from AutoGen v0.5.5, tools are internally managed through `StaticWorkbench`.
However, both tools and workbench were being serialized and deserialized, which caused conflicts during deserialization:
	•	When both are restored, the constructor raises:
```
ValueError: Tools cannot be used with a workbench.
```

The changes address this issue by:
1.	Removing tools from serialization/deserialization:
	•	tools are now considered internal state of `StaticWorkbench`, and are no longer serialized.
	•	Only workbench is serialized, ensuring consistency and avoiding duplication.
2.	Ensuring logical integrity:
	•	Since tools are not used directly after initialization, persisting them separately serves no functional purpose.
	•	This avoids scenarios where both are populated, violating constructor constraints.

Summary:

This change prevents tools/workbench conflicts by fully delegating tool management to `StaticWorkbench` and avoiding unnecessary persistence of tools themselves.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #6405 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
