### PR TITLE
Fix AttributeError when streaming chunk content is None

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
@@ -178,7 +178,9 @@ async def Console(
                 )
             if isinstance(message, ModelClientStreamingChunkEvent):
                 await aprint(message.to_text(), end="", flush=True)
-                streaming_chunks.append(message.content)
+                if message.content is not None:
+                    streaming_chunks.append(message.content)
+
             else:
                 if streaming_chunks:
                     streaming_chunks.clear()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The console streaming renderer unconditionally appends `message.content` from
`ModelClientStreamingChunkEvent`. In edge cases or malformed streams, this can
cause an AttributeError and crash the UI.

## What was changed?
Added a defensive check to ensure `message.content` is not None before appending
it to the streaming buffer. This does not change behavior for valid streaming
chunks and prevents UI crashes.

## Related issue number
Fixes #7130


## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
