### PR TITLE
feat: Support saving JPEG images in JupyterCodeExecutor

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -225,11 +225,11 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
                             case "text/plain":
                                 outputs.append(content)
                             case "image/png":
-                                path = self._save_image(content)
+                                path = self._save_image(content, "png")
                                 output_files.append(path)
                             case "image/jpeg":
-                                # TODO: Should this also be encoded? Images are encoded as both png and jpg
-                                pass
+                                path = self._save_image(content, "jpg")
+                                output_files.append(path)
                             case "text/html":
                                 path = self._save_html(content)
                                 output_files.append(path)
@@ -252,10 +252,10 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
         self._client.nb.cells.pop()
         return output
 
-    def _save_image(self, image_data_base64: str) -> Path:
+    def _save_image(self, image_data_base64: str, extension: str = "png") -> Path:
         """Save image data to a file."""
         image_data = base64.b64decode(image_data_base64)
-        path = self._output_dir / f"{uuid.uuid4().hex}.png"
+        path = self._output_dir / f"{uuid.uuid4().hex}.{extension}"
         path.write_bytes(image_data)
         return path.absolute()
 


### PR DESCRIPTION
## Summary
Adds support for saving `image/jpeg` outputs in the `JupyterCodeExecutor`, mirroring the existing functionality for `image/png`.

## Changes
- Updated `_save_image` to accept an optional `extension` argument (defaulting to 'png').
- Updated `image/png` handler to pass png.
- Implemented `image/jpeg` handler to pass jpg.
- Removed TODO comment regarding JPEG support.

## Impact
- Enables JupyterCodeExecutor to correctly capture and save JPEG images generated by code execution.