### PR TITLE
FIX/McpWorkbench_errors_properties_and_grace_shutdown

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
@@ -177,7 +177,7 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
             description = tool.description or ""
             parameters = ParametersSchema(
                 type="object",
-                properties=tool.inputSchema["properties"],
+                properties=tool.inputSchema.get("properties", {}),
                 required=tool.inputSchema.get("required", []),
                 additionalProperties=tool.inputSchema.get("additionalProperties", False),
             )
@@ -279,3 +279,7 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
     @classmethod
     def _from_config(cls, config: McpWorkbenchConfig) -> Self:
         return cls(server_params=config.server_params)
+
+    def __del__(self) -> None:
+        # Ensure the actor is stopped when the workbench is deleted
+        pass


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Our McpWorkbench required properties however mongodb-lens's some tools do not has it. I will fix it from when properties is None, -> {}
Our McpWorkbench now does not have stop routine with without async with McpWorkbench(params) as workbench: and lazy init. So, I will adding def __del__: pass just insert that, It could show error.

## Related issue number

Closes #6425

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
