### PR TITLE
After successfully adding chromaDB data, return the ID.

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/memory/chromadb.py
+++ b/python/packages/autogen-ext/src/autogen_ext/memory/chromadb.py
@@ -290,7 +290,7 @@ class ChromaDBVectorMemory(Memory, Component[ChromaDBVectorMemoryConfig]):
 
         return UpdateContextResult(memories=query_results)
 
-    async def add(self, content: MemoryContent, cancellation_token: CancellationToken | None = None) -> None:
+    async def add(self, content: MemoryContent, cancellation_token: CancellationToken | None = None) -> str:
         """Add a memory content to ChromaDB."""
         self._ensure_initialized()
         if self._collection is None:
@@ -305,7 +305,10 @@ class ChromaDBVectorMemory(Memory, Component[ChromaDBVectorMemoryConfig]):
             metadata_dict["mime_type"] = str(content.mime_type)
 
             # Add to ChromaDB
-            self._collection.add(documents=[text], metadatas=[metadata_dict], ids=[str(uuid.uuid4())])
+            id_ = str(uuid.uuid4())
+            self._collection.add(documents=[text], metadatas=[metadata_dict], ids=[id_])
+            
+            return id_
 
         except Exception as e:
             logger.error(f"Failed to add content to ChromaDB: {e}")


### PR DESCRIPTION

## Why are these changes needed?

After creation, return the ID that can index the data, allowing direct data operations via the ID.

## Related issue number

No related issue

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
