### PR TITLE
autogen-ext: Support Image generation message on ai agent

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/openai/_openai_agent.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/openai/_openai_agent.py
@@ -579,13 +579,30 @@ class OpenAIAgent(BaseChatAgent, Component[OpenAIAgentConfig]):
             response_obj = await cancellation_token.link_future(
                 asyncio.ensure_future(client.responses.create(**api_params))
             )
-            content = getattr(response_obj, "output_text", None)
-            response_id = getattr(response_obj, "id", None)
-            self._last_response_id = response_id
-            # Use a readable placeholder when the API returns no content to aid debugging
-            content_str: str = str(content) if content is not None else "[no content returned]"
-            self._message_history.append({"role": "assistant", "content": content_str})
-            final_message = TextMessage(source=self.name, content=content_str)
+            output = getattr(response_obj, "output", None)
+            if len(output) > 1:
+                content = []
+                for part in output:
+                    if isinstance(part, ImageGenerationCall):
+                        content.append(AGImage.from_base64(part.result))
+                    elif isinstance(part, ResponseOutputMessage):
+                        content.append(" ".join(c.text for c in part.content))
+                if all(isinstance(part, str) for part in content):
+                    content_str = " ".join(content)
+                    self._message_history.append({"role": "assistant", "content": content_str})
+                    final_message = TextMessage(source=self.name, content="".join(content))
+                else:
+                    content_str = " ".join(part for part in content if isinstance(part, str))   
+                    self._message_history.append({"role": "assistant", "content": content_str})
+                    final_message = MultiModalMessage(source=self.name, content=content)
+            else:
+                content = getattr(response_obj, "output_text", None)
+                response_id = getattr(response_obj, "id", None)
+                self._last_response_id = response_id
+                # Use a readable placeholder when the API returns no content to aid debugging
+                content_str: str = str(content) if content is not None else "[no content returned]"
+                self._message_history.append({"role": "assistant", "content": content_str})
+                final_message = TextMessage(source=self.name, content=content_str)
             response = Response(chat_message=final_message, inner_messages=inner_messages)
             yield response
         except Exception as e:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds support for handling image generation results returned via the OpenAI Responses API in the `OpenAI` agent message stream.

Previously, the agent primarily relied on `response_obj.output_text` (or a fallback placeholder) and would therefore miss non-text outputs contained in `response_obj.output`, such as image generation tool calls. As a result, image-generation-capable models/tools could successfully generate images, but the agent would not surface them to downstream consumers (and message history would not reflect them).

With this change, the agent:

* Parses `response_obj.output` when present.
* Converts `ImageGenerationCall` results (base64) into `AddImage` items so downstream UIs/clients can render images.
* Collects text from `ResponseOutputMessage` parts and returns `TextMessage` when output is purely textual.
* Returns a `MultiModalMessage` when the output includes non-string content (e.g., images), while preserving message history semantics.

This enables image generation responses to be delivered through the same streaming interface and message abstractions used by other modalities.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

N/A
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
