### PR TITLE
fix: add explicit UTF-8 encoding to file operations

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:

--- a/python/docs/src/generate_api_reference.py
+++ b/python/docs/src/generate_api_reference.py
@@ -190,7 +190,7 @@ def generate_rst_files(package_roots: List[Path], reference_dir: Path) -> Set[st
 """
                 
                 # Write the .rst file
-                with open(rst_path, 'w') as f:
+                with open(rst_path, 'w', encoding='utf-8') as f:
                     f.write(rst_content)
                 
                 generated_files.add(module_name)
@@ -288,7 +288,7 @@ def main():
     print("✍️  Writing index.md...")
     content = generate_index_content(toctree_sections)
     
-    with open(index_file, 'w') as f:
+    with open(index_file, 'w', encoding='utf-8') as f:
         f.write(content)
     
     print(f"✅ Generated API documentation index at {index_file}")

--- a/python/fixup_generated_files.py
+++ b/python/fixup_generated_files.py
@@ -24,12 +24,12 @@ substitutions: Dict[str, str] = {
 
 def main():
     for file in files:
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8") as f:
             content = f.read()
 
         print("Fixing imports in file:", file)
         for old, new in substitutions.items():
             content = content.replace(old, new)
 
-        with open(file, "w") as f:
+        with open(file, "w", encoding="utf-8") as f:
             f.write(content)

--- a/python/packages/autogen-ext/examples/mcp_session_host_example.py
+++ b/python/packages/autogen-ext/examples/mcp_session_host_example.py
@@ -63,10 +63,10 @@ def load_model_client_from_config(config_path: str) -> ChatCompletionClient:
 
     # Load config based on file extension
     if config_file.suffix.lower() == ".json":
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             config_data = json.load(f)
     elif config_file.suffix.lower() in [".yml", ".yaml"]:
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             config_data = yaml.safe_load(f)
     else:
         raise ValueError(f"Unsupported config file type: {config_file.suffix}. Use .json, .yml, or .yaml")

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
@@ -73,7 +73,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
             # Load the previously recorded messages and responses from disk.
             self.logger.info("Replay mode enabled.\nRetrieving session from: " + self.session_file_path)
             try:
-                with open(self.session_file_path, "r") as f:
+                with open(self.session_file_path, "r", encoding="utf-8") as f:
                     self.records = json.load(f)
             except Exception as e:
                 error_str = f"\nFailed to load recorded session: '{self.session_file_path}': {e}"
@@ -211,7 +211,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
                 # Create the directory if it doesn't exist.
                 os.makedirs(os.path.dirname(self.session_file_path), exist_ok=True)
                 # Write the records to disk.
-                with open(self.session_file_path, "w") as f:
+                with open(self.session_file_path, "w", encoding="utf-8") as f:
                     json.dump(self.records, f, indent=2)
                     self.logger.info("\nRecorded session was saved to: " + self.session_file_path)
             except Exception as e:

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py
@@ -117,7 +117,7 @@ class PageLogger:
         # Write the hash and other details to a file.
         hash_str, num_files, num_subdirs = hash_directory(self.log_dir)
         hash_path = os.path.join(self.log_dir, "hash.txt")
-        with open(hash_path, "w") as f:
+        with open(hash_path, "w", encoding="utf-8") as f:
             f.write(hash_str)
             f.write("\n")
             f.write("{} files\n".format(num_files))
@@ -386,7 +386,7 @@ class PageLogger:
             return
         # Create a call tree of the log.
         call_tree_path = os.path.join(self.log_dir, self.name + ".html")
-        with open(call_tree_path, "w") as f:
+        with open(call_tree_path, "w", encoding="utf-8") as f:
             f.write(_html_opening("0 Call Tree", finished=finished))
             f.write(f"<h3>{self.name}</h3>")
             f.write("\n")
@@ -498,7 +498,7 @@ class Page:
         Writes the HTML page to disk.
         """
         page_path = os.path.join(self.page_logger.log_dir, self.index_str + ".html")
-        with open(page_path, "w") as f:
+        with open(page_path, "w", encoding="utf-8") as f:
             f.write(_html_opening(self.file_title, finished=self.finished))
             f.write(f"<h3>{self.file_title}</h3>\n")
             for line in self.lines:

--- a/python/packages/autogen-ext/tests/task_centric_memory/utils.py
+++ b/python/packages/autogen-ext/tests/task_centric_memory/utils.py
@@ -27,5 +27,5 @@ def load_yaml_file(file_path: str) -> Any:
     """
     Opens a file and returns its contents.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)

--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -97,12 +97,12 @@ def main() -> None:
 
     if args.config is None:
         if os.path.isfile(DEFAULT_CONFIG_FILE):
-            with open(DEFAULT_CONFIG_FILE, "r") as f:
+            with open(DEFAULT_CONFIG_FILE, "r", encoding="utf-8") as f:
                 config = yaml.safe_load(f)
         else:
             config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)
     else:
-        with open(args.config if isinstance(args.config, str) else args.config[0], "r") as f:
+        with open(args.config if isinstance(args.config, str) else args.config[0], "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
     # Run the task

--- a/python/samples/agentchat_chainlit/app_agent.py
+++ b/python/samples/agentchat_chainlit/app_agent.py
@@ -31,7 +31,7 @@ async def get_weather(city: str) -> str:
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chainlit/app_team.py
+++ b/python/samples/agentchat_chainlit/app_team.py
@@ -14,7 +14,7 @@ from autogen_core.models import ChatCompletionClient
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chainlit/app_team_user_proxy.py
+++ b/python/samples/agentchat_chainlit/app_team_user_proxy.py
@@ -47,7 +47,7 @@ async def user_action_func(prompt: str, cancellation_token: CancellationToken | 
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chess_game/main.py
+++ b/python/samples/agentchat_chess_game/main.py
@@ -101,7 +101,7 @@ async def get_ai_move(board: chess.Board, player: AssistantAgent, max_tries: int
 async def main(human_player: bool, max_tries: int) -> None:
     board = chess.Board()
     # Load the model client from config.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
     player = create_ai_player(model_client)

--- a/python/samples/agentchat_streamlit/agent.py
+++ b/python/samples/agentchat_streamlit/agent.py
@@ -8,7 +8,7 @@ from autogen_core.models import ChatCompletionClient
 class Agent:
     def __init__(self) -> None:
         # Load the model client from config.
-        with open("model_config.yml", "r") as f:
+        with open("model_config.yml", "r", encoding="utf-8") as f:
             model_config = yaml.safe_load(f)
         model_client = ChatCompletionClient.load_component(model_config)
         self.agent = AssistantAgent(

--- a/python/samples/core_async_human_in_the_loop/main.py
+++ b/python/samples/core_async_human_in_the_loop/main.py
@@ -334,7 +334,7 @@ if __name__ == "__main__":
     # if os.path.exists("state.json"):
     #     os.remove("state.json")
 
-    with open("model_config.yml") as f:
+    with open("model_config.yml", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
 
     def get_user_input(question_for_user: str):

--- a/python/samples/core_chainlit/app_agent.py
+++ b/python/samples/core_chainlit/app_agent.py
@@ -55,7 +55,7 @@ async def get_weather(city: str) -> str:
 async def start_chat() -> None:
 
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
     #context = BufferedChatCompletionContext(buffer_size=10)

--- a/python/samples/core_chainlit/app_team.py
+++ b/python/samples/core_chainlit/app_team.py
@@ -83,7 +83,7 @@ async def output_result(_agent: ClosureContext, message: StreamResult, ctx: Mess
 async def start_chat() -> None:
 
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/core_chess_game/main.py
+++ b/python/samples/core_chess_game/main.py
@@ -275,6 +275,6 @@ if __name__ == "__main__":
         handler = logging.FileHandler("chess_game.log")
         logging.getLogger("autogen_core").addHandler(handler)
 
-    with open(args.model_config, "r") as f:
+    with open(args.model_config, "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     asyncio.run(main(model_config))

--- a/python/samples/core_distributed-group-chat/_utils.py
+++ b/python/samples/core_distributed-group-chat/_utils.py
@@ -11,7 +11,7 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 def load_config(file_path: str = os.path.join(os.path.dirname(__file__), "config.yaml")) -> AppConfig:
     model_client = {}
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         config_data = yaml.safe_load(file)
         model_client = config_data["client_config"]
         del config_data["client_config"]

--- a/python/samples/core_streaming_handoffs_fastapi/agent_user.py
+++ b/python/samples/core_streaming_handoffs_fastapi/agent_user.py
@@ -36,7 +36,7 @@ class UserAgent(RoutedAgent):
         if ctx.topic_id is None:
             raise ValueError("MessageContext.topic_id is None, cannot save chat history")
         file_path = os.path.join(chat_history_dir, f"history-{ctx.topic_id.source}.json")
-        with open(file_path, 'w') as f:
+        with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(save_context, f, indent=4)
         
         #End stream

--- a/python/samples/gitty/src/gitty/__main__.py
+++ b/python/samples/gitty/src/gitty/__main__.py
@@ -32,7 +32,7 @@ def check_gh_cli() -> bool:
 
 def edit_config_file(file_path: str) -> None:
     if not os.path.exists(file_path):
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write("# Instructions for gitty agents\n")
             f.write("# Add your configuration below\n")
     editor = os.getenv("EDITOR", "vi")

--- a/python/samples/gitty/src/gitty/_gitty.py
+++ b/python/samples/gitty/src/gitty/_gitty.py
@@ -66,7 +66,7 @@ async def run_gitty(owner: str, repo: str, command: str, number: int) -> None:
     try:
         global_config_path = os.path.expanduser("~/.gitty/config")
         if os.path.exists(global_config_path):
-            with open(global_config_path, "r") as f:
+            with open(global_config_path, "r", encoding="utf-8") as f:
                 global_instructions = f.read().strip()
     except Exception as e:
         print("Warning: Could not load global config:", e)
@@ -77,7 +77,7 @@ async def run_gitty(owner: str, repo: str, command: str, number: int) -> None:
         local_config_path = os.path.join(gitty_dir, "config")
         print(f"Local config path: {local_config_path}")
         if os.path.exists(local_config_path):
-            with open(local_config_path, "r") as f:
+            with open(local_config_path, "r", encoding="utf-8") as f:
                 local_instructions = f.read().strip()
     except Exception as e:
         print("Warning: Could not load local config:", e)

--- a/python/samples/task_centric_memory/utils.py
+++ b/python/samples/task_centric_memory/utils.py
@@ -27,6 +27,6 @@ def load_yaml_file(file_path: str) -> Any:
     """
     Opens a file and returns its contents.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)
 


