### PR TITLE
Fix HttpTool serialization in StaticStreamWorkbench (Issue #7172)

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/http/_http_tool.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/http/_http_tool.py
@@ -42,7 +42,7 @@ class HttpToolConfig(BaseModel):
     """
     The HTTP method to use, will default to POST if not provided.
     """
-    headers: Optional[dict[str, Any]]
+    headers: Optional[dict[str, Any]] = None
     """
     A dictionary of headers to send with the request.
     """

--- a/python/packages/autogen-ext/tests/tools/test_http_tool_serialization.py
+++ b/python/packages/autogen-ext/tests/tools/test_http_tool_serialization.py
@@ -1,0 +1,91 @@
+"""Tests for HttpTool serialization and deserialization (Issue #7172)"""
+
+import pytest
+from autogen_core.tools import StaticStreamWorkbench
+from autogen_ext.tools.http import HttpTool
+
+
+@pytest.mark.asyncio
+async def test_httptool_config_serialization():
+    """Test HttpTool can be serialized and deserialized directly"""
+    tool = HttpTool(
+        name="test_tool",
+        description="test description",
+        scheme="https",
+        host="httpbin.org",
+        port=443,
+        path="/get",
+        method="GET",
+        json_schema={"type": "object", "properties": {}},
+        headers={"Authorization": "Bearer test", "Custom-Header": "value"},
+    )
+    
+    # Serialize
+    config = tool._to_config()
+    
+    # Deserialize
+    restored_tool = HttpTool._from_config(config)
+    
+    # Verify all fields are preserved
+    assert restored_tool.name == tool.name
+    assert restored_tool.server_params.headers == tool.server_params.headers
+    assert restored_tool.server_params.host == tool.server_params.host
+    assert restored_tool.server_params.port == tool.server_params.port
+
+
+@pytest.mark.asyncio
+async def test_httptool_serialization_without_headers():
+    """Test HttpTool serialization works when headers is None"""
+    tool = HttpTool(
+        name="test_tool_no_headers",
+        description="test without headers",
+        scheme="https",
+        host="httpbin.org",
+        port=443,
+        path="/get",
+        method="GET",
+        json_schema={"type": "object", "properties": {}},
+        # headers not provided (defaults to None)
+    )
+    
+    # Serialize and deserialize
+    config = tool._to_config()
+    restored_tool = HttpTool._from_config(config)
+    
+    # Verify headers is None
+    assert restored_tool.server_params.headers is None
+
+
+@pytest.mark.asyncio
+async def test_static_workbench_httptool_serialization():
+    """Test StaticStreamWorkbench can save/load with HttpTool (Issue #7172)"""
+    tool = HttpTool(
+        name="base64_decode",
+        description="base64 decode a value",
+        scheme="https",
+        host="httpbin.org",
+        port=443,
+        path="/base64/{value}",
+        method="GET",
+        json_schema={
+            "type": "object",
+            "properties": {
+                "value": {"type": "string", "description": "The base64 value to decode"},
+            },
+            "required": ["value"],
+        },
+    )
+    
+    # Create workbench
+    workbench = StaticStreamWorkbench(tools=[tool])
+    
+    # Serialize config
+    config = workbench._to_config()
+    
+    # This should not raise validation error (was failing before fix)
+    new_workbench = StaticStreamWorkbench._from_config(config)
+    
+    # Verify workbench works
+    tools = await new_workbench.list_tools()
+    assert len(tools) == 1
+    assert tools[0]["name"] == "base64_decode"


### PR DESCRIPTION
## Description
Fixes #7172 - `StaticStreamWorkbench._from_config()` failed when using `HttpTool` due to Pydantic validation error on the `headers` field.

## Problem
When trying to save and restore a `StaticStreamWorkbench` containing an `HttpTool`, deserialization would fail with:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for HttpToolConfig
headers
  Field required [type=missing, input_value={...}]
```

This prevented users from persisting AI agents that use HTTP tools, which is critical for production deployments.

## Root Cause
The `headers` field in `HttpToolConfig` was defined as `Optional[dict[str, Any]]` without a default value. In Pydantic v2, optional fields must have an explicit default value (typically `None`) to be properly recognized as optional during validation.

## Solution
Added `= None` as the default value for the `headers` field in `HttpToolConfig`:
```python
# Before
headers: Optional[dict[str, Any]]

# After  
headers: Optional[dict[str, Any]] = None
```

This single-line change ensures Pydantic correctly treats the field as optional during both serialization and deserialization.

## Testing
- Verified the reproduction case from issue #7172 now works
- Added unit test for direct HttpTool serialization with headers
- Added unit test for HttpTool serialization without headers
- Added integration test for StaticStreamWorkbench with HttpTool
- All 3 new tests pass successfully

## Changes
- **Modified**: `python/packages/autogen-ext/src/autogen_ext/tools/http/_http_tool.py` (1 line changed)
- **Added**: `python/packages/autogen-ext/tests/tools/test_http_tool_serialization.py` (comprehensive test coverage)

## Impact
This fix enables:
- Persisting AI agents that use HTTP tools
- Saving and restoring workbenches with HttpTool
- Production deployments requiring agent restart capability