### PR TITLE
fix(clients): Improve ImportError messages for optional dependencies

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -23,20 +23,23 @@ from typing import (
 )
 
 import tiktoken
-from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, AsyncStream
-from anthropic.types import (
-    Base64ImageSourceParam,
-    ContentBlock,
-    ImageBlockParam,
-    Message,
-    MessageParam,
-    RawMessageStreamEvent,  # type: ignore
-    TextBlock,
-    TextBlockParam,
-    ToolParam,
-    ToolResultBlockParam,
-    ToolUseBlock,
-)
+try:
+    from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, AsyncStream
+    from anthropic.types import (
+        Base64ImageSourceParam,
+        ContentBlock,
+        ImageBlockParam,
+        Message,
+        MessageParam,
+        RawMessageStreamEvent,  # type: ignore
+        TextBlock,
+        TextBlockParam,
+        ToolParam,
+        ToolResultBlockParam,
+        ToolUseBlock,
+    )
+except ImportError as e:
+    raise ImportError("Please install anthropic using `pip install autogen-ext[anthropic]`") from e
 from autogen_core import (
     EVENT_LOGGER_NAME,
     TRACE_LOGGER_NAME,

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -51,25 +51,28 @@ from autogen_core.models import (
     validate_model_info,
 )
 from autogen_core.tools import Tool, ToolSchema
-from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI
-from openai.types.chat import (
-    ChatCompletion,
-    ChatCompletionChunk,
-    ChatCompletionContentPartParam,
-    ChatCompletionMessageParam,
-    ChatCompletionRole,
-    ChatCompletionToolParam,
-    ParsedChatCompletion,
-    ParsedChoice,
-    completion_create_params,
-)
-from openai.types.chat.chat_completion import Choice
-from openai.types.shared_params import (
-    FunctionDefinition,
-    FunctionParameters,
-    ResponseFormatJSONObject,
-    ResponseFormatText,
-)
+try:
+    from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI
+    from openai.types.chat import (
+        ChatCompletion,
+        ChatCompletionChunk,
+        ChatCompletionContentPartParam,
+        ChatCompletionMessageParam,
+        ChatCompletionRole,
+        ChatCompletionToolParam,
+        ParsedChatCompletion,
+        ParsedChoice,
+        completion_create_params,
+    )
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.shared_params import (
+        FunctionDefinition,
+        FunctionParameters,
+        ResponseFormatJSONObject,
+        ResponseFormatText,
+    )
+except ImportError as e:
+    raise ImportError("Please install openai using `pip install autogen-ext[openai]`") from e
 from pydantic import BaseModel, SecretStr
 from typing_extensions import Self, Unpack
 


### PR DESCRIPTION
Fixes #4605.

## Description
This PR improves the error messages when users attempt to use LLM clients (OpenAI, Anthropic) without installing the necessary optional dependencies. Instead of a generic `ImportError` or `ModuleNotFoundError`, it now provides a helpful message instructing the user to install the specific extra (e.g., `pip install autogen-ext[openai]`).

## Changes
- Wrapped top-level imports in `autogen_ext/models/openai/_openai_client.py` with `try-except ImportError`.
- Wrapped top-level imports in `autogen_ext/models/anthropic/_anthropic_client.py` with `try-except ImportError`.

## Verification
- **Static Analysis**: Verified that the `try-except` blocks correctly wrap the optional imports and raise the new `ImportError` with the custom message.
- **Note**: Runtime verification was limited by local environment constraints (Python 3.9 vs repo requirement >=3.10), but this is a standard pattern for optional dependencies.