### PR TITLE
Update TaskRunnerToolArgs

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/tools/_task_runner_tool.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/tools/_task_runner_tool.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Annotated, Any, AsyncGenerator, List, Mapping
+from typing import Annotated, Any, AsyncGenerator, List, Mapping, Sequence
 
 from autogen_core import CancellationToken
 from autogen_core.tools import BaseStreamTool
@@ -14,7 +14,8 @@ from ..teams import BaseGroupChat
 class TaskRunnerToolArgs(BaseModel):
     """Input for the TaskRunnerTool."""
 
-    task: Annotated[str, "The task to be executed."]
+    task: str | BaseChatMessage | Sequence[BaseChatMessage] | None = None
+    """The task to be executed."""
 
 
 class TaskRunnerTool(BaseStreamTool[TaskRunnerToolArgs, BaseAgentEvent | BaseChatMessage, TaskResult], ABC):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I'm currently developing TeamTool and AgentTool, and I've noticed they are both based on the `TaskRunnerTool` class. Within `TaskRunnerTool`, `self._task_runner.run(task=args.task, cancellation_token=cancellation_token)` is used to run the Team and Agent to obtain results. The `_task_runner` is an instance of either `BaseGroupChat` or `BaseChatAgent`. Their `task` parameter inherently supports these types: `task: str | BaseChatMessage | Sequence[BaseChatMessage] | None = None`. Therefore, the `task` parameter in `TaskRunnerToolArgs` should also support these type definitions. Adding support for the `BaseChatMessage` class allows passing `metadata`, providing more flexible functionality for application developers.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
