### PR TITLE
Add support for specifying the languages to parse from the `CodeExecutorAgent` response

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -111,7 +111,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
             This is only used if `model_client` is not provided.
         max_retries_on_error (int, optional): The maximum number of retries on error. If the code execution fails, the agent will retry up to this number of times.
             If the code execution fails after this number of retries, the agent will yield a reflection result.
-        supported_languages (list[str], optional): List of programming languages that will be parsed and executed from agent response;
+        supported_languages (List[str], optional): List of programming languages that will be parsed and executed from agent response;
             others will be ignored. Defaults to ["python", "bash"].
 
 

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -600,7 +600,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         pass
 
     def _extract_markdown_code_blocks(self, markdown_text: str) -> List[CodeBlock]:
-        pattern = re.compile(rf"```(?:\s*({self._supported_languages_regex}))\n([\s\S]*?)```")
+        pattern = re.compile(rf"```(?:\s*({self._supported_languages_regex}))\n([\s\S]*?)```", re.IGNORECASE)
         matches = pattern.findall(markdown_text)
         code_blocks: List[CodeBlock] = []
         for match in matches:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -54,6 +54,7 @@ class CodeExecutorAgentConfig(BaseModel):
     system_message: str | None = None
     model_client_stream: bool = False
     model_context: ComponentModel | None = None
+    supported_languages: List[str] | None = None
 
 
 class RetryDecision(BaseModel):
@@ -110,6 +111,8 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
             This is only used if `model_client` is not provided.
         max_retries_on_error (int, optional): The maximum number of retries on error. If the code execution fails, the agent will retry up to this number of times.
             If the code execution fails after this number of retries, the agent will yield a reflection result.
+        supported_languages (list[str], optional): List of programming languages that will be parsed and executed from agent response;
+            others will be ignored. Defaults to ["python", "bash"].
 
 
     .. note::
@@ -345,6 +348,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         description: str | None = None,
         system_message: str | None = DEFAULT_SYSTEM_MESSAGE,
         sources: Sequence[str] | None = None,
+        supported_languages: List[str] | None = None,
     ) -> None:
         if description is None:
             if model_client is None:
@@ -357,6 +361,13 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         self._sources = sources
         self._model_client_stream = model_client_stream
         self._max_retries_on_error = max_retries_on_error
+
+        if supported_languages:
+            self._supported_languages = supported_languages
+        else:
+            self._supported_languages = ["python", "bash"]
+
+        self._supported_languages_regex = "|".join(re.escape(lang) for lang in self._supported_languages)
 
         self._model_client = None
         if model_client is not None:
@@ -589,7 +600,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         pass
 
     def _extract_markdown_code_blocks(self, markdown_text: str) -> List[CodeBlock]:
-        pattern = re.compile(r"```(?:\s*([\w\+\-]+))?\n([\s\S]*?)```")
+        pattern = re.compile(rf"```(?:\s*({self._supported_languages_regex}))\n([\s\S]*?)```")
         matches = pattern.findall(markdown_text)
         code_blocks: List[CodeBlock] = []
         for match in matches:
@@ -612,6 +623,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
             ),
             model_client_stream=self._model_client_stream,
             model_context=self._model_context.dump_component(),
+            supported_languages=self._supported_languages,
         )
 
     @classmethod
@@ -627,6 +639,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
             system_message=config.system_message,
             model_client_stream=config.model_client_stream,
             model_context=ChatCompletionContext.load_component(config.model_context) if config.model_context else None,
+            supported_languages=config.supported_languages,
         )
 
     @staticmethod

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -362,7 +362,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         self._model_client_stream = model_client_stream
         self._max_retries_on_error = max_retries_on_error
 
-        if supported_languages:
+        if supported_languages is not None:
             self._supported_languages = supported_languages
         else:
             self._supported_languages = ["python", "bash"]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -112,7 +112,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         max_retries_on_error (int, optional): The maximum number of retries on error. If the code execution fails, the agent will retry up to this number of times.
             If the code execution fails after this number of retries, the agent will yield a reflection result.
         supported_languages (List[str], optional): List of programming languages that will be parsed and executed from agent response;
-            others will be ignored. Defaults to ["python", "bash"].
+            others will be ignored. Defaults to DEFAULT_SUPPORTED_LANGUAGES.
 
 
     .. note::
@@ -332,6 +332,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
     DEFAULT_AGENT_DESCRIPTION = "A Code Execution Agent that generates and executes Python and shell scripts based on user instructions. It ensures correctness, efficiency, and minimal errors while gracefully handling edge cases."
     DEFAULT_SYSTEM_MESSAGE = "You are a Code Execution Agent. Your role is to generate and execute Python code and shell scripts based on user instructions, ensuring correctness, efficiency, and minimal errors. Handle edge cases gracefully. Python code should be provided in ```python code blocks, and sh shell scripts should be provided in ```sh code blocks for execution."
     NO_CODE_BLOCKS_FOUND_MESSAGE = "No code blocks found in the thread. Please provide at least one markdown-encoded code block to execute (i.e., quoting code in ```python or ```sh code blocks)."
+    DEFAULT_SUPPORTED_LANGUAGES = ["python", "bash"]
 
     component_config_schema = CodeExecutorAgentConfig
     component_provider_override = "autogen_agentchat.agents.CodeExecutorAgent"
@@ -365,7 +366,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         if supported_languages is not None:
             self._supported_languages = supported_languages
         else:
-            self._supported_languages = ["python", "bash"]
+            self._supported_languages = CodeExecutorAgent.DEFAULT_SUPPORTED_LANGUAGES
 
         self._supported_languages_regex = "|".join(re.escape(lang) for lang in self._supported_languages)
 


### PR DESCRIPTION
## Why are these changes needed?

The `CodeExecutorAgent` can generate code blocks in various programming languages, some of which may not be supported by the executor environment. Adding support for specifying languages to be parsed helps users ignore unnecessary code blocks, preventing potential execution errors.

## Related issue number
Closes #6471

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
