### PR TITLE
remove superfluous underline in the docs

### DIFF
--- a/python/packages/autogen-core/docs/src/_static/custom.css
+++ b/python/packages/autogen-core/docs/src/_static/custom.css
@@ -34,7 +34,6 @@ html[data-theme="dark"] {
 }
 
 /* Adding header icon hover and focus effects */
-.bd-header a:hover,
 .bd-header a:focus-visible {
   color: var(--pst-color-secondary) !important;
   text-decoration: underline !important;


### PR DESCRIPTION
## Why are these changes needed?

unnecessary underline shown in the docs
before:
<img width="157" alt="image" src="https://github.com/user-attachments/assets/37503e10-6b8a-48ee-ae63-d9a12fe3beb5" />

after:
<img width="151" alt="image" src="https://github.com/user-attachments/assets/ea6c1851-3640-4f64-b8ff-91dcc11a6379" />


## Related issue number

closes https://github.com/microsoft/autogen/issues/6564

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
