### PR TITLE
fix:多source的节点跳不到的问题，例如：agent p\u\e, p->u,p->e,u->e 在运行当中，p或u无法跳到e

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_graph/_digraph_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_graph/_digraph_group_chat.py
@@ -415,7 +415,7 @@ class GraphFlowManager(BaseGroupChatManager):
 
             if self._activation[target][activation_group] == "all":
                 self._remaining[target][activation_group] -= 1
-                if self._remaining[target][activation_group] == 0:
+                if self._remaining[target][activation_group] >= 0:
                     # If all parents are done, add to the ready queue.
                     self._ready.append(target)
                     # Track which activation group was triggered


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
