### PR TITLE
feat: improve infer_lang() robustness with shebang and shell pattern detection

### DIFF
--- a/autogen/code_utils.py
+++ b/autogen/code_utils.py
@@ -84,18 +84,69 @@ def content_str(content: Union[str, List[Union[UserMessageTextContentPart, UserM
 
 
 def infer_lang(code: str) -> str:
-    """infer the language for the code.
-    TODO: make it robust.
-    """
-    if code.startswith("python ") or code.startswith("pip") or code.startswith("python3 "):
-        return "sh"
+    """Infer the language for the code based on syntax patterns.
 
-    # check if code is a valid python code
+    Args:
+        code (str): The code string to analyze.
+
+    Returns:
+        str: The inferred language - "python", "sh", or "unknown".
+    """
+    if not code:
+        return "python"
+
+    code = code.strip()
+
+    # Check for shebang line
+    if code.startswith("#!"):
+        first_line = code.split("\n")[0].lower()
+        if "python" in first_line:
+            return "python"
+        if "bash" in first_line or "/sh" in first_line:
+            return "sh"
+
+    # Shell command patterns - commands that indicate shell execution
+    shell_patterns = (
+        "python ",
+        "python3 ",
+        "pip ",
+        "pip3 ",
+        "cd ",
+        "ls ",
+        "mkdir ",
+        "rm ",
+        "cp ",
+        "mv ",
+        "chmod ",
+        "chown ",
+        "sudo ",
+        "apt ",
+        "apt-get ",
+        "brew ",
+        "npm ",
+        "yarn ",
+        "curl ",
+        "wget ",
+        "echo ",
+        "export ",
+        "source ",
+        "cat ",
+        "grep ",
+        "find ",
+        "tar ",
+        "unzip ",
+        "git ",
+    )
+    for pattern in shell_patterns:
+        if code.startswith(pattern):
+            return "sh"
+
+    # Check if code is a valid python code
     try:
         compile(code, "test", "exec")
         return "python"
     except SyntaxError:
-        # not a valid python code
+        # Not a valid python code
         return UNKNOWN
 
 

--- a/test/test_code_utils.py
+++ b/test/test_code_utils.py
@@ -172,6 +172,18 @@ else:
 def test_infer_lang():
     assert infer_lang("print('hello world')") == "python"
     assert infer_lang("pip install autogen") == "sh"
+    assert infer_lang("pip3 install flaml") == "sh"
+    assert infer_lang("cd .") == "sh"
+    assert infer_lang("ls -l") == "sh"
+    assert infer_lang("#!/bin/bash\necho hello") == "sh"
+    assert infer_lang("#!/usr/bin/python\nprint('hello')") == "python"
+    assert infer_lang("") == "python"
+    assert infer_lang("  python script.py") == "sh"
+    assert infer_lang("apt-get install -y python3") == "sh"
+    assert infer_lang("curl https://example.com") == "sh"
+    assert infer_lang("grep -r 'hello' .") == "sh"
+    assert infer_lang("git status") == "sh"
+    assert infer_lang("npm install") == "sh"
 
     # test infer lang for unknown code/invalid code
     assert infer_lang("dummy text") == UNKNOWN


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR addresses a TODO in `autogen/code_utils.py` to make the `infer_lang()` function more robust.

The previous implementation relied on a simple heuristic that only detected shell code if it started strictly with `python `, `pip`, or `python3 `. This missed many common shell scenarios and shebang-based scripts.

**Improvements included in this PR:**

- **Shebang Detection**: Added support for checking shebang lines (e.g., `#!/bin/bash`, `#!/usr/bin/python`) to accurately identify the language
- **Expanded Shell Patterns**: Significantly expanded the list of shell command patterns to include common commands like `cd`, `ls`, `mkdir`, `git`, `npm`, `curl`, `wget`, `grep`, etc.
- **Robustness**: Added handling for empty input and whitespace stripping before pattern matching
- **Documentation**: Added a proper docstring with Args and Returns

## Related issue number
Note: This enhancement was originally proposed in the [FLAML](https://github.com/microsoft/FLAML/pull/1490) repository. As per @thinkall's guidance, raising it here since autogen has moved to this repository.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.