### PR TITLE
fix(agentchat): clarify tools/workbench mutual exclusion error

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -826,7 +826,10 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
 
         if workbench is not None:
             if self._tools:
-                raise ValueError("Tools cannot be used with a workbench.")
+                raise ValueError(
+                    "Tools and workbench are mutually exclusive. Use either `tools` for direct "
+                    "function tools or `workbench` for environment-provided tools."
+                )
             if isinstance(workbench, Sequence):
                 self._workbench = workbench
             else:

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -1175,7 +1175,10 @@ class TestAssistantAgentValidation:
 
         workbench = MagicMock()
 
-        with pytest.raises(ValueError, match="Tools cannot be used with a workbench"):
+        with pytest.raises(
+            ValueError,
+            match="Tools and workbench are mutually exclusive.*Use either `tools`.*or `workbench`",
+        ):
             AssistantAgent(
                 name="test_agent",
                 model_client=model_client,


### PR DESCRIPTION
## Summary

Fixes #7213 by making the constructor error message actionable when both `tools` and `workbench` are provided to `AssistantAgent`.

## What changed

- Updated the `ValueError` message in `AssistantAgent.__init__` to explicitly describe the mutual exclusion and recommended usage.
- Updated the existing unit test assertion to match the new message.

## Why this helps

The previous message ("Tools cannot be used with a workbench") reported the constraint but did not guide users on what to do next. The new message tells users the two valid options directly.

## Validation

- `cd python && uv run ruff check packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py packages/autogen-agentchat/tests/test_assistant_agent.py`
- `cd python && uv run mypy packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py`
- `cd python && uv run pytest packages/autogen-agentchat/tests/test_assistant_agent.py -k tools_and_workbench_mutually_exclusive -q`

Changed-line coverage (local): 100% (6/6 executable changed lines).
