### PR TITLE
Default usage statistics for streaming responses

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -769,6 +769,12 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             extra_create_args,
         )
 
+        # Force usage statistics if the user hasn't specified any stream options.
+        if "stream_options" not in create_params.create_args:
+            create_params.create_args["stream_options"] = {
+                "include_usage": True,
+            }
+
         if max_consecutive_empty_chunk_tolerance != 0:
             warnings.warn(
                 "The 'max_consecutive_empty_chunk_tolerance' parameter is deprecated and will be removed in the future releases. All of empty chunks will be skipped with a warning.",


### PR DESCRIPTION
## Why are these changes needed?

Enables usage statistics for streaming responses by default.

There is a similar bug in the AzureAI client. Theoretically adding the parameter
```
model_extras={"stream_options": {"include_usage": True}}
```
should fix the problem, but I'm currently unable to test that workflow

## Related issue number

closes https://github.com/microsoft/autogen/issues/6548

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
