### PR TITLE
Update docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,116 +29,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [
+        version:
+          [
             # For main use the workflow target
-            {
-              ref: "${{github.ref}}",
-              dest-dir: dev,
-              uv-version: "0.5.13",
-              sphinx-release-override: "dev",
-            },
-            {
-              ref: "python-v0.5.6",
-              dest-dir: stable,
-              uv-version: "0.5.13",
-              sphinx-release-override: "stable",
-            },
-            {
-              ref: "v0.4.0.post1",
-              dest-dir: "0.4.0",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "v0.4.1",
-              dest-dir: "0.4.1",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "v0.4.2",
-              dest-dir: "0.4.2",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "v0.4.3",
-              dest-dir: "0.4.3",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "v0.4.4",
-              dest-dir: "0.4.4",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.4.5",
-              dest-dir: "0.4.5",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.4.6",
-              dest-dir: "0.4.6",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.4.7",
-              dest-dir: "0.4.7",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.4.8",
-              dest-dir: "0.4.8",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.4.9-website",
-              dest-dir: "0.4.9",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.5.1",
-              dest-dir: "0.5.1",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.5.2",
-              dest-dir: "0.5.2",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.5.3",
-              dest-dir: "0.5.3",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.5.4",
-              dest-dir: "0.5.4",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.5.5",
-              dest-dir: "0.5.5",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
-            {
-              ref: "python-v0.5.6",
-              dest-dir: "0.5.6",
-              uv-version: "0.5.13",
-              sphinx-release-override: "",
-            },
+            { ref: "${{github.ref}}", dest-dir: dev, uv-version: "0.5.13", sphinx-release-override: "dev" },
+            { ref: "python-v0.5.6", dest-dir: stable, uv-version: "0.5.13", sphinx-release-override: "stable" },
+            { ref: "v0.4.0.post1", dest-dir: "0.4.0", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "v0.4.1", dest-dir: "0.4.1", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "v0.4.2", dest-dir: "0.4.2", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "v0.4.3", dest-dir: "0.4.3", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "v0.4.4", dest-dir: "0.4.4", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.4.5", dest-dir: "0.4.5", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.4.6", dest-dir: "0.4.6", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.4.7", dest-dir: "0.4.7", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.4.8", dest-dir: "0.4.8", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.4.9-website", dest-dir: "0.4.9", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.5.1", dest-dir: "0.5.1", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.5.2", dest-dir: "0.5.2", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.5.3", dest-dir: "0.5.3", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.5.4", dest-dir: "0.5.4", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.5.5", dest-dir: "0.5.5", uv-version: "0.5.13", sphinx-release-override: "" },
+            { ref: "python-v0.5.6", dest-dir: "0.5.6", uv-version: "0.5.13", sphinx-release-override: "" },
           ]
     steps:
       - name: Checkout
@@ -328,8 +239,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs:
-      [build-02, build-04, build-04-dotnet, gen-redirects, gen-component-schema]
+    needs: [build-02, build-04, build-04-dotnet, gen-redirects, gen-component-schema]
     if: ${{ needs.build-02.result == 'success' && needs.build-04.result == 'success' && needs.gen-redirects.result == 'success' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -230,17 +230,11 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: pydoc-markdown install
         run: |
           python -m pip install --upgrade pip
-          pip uninstall -y nr.util
-          pip install --no-cache-dir nr.util==0.8.12
-          # Create nr.util package alias for the hyphen variant
-          mkdir -p /tmp/nr-util/nr_util
-          echo 'from setuptools import setup; setup(name="nr-util", version="0.8.12", install_requires=["nr.util>=0.8.12"])' > /tmp/nr-util/setup.py
-          touch /tmp/nr-util/nr_util/__init__.py
-          pip install -e /tmp/nr-util
+          pip install docspec==2.2.1 docspec-python==2.2.1
           pip install pydoc-markdown pyyaml termcolor
           # Pin databind packages as version 4.5.0 is not compatible with pydoc-markdown.
           pip install databind.core==4.4.2 databind.json==4.4.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -234,7 +234,8 @@ jobs:
       - name: pydoc-markdown install
         run: |
           python -m pip install --upgrade pip
-          # Install nr.util with hyphen for compatibility
+          pip install nr.util==0.8.12
+          # Create nr.util package alias for the hyphen variant
           mkdir -p /tmp/nr-util/nr_util
           echo 'from setuptools import setup; setup(name="nr-util", version="0.8.12", install_requires=["nr.util>=0.8.12"])' > /tmp/nr-util/setup.py
           touch /tmp/nr-util/nr_util/__init__.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,27 +29,116 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version:
-          [
+        version: [
             # For main use the workflow target
-            { ref: "${{github.ref}}", dest-dir: dev, uv-version: "0.5.13", sphinx-release-override: "dev" },
-            { ref: "python-v0.5.6", dest-dir: stable, uv-version: "0.5.13", sphinx-release-override: "stable" },
-            { ref: "v0.4.0.post1", dest-dir: "0.4.0", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "v0.4.1", dest-dir: "0.4.1", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "v0.4.2", dest-dir: "0.4.2", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "v0.4.3", dest-dir: "0.4.3", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "v0.4.4", dest-dir: "0.4.4", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.4.5", dest-dir: "0.4.5", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.4.6", dest-dir: "0.4.6", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.4.7", dest-dir: "0.4.7", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.4.8", dest-dir: "0.4.8", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.4.9-website", dest-dir: "0.4.9", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.5.1", dest-dir: "0.5.1", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.5.2", dest-dir: "0.5.2", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.5.3", dest-dir: "0.5.3", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.5.4", dest-dir: "0.5.4", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.5.5", dest-dir: "0.5.5", uv-version: "0.5.13", sphinx-release-override: "" },
-            { ref: "python-v0.5.6", dest-dir: "0.5.6", uv-version: "0.5.13", sphinx-release-override: "" },
+            {
+              ref: "${{github.ref}}",
+              dest-dir: dev,
+              uv-version: "0.5.13",
+              sphinx-release-override: "dev",
+            },
+            {
+              ref: "python-v0.5.6",
+              dest-dir: stable,
+              uv-version: "0.5.13",
+              sphinx-release-override: "stable",
+            },
+            {
+              ref: "v0.4.0.post1",
+              dest-dir: "0.4.0",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "v0.4.1",
+              dest-dir: "0.4.1",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "v0.4.2",
+              dest-dir: "0.4.2",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "v0.4.3",
+              dest-dir: "0.4.3",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "v0.4.4",
+              dest-dir: "0.4.4",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.4.5",
+              dest-dir: "0.4.5",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.4.6",
+              dest-dir: "0.4.6",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.4.7",
+              dest-dir: "0.4.7",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.4.8",
+              dest-dir: "0.4.8",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.4.9-website",
+              dest-dir: "0.4.9",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.5.1",
+              dest-dir: "0.5.1",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.5.2",
+              dest-dir: "0.5.2",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.5.3",
+              dest-dir: "0.5.3",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.5.4",
+              dest-dir: "0.5.4",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.5.5",
+              dest-dir: "0.5.5",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
+            {
+              ref: "python-v0.5.6",
+              dest-dir: "0.5.6",
+              uv-version: "0.5.13",
+              sphinx-release-override: "",
+            },
           ]
     steps:
       - name: Checkout
@@ -145,6 +234,11 @@ jobs:
       - name: pydoc-markdown install
         run: |
           python -m pip install --upgrade pip
+          # Install nr.util with hyphen for compatibility
+          mkdir -p /tmp/nr-util/nr_util
+          echo 'from setuptools import setup; setup(name="nr-util", version="0.8.12", install_requires=["nr.util>=0.8.12"])' > /tmp/nr-util/setup.py
+          touch /tmp/nr-util/nr_util/__init__.py
+          pip install -e /tmp/nr-util
           pip install pydoc-markdown pyyaml termcolor
           # Pin databind packages as version 4.5.0 is not compatible with pydoc-markdown.
           pip install databind.core==4.4.2 databind.json==4.4.2
@@ -238,7 +332,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: [build-02, build-04, build-04-dotnet, gen-redirects, gen-component-schema]
+    needs:
+      [build-02, build-04, build-04-dotnet, gen-redirects, gen-component-schema]
     if: ${{ needs.build-02.result == 'success' && needs.build-04.result == 'success' && needs.gen-redirects.result == 'success' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -234,7 +234,8 @@ jobs:
       - name: pydoc-markdown install
         run: |
           python -m pip install --upgrade pip
-          pip install nr.util==0.8.12
+          pip uninstall -y nr.util
+          pip install --no-cache-dir nr.util==0.8.12
           # Create nr.util package alias for the hyphen variant
           mkdir -p /tmp/nr-util/nr_util
           echo 'from setuptools import setup; setup(name="nr-util", version="0.8.12", install_requires=["nr.util>=0.8.12"])' > /tmp/nr-util/setup.py


### PR DESCRIPTION
Bump python version, pin nr-utils

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

Fix docs build CI bug.
- pydocmkardown depends on pydocspec 
-[ pydocspec was updated May 6](https://pypi.org/project/docspec-python/#history) (two days ago), and includes a problematic dependency (`nr.utils` which is specified as [nr-utils](https://github.com/NiklasRosenstein/python-docspec/blob/61d3e38c55d290da6197236357e1cdfe818d35b5/docspec-python/pyproject.toml#L14C5-L14C23). This caused imports to fail. 
- current fix is fixing the pydocspec version.
- Also using the opportunity to update the python version 3.8 -> 3.9 for the docs build 0.2

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
