### PR TITLE
Fix potential crashes due to uninitialized variables in Gemini and ConversableAgent

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -2229,6 +2229,7 @@ class ConversableAgent(LLMAgent):
         func = self._function_map.get(func_name, None)
 
         is_exec_success = False
+        arguments = None
         if func is not None:
             # Extract arguments from a json-like string and put it into a dict.
             input_string = self._format_json_str(func_call.get("arguments", "{}"))
@@ -2288,6 +2289,7 @@ class ConversableAgent(LLMAgent):
         func = self._function_map.get(func_name, None)
 
         is_exec_success = False
+        arguments = None
         if func is not None:
             # Extract arguments from a json-like string and put it into a dict.
             input_string = self._format_json_str(func_call.get("arguments", "{}"))

--- a/autogen/oai/gemini.py
+++ b/autogen/oai/gemini.py
@@ -176,6 +176,9 @@ class GeminiClient:
         if n_response > 1:
             warnings.warn("Gemini only supports `n=1` for now. We only generate one response.", UserWarning)
 
+        ans = None
+        prompt_tokens = completion_tokens = 0
+
         if "vision" not in model_name:
             # A. create and call the chat model.
             gemini_messages = self._oai_messages_to_gemini_messages(messages)
@@ -214,7 +217,7 @@ class GeminiClient:
 
             prompt_tokens = model.count_tokens(chat.history[:-1]).total_tokens
             completion_tokens = model.count_tokens(ans).total_tokens
-        elif model_name == "gemini-pro-vision":
+        else:
             # B. handle the vision model
             if self.use_vertexai:
                 model = GenerativeModel(


### PR DESCRIPTION
I've identified and fixed several potential `UnboundLocalError` crashes in the Gemini client and `ConversableAgent`.

### Context
1. **`gemini.py`**: The previous implementation of the `create` method had hardcoded checks for specific model names. If a vision model was used that didn't match the hardcoded strings, variables like `ans` would remain uninitialized, leading to a crash. I've added default initializations and switched to a more inclusive `else` block for vision models.
2. **`conversable_agent.py`**: In `execute_function` (both sync and async), if a function was not found and `verbose=True` was set, the code would attempt to print `arguments` before they were defined. I've initialized `arguments` to `None` to prevent this.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I've verified the changes with `py_compile`.