### PR TITLE
fix(azure): handle None types in streaming tool aggregation

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
@@ -547,9 +547,13 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
                     if idx not in full_tool_calls:
                         full_tool_calls[idx] = FunctionCall(id="", arguments="", name="")
 
-                    full_tool_calls[idx].id += tool_call_chunk.id
-                    full_tool_calls[idx].name += tool_call_chunk.function.name
-                    full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
+                    if tool_call_chunk.id:
+                        full_tool_calls[idx].id += tool_call_chunk.id
+                    if tool_call_chunk.function:
+                        if tool_call_chunk.function.name:
+                            full_tool_calls[idx].name += tool_call_chunk.function.name
+                        if tool_call_chunk.function.arguments:
+                            full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
 
         if chunk and chunk.usage:
             prompt_tokens = chunk.usage.prompt_tokens


### PR DESCRIPTION
## Summary

Fixes #7157 where `AzureAIChatCompletionClient` raises `TypeError` during streaming tool calls if chunks contain `None` fields.

## Changes

Added `if is not None` checks in the tool call aggregation loop in `_azure_ai_client.py`:
- Checked `tool_call_chunk.id`
- Checked `tool_call_chunk.function.name`
- Checked `tool_call_chunk.function.arguments`

## Verification

The fix implements standard guard clauses similar to the OpenAI client implementation. This ensures partial updates (which may have None fields) are handled gracefully.