### PR TITLE
Add security warnings and default to DockerCommandLineCodeExecutor

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -454,6 +454,18 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         self._approval_func = approval_func
         self._approval_func_is_async = approval_func is not None and iscoroutinefunction(approval_func)
 
+        # Issue warning if no approval function is set
+        if approval_func is None:
+            import warnings
+
+            warnings.warn(
+                "No approval function set for CodeExecutorAgent. This means code will be executed automatically without human oversight. "
+                "For security, consider setting an approval_func to review and approve code before execution. "
+                "See the CodeExecutorAgent documentation for examples of approval functions.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         if supported_languages is not None:
             self._supported_languages = supported_languages
         else:

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/__init__.py
@@ -1,0 +1,83 @@
+"""Code executor utilities for AutoGen-Ext."""
+
+import warnings
+from typing import Optional
+
+from autogen_core.code_executor import CodeExecutor
+
+# Docker imports for default code executor
+try:
+    import docker as docker_client
+    from docker.errors import DockerException
+
+    from .docker import DockerCommandLineCodeExecutor
+
+    _docker_available = True
+except ImportError:
+    docker_client = None  # type: ignore
+    DockerException = Exception  # type: ignore
+    DockerCommandLineCodeExecutor = None  # type: ignore
+    _docker_available = False
+
+from .local import LocalCommandLineCodeExecutor
+
+
+def _is_docker_available() -> bool:
+    """Check if Docker is available and running."""
+    if not _docker_available:
+        return False
+
+    try:
+        if docker_client is not None:
+            client = docker_client.from_env()
+            client.ping()  # type: ignore
+            return True
+    except DockerException:
+        return False
+
+    return False
+
+
+def create_default_code_executor(work_dir: Optional[str] = None) -> CodeExecutor:
+    """Create a default code executor, preferring Docker if available.
+
+    This function creates a code executor using the following priority:
+    1. DockerCommandLineCodeExecutor if Docker is available
+    2. LocalCommandLineCodeExecutor with a warning if Docker is not available
+
+    Args:
+        work_dir: Optional working directory for the code executor
+
+    Returns:
+        CodeExecutor: A code executor instance
+
+    .. warning::
+        For security, it is recommended to use DockerCommandLineCodeExecutor
+        when available to isolate code execution.
+    """
+    if _is_docker_available() and DockerCommandLineCodeExecutor is not None:
+        try:
+            if work_dir:
+                return DockerCommandLineCodeExecutor(work_dir=work_dir)
+            else:
+                return DockerCommandLineCodeExecutor()
+        except Exception:
+            # Fallback to local if Docker fails to initialize
+            pass
+
+    # Issue warning and use local executor if Docker is not available
+    warnings.warn(
+        "Docker is not available or not running. Using LocalCommandLineCodeExecutor instead of the recommended DockerCommandLineCodeExecutor. "
+        "For security, it is recommended to install Docker and ensure it's running before using code executors. "
+        "To install Docker, visit: https://docs.docker.com/get-docker/",
+        UserWarning,
+        stacklevel=2,
+    )
+
+    if work_dir:
+        return LocalCommandLineCodeExecutor(work_dir=work_dir)
+    else:
+        return LocalCommandLineCodeExecutor()
+
+
+__all__ = ["create_default_code_executor"]

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
@@ -23,10 +23,9 @@ from autogen_core.code_executor import (
     FunctionWithRequirements,
     FunctionWithRequirementsStr,
 )
+from docker.types import DeviceRequest
 from pydantic import BaseModel
 from typing_extensions import Self
-
-from docker.types import DeviceRequest
 
 from .._common import (
     CommandLineCodeResult,
@@ -43,7 +42,6 @@ else:
 
 try:
     import asyncio_atexit
-
     import docker
     from docker.errors import DockerException, ImageNotFound, NotFound
     from docker.models.containers import Container

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
@@ -11,9 +11,10 @@ from typing import List, Optional, Union
 
 from autogen_core import CancellationToken, Component
 from autogen_core.code_executor import CodeBlock, CodeExecutor, CodeResult
-from autogen_ext.code_executors._common import silence_pip
 from pydantic import BaseModel
 from typing_extensions import Self
+
+from autogen_ext.code_executors._common import silence_pip
 
 from ._jupyter_server import JupyterClient, JupyterConnectable, JupyterConnectionInfo, JupyterKernelClient
 

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -159,6 +159,15 @@ $functions"""
         cleanup_temp_files: bool = True,
         virtual_env_context: Optional[SimpleNamespace] = None,
     ):
+        # Issue warning about using LocalCommandLineCodeExecutor
+        warnings.warn(
+            "Using LocalCommandLineCodeExecutor may execute code on the local machine which can be unsafe. "
+            "For security, it is recommended to use DockerCommandLineCodeExecutor instead. "
+            "To install Docker, visit: https://docs.docker.com/get-docker/",
+            UserWarning,
+            stacklevel=2,
+        )
+
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
         self._timeout = timeout

--- a/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one.py
+++ b/python/packages/autogen-ext/src/autogen_ext/teams/magentic_one.py
@@ -14,12 +14,6 @@ from autogen_ext.agents.web_surfer import MultimodalWebSurfer
 from autogen_ext.code_executors import create_default_code_executor
 from autogen_ext.models.openai._openai_client import BaseOpenAIChatCompletionClient
 
-# Docker imports for default code executor - needed for type hints and examples
-try:
-    from autogen_ext.code_executors.docker import DockerCommandLineCodeExecutor
-except ImportError:
-    DockerCommandLineCodeExecutor = None  # type: ignore
-
 SyncInputFunc = Callable[[str], str]
 AsyncInputFunc = Callable[[str, Optional[CancellationToken]], Awaitable[str]]
 InputFuncType = Union[SyncInputFunc, AsyncInputFunc]

--- a/python/packages/autogen-ext/tests/teams/test_magentic_one.py
+++ b/python/packages/autogen-ext/tests/teams/test_magentic_one.py
@@ -115,7 +115,7 @@ def test_docker_availability_check() -> None:
     assert isinstance(result, bool)
 
 
-@patch("autogen_ext.teams.magentic_one._is_docker_available")
+@patch("autogen_ext.code_executors._is_docker_available")
 def test_magentic_one_falls_back_to_local_when_docker_unavailable(
     mock_docker_check: Mock, mock_chat_client: Mock
 ) -> None:
@@ -154,7 +154,7 @@ def test_magentic_one_falls_back_to_local_when_docker_unavailable(
         assert deprecated_warning_found, f"Deprecation warning not found in: {warning_messages}"
 
 
-@patch("autogen_ext.teams.magentic_one._is_docker_available")
+@patch("autogen_ext.code_executors._is_docker_available")
 def test_magentic_one_falls_back_to_local_with_approval_function(
     mock_docker_check: Mock, mock_chat_client: Mock
 ) -> None:


### PR DESCRIPTION
This commit enhances security by:

1. **Default to DockerCommandLineCodeExecutor**: Added create_default_code_executor()
   function that prefers Docker when available, falling back to Local with warnings

2. **LocalCommandLineCodeExecutor warnings**: Added security warning when
   LocalCommandLineCodeExecutor is instantiated directly, recommending Docker instead

3. **CodeExecutorAgent approval warnings**: Added warning when no approval_func
   is set, encouraging human oversight for code execution

4. **Centralized logic**: Created shared utility in autogen_ext.code_executors
   for consistent default executor behavior across the codebase

5. **Updated MagenticOne**: Refactored to use the shared default executor logic
   while maintaining backward compatibility

6. **Test compatibility**: Updated test mocks to work with the new structure

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
