### PR TITLE
fix serialization issue in streamablehttp mcp tools

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_config.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_config.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from typing import Any, Literal
 
 from mcp import StdioServerParameters
@@ -32,8 +31,8 @@ class StreamableHttpServerParams(BaseModel):
 
     url: str  # The endpoint URL.
     headers: dict[str, Any] | None = None  # Optional headers to include in requests.
-    timeout: timedelta = timedelta(seconds=30)  # HTTP timeout for regular operations.
-    sse_read_timeout: timedelta = timedelta(seconds=60 * 5)  # Timeout for SSE read operations.
+    timeout: float = 30.0  # HTTP timeout for regular operations in seconds.
+    sse_read_timeout: float = 300.0  # Timeout for SSE read operations in seconds.
     terminate_on_close: bool = True
 
 

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_streamable_http.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_streamable_http.py
@@ -49,7 +49,6 @@ class StreamableHttpMcpToolAdapter(
         .. code-block:: python
 
             import asyncio
-            from datetime import timedelta
             from autogen_ext.models.openai import OpenAIChatCompletionClient
             from autogen_ext.tools.mcp import StreamableHttpMcpToolAdapter, StreamableHttpServerParams
             from autogen_agentchat.agents import AssistantAgent
@@ -62,8 +61,8 @@ class StreamableHttpMcpToolAdapter(
                 server_params = StreamableHttpServerParams(
                     url="https://api.example.com/mcp",
                     headers={"Authorization": "Bearer your-api-key", "Content-Type": "application/json"},
-                    timeout=timedelta(seconds=30),
-                    sse_read_timeout=timedelta(seconds=60 * 5),
+                    timeout=30.0,  # HTTP timeout in seconds
+                    sse_read_timeout=300.0,  # SSE read timeout in seconds (5 minutes)
                     terminate_on_close=True,
                 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

The current `StreamableHttpServerParams` has timedelta values that are not JSON serializable (config.dump_component.model_dump_json()). 
This make is unusable in UIs like AGS that expect configs to be serializable to json,

```python
class StreamableHttpServerParams(BaseModel):
    """Parameters for connecting to an MCP server over Streamable HTTP."""

    type: Literal["StreamableHttpServerParams"] = "StreamableHttpServerParams"

    url: str  # The endpoint URL.
    headers: dict[str, Any] | None = None  # Optional headers to include in requests.
    timeout: timedelta = timedelta(seconds=30)  # HTTP timeout for regular operations.
    sse_read_timeout: timedelta = timedelta(seconds=60 * 5)  # Timeout for SSE read operations.
    terminate_on_close: bool = True
```

This PR uses float for time outs and casts it to timedelta as needed. 

```python
class StreamableHttpServerParams(BaseModel):
    """Parameters for connecting to an MCP server over Streamable HTTP."""

    type: Literal["StreamableHttpServerParams"] = "StreamableHttpServerParams"

    url: str  # The endpoint URL.
    headers: dict[str, Any] | None = None  # Optional headers to include in requests.
    timeout: float = 30.0  # HTTP timeout for regular operations in seconds.
    sse_read_timeout: float = 300.0  # Timeout for SSE read operations in seconds.
    terminate_on_close: bool = True
```

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
