### PR TITLE
fix: use correct format when adding memory to mem0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ registry.json
 
 # files created by the gitty agent in python/samples/gitty
 .gitty/
+.aider*

--- a/python/packages/autogen-ext/src/autogen_ext/memory/mem0/_mem0.py
+++ b/python/packages/autogen-ext/src/autogen_ext/memory/mem0/_mem0.py
@@ -257,7 +257,7 @@ class Mem0Memory(Memory, Component[Mem0MemoryConfig], ComponentBase[Mem0MemoryCo
             # Suppress warning messages from mem0 MemoryClient
             kwargs = {} if self._client.__class__.__name__ == "Memory" else {"output_format": "v1.1"}
             with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
-                self._client.add(message, user_id=user_id, metadata=metadata, **kwargs)  # type: ignore
+                self._client.add([{"role": "user", "content": message}], user_id=user_id, metadata=metadata, **kwargs)  # type: ignore
         except Exception as e:
             # Log the error but don't crash
             logger.error(f"Error adding to mem0 memory: {str(e)}")

--- a/python/packages/autogen-ext/tests/memory/test_mem0.py
+++ b/python/packages/autogen-ext/tests/memory/test_mem0.py
@@ -105,7 +105,7 @@ async def test_basic_workflow(mock_mem0_class: MagicMock, local_config: Mem0Memo
     call_args = mock_mem0.add.call_args[0]
 
     # Extract content from the list of dict structure: [{'content': '...', 'role': 'user'}]
-    actual_content = call_args[0][0]['content']
+    actual_content = call_args[0][0]["content"]
     assert actual_content == "Paris is known for the Eiffel Tower and amazing cuisine."
 
     call_kwargs = mock_mem0.add.call_args[1]
@@ -179,7 +179,7 @@ async def test_basic_workflow_with_cloud(mock_memory_client_class: MagicMock, cl
     call_args = mock_client.add.call_args
 
     # Extract content from list of dict structure: [{'content': '...', 'role': 'user'}]
-    actual_content = call_args[0][0][0]['content']  # call_args[0][0] gets the first positional arg (the list)
+    actual_content = call_args[0][0][0]["content"]  # call_args[0][0] gets the first positional arg (the list)
     assert test_content in actual_content
 
     assert call_args[1]["user_id"] == cloud_config.user_id
@@ -458,8 +458,8 @@ async def test_init_with_local_config(mock_mem0_class: MagicMock, full_local_con
 @pytest.mark.asyncio
 @patch("autogen_ext.memory.mem0._mem0.Memory0")  # Patches the underlying mem0.Memory class
 async def test_local_config_with_memory_operations(
-        mock_mem0_class: MagicMock,
-        full_local_config: Dict[str, Any],  # full_local_config fixture provides the mock config
+    mock_mem0_class: MagicMock,
+    full_local_config: Dict[str, Any],  # full_local_config fixture provides the mock config
 ) -> None:
     """Test memory operations with local configuration."""
     # Setup mock for the instance that will be created by Mem0Memory

--- a/python/packages/autogen-ext/tests/memory/test_mem0.py
+++ b/python/packages/autogen-ext/tests/memory/test_mem0.py
@@ -103,7 +103,11 @@ async def test_basic_workflow(mock_mem0_class: MagicMock, local_config: Mem0Memo
     # Verify add was called correctly
     mock_mem0.add.assert_called_once()
     call_args = mock_mem0.add.call_args[0]
-    assert call_args[0] == "Paris is known for the Eiffel Tower and amazing cuisine."
+
+    # Extract content from the list of dict structure: [{'content': '...', 'role': 'user'}]
+    actual_content = call_args[0][0]['content']
+    assert actual_content == "Paris is known for the Eiffel Tower and amazing cuisine."
+
     call_kwargs = mock_mem0.add.call_args[1]
     assert call_kwargs["metadata"] == {"category": "city", "country": "France"}
 
@@ -173,7 +177,11 @@ async def test_basic_workflow_with_cloud(mock_memory_client_class: MagicMock, cl
     # Verify add was called correctly
     mock_client.add.assert_called_once()
     call_args = mock_client.add.call_args
-    assert test_content in str(call_args[0][0])  # Check that content was passed
+
+    # Extract content from list of dict structure: [{'content': '...', 'role': 'user'}]
+    actual_content = call_args[0][0][0]['content']  # call_args[0][0] gets the first positional arg (the list)
+    assert test_content in actual_content
+
     assert call_args[1]["user_id"] == cloud_config.user_id
     assert call_args[1]["metadata"]["test"] is True
 
@@ -450,8 +458,8 @@ async def test_init_with_local_config(mock_mem0_class: MagicMock, full_local_con
 @pytest.mark.asyncio
 @patch("autogen_ext.memory.mem0._mem0.Memory0")  # Patches the underlying mem0.Memory class
 async def test_local_config_with_memory_operations(
-    mock_mem0_class: MagicMock,
-    full_local_config: Dict[str, Any],  # full_local_config fixture provides the mock config
+        mock_mem0_class: MagicMock,
+        full_local_config: Dict[str, Any],  # full_local_config fixture provides the mock config
 ) -> None:
     """Test memory operations with local configuration."""
     # Setup mock for the instance that will be created by Mem0Memory


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR uses the correct format when adding a memory to mem0

## Related issue number

Closes #6828

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
