### PR TITLE
autogen-ext: improve import error messages for model clients

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/__init__.py
@@ -1,8 +1,16 @@
-from ._anthropic_client import (
-    AnthropicBedrockChatCompletionClient,
-    AnthropicChatCompletionClient,
-    BaseAnthropicChatCompletionClient,
-)
+try:
+    from ._anthropic_client import (
+        AnthropicBedrockChatCompletionClient,
+        AnthropicChatCompletionClient,
+        BaseAnthropicChatCompletionClient,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Dependencies for Anthropic not found. "
+        "Please install the anthropic package: "
+        "pip install autogen-ext[anthropic]"
+    ) from e
+
 from .config import (
     AnthropicBedrockClientConfiguration,
     AnthropicBedrockClientConfigurationConfigModel,

--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/__init__.py
@@ -1,4 +1,10 @@
-from ._ollama_client import OllamaChatCompletionClient
+try:
+    from ._ollama_client import OllamaChatCompletionClient
+except ImportError as e:
+    raise ImportError(
+        "Dependencies for Ollama not found. " "Please install the ollama package: " "pip install autogen-ext[ollama]"
+    ) from e
+
 from .config import (
     BaseOllamaClientConfigurationConfigModel,
     CreateArgumentsConfigModel,

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/__init__.py
@@ -1,10 +1,17 @@
 from . import _message_transform
-from ._openai_client import (
-    AZURE_OPENAI_USER_AGENT,
-    AzureOpenAIChatCompletionClient,
-    BaseOpenAIChatCompletionClient,
-    OpenAIChatCompletionClient,
-)
+
+try:
+    from ._openai_client import (
+        AZURE_OPENAI_USER_AGENT,
+        AzureOpenAIChatCompletionClient,
+        BaseOpenAIChatCompletionClient,
+        OpenAIChatCompletionClient,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Dependencies for OpenAI not found. " "Please install the openai package: " "pip install autogen-ext[openai]"
+    ) from e
+
 from .config import (
     AzureOpenAIClientConfigurationConfigModel,
     BaseOpenAIClientConfigurationConfigModel,


### PR DESCRIPTION
## Summary
- Add user-friendly ImportError messages when optional dependencies are not installed for Ollama, Anthropic, and OpenAI model clients
- Follow the pattern already used by LlamaCppChatCompletionClient

## Why are these changes needed?
When users try to use model clients without the required optional dependencies installed, they receive raw `ImportError`/`ModuleNotFoundError` exceptions that don't provide guidance on how to fix the issue.

This change wraps imports in try/except blocks to provide clear, actionable error messages like:
```
ImportError: Dependencies for Ollama not found. Please install the ollama package: pip install autogen-ext[ollama]
```

## Related issue number
Closes #4605

## Checks
- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)