### PR TITLE
Fix grammar errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ The AutoGen ecosystem provides everything you need to create AI agents, especial
 
 The _framework_ uses a layered and extensible design. Layers have clearly divided responsibilities and build on top of layers below. This design enables you to use the framework at different levels of abstraction, from high-level APIs to low-level components.
 
-- [Core API](./python/packages/autogen-core/) implements message passing, event-driven agents, and local and distributed runtime for flexibility and power. It also support cross-language support for .NET and Python.
+- [Core API](./python/packages/autogen-core/) implements message passing, event-driven agents, and local and distributed runtime for flexibility and power. It also supports cross-language interoperability for .NET and Python.
 - [AgentChat API](./python/packages/autogen-agentchat/) implements a simpler but opinionated API for rapid prototyping. This API is built on top of the Core API and is closest to what users of v0.2 are familiar with and supports common multi-agent patterns such as two-agent chat or group chats.
-- [Extensions API](./python/packages/autogen-ext/) enables first- and third-party extensions continuously expanding framework capabilities. It support specific implementation of LLM clients (e.g., OpenAI, AzureOpenAI), and capabilities such as code execution.
+- [Extensions API](./python/packages/autogen-ext/) enables first- and third-party extensions continuously expanding framework capabilities. It supports specific implementation of LLM clients (e.g., OpenAI, AzureOpenAI), and capabilities such as code execution.
 
 The ecosystem also supports two essential _developer tools_:
 


### PR DESCRIPTION
## Summary
- Fixed subject-verb agreement: "It support" → "It supports" (2 instances)
- Fixed redundancy: "cross-language support" → "cross-language interoperability" (avoiding "support...support")

## Changes
- Line 170: Core API description
- Line 172: Extensions API description

Small grammar fixes to improve documentation quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)