### PR TITLE
FIX: `MultiModalMessage` in gemini with openai sdk error occured

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_message_transform.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_message_transform.py
@@ -379,7 +379,7 @@ def assistant_condition(message: LLMMessage, context: Dict[str, Any]) -> str:
 
 user_transformer_funcs_gemini: Dict[str, List[Callable[[LLMMessage, Dict[str, Any]], Dict[str, Any]]]] = {
     "text": single_user_transformer_funcs + [_set_empty_to_whitespace],
-    "multimodal": multimodal_user_transformer_funcs + [_set_empty_to_whitespace],
+    "multimodal": multimodal_user_transformer_funcs,
 }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Multimodal message fill context with other routine. However current `_set_empty_to_whitespace` is fill with context.
So, error occured.

And, I checked `multimodal_user_transformer_funcs` and I found it, in this routine, context must not be empty.
Now remove the `_set_empty_to_whitespace` when multimodal message,
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #6439 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
