### PR TITLE
fix(openai): add None check for streaming chunks

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -906,6 +906,11 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         # Process the stream of chunks.
         async for chunk in chunks:
+            # Skip None chunks that can occur during heavy load or in compiled binaries.
+            # See: https://github.com/microsoft/autogen/issues/7130
+            if chunk is None:
+                continue
+
             if first_chunk:
                 first_chunk = False
                 # Emit the start event.

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -901,6 +901,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         empty_chunk_warning_has_been_issued: bool = False
         empty_chunk_warning_threshold: int = 10
         empty_chunk_count = 0
+        none_chunk_count = 0
         first_chunk = True
         is_reasoning = False
 
@@ -909,6 +910,11 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             # Skip None chunks that can occur during heavy load or in compiled binaries.
             # See: https://github.com/microsoft/autogen/issues/7130
             if chunk is None:
+                none_chunk_count += 1
+                if none_chunk_count == 1:
+                    trace_logger.warning(
+                        "Received None chunk in OpenAI stream. This may indicate heavy API load or issues with compiled binaries."
+                    )
                 continue
 
             if first_chunk:


### PR DESCRIPTION
## Summary

Add a None check at the start of the chunk processing loop to prevent `AttributeError` when the OpenAI stream yields `None` chunks.

Fixes #7130

## Problem

The code accesses `chunk.model` without first checking if `chunk` is `None`:

```python
async for chunk in chunks:
    # ...
    maybe_model = chunk.model  # AttributeError if chunk is None!
```

This causes crashes with:
```
AttributeError: 'NoneType' object has no attribute 'model'
```

## When this happens

- During heavy API load
- In compiled binaries (PyInstaller/Nuitka) due to different async timing
- Due to network latency or keepalive packets

## Solution

Add a simple None check at the start of the loop:

```python
async for chunk in chunks:
    if chunk is None:
        continue
    # ... rest of processing
```

## Changes

- `python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py`: Added None check in `create_stream()` method

## Test plan

- [x] Verified the fix matches the proposed solution in the issue
- [x] Verified the check is placed before any attribute access on `chunk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)