### PR TITLE
fix(core): preserve non-requirements decorators in generated code

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/code_executor/_func_with_reqs.py
+++ b/python/packages/autogen-core/src/autogen_core/code_executor/_func_with_reqs.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import functools
 import inspect
 from dataclasses import dataclass, field
@@ -17,6 +18,29 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
+def _strip_first_decorator(code: str) -> str:
+    if not code.startswith("@"):
+        return code
+
+    # Preserve all decorators except the first one (with_requirements) even when
+    # the first decorator spans multiple lines.
+    try:
+        module = ast.parse(code)
+    except SyntaxError:
+        return code[code.index("\n") + 1 :]
+
+    if not module.body or not isinstance(module.body[0], (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return code[code.index("\n") + 1 :]
+
+    function_node = module.body[0]
+    if len(function_node.decorator_list) == 1:
+        start_lineno = function_node.lineno
+    else:
+        start_lineno = function_node.decorator_list[1].lineno
+
+    return "\n".join(code.splitlines()[start_lineno - 1 :])
+
+
 def _to_code(func: Union[FunctionWithRequirements[T, P], Callable[P, T], FunctionWithRequirementsStr]) -> str:
     if isinstance(func, FunctionWithRequirementsStr):
         return func.func
@@ -25,10 +49,8 @@ def _to_code(func: Union[FunctionWithRequirements[T, P], Callable[P, T], Functio
         code = inspect.getsource(func.func)
     else:
         code = inspect.getsource(func)
-    # Strip the decorator
-    if code.startswith("@"):
-        code = code[code.index("\n") + 1 :]
-    return code
+
+    return _strip_first_decorator(code)
 
 
 @dataclass(frozen=True)

--- a/python/packages/autogen-core/tests/test_code_executor.py
+++ b/python/packages/autogen-core/tests/test_code_executor.py
@@ -1,14 +1,16 @@
 import textwrap
 
 import pytest
+from pandas import DataFrame, concat
+
 from autogen_core.code_executor import (
     Alias,
     FunctionWithRequirements,
     FunctionWithRequirementsStr,
     ImportFromModule,
+    with_requirements,
 )
-from autogen_core.code_executor._func_with_reqs import build_python_functions_file
-from pandas import DataFrame, concat
+from autogen_core.code_executor._func_with_reqs import _strip_first_decorator, build_python_functions_file
 
 
 def template_function() -> DataFrame:  # type: ignore
@@ -25,6 +27,25 @@ def template_function() -> DataFrame:  # type: ignore
     df1 = DataFrame.from_dict(data1)  # type: ignore
     df2 = DataFrame.from_dict(data2)  # type: ignore
     return concat([df1, df2])  # type: ignore
+
+
+def retry_like(*, stop: int, wait: int):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+@with_requirements(
+    python_packages=["pandas", "tenacity"],
+    global_imports=[ImportFromModule("pandas", ["DataFrame"])],
+)
+@retry_like(
+    stop=3,
+    wait=2,
+)
+def template_function_with_multiline_decorators() -> DataFrame:  # type: ignore
+    return DataFrame.from_dict({"name": ["John"], "location": ["New York"], "age": [24]})  # type: ignore
 
 
 @pytest.mark.asyncio
@@ -51,3 +72,32 @@ async def test_hashability_Import() -> None:
     functions_module2 = build_python_functions_file([function2])
 
     assert "import pandas as pd" in functions_module2
+
+
+def test_build_python_functions_file_with_multiline_with_requirements_and_other_decorators() -> None:
+    functions_module = build_python_functions_file([template_function_with_multiline_decorators])
+
+    assert "python_packages=" not in functions_module
+    assert "global_imports=" not in functions_module
+    assert "@retry_like(" in functions_module
+    assert "def template_function_with_multiline_decorators()" in functions_module
+    compile(functions_module, "<generated_functions_module>", "exec")
+
+
+def test_strip_first_decorator_single_line_decorator() -> None:
+    code = "@decorator\ndef hello() -> int:\n    return 1\n"
+    stripped = _strip_first_decorator(code)
+    assert stripped.startswith("def hello()")
+    compile(stripped, "<single_line_decorator>", "exec")
+
+
+def test_strip_first_decorator_falls_back_for_syntax_error() -> None:
+    code = "@decorator(\ndef hello() -> int:\n    return 1\n"
+    stripped = _strip_first_decorator(code)
+    assert stripped == "def hello() -> int:\n    return 1\n"
+
+
+def test_strip_first_decorator_falls_back_for_non_function() -> None:
+    code = "@decorator\nclass NotFunction:\n    pass\n"
+    stripped = _strip_first_decorator(code)
+    assert stripped == "class NotFunction:\n    pass\n"


### PR DESCRIPTION
## Summary
Fixes malformed source generation in `build_python_functions_file` when a function is decorated with both `@with_requirements(...)` and other decorators.

`inspect.getsource(...)` currently strips only the first decorator line, which breaks multiline `@with_requirements(...)` blocks and leaves invalid Python in the generated module.

Closes #7209

## What changed
- Added `_strip_first_decorator(...)` in `autogen_core.code_executor._func_with_reqs` to remove the first decorator block using AST line numbers.
  - This correctly handles multiline decorators.
  - It preserves all decorators after the first one.
- Updated `_to_code(...)` to use the new helper.
- Added regression tests in `test_code_executor.py` for:
  - multiline `@with_requirements(...)` + additional decorator
  - single-line decorator stripping
  - fallback behavior for syntax-error and non-function inputs

## Validation
Local checks run:
- `pytest packages/autogen-core/tests/test_code_executor.py -q`
- `ruff check python/packages/autogen-core/src/autogen_core/code_executor/_func_with_reqs.py python/packages/autogen-core/tests/test_code_executor.py`
- `pytest packages/autogen-core/tests/test_code_executor.py -q --cov=autogen_core.code_executor._func_with_reqs --cov-branch --cov-report=xml --cov-report=term-missing`

Results:
- tests: `5 passed`
- changed executable lines coverage in `autogen_core/code_executor/_func_with_reqs.py`: `100% (16/16)`