### PR DESCRIPTION
## Summary
- Add `encoding="utf-8"` parameter to file `open()` calls across the codebase
- Ensures cross-platform compatibility, especially for Windows systems with non-UTF-8 default locales

## Changes
Modified 22 files to add explicit UTF-8 encoding:
- `docs/redirects/redirects.py` - 3 fixes
- `docs/src/generate_api_reference.py` - 2 fixes  
- `fixup_generated_files.py` - 2 fixes
- `packages/autogen-ext/examples/mcp_session_host_example.py` - 2 fixes
- `packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py` - 2 fixes
- `packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py` - 3 fixes
- `packages/autogen-ext/tests/task_centric_memory/utils.py` - 1 fix
- `packages/magentic-one-cli/src/magentic_one_cli/_m1.py` - 2 fixes
- `samples/agentchat_chainlit/` - 3 files
- `samples/agentchat_chess_game/main.py`
- `samples/agentchat_streamlit/agent.py`
- `samples/core_async_human_in_the_loop/main.py`
- `samples/core_chainlit/` - 2 files
- `samples/core_chess_game/main.py`
- `samples/core_distributed-group-chat/_utils.py`
- `samples/core_streaming_handoffs_fastapi/agent_user.py`
- `samples/gitty/src/gitty/` - 2 files
- `samples/task_centric_memory/utils.py`

## Why
On Windows systems with non-UTF-8 default locales (like cp950/Big5), file operations without explicit encoding can fail with `UnicodeDecodeError`. Adding explicit UTF-8 encoding ensures consistent behavior across all platforms.

## Test Plan
- Verify file operations work correctly on systems with various default encodings
- All existing tests should continue to pass

Related to #5566

🤖 Generated with [Claude Code](https://claude.com/claude-code)