### PR TITLE
Update GitHub Models url to the new url

### DIFF
--- a/dotnet/test/AutoGen.AzureAIInference.Tests/ChatCompletionClientAgentTests.cs
+++ b/dotnet/test/AutoGen.AzureAIInference.Tests/ChatCompletionClientAgentTests.cs
@@ -294,7 +294,7 @@ public partial class ChatCompletionClientAgentTests
     private ChatCompletionsClient CreateChatCompletionClient()
     {
         var apiKey = Environment.GetEnvironmentVariable("GH_API_KEY") ?? throw new Exception("Please set GH_API_KEY environment variable.");
-        var endpoint = "https://models.inference.ai.azure.com";
+        var endpoint = "https://models.github.ai/inference";
         return new ChatCompletionsClient(new Uri(endpoint), new Azure.AzureKeyCredential(apiKey));
     }
 

--- a/dotnet/test/AutoGen.Tests/Orchestrator/RolePlayOrchestratorTests.cs
+++ b/dotnet/test/AutoGen.Tests/Orchestrator/RolePlayOrchestratorTests.cs
@@ -292,7 +292,7 @@ public class RolePlayOrchestratorTests
     public async Task LLaMA_3_1_CoderReviewerRunnerTestAsync()
     {
         var apiKey = Environment.GetEnvironmentVariable("GH_API_KEY") ?? throw new InvalidOperationException("GH_API_KEY is not set.");
-        var endPoint = "https://models.inference.ai.azure.com";
+        var endPoint = "https://models.github.ai/inference";
 
         var chatCompletionClient = new ChatCompletionsClient(new Uri(endPoint), new Azure.AzureKeyCredential(apiKey));
         var agent = new ChatCompletionsClientAgent(

--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
@@ -248,7 +248,7 @@
     "\n",
     "client = AzureAIChatCompletionClient(\n",
     "    model=\"Phi-4\",\n",
-    "    endpoint=\"https://models.inference.ai.azure.com\",\n",
+    "    endpoint=\"https://models.github.ai/inference\",\n",
     "    # To authenticate with the model you will need to generate a personal access token (PAT) in your GitHub settings.\n",
     "    # Create your PAT token by following instructions here: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens\n",
     "    credential=AzureKeyCredential(os.environ[\"GITHUB_TOKEN\"]),\n",

--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
@@ -220,7 +220,7 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
         async def main():
             client = AzureAIChatCompletionClient(
                 model="Phi-4",
-                endpoint="https://models.inference.ai.azure.com",
+                endpoint="https://models.github.ai/inference",
                 # To authenticate with the model you will need to generate a personal access token (PAT) in your GitHub settings.
                 # Create your PAT token by following instructions here: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
                 credential=AzureKeyCredential(os.environ["GITHUB_TOKEN"]),
@@ -258,7 +258,7 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
         async def main():
             client = AzureAIChatCompletionClient(
                 model="Phi-4",
-                endpoint="https://models.inference.ai.azure.com",
+                endpoint="https://models.github.ai/inference",
                 # To authenticate with the model you will need to generate a personal access token (PAT) in your GitHub settings.
                 # Create your PAT token by following instructions here: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
                 credential=AzureKeyCredential(os.environ["GITHUB_TOKEN"]),

--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/config/__init__.py
@@ -9,7 +9,7 @@ from azure.ai.inference.models import (
 from azure.core.credentials import AzureKeyCredential
 from azure.core.credentials_async import AsyncTokenCredential
 
-GITHUB_MODELS_ENDPOINT = "https://models.inference.ai.azure.com"
+GITHUB_MODELS_ENDPOINT = "https://models.github.ai/inference"
 
 
 class JsonSchemaFormat(TypedDict, total=False):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For GitHub Models inference, Autogen was using the old URL. That works fine, but doesn't support newer features like [custom models](https://docs.github.com/en/github-models/github-models-at-scale/set-up-custom-model-integration-models-byok) or paid inference. This PR updates the URL to the one used in the GitHub [docs](https://docs.github.com/en/rest/models/inference?apiVersion=2022-11-28#run-an-inference-request).

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
