### PR TITLE
fix(azure): handle None values in streaming tool_calls

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
@@ -543,13 +543,18 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
                     if "index" in tool_call_chunk:
                         idx = tool_call_chunk["index"]
                     else:
-                        idx = tool_call_chunk.id
+                        idx = tool_call_chunk.id if tool_call_chunk.id is not None else 0
                     if idx not in full_tool_calls:
                         full_tool_calls[idx] = FunctionCall(id="", arguments="", name="")
 
-                    full_tool_calls[idx].id += tool_call_chunk.id
-                    full_tool_calls[idx].name += tool_call_chunk.function.name
-                    full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
+                    # Handle None values in streaming deltas (similar to OpenAI client)
+                    if tool_call_chunk.id is not None:
+                        full_tool_calls[idx].id += tool_call_chunk.id
+                    if tool_call_chunk.function is not None:
+                        if tool_call_chunk.function.name is not None:
+                            full_tool_calls[idx].name += tool_call_chunk.function.name
+                        if tool_call_chunk.function.arguments is not None:
+                            full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
 
         if chunk and chunk.usage:
             prompt_tokens = chunk.usage.prompt_tokens


### PR DESCRIPTION
## Summary

Fixes TypeError when streaming tool calls via AzureAIChatCompletionClient when delta chunks have None values.

## Problem

When using `AzureAIChatCompletionClient` with streaming enabled (`model_client_stream=True`) and tool calls, the code crashes with:

```
TypeError: can only concatenate str (not "NoneType") to str
  at autogen_ext/models/azure/_azure_ai_client.py line ~550
```

This occurs because `tool_call_chunk.id`, `tool_call_chunk.function.name`, or `tool_call_chunk.function.arguments` can be `None` in streamed deltas from Azure AI (GitHub Models / Azure AI Foundry).

## Root Cause

The Azure client unconditionally concatenates these fields:

```python
full_tool_calls[idx].id += tool_call_chunk.id
full_tool_calls[idx].name += tool_call_chunk.function.name
full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
```

## Solution

Add None guards before concatenation, matching the pattern already used in the OpenAI client:

```python
if tool_call_chunk.id is not None:
    full_tool_calls[idx].id += tool_call_chunk.id
if tool_call_chunk.function is not None:
    if tool_call_chunk.function.name is not None:
        full_tool_calls[idx].name += tool_call_chunk.function.name
    if tool_call_chunk.function.arguments is not None:
        full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
```

## Testing

This fix follows the same pattern as the OpenAI client (`_openai_client.py` lines 986-993), which already handles None values correctly.

## Environment

- Windows 11
- Python 3.13
- autogen-ext 0.7.5
- Using GitHub Models via Azure AI Foundry endpoint

Fixes #7157
