### PR TITLE
Handle additional message content in ollama client

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py
@@ -675,6 +675,8 @@ class BaseOllamaChatCompletionClient(ChatCompletionClient):
         if result.message.tool_calls is not None:
             if result.message.content is not None and result.message.content != "":
                 thought = result.message.content
+            elif result.message.thinking is not None:
+                thought = result.message.thinking
             # NOTE: If OAI response type changes, this will need to be updated
             content = [
                 FunctionCall(


### PR DESCRIPTION
Enables models to store thinking tokens from model clients

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have access to it, we will shortly find a reviewer and assign them to your PR. -->

## Problem

The `BaseAgent` and `AssistantAgent` clients using Ollama `OllamaChatCompletionClient` don't report `thinking` tokens when using `run(task)`.  Only the `content` field of the tool call is checked for thought, but ollama may also return the thinking tokens in the `thinking` field. This PR updates the check in the `_ollama_client` to also check the `thinking` field.

As a result:
```python
result = await agent.task()

print(result.thinking)  # This is maybe empty even with a reasoning model 
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Changes
- `python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py` - Lines 678-679

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
