### PR TITLE
FIX:Fix HttpTool config round-trip in StaticStreamWorkbench when headers is None

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/http/_http_tool.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/http/_http_tool.py
@@ -16,7 +16,7 @@ class HttpToolConfig(BaseModel):
     """
     The name of the tool.
     """
-    description: Optional[str]
+    description: Optional[str] = None
     """
     A description of the tool.
     """
@@ -42,7 +42,7 @@ class HttpToolConfig(BaseModel):
     """
     The HTTP method to use, will default to POST if not provided.
     """
-    headers: Optional[dict[str, Any]]
+    headers: Optional[dict[str, Any]] = None
     """
     A dictionary of headers to send with the request.
     """

--- a/python/packages/autogen-ext/tests/tools/http/test_http_tool.py
+++ b/python/packages/autogen-ext/tests/tools/http/test_http_tool.py
@@ -4,6 +4,7 @@ import logging
 import httpx
 import pytest
 from autogen_core import CancellationToken, Component, ComponentModel
+from autogen_core.tools import StaticStreamWorkbench
 from autogen_ext.tools.http import HttpTool
 from pydantic import ValidationError
 
@@ -205,3 +206,32 @@ def test_config_deserialization(test_config: ComponentModel) -> None:
     assert tool.server_params.scheme == test_config.config["scheme"]
     assert tool.server_params.method == test_config.config["method"]
     assert tool.server_params.headers == test_config.config["headers"]
+
+
+@pytest.mark.asyncio
+async def test_workbench_from_config_with_missing_headers_field() -> None:
+    tool = HttpTool(
+        name="base64_decode",
+        description="base64 decode a value",
+        scheme="https",
+        host="httpbin.org",
+        port=443,
+        path="/base64/{value}",
+        method="GET",
+        headers=None,
+        json_schema={
+            "type": "object",
+            "properties": {
+                "value": {"type": "string", "description": "The base64 value to decode"},
+            },
+            "required": ["value"],
+        },
+    )
+
+    workbench = StaticStreamWorkbench(tools=[tool])
+    config = workbench.dump_component()
+    new_workbench = StaticStreamWorkbench.load_component(config, StaticStreamWorkbench)
+
+    tools = await new_workbench.list_tools()
+    assert len(tools) == 1
+    assert tools[0]["name"] == "base64_decode"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

What This PR fixes a ValidationError when round-tripping a StaticStreamWorkbench containing an HttpTool created with headers=None via _to_config() / _from_config() .

Why Component.dump_component() serializes configs with exclude_none=True , which drops fields whose value is None . HttpToolConfig.headers was annotated as Optional[...] but had no default, making it required under Pydantic v2. As a result, the serialized config omitted headers , and loading failed with: headers: Field required [type=missing] .

Changes

- Set defaults in HttpToolConfig :
  - headers: Optional[dict[str, Any]] = None
  - description: Optional[str] = None (consistency with “optional” semantics)
- Add regression test to ensure workbench config round-trip works when headers is None .
Tests

- python -m pytest packages/autogen-ext/tests/tools/http/test_http_tool.py -k test_workbench_from_config_with_missing_headers_field
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #7172 

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
