### PR TITLE
Fix: Added an additional filter condition to exclude the run_manager parameter when generating the pydantic schema

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
@@ -169,7 +169,9 @@ class LangChainToolAdapter(BaseTool[BaseModel, Any]):
             fields = {
                 k: (v.annotation, Field(...))
                 for k, v in sig.parameters.items()
-                if k != "self" and v.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+                if k != "self"
+                and v.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+                and k != "run_manager"  # Exclude LangChain callback manager parameters
             }
             args_type = create_model(f"{name}Args", **fields)  # type: ignore
             # Note: type ignore is used due to a LangChain typing limitation


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a critical issue in the LangChainToolAdapter where pydantic schema generation was failing when processing LangChain tools that include `run_manager` parameters. The problem occurred when the adapter attempted to infer the pydantic schema from a LangChain tool's signature and included the `run_manager: Optional[CallbackManagerForToolRun]` parameter, which pydantic couldn't handle due to the complex `CallbackManagerForToolRun` type.

The fix adds an additional filter condition to exclude the `run_manager` parameter when generating the pydantic schema, preventing "Unable to generate pydantic-core schema for CallbackManagerForToolRun" errors.

## Related issue number

Closes #6385

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.