### PR TITLE
fix(core): allow Image validator to be Union-friendly for multimodal payloads

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_image.py
+++ b/python/packages/autogen-core/src/autogen_core/_image.py
@@ -49,7 +49,9 @@ class Image:
     @classmethod
     def from_uri(cls, uri: str) -> Image:
         if not re.match(r"data:image/(?:png|jpeg);base64,", uri):
-            raise ValueError("Invalid URI format. It should be a base64 encoded image URI.")
+            raise ValueError(
+                "Invalid URI format. It should be a base64 encoded image URI."
+            )
 
         # A URI. Remove the prefix and decode the base64 string.
         base64_data = re.sub(r"data:image/(?:png|jpeg);base64,", "", uri)
@@ -79,11 +81,18 @@ class Image:
 
     # Returns openai.types.chat.ChatCompletionContentPartImageParam, which is a TypedDict
     # We don't use the explicit type annotation so that we can avoid a dependency on the OpenAI Python SDK in this package.
-    def to_openai_format(self, detail: Literal["auto", "low", "high"] = "auto") -> Dict[str, Any]:
-        return {"type": "image_url", "image_url": {"url": self.data_uri, "detail": detail}}
+    def to_openai_format(
+        self, detail: Literal["auto", "low", "high"] = "auto"
+    ) -> Dict[str, Any]:
+        return {
+            "type": "image_url",
+            "image_url": {"url": self.data_uri, "detail": detail},
+        }
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
         # Custom validation
         def validate(value: Any, validation_info: ValidationInfo) -> Image:
             if isinstance(value, dict):
@@ -94,7 +103,9 @@ class Image:
             elif isinstance(value, cls):
                 return value
             else:
-                raise TypeError(f"Expected dict or {cls.__name__} instance, got {type(value)}")
+                raise ValueError(
+                    f"Expected dict or {cls.__name__} instance, got {type(value)}"
+                )
 
         # Custom serialization
         def serialize(value: Image) -> dict[str, Any]:

--- a/python/packages/autogen-core/tests/test_image_union_fix.py
+++ b/python/packages/autogen-core/tests/test_image_union_fix.py
@@ -1,0 +1,38 @@
+import pytest
+
+from autogen_core import Image
+from autogen_core.models import UserMessage
+
+
+def test_user_message_mixed_content_serialization() -> None:
+    """
+    Test that UserMessage can correctly serialize and deserialize
+    mixed content containing both Image and string objects.
+    Fixes Issue #7170.
+    """
+    # 1. Setup mixed content (Image + String)
+    test_image_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+    img = Image.from_base64(test_image_b64)
+
+    # 2. Construct the message
+    original_msg = UserMessage(content=[img, "Identify this pixel."], source="user")
+
+    # 3. Perform round-trip JSON serialization
+    # This triggers the custom __get_pydantic_core_schema__ validator
+    json_data = original_msg.model_dump_json()
+
+    # 4. Attempt deserialization (The logic being tested)
+    deserialized_msg = UserMessage.model_validate_json(json_data)
+
+    # 5. Assertions
+    assert isinstance(deserialized_msg.content, list)
+    assert len(deserialized_msg.content) == 2
+    assert isinstance(deserialized_msg.content[0], Image)
+    assert isinstance(deserialized_msg.content[1], str)
+    assert deserialized_msg.content[1] == "Identify this pixel."
+
+
+if __name__ == "__main__":
+    # Allow running directly for quick verification
+    test_user_message_mixed_content_serialization()
+    print("Regression test passed.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a critical bug in `UserMessage` deserialization where mixed-media payloads (containing both `str` and `Image` objects) cause a `TypeError` during JSON deserialization (Issue #7170).

**The Root Cause:**
In Pydantic V2, a `TypeError` raised within a custom validator (specifically in `Image.__get_pydantic_core_schema__`) is interpreted as a terminal failure during Union resolution. This prevents the resolver from attempting subsequent branches in a `Union` or `List[Union[...]]`.

**The Fix:**
By refactoring the `Image` validator to raise a `ValueError` instead of a `TypeError` when a non-dict/non-Image type is encountered, we enable the Pydantic C-engine to treat the current branch as a mismatch rather than a fatal error. This allows the resolver to successfully fall back to the `str` branch, enabling full support for multimodal message schemas in parity with OpenAI and Gemini API standards.

## Related issue number

Closes #7170

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. (No doc changes required for this logic fix).
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
