### PR TITLE
Allow implicit aws credential setting for AnthropicBedrockChatCompletionClient

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -1193,11 +1193,15 @@ class AnthropicBedrockChatCompletionClient(
         if bedrock_info is None:
             raise ValueError("bedrock_info is required for AnthropicBedrockChatCompletionClient")
 
-        # Handle bedrock_info as secretestr
+        # Handle bedrock_info
         aws_region = bedrock_info["aws_region"]
-        aws_access_key = bedrock_info["aws_access_key"]
-        aws_secret_key = bedrock_info["aws_secret_key"]
-        aws_session_token = bedrock_info["aws_session_token"]
+        aws_access_key: Optional[str] = None
+        aws_secret_key: Optional[str] = None
+        aws_session_token: Optional[str] = None
+        if all(key in bedrock_info for key in ("aws_access_key", "aws_secret_key", "aws_session_token")):
+            aws_access_key = bedrock_info["aws_access_key"]
+            aws_secret_key = bedrock_info["aws_secret_key"]
+            aws_session_token = bedrock_info["aws_session_token"]
 
         client = AsyncAnthropicBedrock(
             aws_access_key=aws_access_key,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allows implicit AWS credential setting when using AnthropicBedrockChatCompletionClient in an instance where you have already logged into AWS with SSO and credentials are set as environment variables.

## Related issue number

Closes #6560 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
