### PR TITLE
Fix typo in teams.ipynb documentation

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/teams.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/teams.ipynb
@@ -121,7 +121,7 @@
    "metadata": {},
    "source": [
     "The team runs the agents until the termination condition was met.\n",
-    "In this case, the team ran agents following a round-robin order until the the\n",
+    "In this case, the team ran agents following a round-robin order until the\n",
     "termination condition was met when the word \"APPROVE\" was detected in the\n",
     "agent's response.\n",
     "When the team stops, it returns a {py:class}`~autogen_agentchat.base.TaskResult` object with all the messages produced by the agents in the team."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I fix a typo mistake in the documentation, in the article -> <https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/tutorial/teams.html#running-a-team>

## Related issue number

There was no issue raised i just find a repo mistake and improve it.
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
