### PR TITLE
Update _workbench.py

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
@@ -431,7 +431,7 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
             raise RuntimeError("Actor is not initialized. Please check the server connection.")
 
         result_future = await self._actor.call("get_prompt", {"name": name, "kargs": {"arguments": arguments}})
-        get_prompt_result = await result_future
+        get_prompt_result = result_future
         assert isinstance(
             get_prompt_result, GetPromptResult
         ), f"get_prompt must return a GetPromptResult, instead of: {str(type(get_prompt_result))}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixes an issue in MCPWorkbench.get_prompt where a non-awaitable result is incorrectly awaited, causing the following error:

`TypeError: object GetPromptResult can't be used in 'await' expression`

Root cause:
```
result_future = await self._actor.call("get_prompt", {...})
get_prompt_result = await result_future
```

However, self._actor.call(...) already returns the final GetPromptResult (after the first await), not a coroutine/future. Attempting to await it again results in the error above.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
