### PR TITLE
fix: SocietyOfMindAgent should save its response into context

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_society_of_mind_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_society_of_mind_agent.py
@@ -5,7 +5,7 @@ from autogen_core.model_context import (
     ChatCompletionContext,
     UnboundedChatCompletionContext,
 )
-from autogen_core.models import ChatCompletionClient, LLMMessage, SystemMessage, UserMessage
+from autogen_core.models import ChatCompletionClient, LLMMessage, SystemMessage, UserMessage, AssistantMessage
 from pydantic import BaseModel
 from typing_extensions import Self
 
@@ -206,10 +206,23 @@ class SocietyOfMindAgent(BaseChatAgent, Component[SocietyOfMindAgentConfig]):
                     continue
                 inner_messages.append(inner_msg)
         assert result is not None
+        
+        # Add new user/handoff messages to the model context
+        await self._add_messages_to_context(
+            model_context=model_context,
+            messages=messages,
+        )
 
         if len(inner_messages) == 0:
+            content = "No response."
+            await model_context.add_message(
+                AssistantMessage(
+                    content=content,
+                    source=self.name,
+                )
+            )
             yield Response(
-                chat_message=TextMessage(source=self.name, content="No response."),
+                chat_message=TextMessage(source=self.name, content=content),
                 inner_messages=[],
                 # Response's inner_messages should be empty. Cause that mean is response to outer world.
             )
@@ -236,17 +249,17 @@ class SocietyOfMindAgent(BaseChatAgent, Component[SocietyOfMindAgentConfig]):
                 llm_messages.append(UserMessage(content=self._response_prompt, source="user"))
             completion = await self._model_client.create(messages=llm_messages, cancellation_token=cancellation_token)
             assert isinstance(completion.content, str)
+            await model_context.add_message(
+                AssistantMessage(
+                    content=completion.content,
+                    source=self.name
+                )
+            )
             yield Response(
                 chat_message=TextMessage(source=self.name, content=completion.content, models_usage=completion.usage),
                 inner_messages=[],
                 # Response's inner_messages should be empty. Cause that mean is response to outer world.
             )
-
-        # Add new user/handoff messages to the model context
-        await self._add_messages_to_context(
-            model_context=model_context,
-            messages=messages,
-        )
 
         # Reset the team.
         await self._team.reset()

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_society_of_mind_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_society_of_mind_agent.py
@@ -5,7 +5,7 @@ from autogen_core.model_context import (
     ChatCompletionContext,
     UnboundedChatCompletionContext,
 )
-from autogen_core.models import ChatCompletionClient, LLMMessage, SystemMessage, UserMessage, AssistantMessage
+from autogen_core.models import AssistantMessage, ChatCompletionClient, LLMMessage, SystemMessage, UserMessage
 from pydantic import BaseModel
 from typing_extensions import Self
 
@@ -206,7 +206,7 @@ class SocietyOfMindAgent(BaseChatAgent, Component[SocietyOfMindAgentConfig]):
                     continue
                 inner_messages.append(inner_msg)
         assert result is not None
-        
+
         # Add new user/handoff messages to the model context
         await self._add_messages_to_context(
             model_context=model_context,
@@ -249,12 +249,7 @@ class SocietyOfMindAgent(BaseChatAgent, Component[SocietyOfMindAgentConfig]):
                 llm_messages.append(UserMessage(content=self._response_prompt, source="user"))
             completion = await self._model_client.create(messages=llm_messages, cancellation_token=cancellation_token)
             assert isinstance(completion.content, str)
-            await model_context.add_message(
-                AssistantMessage(
-                    content=completion.content,
-                    source=self.name
-                )
-            )
+            await model_context.add_message(AssistantMessage(content=completion.content, source=self.name))
             yield Response(
                 chat_message=TextMessage(source=self.name, content=completion.content, models_usage=completion.usage),
                 inner_messages=[],

--- a/python/packages/autogen-agentchat/tests/test_society_of_mind_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_society_of_mind_agent.py
@@ -112,8 +112,6 @@ async def test_society_of_mind_agent_multiple_rounds(runtime: AgentRuntime | Non
 
     context_messages = await society_of_mind_agent.model_context.get_messages()
     assert len(context_messages) == 2
-    assert context_messages[0].source == "user"
-    assert context_messages[1].source == "society_of_mind"
 
     # Continue.
     response = await society_of_mind_agent.run()
@@ -122,7 +120,6 @@ async def test_society_of_mind_agent_multiple_rounds(runtime: AgentRuntime | Non
 
     context_messages = await society_of_mind_agent.model_context.get_messages()
     assert len(context_messages) == 3
-    assert context_messages[2].source == "society_of_mind"
 
     # Continue.
     response = await society_of_mind_agent.run()
@@ -131,7 +128,6 @@ async def test_society_of_mind_agent_multiple_rounds(runtime: AgentRuntime | Non
 
     context_messages = await society_of_mind_agent.model_context.get_messages()
     assert len(context_messages) == 4
-    assert context_messages[3].source == "society_of_mind"
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-agentchat/tests/test_society_of_mind_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_society_of_mind_agent.py
@@ -101,20 +101,37 @@ async def test_society_of_mind_agent_multiple_rounds(runtime: AgentRuntime | Non
     inner_termination = MaxMessageTermination(3)
     inner_team = RoundRobinGroupChat([agent1, agent2], termination_condition=inner_termination, runtime=runtime)
     society_of_mind_agent = SocietyOfMindAgent("society_of_mind", team=inner_team, model_client=model_client)
+
+    context_messages = await society_of_mind_agent.model_context.get_messages()
+    assert len(context_messages) == 0
+
     response = await society_of_mind_agent.run(task="Count to 10.")
     assert len(response.messages) == 2
     assert response.messages[0].source == "user"
     assert response.messages[1].source == "society_of_mind"
 
-    # Continue.
-    response = await society_of_mind_agent.run()
-    assert len(response.messages) == 1
-    assert response.messages[0].source == "society_of_mind"
+    context_messages = await society_of_mind_agent.model_context.get_messages()
+    assert len(context_messages) == 2
+    assert context_messages[0].source == "user"
+    assert context_messages[1].source == "society_of_mind"
 
     # Continue.
     response = await society_of_mind_agent.run()
     assert len(response.messages) == 1
     assert response.messages[0].source == "society_of_mind"
+
+    context_messages = await society_of_mind_agent.model_context.get_messages()
+    assert len(context_messages) == 3
+    assert context_messages[2].source == "society_of_mind"
+
+    # Continue.
+    response = await society_of_mind_agent.run()
+    assert len(response.messages) == 1
+    assert response.messages[0].source == "society_of_mind"
+
+    context_messages = await society_of_mind_agent.model_context.get_messages()
+    assert len(context_messages) == 4
+    assert context_messages[3].source == "society_of_mind"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently SocietyOfMindAgent doesn't save its own response message into context, so in a multi round chat scenario, when this SocietyOfMindAgent is picked by upstream orchestrator (e.g. another GroupChat), its last response message shows in neither task messages nor inner context. This results in message lose. Then its inner team won't get same context as other agents in the upper team.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks 

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
