### PR TITLE
fix: Typo in UserProxyAgent and enable Ollama structured output test

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py
@@ -241,7 +241,7 @@ class UserProxyAgent(BaseChatAgent, Component[UserProxyAgentConfig]):
         pass
 
     def _to_config(self) -> UserProxyAgentConfig:
-        # TODO: Add ability to serialie input_func
+        # TODO: Add ability to serialize input_func
         return UserProxyAgentConfig(name=self.name, description=self.description, input_func=None)
 
     @classmethod

--- a/python/packages/autogen-ext/tests/models/test_ollama_chat_completion_client.py
+++ b/python/packages/autogen-ext/tests/models/test_ollama_chat_completion_client.py
@@ -619,7 +619,7 @@ async def test_ollama_create_tools(model: str, ollama_client: OllamaChatCompleti
     assert create_result.finish_reason == "stop"
 
 
-@pytest.mark.skip("TODO: Does Ollama support structured outputs with tools?")
+# @pytest.mark.skip("TODO: Does Ollama support structured outputs with tools?")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model", ["llama3.2:1b"])
 async def test_ollama_create_structured_output_with_tools(


### PR DESCRIPTION
## Summary
Fixes a typo in `_user_proxy_agent.py` and attempts to enable a previously skipped test for Ollama structured outputs.

## Changes
- Fixed `serialie` -> `serialize` in `_user_proxy_agent.py`.
- Un-skipped `test_ollama_create_structured_output_with_tools` in `test_ollama_chat_completion_client.py`.

## Verification
- Typo fix is trivial.
- Test enablement should be verified by CI.