### PR TITLE
fix(autogen-ext): fallback when non-OpenAI endpoints reject parse response_format

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -24,6 +24,7 @@ from typing import (
     Union,
     cast,
 )
+from urllib.parse import urlparse
 
 import tiktoken
 from autogen_core import (
@@ -51,7 +52,7 @@ from autogen_core.models import (
     validate_model_info,
 )
 from autogen_core.tools import Tool, ToolSchema
-from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI
+from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI, BadRequestError
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -660,6 +661,33 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             create_args=create_args,
         )
 
+    def _uses_openai_hosted_endpoint(self) -> bool:
+        base_url = getattr(self._client, "base_url", None)
+        if base_url is None:
+            return True
+
+        host = getattr(base_url, "host", None)
+        if not isinstance(host, str) or not host:
+            parsed = urlparse(str(base_url))
+            host = parsed.hostname or ""
+
+        host = host.lower()
+        return host == "api.openai.com" or host.endswith(".openai.azure.com")
+
+    def _should_fallback_from_parse_error(self, error: BadRequestError) -> bool:
+        if self._uses_openai_hosted_endpoint():
+            return False
+
+        body = getattr(error, "body", None)
+        body_message = ""
+        if isinstance(body, dict):
+            err = body.get("error")
+            if isinstance(err, dict):
+                body_message = str(err.get("message", ""))
+
+        message = f"{error} {body_message}".lower()
+        return "response_format" in message and ("unavailable" in message or "unsupported" in message)
+
     async def create(
         self,
         messages: Sequence[LLMMessage],
@@ -678,6 +706,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             extra_create_args,
         )
         future: Union[Task[ParsedChatCompletion[BaseModel]], Task[ChatCompletion]]
+        using_beta_parse = create_params.response_format is not None
         if create_params.response_format is not None:
             # Use beta client if response_format is not None
             future = asyncio.ensure_future(
@@ -701,8 +730,34 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         if cancellation_token is not None:
             cancellation_token.link_future(future)
-        result: Union[ParsedChatCompletion[BaseModel], ChatCompletion] = await future
-        if create_params.response_format is not None:
+        try:
+            result: Union[ParsedChatCompletion[BaseModel], ChatCompletion] = await future
+        except BadRequestError as error:
+            if using_beta_parse and self._should_fallback_from_parse_error(error):
+                warnings.warn(
+                    "Structured output parse is not supported by this non-OpenAI endpoint. "
+                    "Falling back to response_format=json_object.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                fallback_create_args = dict(create_params.create_args)
+                fallback_create_args["response_format"] = ResponseFormatJSONObject(type="json_object")
+                future = asyncio.ensure_future(
+                    self._client.chat.completions.create(
+                        messages=create_params.messages,
+                        stream=False,
+                        tools=(create_params.tools if len(create_params.tools) > 0 else NOT_GIVEN),
+                        **fallback_create_args,
+                    )
+                )
+                if cancellation_token is not None:
+                    cancellation_token.link_future(future)
+                result = await future
+                using_beta_parse = False
+            else:
+                raise
+
+        if using_beta_parse:
             result = cast(ParsedChatCompletion[Any], result)
 
         # Handle the case where OpenAI API might return None for token counts

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+from enum import Enum
 from typing import Annotated, Any, AsyncGenerator, Dict, List, Literal, Optional, Tuple, TypeVar
 from unittest.mock import AsyncMock, MagicMock
 
@@ -33,6 +34,7 @@ from autogen_ext.models.openai._openai_client import (
 )
 from autogen_ext.models.openai._transformation import TransformerMap, get_transformer
 from autogen_ext.models.openai._transformation.registry import _find_model_family  # pyright: ignore[reportPrivateUsage]
+from openai import BadRequestError
 from openai.lib.streaming.chat import AsyncChatCompletionStreamManager
 from openai.resources.chat.completions import AsyncCompletions
 from openai.types.chat.chat_completion import ChatCompletion, Choice
@@ -802,6 +804,160 @@ async def test_structured_output(monkeypatch: pytest.MonkeyPatch) -> None:
             messages=[UserMessage(content="I am happy.", source="user")],
             json_output=AgentResponse,
             extra_create_args={"response_format": AgentResponse},
+        )
+
+
+@pytest.mark.asyncio
+async def test_structured_output_falls_back_for_non_openai_parse_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CustomStatus(Enum):
+        TODO = "To Do"
+        SUCCESSFUL = "Successful"
+        FAILED = "Failed"
+
+    class StatusResponse(BaseModel):
+        status: CustomStatus = Field(description="The current status")
+
+    called_args: Dict[str, Any] = {}
+
+    async def _mock_parse(*args: Any, **kwargs: Any) -> ParsedChatCompletion[BaseModel]:
+        request = httpx.Request("POST", "https://api.deepseek.com/v1/chat/completions")
+        response = httpx.Response(
+            400,
+            request=request,
+            json={"error": {"message": "This response_format type is unavailable now"}},
+        )
+        raise BadRequestError(
+            "Error code: 400 - {'error': {'message': 'This response_format type is unavailable now'}}",
+            response=response,
+            body=response.json(),
+        )
+
+    async def _mock_create(*args: Any, **kwargs: Any) -> ChatCompletion:
+        called_args["kwargs"] = kwargs
+        return ChatCompletion(
+            id="id1",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content=json.dumps({"status": "Successful"}),
+                        role="assistant",
+                    ),
+                )
+            ],
+            created=0,
+            model="deepseek-chat",
+            object="chat.completion",
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=0),
+        )
+
+    monkeypatch.setattr(AsyncCompletions, "parse", _mock_parse)
+    monkeypatch.setattr(AsyncCompletions, "create", _mock_create)
+
+    model_client = OpenAIChatCompletionClient(
+        model="deepseek-chat",
+        base_url="https://api.deepseek.com/v1",
+        api_key="",
+        model_info=ModelInfo(
+            vision=False,
+            function_calling=False,
+            json_output=True,
+            family="unknown",
+            structured_output=True,
+        ),
+        response_format=StatusResponse,
+    )
+
+    cancellation_token = CancellationToken()
+
+    with pytest.warns(UserWarning, match="Falling back to response_format=json_object"):
+        create_result = await model_client.create(
+            messages=[UserMessage(content="Return current status", source="user")],
+            cancellation_token=cancellation_token,
+        )
+
+    assert isinstance(create_result.content, str)
+    assert json.loads(create_result.content)["status"] == "Successful"
+    assert called_args["kwargs"]["response_format"] == {"type": "json_object"}
+
+
+def test_parse_fallback_endpoint_detection_branches() -> None:
+    class UrlWithoutHost:
+        def __str__(self) -> str:
+            return "https://api.deepseek.com/v1"
+
+    class UrlOpenAI:
+        def __str__(self) -> str:
+            return "https://api.openai.com/v1"
+
+    class StubClient:
+        def __init__(self, base_url: Any) -> None:
+            self.base_url = base_url
+
+    model_client = OpenAIChatCompletionClient(
+        model="gpt-4.1-nano-2025-04-14",
+        api_key="",
+    )
+
+    request = httpx.Request("POST", "https://api.deepseek.com/v1/chat/completions")
+    response = httpx.Response(
+        400,
+        request=request,
+        json={"error": {"message": "This response_format type is unavailable now"}},
+    )
+    error = BadRequestError(
+        "Error code: 400 - {'error': {'message': 'This response_format type is unavailable now'}}",
+        response=response,
+        body=response.json(),
+    )
+
+    model_client._client = StubClient(None)  # type: ignore[attr-defined]
+    assert model_client._uses_openai_hosted_endpoint() is True
+    assert model_client._should_fallback_from_parse_error(error) is False
+
+    model_client._client = StubClient(UrlWithoutHost())  # type: ignore[attr-defined]
+    assert model_client._uses_openai_hosted_endpoint() is False
+    assert model_client._should_fallback_from_parse_error(error) is True
+
+    model_client._client = StubClient(UrlOpenAI())  # type: ignore[attr-defined]
+    assert model_client._uses_openai_hosted_endpoint() is True
+    assert model_client._should_fallback_from_parse_error(error) is False
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parse_error_reraises_on_openai_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StatusResponse(BaseModel):
+        status: str
+
+    async def _mock_parse(*args: Any, **kwargs: Any) -> ParsedChatCompletion[BaseModel]:
+        request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        response = httpx.Response(
+            400,
+            request=request,
+            json={"error": {"message": "This response_format type is unavailable now"}},
+        )
+        raise BadRequestError(
+            "Error code: 400 - {'error': {'message': 'This response_format type is unavailable now'}}",
+            response=response,
+            body=response.json(),
+        )
+
+    monkeypatch.setattr(AsyncCompletions, "parse", _mock_parse)
+
+    model_client = OpenAIChatCompletionClient(
+        model="gpt-4.1-nano-2025-04-14",
+        api_key="",
+        response_format=StatusResponse,
+    )
+
+    with pytest.raises(BadRequestError):
+        await model_client.create(
+            messages=[UserMessage(content="Return current status", source="user")],
         )
 
 


