### PR TITLE
Fix encoding issues in text file operations for non-English Windows systems

### DIFF
--- a/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
@@ -20,7 +20,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])
@@ -30,7 +30,7 @@ async def main() -> None:
     
     # Read the prompt
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt", encoding="utf-8") as fh:
         prompt = fh.read().strip()
     filename = "__FILE_NAME__".strip()
 

--- a/python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py
@@ -25,7 +25,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])

--- a/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py
+++ b/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py
@@ -15,7 +15,7 @@ from autogen_core.models import ChatCompletionClient
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(config["model_config"])
 
@@ -48,7 +48,7 @@ async def main() -> None:
     agent_team = RoundRobinGroupChat([coder_agent, executor], max_turns=12, termination_condition=termination)
 
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt", encoding="utf-8") as fh:
         prompt = fh.read()
 
     task = f"""Complete the following python function. Format your output as Markdown python code block containing the entire function definition:

--- a/python/packages/autogen-ext/tests/task_centric_memory/utils.py
+++ b/python/packages/autogen-ext/tests/task_centric_memory/utils.py
@@ -27,5 +27,5 @@ def load_yaml_file(file_path: str) -> Any:
     """
     Opens a file and returns its contents.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)


### PR DESCRIPTION
## Problem

This PR addresses issue #5566 where AutoGen fails on non-English Windows systems with UnicodeDecodeError when reading text files. While the specific playwright_controller.py file mentioned in the issue was already fixed in PR #6094, this issue highlighted a broader pattern of missing encoding specifications in file operations throughout the codebase.

## Root Cause

On Windows systems with non-English locales (e.g., CP950 for Chinese, CP932 for Japanese), Python's default encoding for open() is not UTF-8. When files contain non-ASCII characters, this causes UnicodeDecodeError crashes.

## Solution

Added explicit encoding='utf-8' parameter to open() calls for text files that:
1. Are user-facing configuration files (config.yaml, prompt.txt)
2. Could contain non-ASCII content
3. Are read by core functionality

## Files Fixed

- python/packages/autogen-ext/tests/task_centric_memory/utils.py - YAML config loading
- python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py - Config and prompt files
- python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py - Config and prompt files  
- python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py - Config files

## Impact

- Fixes crashes on Chinese/Japanese/Korean Windows systems
- Maintains backward compatibility on all platforms
- Follows Python best practices for text file handling
- No performance impact

## Testing

All changes are syntactically verified. The fix ensures consistent UTF-8 handling across platforms, preventing locale-specific encoding issues.

Closes #5566