### PR TITLE
fix(docs): make back-to-top button keyboard accessible

### DIFF
--- a/python/docs/src/_static/custom.js
+++ b/python/docs/src/_static/custom.js
@@ -84,6 +84,28 @@ document.addEventListener('DOMContentLoaded', function () {
   if (targetNode) {
     observer.observe(targetNode, config);
   }
+
+  // Make back-to-top button keyboard accessible (#6090 issue 25)
+  const backToTopButton = document.querySelector('.back-to-top');
+  if (backToTopButton) {
+    // Ensure the button is focusable
+    if (!backToTopButton.hasAttribute('tabindex')) {
+      backToTopButton.setAttribute('tabindex', '0');
+    }
+    // Add accessible label
+    backToTopButton.setAttribute('aria-label', 'Back to top');
+    backToTopButton.setAttribute('role', 'button');
+    
+    // Handle keyboard activation (Enter and Space)
+    backToTopButton.addEventListener('keydown', function(event) {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+        // Announce the action
+        announceMessage(liveRegion, 'Scrolled to top of page');
+      }
+    });
+  }
 });
 
 async function copyToClipboard(button) {


### PR DESCRIPTION
## Summary
Makes the back-to-top button keyboard accessible, addressing issue #25 from #6090.

## Changes
- Added `tabindex='0'` to make the button focusable via keyboard navigation
- Added `aria-label='Back to top'` for screen readers
- Added `role='button'` for proper semantics
- Added keydown handler to activate on Enter/Space keys
- Added screen reader announcement when scrolling to top

## Testing
1. Navigate to any docs page
2. Scroll down until back-to-top button appears
3. Tab to the button (should now be reachable)
4. Press Enter or Space (should scroll to top)
5. Screen reader should announce 'Scrolled to top of page'

## Related Issues
Partially fixes #6090 (issue 25: Back to Top control is not accessible with keyboard)