### PR TITLE
AutoGen Studio: Serve responding complete messages

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/datamodel/types.py
+++ b/python/packages/autogen-studio/autogenstudio/datamodel/types.py
@@ -1,13 +1,13 @@
 # from dataclasses import Field
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, Sequence, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence
 
 from autogen_agentchat.base import TaskResult
 from autogen_agentchat.messages import ChatMessage, TextMessage
 from autogen_core import ComponentModel
 from autogen_core.models import UserMessage
 from autogen_ext.models.openai import OpenAIChatCompletionClient
-from pydantic import BaseModel, ConfigDict, SecretStr, Field
+from pydantic import BaseModel, ConfigDict, SecretStr
 
 
 class MessageConfig(BaseModel):
@@ -109,73 +109,10 @@ class SettingsConfig(BaseModel):
 # web request/response data models
 
 
-class RequestUsage(BaseModel):
-    prompt_tokens: int
-    completion_tokens: int
-
-
-class FunctionCall(BaseModel):
-    id: str
-    arguments: str  # Could also be Dict[str, Any] if parsed
-    name: str
-
-
-class FunctionExecutionResult(BaseModel):
-    content: str
-    name: str
-    call_id: str
-    is_error: bool
-
-
-class BaseMessage(BaseModel):
-    source: str
-    models_usage: Optional[RequestUsage] = None
-    metadata: Dict[str, Optional[str]] = Field(default_factory=dict)
-    type: str  # Overridden by subclasses
-
-
-class TextMessage(BaseMessage):
-    content: str
-    type: Literal["TextMessage"] = "TextMessage"
-
-
-class ToolCallRequestEvent(BaseMessage):
-    content: List[FunctionCall]
-    type: Literal["ToolCallRequestEvent"] = "ToolCallRequestEvent"
-
-
-class ToolCallExecutionEvent(BaseMessage):
-    content: List[FunctionExecutionResult]
-    type: Literal["ToolCallExecutionEvent"] = "ToolCallExecutionEvent"
-
-
-class ToolCallSummaryMessage(BaseMessage):
-    content: str
-    type: Literal["ToolCallSummaryMessage"] = "ToolCallSummaryMessage"
-
-
-MessageUnion = Union[
-    TextMessage,
-    ToolCallRequestEvent,
-    ToolCallExecutionEvent,
-    ToolCallSummaryMessage,
-]
-
-class TaskResult(BaseModel):
-    messages: List[MessageUnion]
-    stop_reason: Optional[str] = None
-
-
-class TaskResponse(BaseModel):
-    task_result: TaskResult
-    usage: Optional[str] = ""
-    duration: float
-
-
 class Response(BaseModel):
     message: str
     status: bool
-    data: Optional[TaskResponse] = None
+    data: Optional[Any] = None
 
 
 class SocketMessage(BaseModel):

