### PR TITLE
Make CodeExecutionTool support multiple languages

### DIFF
--- a/python/docs/src/user-guide/core-user-guide/components/tools.ipynb
+++ b/python/docs/src/user-guide/core-user-guide/components/tools.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "## Built-in Tools\n",
     "\n",
-    "One of the built-in tools is the {py:class}`~autogen_ext.tools.code_execution.PythonCodeExecutionTool`,\n",
+    "One of the built-in tools is the {py:class}`~autogen_ext.tools.code_execution.CodeExecutionTool`,\n",
     "which allows agents to execute Python code snippets.\n",
     "\n",
     "Here is how you create the tool and use it."
@@ -45,17 +45,17 @@
    "source": [
     "from autogen_core import CancellationToken\n",
     "from autogen_ext.code_executors.docker import DockerCommandLineCodeExecutor\n",
-    "from autogen_ext.tools.code_execution import PythonCodeExecutionTool\n",
+    "from autogen_ext.tools.code_execution import CodeExecutionTool\n",
     "\n",
     "# Create the tool.\n",
     "code_executor = DockerCommandLineCodeExecutor()\n",
     "await code_executor.start()\n",
-    "code_execution_tool = PythonCodeExecutionTool(code_executor)\n",
+    "code_execution_tool = CodeExecutionTool(code_executor)\n",
     "cancellation_token = CancellationToken()\n",
     "\n",
     "# Use the tool directly without an agent.\n",
     "code = \"print('Hello, world!')\"\n",
-    "result = await code_execution_tool.run_json({\"code\": code}, cancellation_token)\n",
+    "result = await code_execution_tool.run_json({\"language\":\"python\", \"code\": code}, cancellation_token)\n",
     "print(code_execution_tool.return_value_as_string(result))"
    ]
   },
@@ -66,7 +66,7 @@
     "The {py:class}`~autogen_ext.code_executors.docker.DockerCommandLineCodeExecutor`\n",
     "class is a built-in code executor that runs Python code snippets in a subprocess\n",
     "in the command line environment of a docker container.\n",
-    "The {py:class}`~autogen_ext.tools.code_execution.PythonCodeExecutionTool` class wraps the code executor\n",
+    "The {py:class}`~autogen_ext.tools.code_execution.CodeExecutionTool` class wraps the code executor\n",
     "and provides a simple interface to execute Python code snippets.\n",
     "\n",
     "Examples of other built-in tools\n",

--- a/python/docs/src/user-guide/core-user-guide/cookbook/tool-use-with-intervention.ipynb
+++ b/python/docs/src/user-guide/core-user-guide/cookbook/tool-use-with-intervention.ipynb
@@ -40,7 +40,7 @@
     "from autogen_core.tools import ToolSchema\n",
     "from autogen_ext.code_executors.docker import DockerCommandLineCodeExecutor\n",
     "from autogen_ext.models.openai import OpenAIChatCompletionClient\n",
-    "from autogen_ext.tools.code_execution import PythonCodeExecutionTool"
+    "from autogen_ext.tools.code_execution import CodeExecutionTool"
    ]
   },
   {
@@ -169,7 +169,7 @@
     "First, we create a Docker-based command-line code executor\n",
     "using {py:class}`~autogen_ext.code_executors.docker.DockerCommandLineCodeExecutor`,\n",
     "and then use it to instantiate a built-in Python code execution tool\n",
-    "{py:class}`~autogen_core.tools.PythonCodeExecutionTool`\n",
+    "{py:class}`~autogen_core.tools.CodeExecutionTool`\n",
     "that runs code in a Docker container."
    ]
   },
@@ -182,8 +182,8 @@
     "# Create the docker executor for the Python code execution tool.\n",
     "docker_executor = DockerCommandLineCodeExecutor()\n",
     "\n",
