### PR TITLE
Fix OrTerminationCondition to raise TerminatedException instead of RuntimeError

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/base/_termination.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/base/_termination.py
@@ -104,7 +104,7 @@ class AndTerminationCondition(TerminationCondition, Component[AndTerminationCond
 
     async def __call__(self, messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> StopMessage | None:
         if self.terminated:
-            raise TerminatedException("Termination condition has already been reached.")
+            raise TerminatedException("Termination condition has already been reached")
         # Check all remaining conditions.
         stop_messages = await asyncio.gather(
             *[condition(messages) for condition in self._conditions if not condition.terminated]
@@ -155,7 +155,7 @@ class OrTerminationCondition(TerminationCondition, Component[OrTerminationCondit
 
     async def __call__(self, messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> StopMessage | None:
         if self.terminated:
-            raise RuntimeError("Termination condition has already been reached")
+            raise TerminatedException("Termination condition has already been reached")
         stop_messages = await asyncio.gather(*[condition(messages) for condition in self._conditions])
         stop_messages_filter = [stop_message for stop_message in stop_messages if stop_message is not None]
         if len(stop_messages_filter) > 0:


### PR DESCRIPTION
## Summary

- Fix `OrTerminationCondition` to raise `TerminatedException` instead of `RuntimeError` when the termination condition has already been reached
- Standardize error message format by removing trailing period from `AndTerminationCondition`

## Problem

`OrTerminationCondition.__call__` was raising `RuntimeError` when called after the condition was already terminated:

```python
# OrTerminationCondition (line 158) - BEFORE
raise RuntimeError("Termination condition has already been reached")
```

However, `AndTerminationCondition` and all other termination conditions in `_terminations.py` raise `TerminatedException`:

```python
# AndTerminationCondition (line 107)
raise TerminatedException("Termination condition has already been reached.")

# All conditions in _terminations.py (e.g., MaxMessageTermination, TextMentionTermination, etc.)
raise TerminatedException("Termination condition has already been reached")
```

## Solution

1. Changed `OrTerminationCondition` to raise `TerminatedException` instead of `RuntimeError`
2. Removed trailing period from `AndTerminationCondition` error message to match the convention used in all other termination conditions

This ensures consistent exception handling across all termination condition implementations.

## Testing

The existing test `test_or_termination` passes. The fix aligns `OrTerminationCondition` with the expected behavior documented in `TerminationCondition.__call__` docstring which states:

> Raises:
>     TerminatedException: If the termination condition has already been reached.