### PR TITLE
Enhance output_content_type detection in AssistantAgent.

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -684,7 +684,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         self._output_content_type: type[BaseModel] | None = output_content_type
         self._output_content_type_format = output_content_type_format
         self._structured_message_factory: StructuredMessageFactory | None = None
-        if output_content_type is not None:
+        if output_content_type is not None and isinstance(output_content_type, type) and issubclass(output_content_type, BaseModel):
             self._structured_message_factory = StructuredMessageFactory(
                 input_model=output_content_type, format_string=output_content_type_format
             )
@@ -1013,7 +1013,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
 
         # If direct text response (string)
         if isinstance(model_result.content, str):
-            if output_content_type:
+            if output_content_type and isinstance(output_content_type, type) and issubclass(output_content_type, BaseModel):
                 content = output_content_type.model_validate_json(model_result.content)
                 yield Response(
                     chat_message=StructuredMessage[output_content_type](  # type: ignore[valid-type]
@@ -1234,7 +1234,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
             )
         )
 
-        if output_content_type:
+        if output_content_type and isinstance(output_content_type, type) and issubclass(output_content_type, BaseModel):
             content = output_content_type.model_validate_json(reflection_result.content)
             yield Response(
                 chat_message=StructuredMessage[output_content_type](  # type: ignore[valid-type]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Enhance output_content_type checking in AssistantAgent to prevent illegal types from being used to construct StructuredMessage.
This will also allow setting `output_content_type=True` on the `AssistantAgent` to output JSON output instead of json code blocks.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/microsoft/autogen/issues/6727

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
