### PR TITLE
Fix JSONDecodeError when tool_call.arguments is empty string in AssistantAgent._execute_tool_call

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -1544,7 +1544,11 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         """Execute a single tool call and return the result."""
         # Load the arguments from the tool call.
         try:
-            arguments = json.loads(tool_call.arguments)
+            # Handle empty string as empty dict to support tools with no parameters
+            if not tool_call.arguments or tool_call.arguments.strip() == "":
+                arguments = {}
+            else:
+                arguments = json.loads(tool_call.arguments)
         except json.JSONDecodeError as e:
             return (
                 tool_call,


### PR DESCRIPTION
## Description
When using Claude models (or other LLM providers) with tool calling, the `tool_call.arguments`  field may be an empty string `""` instead of `"{}"` for tools that don't require parameters.

This causes a `JSONDecodeError[ in ](file://core/mt_llm_client.py#90#24)AssistantAgent._execute_tool_call` method, even though  the tool call is valid and should be executed with empty arguments.

## Current Behavior
```python
# In _assistant_agent.py line 1547
arguments = json.loads(tool_call.arguments)  # Raises JSONDecodeError for ""
```

When `tool_call.arguments = ""`, this raises:

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
