### PR TITLE
Enhance debugging by handling tool call errors explicitly

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -86,9 +86,10 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
             if result.isError:
                 raise Exception(f"MCP tool execution failed: {result.content}")
             return result.content
-        except Exception as e:
-            error_message = self._format_errors(e)
-            raise Exception(error_message) from e
+        except ExceptionGroup as eg:
+            # Construct a message with all nested exception messages and args
+            exception_msg = "\n".join([f"{e.__class__.__name__}: {str(e)}\n{e.args}" for e in eg.exceptions])
+            raise Exception(exception_msg) from eg
 
     @classmethod
     async def from_server_params(cls, server_params: TServerParams, tool_name: str) -> "McpToolAdapter[TServerParams]":


### PR DESCRIPTION
Adds an exception handler to capture and surface detailed errors from the tool call. Without this, failures result in a generic error message, making it difficult to debug or identify the root cause.

