### PR TITLE
Add ollama chat completion client to WELL KNOWN PROVIDES

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_component_config.py
+++ b/python/packages/autogen-core/src/autogen_core/_component_config.py
@@ -49,6 +49,8 @@ WELL_KNOWN_PROVIDERS = {
     "AzureOpenAIChatCompletionClient": "autogen_ext.models.openai.AzureOpenAIChatCompletionClient",
     "openai_chat_completion_client": "autogen_ext.models.openai.OpenAIChatCompletionClient",
     "OpenAIChatCompletionClient": "autogen_ext.models.openai.OpenAIChatCompletionClient",
+    "OllamaChatCompletionClient": "autogen_ext.models.ollama.OllamaChatCompletionClient",
+    "ollama_chat_completion_client": "autogen_ext.models.ollama.OllamaChatCompletionClient",
 }
 
 


### PR DESCRIPTION
## Why are these changes needed?
This change needed to load a model client with ollama provider

Follow instruction on: https://microsoft.github.io/autogen/stable//reference/python/autogen_ext.models.ollama.html#module-autogen_ext.models.ollama

The client can create from config by `client = ChatCompletionClient.load_component(config)`. But these lines
```
output = loaded_model.provider.rsplit(".", maxsplit=1)
        if len(output) != 2:
            raise ValueError("Invalid")
```
will make load process failure if the provider not in well known list.


## Related issue number

I do not create issue. I am facing this issue and try to fix that first.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
