### PR TITLE
Fix mutable default in ListMemoryConfig

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/memory/_list_memory.py
+++ b/python/packages/autogen-core/src/autogen_core/memory/_list_memory.py
@@ -15,7 +15,7 @@ class ListMemoryConfig(BaseModel):
 
     name: str | None = None
     """Optional identifier for this memory instance."""
-    memory_contents: List[MemoryContent] = []
+    memory_contents: List[MemoryContent] = Field(default_factory=list)
     """List of memory contents stored in this memory instance."""
 
 


### PR DESCRIPTION
### Fix mutable default in [ListMemoryConfig](cci:2://file:///c:/Users/T2430514/Downloads/autogen/python/packages/autogen-core/src/autogen_core/memory/_list_memory.py:12:0-18:65)

[ListMemoryConfig](cci:2://file:///c:/Users/T2430514/Downloads/autogen/python/packages/autogen-core/src/autogen_core/memory/_list_memory.py:12:0-18:65) used a shared empty list (`memory_contents: List[MemoryContent] = []`) as its default, causing every [ListMemory](cci:2://file:///c:/Users/T2430514/Downloads/autogen/python/packages/autogen-core/src/autogen_core/memory/_list_memory.py:21:0-171:79) instance to share the same underlying list. This unexpected state leakage let memories written in one instance silently surface in others, breaking isolation and leading to hard-to-reproduce bugs.  
Replaced the mutable default with a safe Pydantic `Field(default_factory=list)`, ensuring each configuration—and thus each [ListMemory](cci:2://file:///c:/Users/T2430514/Downloads/autogen/python/packages/autogen-core/src/autogen_core/memory/_list_memory.py:21:0-171:79)—gets its own independent list.