### PR DESCRIPTION
## Summary
Fixes #7201 by adding a compatibility fallback for non-OpenAI endpoints when structured-output parsing is rejected.

When `response_format` is a Pydantic model, the client uses `beta.chat.completions.parse(...)`. Some OpenAI-compatible providers (e.g. DeepSeek-compatible endpoints) return `400` with messages such as "response_format type is unavailable" for this path.

This PR keeps the existing OpenAI behavior, but for non-OpenAI endpoints only:
- catches `BadRequestError` from `beta.parse`
- detects unsupported `response_format` errors
- retries with regular `chat.completions.create(...)` and `response_format={"type":"json_object"}`

## Why this is safe
- OpenAI/Azure-hosted endpoints keep current behavior (no fallback path).
- Fallback is only triggered on explicit parse rejection errors.
- Existing structured-output tests still pass.

## Changes
- `python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py`
  - Added endpoint detection helper.
  - Added parse-error fallback gate for non-OpenAI endpoints.
  - Added retry path with `json_object` response format.
- `python/packages/autogen-ext/tests/models/test_openai_model_client.py`
  - Added regression test for DeepSeek-style parse rejection fallback.
  - Added coverage tests for endpoint detection branches.
  - Added regression test verifying parse errors are still re-raised on OpenAI endpoints.

## Validation
- `uv run --project python/packages/autogen-ext ruff check python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py python/packages/autogen-ext/tests/models/test_openai_model_client.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run pytest -q packages/autogen-ext/tests/models/test_openai_model_client.py -k "structured_output_falls_back_for_non_openai_parse_unsupported or parse_fallback_endpoint_detection_branches or structured_output_parse_error_reraises_on_openai_endpoint or test_structured_output"`
- Changed executable lines in touched source file are covered (100%).