-    "# Create the Python code execution tool.\n",
-    "python_tool = PythonCodeExecutionTool(executor=docker_executor)"
+    "# Create the code execution tool.\n",
+    "execution_tool = CodeExecutionTool(executor=docker_executor)"
    ]
   },
   {
@@ -216,7 +216,7 @@
     "    \"tool_executor_agent\",\n",
     "    lambda: ToolAgent(\n",
     "        description=\"Tool Executor Agent\",\n",
-    "        tools=[python_tool],\n",
+    "        tools=[execution_tool],\n",
     "    ),\n",
     ")\n",
     "model_client = OpenAIChatCompletionClient(model=\"gpt-4o-mini\")\n",
@@ -227,7 +227,7 @@
     "        description=\"Tool Use Agent\",\n",
     "        system_messages=[SystemMessage(content=\"You are a helpful AI Assistant. Use your tools to solve problems.\")],\n",
     "        model_client=model_client,\n",
-    "        tool_schema=[python_tool.schema],\n",
+    "        tool_schema=[execution_tool.schema],\n",
     "        tool_agent_type=tool_agent_type,\n",
     "    ),\n",
     ")"

--- a/python/packages/autogen-ext/src/autogen_ext/agents/openai/_openai_agent.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/openai/_openai_agent.py
@@ -536,7 +536,7 @@ class OpenAIAgent(BaseChatAgent, Component[OpenAIAgentConfig]):
                     f"Tool 'local_shell' is only supported with model 'codex-mini-latest', "
                     f"but current model is '{self._model}'. "
                     f"This tool is available exclusively through the Responses API and has severe limitations. "
-                    f"Consider using autogen_ext.tools.code_execution.PythonCodeExecutionTool with "
+                    f"Consider using autogen_ext.tools.code_execution.CodeExecutionTool with "
                     f"autogen_ext.code_executors.local.LocalCommandLineCodeExecutor for shell execution instead."
                 )
             self._tools.append({"type": "local_shell"})
@@ -580,7 +580,7 @@ class OpenAIAgent(BaseChatAgent, Component[OpenAIAgentConfig]):
                     f"Tool 'local_shell' is only supported with model 'codex-mini-latest', "
                     f"but current model is '{self._model}'. "
                     f"This tool is available exclusively through the Responses API and has severe limitations. "
