### PR TITLE
fix: improve import error messages for LLM client dependencies (#4605)

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/__init__.py
@@ -1,16 +1,24 @@
-from ._anthropic_client import (
-    AnthropicBedrockChatCompletionClient,
-    AnthropicChatCompletionClient,
-    BaseAnthropicChatCompletionClient,
-)
-from .config import (
-    AnthropicBedrockClientConfiguration,
-    AnthropicBedrockClientConfigurationConfigModel,
-    AnthropicClientConfiguration,
-    AnthropicClientConfigurationConfigModel,
-    BedrockInfo,
-    CreateArgumentsConfigModel,
-)
+try:
+    from ._anthropic_client import (
+        AnthropicBedrockChatCompletionClient,
+        AnthropicChatCompletionClient,
+        BaseAnthropicChatCompletionClient,
+    )
+    from .config import (
+        AnthropicBedrockClientConfiguration,
+        AnthropicBedrockClientConfigurationConfigModel,
+        AnthropicClientConfiguration,
+        AnthropicClientConfigurationConfigModel,
+        BedrockInfo,
+        CreateArgumentsConfigModel,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Dependencies for Anthropic client not found. "
+        "Please install the Anthropic package: "
+        "pip install autogen-ext[anthropic]\n"
+        f"Original error: {e}"
+    ) from e
 
 __all__ = [
     "AnthropicChatCompletionClient",

--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/__init__.py
@@ -1,4 +1,12 @@
-from ._azure_ai_client import AzureAIChatCompletionClient
-from .config import AzureAIChatCompletionClientConfig
+try:
+    from ._azure_ai_client import AzureAIChatCompletionClient
+    from .config import AzureAIChatCompletionClientConfig
+except ImportError as e:
+    raise ImportError(
+        "Dependencies for Azure AI client not found. "
+        "Please install the Azure AI Inference package: "
+        "pip install autogen-ext[azure]\n"
+        f"Original error: {e}"
+    ) from e
 
 __all__ = ["AzureAIChatCompletionClient", "AzureAIChatCompletionClientConfig"]

--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/__init__.py
@@ -1,8 +1,16 @@
-from ._ollama_client import OllamaChatCompletionClient
-from .config import (
-    BaseOllamaClientConfigurationConfigModel,
-    CreateArgumentsConfigModel,
-)
+try:
+    from ._ollama_client import OllamaChatCompletionClient
+    from .config import (
+        BaseOllamaClientConfigurationConfigModel,
+        CreateArgumentsConfigModel,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Dependencies for Ollama client not found. "
+        "Please install the Ollama package: "
+        "pip install autogen-ext[ollama]\n"
+        f"Original error: {e}"
+    ) from e
 
 __all__ = [
     "OllamaChatCompletionClient",

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/__init__.py
@@ -1,16 +1,24 @@
-from . import _message_transform
-from ._openai_client import (
-    AZURE_OPENAI_USER_AGENT,
-    AzureOpenAIChatCompletionClient,
-    BaseOpenAIChatCompletionClient,
-    OpenAIChatCompletionClient,
-)
-from .config import (
-    AzureOpenAIClientConfigurationConfigModel,
-    BaseOpenAIClientConfigurationConfigModel,
-    CreateArgumentsConfigModel,
-    OpenAIClientConfigurationConfigModel,
-)
+try:
+    from . import _message_transform
+    from ._openai_client import (
+        AZURE_OPENAI_USER_AGENT,
+        AzureOpenAIChatCompletionClient,
+        BaseOpenAIChatCompletionClient,
+        OpenAIChatCompletionClient,
+    )
+    from .config import (
+        AzureOpenAIClientConfigurationConfigModel,
+        BaseOpenAIClientConfigurationConfigModel,
+        CreateArgumentsConfigModel,
+        OpenAIClientConfigurationConfigModel,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Dependencies for OpenAI client not found. "
+        "Please install the OpenAI package: "
+        "pip install autogen-ext[openai]\n"
+        f"Original error: {e}"
+    ) from e
 
 __all__ = [
     "OpenAIChatCompletionClient",


### PR DESCRIPTION
Add try-except blocks to model client __init__.py files (OpenAI, Anthropic, Azure, Ollama) to provide clear, actionable error messages when required dependencies are missing.

This improvement helps users quickly identify and install missing packages instead of encountering generic ImportError messages.

Changes:
- Wrap imports in try-except blocks for all main LLM client modules
- Include specific installation instructions (e.g., pip install autogen-ext[openai])
- Preserve original error context with 'raise ... from e' for debugging
- Consistent error message format across all client implementations

Fixes #4605

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
