### PR TITLE
test_docker_commandline_code_executor.py : 161.66s -> 108.07

### DIFF
--- a/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
@@ -32,7 +32,7 @@ def docker_tests_enabled() -> bool:
         return False
 
 
-@pytest_asyncio.fixture(scope="function")  # type: ignore
+@pytest_asyncio.fixture(scope="module")  # type: ignore
 async def executor_and_temp_dir(
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[tuple[DockerCommandLineCodeExecutor, str], None]:

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
@@ -255,17 +255,12 @@ async def test_docker_commandline_code_executor_extra_args() -> None:
 async def test_docker_commandline_code_executor_serialization() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         executor = DockerCommandLineCodeExecutor(work_dir=temp_dir)
-        await executor.start()
 
         executor_config = executor.dump_component()
         loaded_executor = DockerCommandLineCodeExecutor.load_component(executor_config)
-        await loaded_executor.start()
 
         assert executor.bind_dir == loaded_executor.bind_dir
         assert executor.timeout == loaded_executor.timeout
-
-        await executor.stop()
-        await loaded_executor.stop()
 
 
 def test_invalid_timeout() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Current autogen-ext's test is too slow.
So, I will search slow test case and makes more fast.

[init docker executor function to module 180s->140s](https://github.com/microsoft/autogen/commit/a3cf70bcf8017b9036dcf89b68ca0fa60b92a0fa)
[reuse executor at some tests 140s->120s](https://github.com/microsoft/autogen/commit/ca15938afa6253bd8db1b74d677f9bb427aed627)
[Remove unnecessary start of docker 120s->110s](https://github.com/microsoft/autogen/commit/61247611e01eff05c372e2bdc8b64c3a83c6d534)

## Related issue number

<!-- For example: "Closes #1234" -->
Part of #6376

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