-                    f"Consider using autogen_ext.tools.code_execution.PythonCodeExecutionTool with "
+                    f"Consider using autogen_ext.tools.code_execution.CodeExecutionTool with "
                     f"autogen_ext.code_executors.local.LocalCommandLineCodeExecutor for shell execution instead."
                 )
             tool_def = {"type": "local_shell"}

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
@@ -97,7 +97,7 @@ class DockerJupyterCodeExecutor(CodeExecutor, Component[DockerJupyterCodeExecuto
 
         asyncio.run(main())
 
-    Example of using it with :class:`~autogen_ext.tools.code_execution.PythonCodeExecutionTool`:
+    Example of using it with :class:`~autogen_ext.tools.code_execution.CodeExecutionTool`:
 
     .. code-block:: python
 
@@ -105,13 +105,13 @@ class DockerJupyterCodeExecutor(CodeExecutor, Component[DockerJupyterCodeExecuto
         from autogen_agentchat.agents import AssistantAgent
         from autogen_ext.code_executors.docker_jupyter import DockerJupyterCodeExecutor, DockerJupyterServer
         from autogen_ext.models.openai import OpenAIChatCompletionClient
-        from autogen_ext.tools.code_execution import PythonCodeExecutionTool
+        from autogen_ext.tools.code_execution import CodeExecutionTool
 
 
         async def main() -> None:
             async with DockerJupyterServer() as jupyter_server:
                 async with DockerJupyterCodeExecutor(jupyter_server=jupyter_server) as executor:
-                    tool = PythonCodeExecutionTool(executor)
+                    tool = CodeExecutionTool(executor)
                     model_client = OpenAIChatCompletionClient(model="gpt-4o")
                     agent = AssistantAgent("assistant", model_client=model_client, tools=[tool])
                     result = await agent.run(task="What is the 10th Fibonacci number? Use Python to calculate it.")

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -72,7 +72,7 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
 
         asyncio.run(main())
 
-    Example of using it with :class:`~autogen_ext.tools.code_execution.PythonCodeExecutionTool`:
+    Example of using it with :class:`~autogen_ext.tools.code_execution.CodeExecutionTool`:
 
     .. code-block:: python
 
@@ -80,12 +80,12 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
         from autogen_agentchat.agents import AssistantAgent
         from autogen_ext.code_executors.jupyter import JupyterCodeExecutor
         from autogen_ext.models.openai import OpenAIChatCompletionClient
-        from autogen_ext.tools.code_execution import PythonCodeExecutionTool
+        from autogen_ext.tools.code_execution import CodeExecutionTool
 
 
         async def main() -> None:
             async with JupyterCodeExecutor() as executor:
-                tool = PythonCodeExecutionTool(executor)
+                tool = CodeExecutionTool(executor)
                 model_client = OpenAIChatCompletionClient(model="gpt-4o")
                 agent = AssistantAgent("assistant", model_client=model_client, tools=[tool])
                 result = await agent.run(task="What is the 10th Fibonacci number? Use Python to calculate it.")

--- a/python/packages/autogen-ext/src/autogen_ext/tools/code_execution/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/code_execution/__init__.py
@@ -1,3 +1,3 @@
-from ._code_execution import CodeExecutionInput, CodeExecutionResult, PythonCodeExecutionTool
+from ._code_execution import CodeExecutionInput, CodeExecutionResult, CodeExecutionTool
 
-__all__ = ["CodeExecutionInput", "CodeExecutionResult", "PythonCodeExecutionTool"]
+__all__ = ["CodeExecutionInput", "CodeExecutionResult", "CodeExecutionTool"]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/code_execution/_code_execution.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/code_execution/_code_execution.py
@@ -26,9 +26,7 @@ class CodeExecutionToolConfig(BaseModel):
     description: str = "Execute code blocks."
 
 
-class CodeExecutionTool(
-    BaseTool[CodeExecutionInput, CodeExecutionResult], Component[CodeExecutionToolConfig]
-):
+class CodeExecutionTool(BaseTool[CodeExecutionInput, CodeExecutionResult], Component[CodeExecutionToolConfig]):
     """A tool that executes code in a code executor and returns output.
 
     Example executors:

--- a/python/packages/autogen-ext/tests/tools/test_code_executor_tool.py
+++ b/python/packages/autogen-ext/tests/tools/test_code_executor_tool.py
@@ -4,22 +4,22 @@ import tempfile
 import pytest
 from autogen_core import CancellationToken
 from autogen_ext.code_executors.local import LocalCommandLineCodeExecutor
-from autogen_ext.tools.code_execution import CodeExecutionInput, PythonCodeExecutionTool
+from autogen_ext.tools.code_execution import CodeExecutionInput, CodeExecutionTool
 
 
 @pytest.mark.asyncio
-async def test_python_code_execution_tool(caplog: pytest.LogCaptureFixture) -> None:
-    """Test basic functionality of PythonCodeExecutionTool."""
+async def test_code_execution_tool(caplog: pytest.LogCaptureFixture) -> None:
+    """Test basic functionality of CodeExecutionTool."""
     # Create a temporary directory for the executor
     with tempfile.TemporaryDirectory() as temp_dir:
         # Initialize the executor and tool
         executor = LocalCommandLineCodeExecutor(work_dir=temp_dir)
-        tool = PythonCodeExecutionTool(executor=executor)
+        tool = CodeExecutionTool(executor=executor)
 
         with caplog.at_level(logging.INFO):
             # Test simple code execution
             code = "print('hello world!')"
-            result = await tool.run_json(args={"code": code}, cancellation_token=CancellationToken())
+            result = await tool.run_json(args={"code": code, "language": "python"}, cancellation_token=CancellationToken())
             # Check log output
             assert "hello world!" in caplog.text
 
@@ -30,7 +30,7 @@ async def test_python_code_execution_tool(caplog: pytest.LogCaptureFixture) -> N
         # Test code with computation
         code = """a = 100 + 200 \nprint(f'Result: {a}')
         """
-        result = await tool.run(args=CodeExecutionInput(code=code), cancellation_token=CancellationToken())
+        result = await tool.run(args=CodeExecutionInput(language="python", code=code), cancellation_token=CancellationToken())
 
         # Verify computation result
         assert result.success is True
@@ -38,26 +38,39 @@ async def test_python_code_execution_tool(caplog: pytest.LogCaptureFixture) -> N
 
         # Test error handling
         code = "print(undefined_variable)"
-        result = await tool.run(args=CodeExecutionInput(code=code), cancellation_token=CancellationToken())
+        result = await tool.run(args=CodeExecutionInput(language="python", code=code), cancellation_token=CancellationToken())
 
         # Verify error handling
         assert result.success is False
         assert "NameError" in result.output
 
+        # Test shell command execution
+        code = "echo 'hello world!'"
+        result = await tool.run(args=CodeExecutionInput(language="sh", code=code), cancellation_token=CancellationToken())
 
-def test_python_code_execution_tool_serialization() -> None:
-    """Test serialization and deserialization of PythonCodeExecutionTool."""
+        assert result.success is True
+        assert "hello world!" in result.output
+
+        code = "fake_command"
+        result = await tool.run(args=CodeExecutionInput(language="sh", code=code), cancellation_token=CancellationToken())
+
+        assert result.success is False
+        assert "fake_command: command not found" in result.output
+
+
+def test_code_execution_tool_serialization() -> None:
+    """Test serialization and deserialization of CodeExecutionTool."""
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create original tool
         executor = LocalCommandLineCodeExecutor(work_dir=temp_dir)
-        original_tool = PythonCodeExecutionTool(executor=executor)
+        original_tool = CodeExecutionTool(executor=executor)
 
         # Serialize
         config = original_tool.dump_component()
         assert config.config.get("executor") is not None
 
         # Deserialize
-        loaded_tool = PythonCodeExecutionTool.load_component(config)
+        loaded_tool = CodeExecutionTool.load_component(config)
 
         # Verify the loaded tool has the same configuration
-        assert isinstance(loaded_tool, PythonCodeExecutionTool)
+        assert isinstance(loaded_tool, CodeExecutionTool)

--- a/python/packages/autogen-ext/tests/tools/test_code_executor_tool.py
+++ b/python/packages/autogen-ext/tests/tools/test_code_executor_tool.py
@@ -19,7 +19,9 @@ async def test_code_execution_tool(caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level(logging.INFO):
             # Test simple code execution
             code = "print('hello world!')"
-            result = await tool.run_json(args={"code": code, "language": "python"}, cancellation_token=CancellationToken())
+            result = await tool.run_json(
+                args={"code": code, "language": "python"}, cancellation_token=CancellationToken()
+            )
             # Check log output
             assert "hello world!" in caplog.text
 
@@ -30,7 +32,9 @@ async def test_code_execution_tool(caplog: pytest.LogCaptureFixture) -> None:
         # Test code with computation
         code = """a = 100 + 200 \nprint(f'Result: {a}')
         """
-        result = await tool.run(args=CodeExecutionInput(language="python", code=code), cancellation_token=CancellationToken())
+        result = await tool.run(
+            args=CodeExecutionInput(language="python", code=code), cancellation_token=CancellationToken()
+        )
 
         # Verify computation result
         assert result.success is True
@@ -38,7 +42,9 @@ async def test_code_execution_tool(caplog: pytest.LogCaptureFixture) -> None:
 
         # Test error handling
         code = "print(undefined_variable)"
-        result = await tool.run(args=CodeExecutionInput(language="python", code=code), cancellation_token=CancellationToken())
+        result = await tool.run(
+            args=CodeExecutionInput(language="python", code=code), cancellation_token=CancellationToken()
+        )
 
         # Verify error handling
         assert result.success is False
@@ -46,16 +52,20 @@ async def test_code_execution_tool(caplog: pytest.LogCaptureFixture) -> None:
 
         # Test shell command execution
         code = "echo 'hello world!'"
-        result = await tool.run(args=CodeExecutionInput(language="sh", code=code), cancellation_token=CancellationToken())
+        result = await tool.run(
+            args=CodeExecutionInput(language="sh", code=code), cancellation_token=CancellationToken()
+        )
 
         assert result.success is True
         assert "hello world!" in result.output
 
         code = "fake_command"
-        result = await tool.run(args=CodeExecutionInput(language="sh", code=code), cancellation_token=CancellationToken())
+        result = await tool.run(
+            args=CodeExecutionInput(language="sh", code=code), cancellation_token=CancellationToken()
+        )
 
         assert result.success is False
-        assert "fake_command: command not found" in result.output
+        assert "fake_command: not found" in result.output
 
 
 def test_code_execution_tool_serialization() -> None:


### PR DESCRIPTION
## Why are these changes needed?

We can execute multiple languages with this tool, not just python.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
