### PR TITLE
fix: clean up temporary output directory in JupyterCodeExecutor.stop()

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -145,11 +145,13 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
 
-        self._output_dir: Path = Path(tempfile.mkdtemp()) if output_dir is None else Path(output_dir)
-        self._output_dir.mkdir(exist_ok=True, parents=True)
-
         self._temp_dir: Optional[tempfile.TemporaryDirectory[str]] = None
-        self._temp_dir_path: Optional[Path] = None
+        if output_dir is None:
+            self._temp_dir = tempfile.TemporaryDirectory()
+            self._output_dir = Path(self._temp_dir.name)
+        else:
+            self._output_dir = Path(output_dir)
+        self._output_dir.mkdir(exist_ok=True, parents=True)
 
         self._started = False
 
@@ -306,6 +308,11 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
             self.kernel_context = None
 
         self._client = None
+
+        if self._temp_dir is not None:
+            self._temp_dir.cleanup()
+            self._temp_dir = None
+
         self._started = False
 
     def _to_config(self) -> JupyterCodeExecutorConfig:

--- a/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
@@ -225,3 +225,28 @@ async def test_runtime_error_not_started() -> None:
     code_blocks = [CodeBlock(code="print('hello world!')", language="python")]
     with pytest.raises(RuntimeError, match="Executor must be started before executing cells"):
         await executor.execute_code_blocks(code_blocks, CancellationToken())
+
+
+@pytest.mark.asyncio
+async def test_temp_dir_cleanup_on_stop() -> None:
+    """Test that temporary output directory is cleaned up when stop() is called."""
+    executor = JupyterCodeExecutor()
+    temp_dir = executor.output_dir
+    assert temp_dir.exists()
+
+    await executor.start()
+    await executor.stop()
+
+    assert not temp_dir.exists(), "Temporary output directory should be cleaned up after stop()"
+
+
+@pytest.mark.asyncio
+async def test_user_provided_output_dir_not_cleaned_up(tmp_path: Path) -> None:
+    """Test that user-provided output directory is NOT cleaned up when stop() is called."""
+    executor = JupyterCodeExecutor(output_dir=tmp_path)
+    assert executor.output_dir == tmp_path
+
+    await executor.start()
+    await executor.stop()
+
+    assert tmp_path.exists(), "User-provided output directory should not be cleaned up after stop()"


### PR DESCRIPTION
## Summary

Fixes #7217

`JupyterCodeExecutor` creates a temporary directory via `tempfile.mkdtemp()` when no `output_dir` is provided, but never cleans it up in `stop()`. This causes leaked directories and their contents (generated images, HTML files) to accumulate on disk over time.

This is inconsistent with every other executor in the codebase (`LocalCommandLineCodeExecutor`, `DockerCommandLineCodeExecutor`, `AzureContainerCodeExecutor`) which all properly clean up their temporary directories.

### Changes

- Replace `tempfile.mkdtemp()` with `tempfile.TemporaryDirectory()` in `__init__`, matching the pattern used by all other executors
- Add `cleanup()` call in `stop()` to properly clean up the temporary directory
- User-provided `output_dir` directories are not affected (only auto-created temp dirs are cleaned up)
- Remove the unused `_temp_dir_path` field

### Tests

Added two new tests:
- `test_temp_dir_cleanup_on_stop` -- verifies the temporary directory is removed after `stop()`
- `test_user_provided_output_dir_not_cleaned_up` -- verifies user-provided directories are preserved after `stop()`