### PR TITLE
Add OpenRouter Integration Examples to `models.ipynb` Documentation

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
@@ -485,6 +485,147 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## OpenRouter (third-party)\n",
+    "\n",
+    "[OpenRouter](https://openrouter.ai/) is a unified API that provides access to multiple AI models from different providers including OpenAI, Anthropic, Google, Meta, and many others through a single endpoint. It offers an [OpenAI-compatible API](https://openrouter.ai/docs#quick-start), making it easy to switch between different models.\n",
+    "\n",
+    "You can use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with OpenRouter to access any of their supported models.\n",
+    "\n",
+    "This integration fully supports the following OpenAI client library features:\n",
+    "* Chat completions\n",
+    "* Model selection from multiple providers\n",
+    "* Temperature/sampling\n",
+    "* Streaming\n",
+    "* Function calling (tools)\n",
+    "* JSON output mode\n",
+    "* Structured output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "Setup:\n",
+    "1. Install required packages: pip install python-dotenv autogen-agentchat autogen-ext[openai]\n",
+    "2. Create a .env file with: OPENROUTER_API_KEY=your_key_here\n",
+    "3. Get your API key from: https://openrouter.ai/\n",
+    "\"\"\"\n",
+    "\n",
+    "import asyncio\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from autogen_ext.models.openai import OpenAIChatCompletionClient\n",
+    "from autogen_core.models import ModelInfo\n",
+    "from autogen_agentchat.messages import TextMessage, ModelClientStreamingChunkEvent\n",
+    "from autogen_agentchat.agents import AssistantAgent\n",
+    "from autogen_agentchat.base import TaskResult\n",
+    "\n",
+    "# Load environment variables\n",
+    "load_dotenv()\n",
+    "\n",
+    "# OpenRouter configuration\n",
+    "api_key = os.getenv(\"OPENROUTER_API_KEY\")\n",
+    "\n",
+    "client = OpenAIChatCompletionClient(\n",
+    "    model=\"moonshotai/kimi-k2:free\",\n",
+    "    base_url=\"https://openrouter.ai/api/v1\",\n",
+    "    api_key=api_key,\n",
+    "    model_info=ModelInfo(\n",
+    "        vision=False,\n",
+    "        function_calling=True,\n",
+    "        json_output=True,\n",
+    "        family=\"unknown\",\n",
+    "        structured_output=True\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[user] What is the capital of India?\n",
+      "[my_assistant] The capital of India is **New Delhi**.\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "Basic AutoGen chat with OpenRouter\n",
+    "\"\"\"\n",
+    "\n",
+    "async def basic_chat():\n",
+    "    agent = AssistantAgent(name='my_assistant', model_client=client)\n",
+    "    res = await agent.run(task='What is the capital of India?')\n",
+    "\n",
+    "    for msg in res.messages:\n",
+    "        print(f\"[{msg.source}] {msg.content}\")\n",
+    "\n",
+    "# Run the basic example\n",
+    "await basic_chat()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[user full response]: What are the 5 most unique places to visit in India. Keep it under 50 words for each.\n",
+      "[my_assistant streaming]: 1. Majuli Assam – World’s largest river island on Brahmaputra, home to Mising tribes, satras, masked dances and drifting life lived on stilts.  \n",
+      "2. Ziro Arunachal – Emerald rice terraces, Apatani nose-plate women, pine forests, and warmest tribal homestays under starlit valleys.  \n",
+      "3. Lonar Maharashtra – Meteor-born saltwater crater lake wrapped in mythic temples and magnetic soils.  \n",
+      "4. Rann Utsav Kutch – Vast white salt desert glowing under moon tents, mirage festivals, flamingo skies and mirrored horizon nights.  \n",
+      "5. Living Root Bridges Meghalaya – Tangled living ficus ladders in cherrapunji’s rainforests, centuries of Khasi bio-engineering walkable daily."
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "Streaming chat with real-time response\n",
+    "\"\"\"\n",
+    "\n",
+    "async def streaming_chat():\n",
+    "    agent = AssistantAgent(\n",
+    "        name=\"my_assistant\",\n",
+    "        model_client=client,\n",
+    "        system_message=\"You are a helpful assistant.\",\n",
+    "        model_client_stream=True\n",
+    "    )\n",
+    "\n",
+    "    first_chunk = True\n",
+    "    async for event in agent.run_stream(task=\"What are the 5 most unique places to visit in India. Keep it under 50 words for each.\"):\n",
+    "        if isinstance(event, ModelClientStreamingChunkEvent):\n",
+    "            if first_chunk:\n",
+    "                print(f\"[{event.source} streaming]: \", end='', flush=True)\n",
+    "                first_chunk = False\n",
+    "            print(event.content, end='', flush=True)\n",
+    "        elif isinstance(event, TextMessage):\n",
+    "            if event.source == 'user':\n",
+    "                print(f\"\\n[{event.source} full response]: {event.content}\")\n",
+    "        elif isinstance(event, TaskResult):\n",
+    "            break\n",
+    "\n",
+    "# Run the streaming example\n",
+    "await streaming_chat()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Semantic Kernel Adapter\n",
     "\n",
     "The {py:class}`~autogen_ext.models.semantic_kernel.SKChatCompletionAdapter`\n",
@@ -580,7 +721,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -594,7 +735,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Why are these changes needed?
Adds OpenRouter integration section to the existing models.ipynb notebook. OpenRouter provides access to multiple AI models from different providers (OpenAI, Anthropic, Google, Meta, etc.) through a unified OpenAI-compatible API, but this integration wasn't documented. This addition provides working examples that I've tested locally, demonstrating both basic chat and streaming functionality with OpenRouter models.

## Related issue number
N/A - Documentation enhancement

## Checks
- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.