### PR TITLE
Fix LangChainToolAdapter pydantic schema error for tools with internal fields

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
@@ -162,7 +162,20 @@ class LangChainToolAdapter(BaseTool[BaseModel, Any]):
 
         # Determine args_type
         if self._langchain_tool.args_schema:  # pyright: ignore
-            args_type = self._langchain_tool.args_schema  # pyright: ignore
+            # Use the tool's args property (which filters out internal fields like
+            # run_manager and callbacks) to rebuild a clean pydantic model.
+            # This avoids schema generation errors for types like
+            # CallbackManagerForToolRun that pydantic cannot handle.
+            schema_cls = self._langchain_tool.args_schema  # pyright: ignore
+            filtered_field_names = set(self._langchain_tool.args.keys())
+            filtered_fields: Dict[str, Any] = {}
+            for field_name, field_info in schema_cls.model_fields.items():
+                if field_name in filtered_field_names:
+                    filtered_fields[field_name] = (field_info.annotation, field_info)
+            if filtered_fields:
+                args_type = create_model(f"{name}Args", **filtered_fields)  # type: ignore
+            else:
+                args_type = schema_cls
         else:
             # Infer args_type from the callable's signature
             sig = inspect.signature(cast(Callable[..., Any], self._callable))  # type: ignore


### PR DESCRIPTION
## Summary
Some LangChain tools (e.g., `GoogleDriveSearchTool`) have an `args_schema` that includes internal fields like `run_manager` (`CallbackManagerForToolRun`) which pydantic cannot serialize. This causes a `PydanticSchemaGenerationError` when creating a `LangChainToolAdapter`.

## Fix
Rebuild the pydantic model using only the filtered fields from the LangChain tool's `.args` property, which already excludes internal fields like `run_manager` and `callbacks`. This is consistent with how LangChain itself exposes tool arguments.

## Related Issue
Fixes #6385