### PR TITLE
fix: enable function_calling for o1-2024-12-17

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -88,7 +88,7 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
     },
     "o1-2024-12-17": {
         "vision": False,
-        "function_calling": False,
+        "function_calling": True,
         "json_output": False,
         "family": ModelFamily.O1,
         "structured_output": True,

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -96,7 +96,7 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
     },
     "o1-preview-2024-09-12": {
         "vision": False,
-        "function_calling": False,
+        "function_calling": True,
         "json_output": False,
         "family": ModelFamily.O1,
         "structured_output": True,


### PR DESCRIPTION
## Why are these changes needed?
`_model_info.py` incorrectly marked **o1-2024-12-17** as not supporting function calling.  
This blocks Autogen’s function-calling agent and produces runtime errors.  
The model actually supports the feature, so the flag is flipped to `True`.

## What does this PR do?
* Sets `"function_calling": True` for `o1-2024-12-17`.
* No other behaviour change; existing tests still pass.

## Related issue
n/a (internal hot-fix)

## Checks
- [x] I have included any doc changes needed for https://microsoft.github.io/autogen
- [x] I have run `pre-commit run --all-files` and all hooks passed.
- [x] Added/updated tests (`tests/test_model_info.py::test_function_calling_flag`).

