### PR TITLE
AutoGen Studio: Serve Teams Folder

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/cli.py
+++ b/python/packages/autogen-studio/autogenstudio/cli.py
@@ -87,6 +87,7 @@ def ui(
 @app.command()
 def serve(
     team: str = "",
+    teamfolder: str = "",
     host: str = "127.0.0.1",
     port: int = 8084,
     workers: int = 1,
@@ -98,6 +99,7 @@ def serve(
 
     Args:
         team (str): Path to the team json file.
+        teamfolder (str): Path to folder containing team json files (team or teamfolder is required).
         host (str, optional): Host to run the UI on. Defaults to 127.0.0.1 (localhost).
         port (int, optional): Port to run the UI on. Defaults to 8084
         workers (int, optional): Number of workers to run the UI with. Defaults to 1.
@@ -108,10 +110,11 @@ def serve(
 
     os.environ["AUTOGENSTUDIO_API_DOCS"] = str(docs)
     os.environ["AUTOGENSTUDIO_TEAM_FILE"] = team
-
-    # validate the team file
-    if not os.path.exists(team):
-        raise ValueError(f"Team file not found: {team}")
+    os.environ["AUTOGENSTUDIO_TEAM_FOLDER"] = teamfolder
+    
+    # validate the team file and folder
+    if not os.path.exists(team) and not os.path.exists(teamfolder):
+        raise ValueError(f"Team file or folder not found: {team}")
 
     uvicorn.run(
         "autogenstudio.web.serve:app",

--- a/python/packages/autogen-studio/autogenstudio/web/serve.py
+++ b/python/packages/autogen-studio/autogenstudio/web/serve.py
@@ -25,3 +25,36 @@ async def predict(task: str):
         response.message = str(e)
         response.status = False
     return response
+
+
+@app.get("/predict_team/{team}/{task}")
+async def predict_model(team: str, task: str):
+    response = Response(message="Task successfully completed", status=True, data=None)
+    try:
+        team_folder_path = os.environ.get("AUTOGENSTUDIO_TEAM_FOLDER")
+
+        if team_folder_path is None:
+            raise ValueError("AUTOGENSTUDIO_TEAM_FOLDER environment variable is not set")
+
+        if not os.path.isdir(team_folder_path):
+            raise ValueError("Team folder not found.")
+
+        team_files = {}
+        for f in os.listdir(team_folder_path):
+            if os.path.isfile(os.path.join(team_folder_path, f)):
+                filename = f.split(".")[0]
+                team_files[filename] = os.path.join(team_folder_path, f)
+
+        if not team_files:
+            raise ValueError("No files found in team folder path.")
+
+        if team not in team_files:
+            raise ValueError(f"Model {team} not found in team folder path.")
+
+        team_file_path = team_files[team]
+        result_message = await team_manager.run(task=task, team_config=team_file_path)
+        response.data = result_message
+    except Exception as e:
+        response.message = str(e)
+        response.status = False
+    return response

--- a/python/packages/autogen-studio/tests/test_serve.py
+++ b/python/packages/autogen-studio/tests/test_serve.py
@@ -1,0 +1,105 @@
+import os
+from fastapi.testclient import TestClient
+from autogenstudio.web.serve import app
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.base import TaskResult
+from autogenstudio.datamodel.types import TeamResult
+
+
+client = TestClient(app)
+
+def test_predict_success(monkeypatch):
+    monkeypatch.setenv("AUTOGENSTUDIO_TEAM_FILE", "test_team_config.json")
+
+    async def mock_run(*args, **kwargs):
+        assert kwargs.get('task') == 'test_task', f"Expected task='test_task', got {kwargs.get('task')}"
+        text_message = TextMessage(
+            source="agent1",
+            content="Mission accomplished.",
+            metadata={"topic": "status"}
+        )
+        task_result = TaskResult(messages=[text_message], stop_reason="test")
+        team_result = TeamResult(
+            task_result=task_result,
+            usage="3 tokens",
+            duration=0.45
+        )
+        return team_result
+    
+    from autogenstudio.web.serve import team_manager
+    team_manager.run = mock_run
+    
+    response = client.get("/predict/test_task")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] is True
+    assert data["message"] == "Task successfully completed"
+
+def test_predict_missing_env_var():
+    # Ensure environment variable is not set
+    if "AUTOGENSTUDIO_TEAM_FILE" in os.environ:
+        del os.environ["AUTOGENSTUDIO_TEAM_FILE"]
+    
+    response = client.get("/predict/test_task")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] is False
+    assert "AUTOGENSTUDIO_TEAM_FILE environment variable is not set" in data["message"]
+
+def test_predict_team_success(monkeypatch):
+    monkeypatch.setenv("AUTOGENSTUDIO_TEAM_FOLDER", "notebooks")
+
+    async def mock_run(*args, **kwargs):
+        assert kwargs.get('task') == 'test_task', f"Expected task='test_task', got {kwargs.get('task')}"
+        assert kwargs.get('team_config') == 'notebooks/team.json', f"Expected team_config='notebooks/team.json', got {kwargs.get('team_config')}"
+        text_message = TextMessage(
+            source="agent1",
+            content="Mission accomplished.",
+            metadata={"topic": "status"}
+        )
+        task_result = TaskResult(messages=[text_message], stop_reason="test")
+        team_result = TeamResult(
+            task_result=task_result,
+            usage="3 tokens",
+            duration=0.45
+        )
+        return team_result
+    
+    from autogenstudio.web.serve import team_manager
+    team_manager.run = mock_run
+    
+    response = client.get("/predict_team/team/test_task")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] is True
+    assert data["message"] == "Task successfully completed"
+
+def test_predict_team_missing_env_var():
+    # Ensure environment variable is not set
+    if "AUTOGENSTUDIO_TEAM_FOLDER" in os.environ:
+        del os.environ["AUTOGENSTUDIO_TEAM_FOLDER"]
+    
+    response = client.get("/predict_team/test_team/test_task")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] is False
+    assert "AUTOGENSTUDIO_TEAM_FOLDER environment variable is not set" in data["message"]
+
+
+def test_predict_team_manager_error(monkeypatch):
+    monkeypatch.setenv("AUTOGENSTUDIO_TEAM_FOLDER", "notebooks")
+    
+    # Mock the team_manager.run method to raise an exception
+    async def mock_run(*args, **kwargs):
+        assert kwargs.get('task') == 'test_task', f"Expected task='test_task', got {kwargs.get('task')}"
+        assert kwargs.get('team_config') == 'notebooks/team.json', f"Expected team_config='notebooks/team.json', got {kwargs.get('team_config')}"
+        raise Exception("Test error")
+    
+    from autogenstudio.web.serve import team_manager
+    team_manager.run = mock_run
+    
+    response = client.get("/predict_team/team/test_task")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] is False
+    assert data["message"] == "Test error" 


### PR DESCRIPTION


## Why are these changes needed?

AutoGen Studio enable us to create many Teams json, and we can serve only one file.

This PR's open a discussion and initial proposal on having multiple teams loaded into the AutoGen Studio Serve.

It introduces:
* A new endpoint where you will be able to select what team file you want to predict 
* A new parameter to the cli, to point the teams folder
* Unit tests for server.py


## Related issue number

Feature proposal - Feel free to proposa changes or discard if is not a good fit to support this feature.

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.

** There is no documentation about serve, work needed**

- [ X ] I've added tests (if relevant) corresponding to the changes introduced in this PR.

- [ ] I've made sure all auto checks have passed.
** Pending **