### PR TITLE
Fix _mentioned_agents() to ignore reasoning tags in speaker selection

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -321,6 +321,10 @@ class SelectorGroupChatManager(BaseGroupChatManager):
         Returns:
             Dict: a counter for mentioned agents.
         """
+        # Strip reasoning blocks (like <thinking>, <reflection>, etc.) before counting mentions
+        # This prevents agent mentions in internal reasoning from affecting speaker selection
+        cleaned_content = self._strip_reasoning_blocks(message_content)
+
         mentions: Dict[str, int] = dict()
         for name in agent_names:
             # Finds agent mentions, taking word boundaries into account,
@@ -335,10 +339,49 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                 + r")(?=\W)"
             )
             # Pad the message to help with matching
-            count = len(re.findall(regex, f" {message_content} "))
+            count = len(re.findall(regex, f" {cleaned_content} "))
             if count > 0:
                 mentions[name] = count
         return mentions
+
+    def _strip_reasoning_blocks(self, content: str) -> str:
+        """Strip reasoning blocks from message content.
+
+        Removes common reasoning tags like <thinking>, <reflection>, <reasoning>, etc.
+        that models use for internal reasoning, to prevent agent mentions in these
+        blocks from affecting speaker selection.
+
+        Args:
+            content: The message content to clean
+
+        Returns:
+            str: Content with reasoning blocks removed
+        """
+        # Common reasoning tags used by various models
+        reasoning_tags = [
+            "thinking",
+            "thought",
+            "reflection",
+            "reasoning",
+            "analysis",
+            "internal",
+            "scratch",
+            "planning",
+        ]
+
+        # Build regex pattern to match any of these tags (case-insensitive)
+        # Matches both self-closing and paired tags
+        pattern = "|".join(reasoning_tags)
+        # Match opening tag, content, and closing tag (non-greedy)
+        tag_pattern = rf"<({pattern})(?:\s[^>]*)?>.*?</\1>"
+        # Also match self-closing tags
+        self_closing_pattern = rf"<({pattern})(?:\s[^>]*)?/>"
+
+        # Remove all matched reasoning blocks
+        cleaned = re.sub(tag_pattern, "", content, flags=re.IGNORECASE | re.DOTALL)
+        cleaned = re.sub(self_closing_pattern, "", cleaned, flags=re.IGNORECASE)
+
+        return cleaned
 
 
 class SelectorGroupChatConfig(BaseModel):

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -1944,3 +1944,53 @@ async def test_selector_group_chat_streaming(runtime: AgentRuntime | None) -> No
 
     # Content-based verification instead of index-based
     # Note: The streaming test verifies the streaming behavior, not the final result content
+
+
+@pytest.mark.asyncio
+async def test_selector_group_chat_ignores_thinking_tags(runtime: AgentRuntime | None) -> None:
+    """Test that _mentioned_agents ignores agent mentions inside reasoning tags."""
+    # Model response mentions agent1 and agent2 in thinking, but only agent3 in the actual response
+    model_client = ReplayChatCompletionClient(
+        [
+            "<thinking>Maybe agent1 could help, or agent2 might be better</thinking>I suggest agent3 takes the next step.",
+        ]
+    )
+    agent1 = _StopAgent("agent1", description="agent 1", stop_at=1)
+    agent2 = _EchoAgent("agent2", description="agent 2")
+    agent3 = _EchoAgent("agent3", description="agent 3")
+    termination = MaxMessageTermination(2)
+    team = SelectorGroupChat(
+        participants=[agent1, agent2, agent3],
+        model_client=model_client,
+        termination_condition=termination,
+        runtime=runtime,
+    )
+    result = await team.run(task="task")
+
+    # Should select agent3, not agent1 or agent2 from the thinking block
+    assert len(result.messages) == 2
+    assert isinstance(result.messages[0], TextMessage)
+    assert result.messages[0].content == "task"
+    assert isinstance(result.messages[1], TextMessage)
+    assert result.messages[1].source == "agent3"
+
+    # Test with multiple reasoning tag types
+    model_client2 = ReplayChatCompletionClient(
+        [
+            "<reflection>agent1 should handle this</reflection><planning>or maybe agent2</planning>Let agent3 proceed.",
+        ]
+    )
+    agent1_2 = _StopAgent("agent1", description="agent 1", stop_at=1)
+    agent2_2 = _EchoAgent("agent2", description="agent 2")
+    agent3_2 = _EchoAgent("agent3", description="agent 3")
+    team2 = SelectorGroupChat(
+        participants=[agent1_2, agent2_2, agent3_2],
+        model_client=model_client2,
+        termination_condition=MaxMessageTermination(2),
+        runtime=runtime,
+    )
+    result2 = await team2.run(task="task")
+
+    # Should still select agent3
+    assert len(result2.messages) == 2
+    assert result2.messages[1].source == "agent3"


### PR DESCRIPTION
## Summary
Fixes #6891

When LLMs use reasoning tags like `<thinking>`, `<reflection>`, `<planning>`, etc., agent mentions inside these blocks should not affect speaker selection. This PR filters out common reasoning blocks before counting agent mentions.

## Problem
The issue occurred because models like Qwen would mention agents in their internal reasoning (e.g., `"<thinking>Maybe AgentA or AgentB could help</thinking>I suggest AgentC"`), and the selector would incorrectly count those mentions, leading to wrong speaker selection.

## Solution
- Added `_strip_reasoning_blocks()` method to remove common reasoning tags:
  - `thinking`, `thought`, `reflection`, `reasoning`
  - `analysis`, `internal`, `scratch`, `planning`
- Updated `_mentioned_agents()` to use cleaned content before counting
- Added comprehensive test case

## Testing
- Manual unit tests confirm correct behavior:
  - Reasoning blocks are stripped before counting
  - Multiple tag types are handled
  - Case-insensitive matching
  - Tags with attributes are supported
- Added test case `test_selector_group_chat_ignores_thinking_tags`

## Example
Before:
```
<thinking>Maybe agent1 or agent2 could help</thinking>I suggest agent3
```
Would count: agent1=1, agent2=1, agent3=1 (incorrect)

After:
Would count: agent3=1 only (correct)