### PR TITLE
Extend pydantic model capability for anyOf/oneOf item typing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -217,7 +217,7 @@ jobs:
           uv venv --python=3.11
           source .venv/bin/activate
           # Only pin version to ensure compatibility
-          uv pip install -U 'setuptools-scm>=8.1'
+          uv pip install -U 'setuptools-scm==9.0.3'
           uv sync --locked --all-extras
           poe --directory ${{ matrix.version.poe-dir }} docs-build
           mkdir -p docs-staging/${{ matrix.version.dest-dir }}/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -217,7 +217,7 @@ jobs:
           uv venv --python=3.11
           source .venv/bin/activate
           # Only pin version to ensure compatibility
-          uv pip install -U 'setuptools-scm==9.0.3'
+          uv pip install -U 'setuptools-scm==8.3.1'
           uv sync --locked --all-extras
           poe --directory ${{ matrix.version.poe-dir }} docs-build
           mkdir -p docs-staging/${{ matrix.version.dest-dir }}/

--- a/python/packages/autogen-core/src/autogen_core/utils/_json_to_pydantic.py
+++ b/python/packages/autogen-core/src/autogen_core/utils/_json_to_pydantic.py
@@ -174,7 +174,31 @@ class _JSONSchemaToPydantic:
                 json_type = s.get("type")
                 if json_type not in TYPE_MAPPING:
                     raise UnsupportedKeywordError(f"Unsupported or missing type `{json_type}` in union")
-                types.append(TYPE_MAPPING[json_type])
+
+                # Handle array types with items specification
+                if json_type == "array" and "items" in s:
+                    item_schema = s["items"]
+                    if "$ref" in item_schema:
+                        item_type = self.get_ref(item_schema["$ref"].split("/")[-1])
+                    else:
+                        item_type_name = item_schema.get("type")
+                        if item_type_name is None:
+                            item_type = str
+                        elif item_type_name not in TYPE_MAPPING:
+                            raise UnsupportedKeywordError(f"Unsupported item type `{item_type_name}` in union array")
+                        else:
+                            item_type = TYPE_MAPPING[item_type_name]
+
+                    constraints = {}
+                    if "minItems" in s:
+                        constraints["min_length"] = s["minItems"]
+                    if "maxItems" in s:
+                        constraints["max_length"] = s["maxItems"]
+
+                    array_type = conlist(item_type, **constraints) if constraints else List[item_type]  # type: ignore[valid-type]
+                    types.append(array_type)
+                else:
+                    types.append(TYPE_MAPPING[json_type])
         return types
 
     def _extract_field_type(self, key: str, value: Dict[str, Any], model_name: str, root_schema: Dict[str, Any]) -> Any:
@@ -232,7 +256,7 @@ class _JSONSchemaToPydantic:
             else:
                 item_type_name = item_schema.get("type")
                 if item_type_name is None:
-                    item_type = List[str]
+                    item_type = str
                 elif item_type_name not in TYPE_MAPPING:
                     raise UnsupportedKeywordError(
                         f"Unsupported or missing item type `{item_type_name}` for array field `{key}` in `{model_name}`"

--- a/python/packages/autogen-core/tests/test_json_to_pydantic.py
+++ b/python/packages/autogen-core/tests/test_json_to_pydantic.py
@@ -551,6 +551,82 @@ def test_oneof_with_discriminator(converter: _JSONSchemaToPydantic) -> None:
     assert model_schema["properties"]["pet"]["discriminator"]["propertyName"] == "pet_type"
 
 
+def test_anyof_array_with_item_constraints(converter: _JSONSchemaToPydantic) -> None:
+    """Test anyOf branch as array with items and min/max constraints."""
+    schema = {
+        "title": "ArrayOrString",
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                        "maxItems": 3,
+                    },
+                    {"type": "string"},
+                ]
+            }
+        },
+        "required": ["value"],
+    }
+
+    Model = converter.json_schema_to_pydantic(schema, "ArrayOrString")
+
+    m1 = Model(value="hello")
+    assert m1.value == "hello"  # type: ignore[attr-defined]
+
+    m2 = Model(value=["a", "b"])
+    assert m2.value == ["a", "b"]  # type: ignore[attr-defined]
+
+    with pytest.raises(ValidationError):
+        Model(value=["one", "two", "three", "four"])
+
+    with pytest.raises(ValidationError):
+        Model(value=[])
+
+
+def test_oneof_array_with_ref_items(converter: _JSONSchemaToPydantic) -> None:
+    """Test oneOf branch as array whose items are a $ref object."""
+    schema = {
+        "title": "RefArrayOrInt",
+        "type": "object",
+        "properties": {
+            "payload": {
+                "oneOf": [
+                    {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Item"},
+                        "minItems": 1,
+                    },
+                    {"type": "integer"},
+                ]
+            }
+        },
+        "required": ["payload"],
+        "$defs": {
+            "Item": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}, "count": {"type": "integer"}},
+                "required": ["name"],
+                "title": "Item",
+            }
+        },
+    }
+
+    Model = converter.json_schema_to_pydantic(schema, "RefArrayOrInt")
+
+    m1 = Model(payload=42)
+    assert m1.payload == 42  # type: ignore[attr-defined]
+
+    m2 = Model(payload=[{"name": "widget", "count": 5}, {"name": "gadget"}])
+    assert [it.name for it in m2.payload] == ["widget", "gadget"]  # type: ignore[attr-defined]
+
+    with pytest.raises(ValidationError):
+        Model(payload=[])
+
+
 def test_allof_merging_with_refs(converter: _JSONSchemaToPydantic) -> None:
     schema = {
         "title": "EmployeeWithDepartment",


### PR DESCRIPTION
## Why are these changes needed?

This change extends `_JSONSchemaToPydantic`’s union-type handling to correctly process `anyOf`/`oneOf` branches that are arrays with defined `items`.  

Previously, arrays inside a union were treated generically, losing:
- the specific `items` type (including `$ref` references)
- array constraints (`minItems`, `maxItems`)

With this update:
- `$ref` in `items` is resolved to the correct Pydantic type
- primitive `items.type` is mapped via `TYPE_MAPPING`
- sensible default (`str`) is applied when `items.type` is omitted
- `minItems`/`maxItems` are enforced via `conlist`

This brings union-array handling in line with how standalone array fields are already processed, improving type accuracy and validation consistency.

Example of a json schema now properly mapped:

```json
{
  "type": "object",
  "properties": {
    "value": {
      "anyOf": [
        {
          "type": "array",
          "items": { "type": "string" },
          "minItems": 1,
          "maxItems": 3
        },
        { "type": "string" }
      ]
    }
  },
  "required": ["value"]
}
```

Unrelated failing test in autogen-agentchat: FAILED packages\autogen-agentchat\tests\test_code_executor_agent.py::test_self_debugging_loop - AssertionError: Expected mean = sum(numbers) / len(numbers

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
