### PR TITLE
updated protobuf version and dependent libraries to address vulnerability in autogen-core library

### DIFF
--- a/python/packages/autogen-core/pyproject.toml
+++ b/python/packages/autogen-core/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pillow>=11.0.0",
     "typing-extensions>=4.0.0",
     "pydantic<3.0.0,>=2.10.0",
-    "protobuf~=5.29.3",
+    "protobuf~=6.33.5",
     "opentelemetry-api>=1.34.1",
     "jsonref~=1.1.0",
 ]

--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -77,7 +77,7 @@ redis = [
 ]
 
 grpc = [
-    "grpcio~=1.70.0",
+    "grpcio~=1.78.0",
 ]
 
 jupyter-executor = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
     "pytest_mock",
     "poethepoet",
     "packaging",
-    "grpcio-tools~=1.70.0",
+    "grpcio-tools~=1.78.0",
     "mypy-protobuf",
     "cookiecutter",
     "tomli",


### PR DESCRIPTION
## Why are these changes needed?

The project builds are failing due to a high vulnerability [CVE-2026-0994](https://www.mend.io/vulnerability-database/CVE-2026-0994) with `protobuf` version `5.29.5`. This vulnerability has been addressed and fixed in the latest release of protobuf (version `6.33.5`). We need to incorporate this latest version in `autogen-core` in order to allow project builds to pass the vulnerability scans.

## Related issue number

Not Applicable

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
