### PR TITLE
Update _assistant_agent.py

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -1450,7 +1450,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
                 tool_choice="none",  # Do not use tools in reflection flow.
             )
 
-        if not reflection_result or not isinstance(reflection_result.content, str):
+        if not reflection_result or not isinstance(reflection_result.content, str | list):
             raise RuntimeError("Reflect on tool use produced no valid text response.")
 
         # --- NEW: If the reflection produced a thought, yield it ---
@@ -1482,7 +1482,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         else:
             yield Response(
                 chat_message=TextMessage(
-                    content=reflection_result.content,
+                    content=reflection_result.content if isinstance(reflection_result.content, str) else "",
                     source=agent_name,
                     models_usage=reflection_result.usage,
                     id=reflection_message_id,


### PR DESCRIPTION
solve  RuntimeError("Reflect on tool use produced no valid text response.") When "reflection_result.content" is a Function_calls LIST. The situation occurs in consecutive multiple tool calls. 


**For example**
Task prompt: "Please tell me a story about Little Red Riding Hood and draw it in five scenes"

print(reflection_result):
------------------ Reflection1 Result ------------------
finish_reason='function_calls' content=[FunctionCall(id='call_30151179', arguments='{"prompt":"some scenery description"}', name='generate_ai_image_tool')] usage=RequestUsage(prompt_tokens=0, completion_tokens=0) cached=False logprobs=None thought='scenery 1 result image: ![img](https://xxx.com/x.jpg). Generating scenery 2...'
------------------ Reflection1 end ------------------
Content is a List so it raise a runtime error.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