--- a/python/packages/autogen-studio/autogenstudio/web/serve.py
+++ b/python/packages/autogen-studio/autogenstudio/web/serve.py
@@ -35,7 +35,7 @@ def force_model_dump(obj: Any) -> Any:
     """
     if isinstance(obj, BaseModel):
         output = {}
-        for name, _field in obj.__fields__.items():
+        for name, _field in obj.model_fields.items():
             value = getattr(obj, name)
             output[name] = force_model_dump(value)
         return output

--- a/python/packages/autogen-studio/autogenstudio/web/serve.py
+++ b/python/packages/autogen-studio/autogenstudio/web/serve.py
@@ -1,6 +1,8 @@
 import os
 
 from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Any
 
 from ..datamodel import Response
 from ..teammanager import TeamManager
@@ -20,8 +22,26 @@ async def predict(task: str):
             raise ValueError("AUTOGENSTUDIO_TEAM_FILE environment variable is not set")
 
         result_message = await team_manager.run(task=task, team_config=team_file_path)
-        response.data = result_message
+        response.data = force_model_dump(result_message)
     except Exception as e:
         response.message = str(e)
         response.status = False
     return response
+
+def force_model_dump(obj: Any) -> Any:
+    """
+    Force dump all fields of a Pydantic BaseModel, even when inherited
+    from ABCs as BaseAgentEvent and BaseChatMessage.
+    """
+    if isinstance(obj, BaseModel):
+        output = {}
+        for name, _field in obj.__fields__.items():
+            value = getattr(obj, name)
+            output[name] = force_model_dump(value)
+        return output
+    elif isinstance(obj, list):
+        return [force_model_dump(item) for item in obj]
+    elif isinstance(obj, dict):
+        return {k: force_model_dump(v) for k, v in obj.items()}
+    else:
+        return obj

--- a/python/packages/autogen-studio/tests/test_serve.py
+++ b/python/packages/autogen-studio/tests/test_serve.py
@@ -1,0 +1,53 @@
+import os
+from fastapi.testclient import TestClient
+from autogenstudio.web.serve import app
+
+client = TestClient(app)
+
+def test_predict_success(monkeypatch):
+    # Mock environment variable
+    monkeypatch.setenv("AUTOGENSTUDIO_TEAM_FILE", "test_team_config.json")
+    
+    # Mock the team_manager.run method
+    async def mock_run(*args, **kwargs):
+        assert kwargs.get('task') == 'test_task', f"Expected task='test_task', got {kwargs.get('task')}"
+        return "Test result"
+    
+    from autogenstudio.web.serve import team_manager
+    team_manager.run = mock_run
+    
+    response = client.get("/predict/test_task")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] is True
+    assert data["message"] == "Task successfully completed"
+    assert data["data"] == "Test result"
+
+def test_predict_missing_env_var():
+    # Ensure environment variable is not set
+    if "AUTOGENSTUDIO_TEAM_FILE" in os.environ:
+        del os.environ["AUTOGENSTUDIO_TEAM_FILE"]
+    
+    response = client.get("/predict/test_task")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] is False
+    assert "AUTOGENSTUDIO_TEAM_FILE environment variable is not set" in data["message"]
+
+def test_predict_team_manager_error(monkeypatch):
+    # Mock environment variable
+    monkeypatch.setenv("AUTOGENSTUDIO_TEAM_FILE", "test_team_config.json")
+    
+    # Mock the team_manager.run method to raise an exception
+    async def mock_run(*args, **kwargs):
+        assert kwargs.get('task') == 'test_task', f"Expected task='test_task', got {kwargs.get('task')}"
+        raise Exception("Test error")
+    
+    from autogenstudio.web.serve import team_manager
+    team_manager.run = mock_run
+    
+    response = client.get("/predict/test_task")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] is False
+    assert data["message"] == "Test error" 


### PR DESCRIPTION


## Why are these changes needed?

Run the Studio with serve:
autogenstudio serve --team notebooks/team.json --port 8084

Open the doc endpoint (http://127.0.0.1:8084/docs) and make a request, you will notice the response does not show content for messages.

With this fix you will see full payload:
![Screenshot from 2025-05-13 02-35-54](https://github.com/user-attachments/assets/f287ac21-3117-4ae9-bd15-ae4f8ad7ac11)


This error might be something related to FastAPI vs pydantic, as we are using some "complex" model structuring .
TaskResult -> BaseChatMessage(BaseMessage, ABC) -> BaseTextChatMessage(BaseChatMessage, ABC) -> TextMessage(BaseTextChatMessage)

Probably the serializer use its parent to serialize, and then can't access extension attributes declared by children classes.


## Related issue number

Opened a discussion on discord.

## Checks

- [ X ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
** As this is more like a bug, I believe doc change is not needed, as is expected to see full LLM results **

- [ X ] I've added tests (if relevant) corresponding to the changes introduced in this PR.

- [  ] I've made sure all auto checks have passed.
** Checkin **