### PR TITLE
fix(autogen-ext): support http_client in config schema and fail fast on serialization

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1504,6 +1504,8 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
 
     def _to_config(self) -> OpenAIClientConfigurationConfigModel:
         copied_config = self._raw_config.copy()
+        if copied_config.get("http_client") is not None:
+            raise ValueError("http_client cannot be component serialized")
         return OpenAIClientConfigurationConfigModel(**copied_config)
 
     @classmethod
@@ -1722,6 +1724,8 @@ class AzureOpenAIChatCompletionClient(
         from ...auth.azure import AzureTokenProvider
 
         copied_config = self._raw_config.copy()
+        if copied_config.get("http_client") is not None:
+            raise ValueError("http_client cannot be component serialized")
         if "azure_ad_token_provider" in copied_config:
             if not isinstance(copied_config["azure_ad_token_provider"], AzureTokenProvider):
                 raise ValueError("azure_ad_token_provider must be a AzureTokenProvider to be component serialized")

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -1,9 +1,12 @@
-from typing import Awaitable, Callable, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Literal, Optional, Union
 
 from autogen_core import ComponentModel
 from autogen_core.models import ModelCapabilities, ModelInfo  # type: ignore
 from pydantic import BaseModel, SecretStr
 from typing_extensions import Required, TypedDict
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class JSONSchema(TypedDict, total=False):
@@ -74,6 +77,7 @@ class BaseOpenAIClientConfiguration(CreateArguments, total=False):
     include_name_in_message: bool
     """Whether to include the 'name' field in user message parameters. Defaults to True. Set to False for providers that don't support the 'name' field."""
     default_headers: Dict[str, str] | None
+    http_client: "httpx.AsyncClient | None"
 
 
 # See OpenAI docs for explanation of these parameters
@@ -120,6 +124,8 @@ class BaseOpenAIClientConfigurationConfigModel(CreateArgumentsConfigModel):
     add_name_prefixes: bool | None = None
     include_name_in_message: bool | None = None
     default_headers: Dict[str, str] | None = None
+    # Non-serializable runtime object. Accepted in in-memory config paths only.
+    http_client: Any = None
 
 
 # See OpenAI docs for explanation of these parameters

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -206,6 +206,22 @@ async def test_openai_chat_completion_client_serialization() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openai_chat_completion_client_serialization_raises_with_http_client() -> None:
+    runtime_http_client = httpx.AsyncClient(trust_env=False, verify=False)
+    try:
+        client = OpenAIChatCompletionClient(
+            model="gpt-4.1-nano",
+            api_key="api_key",
+            http_client=runtime_http_client,
+        )
+
+        with pytest.raises(ValueError, match="http_client cannot be component serialized"):
+            client.dump_component()
+    finally:
+        await runtime_http_client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_openai_chat_completion_client_raise_on_unknown_model() -> None:
     with pytest.raises(ValueError, match="model_info is required"):
         _ = OpenAIChatCompletionClient(model="unknown", api_key="api_key")
@@ -248,6 +264,32 @@ async def test_azure_openai_chat_completion_client() -> None:
         },
     )
     assert client
+
+
+@pytest.mark.asyncio
+async def test_azure_openai_chat_completion_client_serialization_raises_with_http_client() -> None:
+    runtime_http_client = httpx.AsyncClient(trust_env=False, verify=False)
+    try:
+        client = AzureOpenAIChatCompletionClient(
+            azure_deployment="gpt-4o-1",
+            model="gpt-4o",
+            api_key="api_key",
+            api_version="2020-08-04",
+            azure_endpoint="https://dummy.com",
+            http_client=runtime_http_client,
+            model_info={
+                "vision": True,
+                "function_calling": True,
+                "json_output": True,
+                "family": ModelFamily.GPT_4O,
+                "structured_output": True,
+            },
+        )
+
+        with pytest.raises(ValueError, match="http_client cannot be component serialized"):
+            client.dump_component()
+    finally:
+        await runtime_http_client.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This PR fixes the `http_client` configuration gap for `autogen-ext` OpenAI clients.

## Problem
Issue #7107 reports that users need to pass a custom `http_client` (for example for custom TLS behavior), but the OpenAI client configuration schema did not expose this field. This caused config paths to silently drop it.

## Changes
- Added `http_client` to `BaseOpenAIClientConfiguration`
- Added `http_client` to `BaseOpenAIClientConfigurationConfigModel` so config parsing keeps the field in in-memory config paths
- Added explicit guard in component serialization:
  - `OpenAIChatCompletionClient._to_config` now raises `ValueError` if `http_client` is set
  - `AzureOpenAIChatCompletionClient._to_config` now raises `ValueError` if `http_client` is set

This avoids silent loss of runtime-only objects during component serialization.

## Tests
Added regression coverage in `test_openai_model_client.py`:
- `test_openai_chat_completion_client_serialization_raises_with_http_client`
- `test_azure_openai_chat_completion_client_serialization_raises_with_http_client`

## Local validation
- `uv run --project python/packages/autogen-ext --with ruff ruff check python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py python/packages/autogen-ext/tests/models/test_openai_model_client.py`
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy uv run --project python/packages/autogen-ext --with pytest pytest -q python/packages/autogen-ext/tests/models/test_openai_model_client.py -k "serialization_raises_with_http_client or test_openai_chat_completion_client_serialization"`

Closes #7107
