### PR TITLE
Typo in docs for 'NoOpTracerProvider'

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/tracing.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tracing.ipynb
@@ -97,7 +97,7 @@
     "AgentChat teams are run using the AutoGen Core's agent runtime.\n",
     "In turn, the runtime is already instrumented to log, see [Core Telemetry Guide](../core-user-guide/framework/telemetry.md).\n",
     "To disable the agent runtime telemetry, you can set the `trace_provider` to\n",
-    "`opentelemetry.trace.NoOpTraceProvider` in the runtime constructor.\n",
+    "`opentelemetry.trace.NoOpTracerProvider` in the runtime constructor.\n",
     "\n",
     "Additionally, you can set the environment variable `AUTOGEN_DISABLE_RUNTIME_TRACING` to `true` to disable the agent runtime telemetry if you don't have access to the runtime constructor. For example, if you are using `ComponentConfig`.\n",
     "```"

--- a/python/docs/src/user-guide/core-user-guide/framework/telemetry.md
+++ b/python/docs/src/user-guide/core-user-guide/framework/telemetry.md
@@ -10,7 +10,7 @@ These are the components that are currently instrumented:
 
 ```{note}
 To disable the agent runtime telemetry, you can set the `trace_provider` to
-`opentelemetry.trace.NoOpTraceProvider` in the runtime constructor.
+`opentelemetry.trace.NoOpTracerProvider` in the runtime constructor.
 
 Additionally, you can set the environment variable `AUTOGEN_DISABLE_RUNTIME_TRACING` to `true` to disable the agent runtime telemetry if you don't have access to the runtime constructor. For example, if you are using `ComponentConfig`.
 ```


### PR DESCRIPTION
Quick fix for a typo that caused a minute of confusion when I was looking for the `NoOpTracerProvider` class.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
