### PR TITLE
Add option to auto-delete temporary files in LocalCommandLineCodeExecutor

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -191,7 +191,7 @@ $functions"""
 
         self._cleanup_temp_files = cleanup_temp_files
         self._virtual_env_context: Optional[SimpleNamespace] = virtual_env_context
-        
+
         self._temp_dir: Optional[tempfile.TemporaryDirectory[str]] = None
         self._started = False
 
@@ -246,16 +246,16 @@ $functions"""
                 self._temp_dir = tempfile.TemporaryDirectory()
                 self._started = True
             return Path(self._temp_dir.name)
-        
+
     @property
     def functions(self) -> List[str]:
         raise NotImplementedError
-    
+
     @property
     def functions_module(self) -> str:
         """(Experimental) The module name for the functions."""
         return self._functions_module
-    
+
     @property
     def cleanup_temp_files(self) -> bool:
         """(Experimental) Whether to automatically clean up temporary files after execution."""
@@ -504,7 +504,7 @@ $functions"""
             timeout=self._timeout,
             work_dir=str(self.work_dir),
             functions_module=self._functions_module,
-            cleanup_temp_files=self._cleanup_temp_files
+            cleanup_temp_files=self._cleanup_temp_files,
         )
 
     @classmethod
@@ -513,5 +513,5 @@ $functions"""
             timeout=config.timeout,
             work_dir=Path(config.work_dir) if config.work_dir is not None else None,
             functions_module=config.functions_module,
-            cleanup_temp_files=config.cleanup_temp_files
+            cleanup_temp_files=config.cleanup_temp_files,
         )

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -39,6 +39,7 @@ class LocalCommandLineCodeExecutorConfig(BaseModel):
     timeout: int = 60
     work_dir: Optional[str] = None
     functions_module: str = "functions"
+    cleanup_temp_files: bool = True
 
 
 class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeExecutorConfig]):
@@ -154,6 +155,7 @@ $functions"""
             ]
         ] = [],
         functions_module: str = "functions",
+        cleanup_temp_files: bool = True,
         virtual_env_context: Optional[SimpleNamespace] = None,
     ):
         if timeout < 1:
@@ -186,7 +188,9 @@ $functions"""
             raise ValueError("Module name must be a valid Python identifier")
         self._functions_module = functions_module
 
+        self._cleanup_temp_files = cleanup_temp_files
         self._virtual_env_context: Optional[SimpleNamespace] = virtual_env_context
+        
         self._temp_dir: Optional[tempfile.TemporaryDirectory[str]] = None
         self._started = False
 
@@ -250,6 +254,11 @@ $functions"""
     def functions_module(self) -> str:
         """(Experimental) The module name for the functions."""
         return self._functions_module
+    
+    @property
+    def cleanup_temp_files(self) -> bool:
+        """(Experimental) Whether to automatically clean up temporary files after execution."""
+        return self._cleanup_temp_files
 
     async def _setup_functions(self, cancellation_token: CancellationToken) -> None:
         func_file_content = build_python_functions_file(self._functions)
@@ -443,7 +452,16 @@ $functions"""
                 break
 
         code_file = str(file_names[0]) if file_names else None
-        return CommandLineCodeResult(exit_code=exitcode, output=logs_all, code_file=code_file)
+        code_result = CommandLineCodeResult(exit_code=exitcode, output=logs_all, code_file=code_file)
+
+        if self._cleanup_temp_files:
+            for file in file_names:
+                try:
+                    file.unlink(missing_ok=True)
+                except OSError as error:
+                    logging.error(f"Failed to delete temporary file {file}: {error}")
+
+        return code_result
 
     async def restart(self) -> None:
         """(Experimental) Restart the code executor."""
@@ -485,6 +503,7 @@ $functions"""
             timeout=self._timeout,
             work_dir=str(self.work_dir),
             functions_module=self._functions_module,
+            cleanup_temp_files=self._cleanup_temp_files
         )
 
     @classmethod
@@ -493,4 +512,5 @@ $functions"""
             timeout=config.timeout,
             work_dir=Path(config.work_dir) if config.work_dir is not None else None,
             functions_module=config.functions_module,
+            cleanup_temp_files=config.cleanup_temp_files
         )

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -79,6 +79,7 @@ class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeE
             a default working directory will be used. The default working directory is a temporary directory.
         functions (List[Union[FunctionWithRequirements[Any, A], Callable[..., Any]]]): A list of functions that are available to the code executor. Default is an empty list.
         functions_module (str, optional): The name of the module that will be created to store the functions. Defaults to "functions".
+        cleanup_temp_files (bool, optional): Whether to automatically clean up temporary files after execution. Defaults to True.
         virtual_env_context (Optional[SimpleNamespace], optional): The virtual environment context. Defaults to None.
 
     .. note::

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -399,3 +399,29 @@ async def test_ps1_script(executor_and_temp_dir: ExecutorFixture) -> None:
     assert result.exit_code == 0
     assert "hello from powershell!" in result.output
     assert result.code_file is not None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_temp_files_behavior() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Test with cleanup_temp_files=True (default)
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir, cleanup_temp_files=True)
+        await executor.start()
+        cancellation_token = CancellationToken()
+        code_blocks = [CodeBlock(code="print('cleanup test')", language="python")]
+        result = await executor.execute_code_blocks(code_blocks, cancellation_token)
+        assert result.exit_code == 0
+        assert "cleanup test" in result.output
+        # The code file should have been deleted
+        assert not Path(result.code_file).exists()
+
+        # Test with cleanup_temp_files=False
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir, cleanup_temp_files=False)
+        await executor.start()
+        cancellation_token = CancellationToken()
+        code_blocks = [CodeBlock(code="print('no cleanup')", language="python")]
+        result = await executor.execute_code_blocks(code_blocks, cancellation_token)
+        assert result.exit_code == 0
+        assert "no cleanup" in result.output
+        # The code file should still exist
+        assert Path(result.code_file).exists()

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -413,6 +413,7 @@ async def test_cleanup_temp_files_behavior() -> None:
         assert result.exit_code == 0
         assert "cleanup test" in result.output
         # The code file should have been deleted
+        assert result.code_file is not None
         assert not Path(result.code_file).exists()
 
         # Test with cleanup_temp_files=False
@@ -424,4 +425,5 @@ async def test_cleanup_temp_files_behavior() -> None:
         assert result.exit_code == 0
         assert "no cleanup" in result.output
         # The code file should still exist
+        assert result.code_file is not None
         assert Path(result.code_file).exists()

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -109,7 +109,7 @@ async def executor_and_temp_dir(
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[tuple[LocalCommandLineCodeExecutor, str], None]:
     with tempfile.TemporaryDirectory() as temp_dir:
-        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir)
+        executor = LocalCommandLineCodeExecutor(work_dir=temp_dir, cleanup_temp_files=False)
         await executor.start()
         yield executor, temp_dir
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `LocalCommandLineCodeExecutor `creates temporary files for each code execution, which can accumulate over time and clutter the filesystem - especially when a temporary working directory is not used. These changes introduce an option to automatically delete temporary files after execution, helping to prevent file system debris, reduce disk usage, and ensure cleaner runtime environments in long-running or repeated execution scenarios.

## Related issue number

Closes #4380

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
