### PR TITLE
FIX: GraphFlow serialize/deserialize and adding test

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_graph/_digraph_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_graph/_digraph_group_chat.py
@@ -646,6 +646,9 @@ class GraphFlow(BaseGroupChat, Component[GraphFlowConfig]):
         runtime: AgentRuntime | None = None,
         custom_message_types: List[type[BaseAgentEvent | BaseChatMessage]] | None = None,
     ) -> None:
+        self._input_participants = participants
+        self._input_termination_condition = termination_condition
+
         stop_agent = _StopAgent()
         stop_agent_termination = StopMessageTermination()
         termination_condition = (
@@ -700,8 +703,10 @@ class GraphFlow(BaseGroupChat, Component[GraphFlowConfig]):
 
     def _to_config(self) -> GraphFlowConfig:
         """Converts the instance into a configuration object."""
-        participants = [participant.dump_component() for participant in self._participants]
-        termination_condition = self._termination_condition.dump_component() if self._termination_condition else None
+        participants = [participant.dump_component() for participant in self._input_participants]
+        termination_condition = (
+            self._input_termination_condition.dump_component() if self._input_termination_condition else None
+        )
         return GraphFlowConfig(
             participants=participants,
             termination_condition=termination_condition,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
❗ Before

Previously, GraphFlow.__init__() modified the inner_chats and termination_condition for internal execution logic (e.g., constructing _StopAgent or composing OrTerminationCondition).
However, these modified values were also used during dump_component(), meaning the serialized config no longer matched the original inputs.

As a result:
	1.	dump_component() → load_component() → dump_component() produced non-idempotent configs.
	2.	Internal-only constructs like _StopAgent were mistakenly serialized, even though they should only exist in runtime.

⸻

✅ After

This patch changes the behavior to:
	•	Store original inner_chats and termination_condition as-is at initialization.
	•	During to_config(), serialize only the original unmodified versions.
	•	Avoid serializing _StopAgent or other dynamically built agents.
	•	Ensure deserialization (from_config) produces a logically equivalent object without additional nesting or duplication.

This ensures that:
	•	GraphFlow.dump_component() → load_component() round-trip produces consistent, minimal configs.
	•	Internal execution logic and serialized component structure are properly separated.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #6431 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
