### PR TITLE
Fix loading streaming Bedrock response with tool usage with empty argument

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -881,7 +881,8 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
                     tool_calls[current_tool_id] = {
                         "id": chunk.content_block.id,
                         "name": chunk.content_block.name,
-                        "input": "",  # Will be populated from deltas
+                        "input": json.dumps(chunk.content_block.input),
+                        "partial_json": "", # May be populated from deltas
                     }
 
             elif chunk.type == "content_block_delta":
@@ -896,10 +897,15 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
                 elif hasattr(chunk.delta, "type") and chunk.delta.type == "input_json_delta":
                     if current_tool_id is not None and hasattr(chunk.delta, "partial_json"):
                         # Accumulate partial JSON for the current tool
-                        tool_calls[current_tool_id]["input"] += chunk.delta.partial_json
+                        tool_calls[current_tool_id]["partial_json"] += chunk.delta.partial_json
 
             elif chunk.type == "content_block_stop":
                 # End of a content block (could be text or tool)
+                if current_tool_id is not None:
+                    # If there was partial JSON accumulated, use it as the input
+                    if len(tool_calls[current_tool_id]["partial_json"]) > 0:
+                        tool_calls[current_tool_id]["input"] = tool_calls[current_tool_id]["partial_json"]
+                    del tool_calls[current_tool_id]["partial_json"]
                 current_tool_id = None
 
             elif chunk.type == "message_delta":

--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -882,7 +882,7 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
                         "id": chunk.content_block.id,
                         "name": chunk.content_block.name,
                         "input": json.dumps(chunk.content_block.input),
-                        "partial_json": "", # May be populated from deltas
+                        "partial_json": "",  # May be populated from deltas
                     }
 
             elif chunk.type == "content_block_delta":

--- a/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
@@ -34,6 +34,7 @@ def _add_numbers(a: int, b: int) -> int:
     """Add two numbers together."""
     return a + b
 
+
 def _ask_for_input() -> str:
     """Function that asks for user input. Used to test empty input handling, such as in `pass_to_user` tool."""
     return "Further input from user"
@@ -1032,11 +1033,7 @@ async def test_streaming_tool_usage_with_no_arguments(provider) -> None:
         model = os.getenv("ANTHROPIC_BEDROCK_MODEL", "us.anthropic.claude-3-haiku-20240307-v1:0")
         client = AnthropicBedrockChatCompletionClient(
             model=model,
-            bedrock_info=BedrockInfo(
-                aws_access_key=access_key,
-                aws_secret_key=secret_key,
-                aws_region=region
-            ),
+            bedrock_info=BedrockInfo(aws_access_key=access_key, aws_secret_key=secret_key, aws_region=region),
             model_info=ModelInfo(
                 vision=False, function_calling=True, json_output=False, family="unknown", structured_output=True
             ),
@@ -1049,12 +1046,12 @@ async def test_streaming_tool_usage_with_no_arguments(provider) -> None:
 
     chunks: List[str | CreateResult] = []
     async for chunk in client.create_stream(
-            messages=[
-                SystemMessage(content="When user intent is unclear, ask for more input"),
-                UserMessage(content="Erm...", source="user"),
-            ],
-            tools=[ask_for_input_tool],
-            tool_choice="required",
+        messages=[
+            SystemMessage(content="When user intent is unclear, ask for more input"),
+            UserMessage(content="Erm...", source="user"),
+        ],
+        tools=[ask_for_input_tool],
+        tool_choice="required",
     ):
         chunks.append(chunk)
 
@@ -1093,11 +1090,7 @@ async def test_streaming_tool_usage_with_arguments(provider: str) -> None:
         model = os.getenv("ANTHROPIC_BEDROCK_MODEL", "us.anthropic.claude-3-haiku-20240307-v1:0")
         client = AnthropicBedrockChatCompletionClient(
             model=model,
-            bedrock_info=BedrockInfo(
-                aws_access_key=access_key,
-                aws_secret_key=secret_key,
-                aws_region=region
-            ),
+            bedrock_info=BedrockInfo(aws_access_key=access_key, aws_secret_key=secret_key, aws_region=region),
             model_info=ModelInfo(
                 vision=False, function_calling=True, json_output=False, family="unknown", structured_output=True
             ),
@@ -1108,12 +1101,12 @@ async def test_streaming_tool_usage_with_arguments(provider: str) -> None:
 
     chunks: List[str | CreateResult] = []
     async for chunk in client.create_stream(
-            messages=[
-                SystemMessage(content="Use the tools to evaluate calculations"),
-                UserMessage(content="2 + 2", source="user"),
-            ],
-            tools=[add_numbers],
-            tool_choice="required",
+        messages=[
+            SystemMessage(content="Use the tools to evaluate calculations"),
+            UserMessage(content="2 + 2", source="user"),
+        ],
+        tools=[add_numbers],
+        tool_choice="required",
     ):
         chunks.append(chunk)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using streaming with Bedrock client, the tool use response may not contain `partialJson` increments for tool argument if that argument is empty. In this case an empty string was used as input instead of the input provided in the starting chunk of the tool use block (empty json object). This led to an error during subsequent attempted tool invocation, when an empty string was being parsed as a json.
Note that added Bedrock test cases only run if AWS credentials are present in the environment variables.

## Related issue number

Closes #6661

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
