### PR TITLE
fix: graphflow prematurly completing by adding triggered_activation_groups to the team's state

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_graph/_digraph_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_graph/_digraph_group_chat.py
@@ -517,6 +517,7 @@ class GraphFlowManager(BaseGroupChatManager):
             "remaining": {target: dict(counter) for target, counter in self._remaining.items()},
             "enqueued_any": dict(self._enqueued_any),
             "ready": list(self._ready),
+            "triggered_activation_groups": {target: list(groups) for target, groups in self._triggered_activation_groups.items()},
         }
         return state
 
@@ -527,6 +528,7 @@ class GraphFlowManager(BaseGroupChatManager):
         self._remaining = {target: Counter(groups) for target, groups in state["remaining"].items()}
         self._enqueued_any = state["enqueued_any"]
         self._ready = deque(state["ready"])
+        self._triggered_activation_groups = {target: set(groups) for target, groups in state["triggered_activation_groups"].items()}
 
     async def reset(self) -> None:
         """Reset execution state to the start of the graph."""


### PR DESCRIPTION
Consider this simple graph
<img width="1298" height="734" alt="image" src="https://github.com/user-attachments/assets/c06f5918-4361-4231-a599-b426d3894c54" />

Node `A` has two edges with activation_conditions `loopback` and `next`.
Node `B` is a leaf node.
Both nodes are autogen agents.
Node `A` always emits a stop message response with a text that activate loopback edge.

- Current behavior 

```python
# create_flow returns a team, which consists of two agents as per depicted pic above
team_one = create_flow()
result_one: TaskResult = await team_one.run(task="Start")

# As expected the graph will terminate due to the `StopMessage`
assert result_one.stop_reason == "Stop message received"

# And if I run team_one again the graph will terminate due to the `StopMessage` (as expected)
result_one: TaskResult = await team_one.run(task="Continue")
assert result_one.stop_reason == "Stop message received"

# Let's export state from one team and loads it into another. 
# Which is useful when we want to stop for human in the loop without a process hanging.
team_two = create_flow()
await team_two.load_state(await team_one.save_state())

# But now the graph stopped due to execution complete instead
result_two: TaskResult = await team_two.run(task="Continue")
assert result_two.stop_reason == "Digraph execution is complete"
```

- Expected behavior
```sh
# Both graphs must stop due to `StopMessage`
assert result_one.stop_reason == "Stop message received"
assert result_two.stop_reason == "Stop message received"
```

## Why are these changes needed?
Consistent behavior.  

## Related issue number
Maybe #7043 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
