### PR TITLE
feat(autogen-ext): improve import error message for openai dependency

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -51,25 +51,28 @@ from autogen_core.models import (
     validate_model_info,
 )
 from autogen_core.tools import Tool, ToolSchema
-from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI
-from openai.types.chat import (
-    ChatCompletion,
-    ChatCompletionChunk,
-    ChatCompletionContentPartParam,
-    ChatCompletionMessageParam,
-    ChatCompletionRole,
-    ChatCompletionToolParam,
-    ParsedChatCompletion,
-    ParsedChoice,
-    completion_create_params,
-)
-from openai.types.chat.chat_completion import Choice
-from openai.types.shared_params import (
-    FunctionDefinition,
-    FunctionParameters,
-    ResponseFormatJSONObject,
-    ResponseFormatText,
-)
+try:
+    from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI
+    from openai.types.chat import (
+        ChatCompletion,
+        ChatCompletionChunk,
+        ChatCompletionContentPartParam,
+        ChatCompletionMessageParam,
+        ChatCompletionRole,
+        ChatCompletionToolParam,
+        ParsedChatCompletion,
+        ParsedChoice,
+        completion_create_params,
+    )
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.shared_params import (
+        FunctionDefinition,
+        FunctionParameters,
+        ResponseFormatJSONObject,
+        ResponseFormatText,
+    )
+except ImportError:
+    raise ImportError("Please install openai using `pip install autogen-ext[openai]`")
 from pydantic import BaseModel, SecretStr
 from typing_extensions import Self, Unpack
 


### PR DESCRIPTION
### Summary
Improved the import error message when 'openai' is missing in 'autogen-ext'.

### Changes
- Wrapped 'openai' imports in 'python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py' with a try-except block.
- Raises a descriptive ImportError: 'Please install openai using pip install autogen-ext[openai]'.

### Why
Fixes #4605. Users were facing confusing ModuleNotFoundErrors when the optional openai dependency was missing. This makes the resolution clear.