### PR TITLE
docs: fix shell command with escaped brackets in pip install

### DIFF
--- a/python/samples/agentchat_chainlit/README.md
+++ b/python/samples/agentchat_chainlit/README.md
@@ -10,7 +10,7 @@ and support streaming messages.
 To run this sample, you will need to install the following packages:
 
 ```shell
-pip install -U chainlit autogen-agentchat autogen-ext[openai] pyyaml
+pip install -U chainlit autogen-agentchat "autogen-ext[openai]" pyyaml
 ```
 
 To use other model providers, you will need to install a different extra


### PR DESCRIPTION
Fix the installation command in python/samples/agentchat_chainlit/README.md by properly escaping or quoting package names with square brackets to prevent shell interpretation errors in zsh and other shells.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

[AS-IS]
![image](https://github.com/user-attachments/assets/d6c8c95a-eb45-4206-a147-cd74aa6e949f)

[After fixed]
![image](https://github.com/user-attachments/assets/f2ffea4b-f993-4888-8559-c19e2b5c6eea)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
