### PR TITLE
fix: correct 'overriden' typo to 'overridden'

### DIFF
--- a/python/docs/src/user-guide/core-user-guide/faqs.md
+++ b/python/docs/src/user-guide/core-user-guide/faqs.md
@@ -33,7 +33,7 @@ host = GrpcWorkerAgentRuntimeHost(address=host_address, extra_grpc_config=extra_
 worker1 = GrpcWorkerAgentRuntime(host_address=host_address, extra_grpc_config=extra_grpc_config)
 ```
 
-**Note**: When `GrpcWorkerAgentRuntime` creates a host connection for the clients, it uses `DEFAULT_GRPC_CONFIG` from `HostConnection` class as default set of values which will can be overriden if you pass parameters with the same name using `extra_grpc_config`.
+**Note**: When `GrpcWorkerAgentRuntime` creates a host connection for the clients, it uses `DEFAULT_GRPC_CONFIG` from `HostConnection` class as default set of values which will can be overridden if you pass parameters with the same name using `extra_grpc_config`.
 
 ## What are model capabilities and how do I specify them?
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/config/__init__.py
@@ -21,7 +21,7 @@ class BaseOllamaClientConfiguration(CreateArguments, total=False):
     headers: Optional[Mapping[str, str]]
     model_capabilities: ModelCapabilities  # type: ignore
     model_info: ModelInfo
-    """What functionality the model supports, determined by default from model name but is overriden if value passed."""
+    """What functionality the model supports, determined by default from model name but is overridden if value passed."""
     options: Optional[Union[Mapping[str, Any], Options]]
 
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -70,7 +70,7 @@ class BaseOpenAIClientConfiguration(CreateArguments, total=False):
     model_capabilities: ModelCapabilities  # type: ignore
     model_info: ModelInfo
     add_name_prefixes: bool
-    """What functionality the model supports, determined by default from model name but is overriden if value passed."""
+    """What functionality the model supports, determined by default from model name but is overridden if value passed."""
     include_name_in_message: bool
     """Whether to include the 'name' field in user message parameters. Defaults to True. Set to False for providers that don't support the 'name' field."""
     default_headers: Dict[str, str] | None


### PR DESCRIPTION
Fixed 3 instances of the typo 'overriden' → 'overridden':

- `python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py` — docstring
- `python/packages/autogen-ext/src/autogen_ext/models/ollama/config/__init__.py` — docstring  
- `python/docs/src/user-guide/core-user-guide/faqs.md` — documentation