### PR TITLE
Fix .NET installation guide: remove reference to non-existent NuGet package

### DIFF
--- a/docs/dotnet/core/installation.md
+++ b/docs/dotnet/core/installation.md
@@ -31,7 +31,7 @@ The *Core* and *Contracts* packages will give you what you need for writing and 
 
 ```sh
 dotnet add package Microsoft.AutoGen.AgentChat --version 0.4.0-dev-1
-dotnet add package Microsoft.AutoGen.Agents --version 0.4.0-dev-1
+Note: The Microsoft.AutoGen.Agents package is not currently available on NuGet. This feature is planned for a future release.
 dotnet add package Microsoft.AutoGen.Extensions --version 0.4.0-dev-1
 ```
 


### PR DESCRIPTION
This PR addresses issue #6244 by removing the instruction to install the Microsoft.AutoGen.Agents package, which does not exist on NuGet. Added a note indicating that the package is planned for a future release.

Closes #6244.