### PR TITLE
Fix not supported field warnings in count_tokens_openai

### DIFF
--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -137,7 +137,10 @@ async def test_token_limited_model_context_with_token_limit(
         await model_context.add_message(msg)
 
     retrieved = await model_context.get_messages()
-    assert len(retrieved) == 1  # Token limit set very low, will remove 2 of the messages
+    # Token limit set low, will remove some messages
+    # OpenAI: keeps 2 messages (29 tokens with limit 30)
+    # Ollama: keeps 1 message (20 tokens with limit 20)
+    assert len(retrieved) < len(messages)  # Some messages removed due to token limit
     assert retrieved != messages  # Will not be equal to the original messages
 
     await model_context.clear()
@@ -151,7 +154,7 @@ async def test_token_limited_model_context_with_token_limit(
     await model_context.clear()
     await model_context.load_state(state)
     retrieved = await model_context.get_messages()
-    assert len(retrieved) == 1
+    assert len(retrieved) < len(messages)  # Some messages removed due to token limit
     assert retrieved != messages
 
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -397,13 +397,13 @@ def count_tokens_openai(
                             tool_tokens -= 3
                             for o in v["anyOf"]:  # type: ignore
                                 tool_tokens += 3
-                                tool_tokens += len(encoding.encode(str(o["type"])))
+                                tool_tokens += len(encoding.encode(str(o["type"])))  # pyright: ignore
                         elif field == "default":
                             tool_tokens += 2
                             tool_tokens += len(encoding.encode(json.dumps(v["default"])))
                         elif field == "title":
                             tool_tokens += 2
-                            tool_tokens += len(encoding.encode(str(v["title"])))
+                            tool_tokens += len(encoding.encode(str(v["title"])))  # pyright: ignore
                         elif field == "enum":
                             tool_tokens -= 3
                             for o in v["enum"]:  # pyright: ignore

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -393,6 +393,17 @@ def count_tokens_openai(
                         elif field == "description":
                             tool_tokens += 2
                             tool_tokens += len(encoding.encode(v["description"]))  # pyright: ignore
+                        elif field == "anyOf":
+                            tool_tokens -= 3
+                            for o in v["anyOf"]:
+                                tool_tokens += 3
+                                tool_tokens += len(encoding.encode(o["type"]))
+                        elif field == "default":
+                            tool_tokens += 2
+                            tool_tokens += len(encoding.encode(json.dumps(v["default"])))
+                        elif field == "title":
+                            tool_tokens += 2
+                            tool_tokens += len(encoding.encode(v["title"]))
                         elif field == "enum":
                             tool_tokens -= 3
                             for o in v["enum"]:  # pyright: ignore

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -415,7 +415,9 @@ def count_tokens_openai(
                 if len(parameters["properties"]) == 0:  # pyright: ignore
                     tool_tokens -= 2
         num_tokens += tool_tokens
-    num_tokens += 12
+
+    if oai_tools:
+        num_tokens += 12
     return num_tokens
 
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -395,15 +395,15 @@ def count_tokens_openai(
                             tool_tokens += len(encoding.encode(v["description"]))  # pyright: ignore
                         elif field == "anyOf":
                             tool_tokens -= 3
-                            for o in v["anyOf"]:
+                            for o in v["anyOf"]:  # type: ignore
                                 tool_tokens += 3
-                                tool_tokens += len(encoding.encode(o["type"]))
+                                tool_tokens += len(encoding.encode(str(o["type"])))
                         elif field == "default":
                             tool_tokens += 2
                             tool_tokens += len(encoding.encode(json.dumps(v["default"])))
                         elif field == "title":
                             tool_tokens += 2
-                            tool_tokens += len(encoding.encode(v["title"]))
+                            tool_tokens += len(encoding.encode(str(v["title"])))
                         elif field == "enum":
                             tool_tokens -= 3
                             for o in v["enum"]:  # pyright: ignore

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import Annotated, Any, AsyncGenerator, Dict, List, Literal, Tuple, TypeVar, Optional
+from typing import Annotated, Any, AsyncGenerator, Dict, List, Literal, Optional, Tuple, TypeVar
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -450,16 +450,13 @@ async def test_openai_chat_completion_client_count_tokens(monkeypatch: pytest.Mo
     def tool2(test1: int, test2: List[int]) -> str:
         return str(test1) + str(test2)
 
-    def tool3(
-            test1: Annotated[Optional[str], "example"] = None,
-            test2: Literal["1", "2"] = "2"
-    ) -> str:
+    def tool3(test1: Annotated[Optional[str], "example"] = None, test2: Literal["1", "2"] = "2") -> str:
         return str(test1) + str(test2)
 
     tools = [
         FunctionTool(tool1, description="example tool 1"),
         FunctionTool(tool2, description="example tool 2"),
-        FunctionTool(tool3, description="example tool 3")
+        FunctionTool(tool3, description="example tool 3"),
     ]
 
     mockcalculate_vision_tokens = MagicMock()

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -465,17 +465,19 @@ async def test_openai_chat_completion_client_count_tokens(monkeypatch: pytest.Mo
     mockcalculate_vision_tokens = MagicMock()
     monkeypatch.setattr("autogen_ext.models.openai._openai_client.calculate_vision_tokens", mockcalculate_vision_tokens)
 
-    num_tokens = client.count_tokens(messages, tools=tools)
+    # Test count_tokens without tools
+    num_tokens = client.count_tokens(messages)
     assert num_tokens
 
     # Check that calculate_vision_tokens was called
     mockcalculate_vision_tokens.assert_called_once()
-
-    # Check that tools are optional and do not affect non-vision token counting
     mockcalculate_vision_tokens.reset_mock()
-    num_tokens = client.count_tokens(messages)
+
+    # Test count_tokens with tools
+    num_tokens = client.count_tokens(messages, tools=tools)
     assert num_tokens
 
+    # Check that calculate_vision_tokens was called
     mockcalculate_vision_tokens.assert_called_once()
 
     remaining_tokens = client.remaining_tokens(messages, tools=tools)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#### 1. `OpenAIChatCompletionClient.count_tokens` (from autogen_ext.models.openai) ignores several JSON Schema fields of Tools (e.g., anyOf, default, title), printing Not supported field ... warnings and producing consistent gaps between the pre-send estimate and usage.prompt_tokens.

**Autogen Tool description example**

```python
def tool3(
        test1: Annotated[Optional[str], "example"] = None,
        test2: Literal["1", "2"] = "2"
) -> str:
    return str(test1) + str(test2)

tools = [ FunctionTool(tool3, description="example tool 3") ]
client.count_tokens(messages, tools=tools)
```
**Printed warning log**
```bash
Not supported field anyOf
Not supported field default
Not supported field title
```

**Changes**
  - Add anyOf, default, title in `count_tokens_openai`
```python
elif field == "anyOf":
    tool_tokens -= 3
    for o in v["anyOf"]:
        tool_tokens += 3
        tool_tokens += len(encoding.encode(o["type"]))
elif field == "default":
    tool_tokens += 2
    tool_tokens += len(encoding.encode(json.dumps(v["default"])))
elif field == "title":
    tool_tokens += 2
    tool_tokens += len(encoding.encode(v["title"]))
``` 

**Limitations**
- This change reduces—but does not eliminate—the discrepancy between estimated token counts and actual usage.
- I don't currently know the exact logic behind counting message tokens in the `count_tokens_openai` function, so I just made it similar to other fields.
  - The only reference I've found at this point is the token calculation guide in the OpenAI Cookbook: https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
  - If there are official guidelines or recommended constants beyond the Cookbook, I’d appreciate pointers

#### 2. In actual requests, Autogen omits the tools parameter when no tools are provided. But the current implementation adds +12 unconditionally, which overcounts tokens for tool-less calls.

- Per OpenAI’s cookbook heuristics for tool-call counting, func_end = 12 represents the wrapper overhead that applies only when a tools array exists.
  - I referenced this article : https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken 

- Changes
  - func_end(+12) only when tools exist in `count_tokens_openai`
```python
# num_tokens += 12 # before
 if oai_tools:     # changed
    num_tokens += 12
return num_tokens
```

- Difference in results before / after modification
```python
messages = [UserMessage(content="What is the current time in Seoul?", source="user")]
model_client = OpenAIChatCompletionClient(model="gpt-4o")
token_estimate = model_client.count_tokens(messages=messages)

create_result = await model_client.create(
    messages=messages,
    cancellation_token=ctx.cancellation_token,
)
token_usage = create_result.usage.prompt_tokens

if token_usage != token_estimate:
    print(f"Token usage mismatch: estimated {token_estimate}, actual {token_usage}")
```

```bash
# before
Token usage mismatch: estimated 29, actual 16
# after
Token usage mismatch: estimated 17, actual 16
```


## Related issue number
Closes #6980 

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
