### PR TITLE
feat: add CAMB AI tool integration for speech & audio

### DIFF
--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -41,6 +41,7 @@ llama-cpp = [
     "llama-cpp-python>=0.3.8",
 ]
 
+camb = ["camb-sdk>=1.0.0"]
 graphrag = ["graphrag>=2.3.0"]
 chromadb = ["chromadb>=1.0.0"]
 mem0 = ["mem0ai>=0.1.98"]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/__init__.py
@@ -1,0 +1,31 @@
+from ._audio_separation import AudioSeparationArgs, CambAudioSeparationTool
+from ._config import CambToolConfig
+from ._text_to_sound import CambTextToSoundTool, TextToSoundArgs
+from ._toolkit import CambAIToolkit
+from ._transcription import CambTranscriptionTool, TranscriptionArgs
+from ._translated_tts import CambTranslatedTTSTool, TranslatedTTSArgs
+from ._translation import CambTranslationTool, TranslationArgs
+from ._tts import CambTTSTool, TTSArgs
+from ._voice_clone import CambVoiceCloneTool, VoiceCloneArgs
+from ._voice_list import CambVoiceListTool, VoiceListArgs
+
+__all__ = [
+    "AudioSeparationArgs",
+    "CambAIToolkit",
+    "CambAudioSeparationTool",
+    "CambTextToSoundTool",
+    "CambToolConfig",
+    "CambTranscriptionTool",
+    "CambTranslatedTTSTool",
+    "CambTranslationTool",
+    "CambTTSTool",
+    "CambVoiceCloneTool",
+    "CambVoiceListTool",
+    "TextToSoundArgs",
+    "TranscriptionArgs",
+    "TranslatedTTSArgs",
+    "TranslationArgs",
+    "TTSArgs",
+    "VoiceCloneArgs",
+    "VoiceListArgs",
+]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_audio_separation.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_audio_separation.py
@@ -1,0 +1,131 @@
+import json
+from typing import Optional
+
+from autogen_core import CancellationToken
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+from ._base import CambBaseTool
+from ._config import CambToolConfig
+
+
+class AudioSeparationArgs(BaseModel):
+    """Arguments for the CAMB.AI audio separation tool."""
+
+    audio_url: Optional[str] = Field(
+        default=None,
+        description="URL of the audio file to separate.",
+    )
+    audio_file_path: Optional[str] = Field(
+        default=None,
+        description="Local file path of the audio file to separate.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_audio_source(self) -> "AudioSeparationArgs":
+        if not self.audio_url and not self.audio_file_path:
+            raise ValueError("Either audio_url or audio_file_path must be provided.")
+        if self.audio_url and self.audio_file_path:
+            raise ValueError("Only one of audio_url or audio_file_path should be provided.")
+        return self
+
+
+class CambAudioSeparationTool(CambBaseTool[AudioSeparationArgs, str]):
+    """Audio separation tool using CAMB.AI.
+
+    Separates vocals from background audio using the CAMB.AI audio separation API.
+    Returns a JSON string with vocals and background URLs.
+
+    .. note::
+        This tool requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambAudioSeparationTool, AudioSeparationArgs
+
+        async def main():
+            tool = CambAudioSeparationTool(api_key="your-api-key")
+            result = await tool.run(
+                AudioSeparationArgs(audio_file_path="/path/to/audio.mp3"),
+                CancellationToken(),
+            )
+            print(f"Separation result: {result}")
+
+        asyncio.run(main())
+    """
+
+    component_provider_override = "autogen_ext.tools.camb.CambAudioSeparationTool"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=AudioSeparationArgs,
+            return_type=str,
+            name="camb_audio_separation",
+            description=(
+                "Separate vocals from background audio using CAMB.AI. "
+                "Returns JSON with vocals and background URLs."
+            ),
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_poll_attempts=max_poll_attempts,
+            poll_interval=poll_interval,
+        )
+
+    async def run(self, args: AudioSeparationArgs, cancellation_token: CancellationToken) -> str:
+        client = self._get_client()
+
+        kwargs: dict = {}
+        if args.audio_url:
+            kwargs["media_url"] = args.audio_url
+        elif args.audio_file_path:
+            kwargs["media_file"] = open(args.audio_file_path, "rb")
+
+        try:
+            task = await client.audio_separation.create_audio_separation(**kwargs)
+        finally:
+            if "media_file" in kwargs:
+                kwargs["media_file"].close()
+
+        task_id = task.task_id
+
+        status = await self._poll_task_status(
+            client.audio_separation.get_audio_separation_status,
+            task_id,
+        )
+
+        run_id = status.run_id
+        result = await client.audio_separation.get_audio_separation_run_info(run_id)
+
+        output = {
+            "foreground_audio_url": getattr(result, "foreground_audio_url", None),
+            "background_audio_url": getattr(result, "background_audio_url", None),
+        }
+        return json.dumps(output)
+
+    @classmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_poll_attempts=config.max_poll_attempts,
+            poll_interval=config.poll_interval,
+        )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_base.py
@@ -1,0 +1,166 @@
+import asyncio
+import os
+import struct
+import tempfile
+from abc import abstractmethod
+from typing import Any, Generic, Optional, TypeVar
+
+from autogen_core import CancellationToken, Component
+from autogen_core.tools import BaseTool
+from pydantic import BaseModel
+from typing_extensions import Self
+
+from ._config import CambToolConfig
+
+ArgsT = TypeVar("ArgsT", bound=BaseModel)
+ReturnT = TypeVar("ReturnT")
+
+
+class CambBaseTool(BaseTool[ArgsT, ReturnT], Component[CambToolConfig], Generic[ArgsT, ReturnT]):
+    """Abstract base class for CAMB.AI tools.
+
+    Manages the AsyncCambAI client lifecycle and provides shared utilities
+    for polling async tasks, saving audio, and detecting audio formats.
+    Uses the ``camb-sdk`` package with its native async client.
+    """
+
+    component_type = "tool"
+    component_config_schema = CambToolConfig
+
+    def __init__(
+        self,
+        args_type: type[ArgsT],
+        return_type: type[ReturnT],
+        name: str,
+        description: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=args_type,
+            return_type=return_type,
+            name=name,
+            description=description,
+        )
+        self._api_key = api_key
+        self._base_url = base_url
+        self._timeout = timeout
+        self._max_poll_attempts = max_poll_attempts
+        self._poll_interval = poll_interval
+        self._client: Any = None
+
+    def _get_api_key(self) -> str:
+        """Resolve API key from parameter or environment variable."""
+        key = self._api_key or os.environ.get("CAMB_API_KEY")
+        if not key:
+            raise ValueError(
+                "CAMB.AI API key is required. Provide it via the api_key parameter "
+                "or set the CAMB_API_KEY environment variable."
+            )
+        return key
+
+    def _get_client(self) -> Any:
+        """Get or create the AsyncCambAI client (lazy initialization)."""
+        if self._client is None:
+            from camb.client import AsyncCambAI
+
+            kwargs: dict[str, Any] = {"api_key": self._get_api_key()}
+            if self._base_url:
+                kwargs["base_url"] = self._base_url
+            if self._timeout is not None:
+                kwargs["timeout"] = self._timeout
+            self._client = AsyncCambAI(**kwargs)
+        return self._client
+
+    async def _poll_task_status(
+        self,
+        status_func: Any,
+        task_id: str,
+    ) -> Any:
+        """Poll an async task until completion or failure.
+
+        Args:
+            status_func: Async function to call for status checks (e.g. client.transcription.get_transcription_task_status).
+            task_id: The task ID to poll.
+
+        Returns:
+            The final status result when the task completes.
+
+        Raises:
+            RuntimeError: If the task fails or times out.
+        """
+        for _ in range(self._max_poll_attempts):
+            result = await status_func(task_id)
+            status = getattr(result, "status", None)
+            if status is None and hasattr(result, "message"):
+                status = getattr(result.message, "status", None)
+            if status in ("SUCCESS", "complete", "completed"):
+                return result
+            if status in ("ERROR", "TIMEOUT", "PAYMENT_REQUIRED", "failed", "error"):
+                reason = getattr(result, "exception_reason", "") or ""
+                raise RuntimeError(f"CAMB.AI task failed with status: {status}. {reason}")
+            await asyncio.sleep(self._poll_interval)
+        raise RuntimeError(
+            f"CAMB.AI task timed out after {self._max_poll_attempts * self._poll_interval}s"
+        )
+
+    @staticmethod
+    def _detect_audio_format(data: bytes) -> str:
+        """Detect audio format from raw bytes."""
+        if data[:4] == b"RIFF":
+            return "wav"
+        if data[:3] == b"ID3" or data[:2] == b"\xff\xfb":
+            return "mp3"
+        if data[:4] == b"fLaC":
+            return "flac"
+        if data[:4] == b"OggS":
+            return "ogg"
+        return "wav"
+
+    @staticmethod
+    def _add_wav_header(
+        raw_data: bytes, sample_rate: int = 24000, channels: int = 1, bits_per_sample: int = 16
+    ) -> bytes:
+        """Add a WAV header to raw PCM audio data."""
+        data_size = len(raw_data)
+        header = struct.pack(
+            "<4sI4s4sIHHIIHH4sI",
+            b"RIFF",
+            36 + data_size,
+            b"WAVE",
+            b"fmt ",
+            16,
+            1,  # PCM format
+            channels,
+            sample_rate,
+            sample_rate * channels * bits_per_sample // 8,
+            channels * bits_per_sample // 8,
+            bits_per_sample,
+            b"data",
+            data_size,
+        )
+        return header + raw_data
+
+    @staticmethod
+    def _save_audio(data: bytes, extension: str = "wav") -> str:
+        """Save audio data to a temporary file and return the file path."""
+        with tempfile.NamedTemporaryFile(suffix=f".{extension}", delete=False) as f:
+            f.write(data)
+            return f.name
+
+    def _to_config(self) -> CambToolConfig:
+        return CambToolConfig(
+            api_key=self._api_key,
+            base_url=self._base_url,
+            timeout=self._timeout,
+            max_poll_attempts=self._max_poll_attempts,
+            poll_interval=self._poll_interval,
+        )
+
+    @classmethod
+    @abstractmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        ...

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_config.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_config.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class CambToolConfig(BaseModel):
+    """Configuration for CAMB.AI tools.
+
+    Args:
+        api_key: CAMB.AI API key. If not provided, falls back to CAMB_API_KEY environment variable.
+        base_url: Base URL for the CAMB.AI API.
+        timeout: Request timeout in seconds.
+        max_poll_attempts: Maximum number of polling attempts for async tasks.
+        poll_interval: Interval between polling attempts in seconds.
+    """
+
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+    timeout: Optional[float] = None
+    max_poll_attempts: int = 60
+    poll_interval: float = 2.0

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_text_to_sound.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_text_to_sound.py
@@ -1,0 +1,127 @@
+from typing import Optional
+
+from autogen_core import CancellationToken
+from pydantic import BaseModel, Field
+from typing_extensions import Self
+
+from ._base import CambBaseTool
+from ._config import CambToolConfig
+
+
+class TextToSoundArgs(BaseModel):
+    """Arguments for the CAMB.AI text-to-sound tool."""
+
+    prompt: str = Field(
+        ...,
+        description="Text description of the sound or music to generate.",
+    )
+    duration: Optional[float] = Field(
+        default=None,
+        description="Duration of the generated audio in seconds.",
+    )
+    audio_type: Optional[str] = Field(
+        default=None,
+        description="Type of audio to generate: 'music' or 'sound'.",
+    )
+
+
+class CambTextToSoundTool(CambBaseTool[TextToSoundArgs, str]):
+    """Text-to-sound generation tool using CAMB.AI.
+
+    Generates sounds or music from text descriptions using the CAMB.AI API.
+    Returns the file path to the generated audio file.
+
+    .. note::
+        This tool requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambTextToSoundTool, TextToSoundArgs
+
+        async def main():
+            tool = CambTextToSoundTool(api_key="your-api-key")
+            result = await tool.run(
+                TextToSoundArgs(prompt="Ocean waves crashing on a beach"),
+                CancellationToken(),
+            )
+            print(f"Audio saved to: {result}")
+
+        asyncio.run(main())
+    """
+
+    component_provider_override = "autogen_ext.tools.camb.CambTextToSoundTool"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=TextToSoundArgs,
+            return_type=str,
+            name="camb_text_to_sound",
+            description=(
+                "Generate sounds or music from text descriptions using CAMB.AI. "
+                "Returns the file path to the generated audio."
+            ),
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_poll_attempts=max_poll_attempts,
+            poll_interval=poll_interval,
+        )
+
+    async def run(self, args: TextToSoundArgs, cancellation_token: CancellationToken) -> str:
+        client = self._get_client()
+
+        kwargs: dict = {"prompt": args.prompt}
+        if args.duration is not None:
+            kwargs["duration"] = args.duration
+        if args.audio_type is not None:
+            kwargs["audio_type"] = args.audio_type
+
+        task = await client.text_to_audio.create_text_to_audio(**kwargs)
+        task_id = task.task_id
+
+        status = await self._poll_task_status(
+            client.text_to_audio.get_text_to_audio_status,
+            task_id,
+        )
+
+        run_id = status.run_id
+
+        chunks: list[bytes] = []
+        async for chunk in client.text_to_audio.get_text_to_audio_result(run_id):
+            chunks.append(chunk)
+
+        audio_data = b"".join(chunks)
+        if not audio_data:
+            raise RuntimeError("CAMB.AI text-to-sound returned no audio data.")
+
+        fmt = self._detect_audio_format(audio_data)
+        if fmt == "wav" and audio_data[:4] != b"RIFF":
+            audio_data = self._add_wav_header(audio_data)
+        return self._save_audio(audio_data, fmt)
+
+    @classmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_poll_attempts=config.max_poll_attempts,
+            poll_interval=config.poll_interval,
+        )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_toolkit.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_toolkit.py
@@ -1,0 +1,129 @@
+from typing import Optional
+
+from autogen_core.tools import BaseTool
+
+from ._audio_separation import AudioSeparationArgs, CambAudioSeparationTool
+from ._text_to_sound import CambTextToSoundTool, TextToSoundArgs
+from ._tts import CambTTSTool, TTSArgs
+from ._transcription import CambTranscriptionTool, TranscriptionArgs
+from ._translated_tts import CambTranslatedTTSTool, TranslatedTTSArgs
+from ._translation import CambTranslationTool, TranslationArgs
+from ._voice_clone import CambVoiceCloneTool, VoiceCloneArgs
+from ._voice_list import CambVoiceListTool, VoiceListArgs
+
+
+class CambAIToolkit:
+    """Factory class to create all CAMB.AI tools with shared configuration.
+
+    Creates all 8 CAMB.AI tools with shared API key, base URL, and timeout settings.
+    Use the ``include_*`` flags to selectively enable or disable specific tools.
+
+    .. note::
+        This toolkit requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambAIToolkit, TTSArgs
+
+        async def main():
+            toolkit = CambAIToolkit(api_key="your-api-key")
+            tools = toolkit.get_tools()
+            # Use the TTS tool
+            tts = tools[0]
+            result = await tts.run(TTSArgs(text="Hello from AutoGen!"), CancellationToken())
+            print(f"Audio saved to: {result}")
+
+        asyncio.run(main())
+
+    Args:
+        api_key: CAMB.AI API key. Falls back to CAMB_API_KEY environment variable.
+        base_url: Base URL for the CAMB.AI API.
+        timeout: Request timeout in seconds.
+        max_poll_attempts: Maximum number of polling attempts for async tasks.
+        poll_interval: Interval between polling attempts in seconds.
+        include_tts: Include the text-to-speech tool.
+        include_translation: Include the translation tool.
+        include_transcription: Include the transcription tool.
+        include_translated_tts: Include the translated text-to-speech tool.
+        include_voice_clone: Include the voice cloning tool.
+        include_voice_list: Include the voice listing tool.
+        include_text_to_sound: Include the text-to-sound tool.
+        include_audio_separation: Include the audio separation tool.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+        include_tts: bool = True,
+        include_translation: bool = True,
+        include_transcription: bool = True,
+        include_translated_tts: bool = True,
+        include_voice_clone: bool = True,
+        include_voice_list: bool = True,
+        include_text_to_sound: bool = True,
+        include_audio_separation: bool = True,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url
+        self._timeout = timeout
+        self._max_poll_attempts = max_poll_attempts
+        self._poll_interval = poll_interval
+        self._include_tts = include_tts
+        self._include_translation = include_translation
+        self._include_transcription = include_transcription
+        self._include_translated_tts = include_translated_tts
+        self._include_voice_clone = include_voice_clone
+        self._include_voice_list = include_voice_list
+        self._include_text_to_sound = include_text_to_sound
+        self._include_audio_separation = include_audio_separation
+
+    def _make_kwargs(self) -> dict:
+        return {
+            "api_key": self._api_key,
+            "base_url": self._base_url,
+            "timeout": self._timeout,
+            "max_poll_attempts": self._max_poll_attempts,
+            "poll_interval": self._poll_interval,
+        }
+
+    def get_tools(self) -> list[BaseTool]:  # type: ignore[type-arg]
+        """Create and return the enabled CAMB.AI tools.
+
+        Returns:
+            A list of CAMB.AI tool instances configured with shared settings.
+        """
+        kwargs = self._make_kwargs()
+        tools: list[BaseTool] = []  # type: ignore[type-arg]
+
+        if self._include_tts:
+            tools.append(CambTTSTool(**kwargs))
+        if self._include_translation:
+            tools.append(CambTranslationTool(**kwargs))
+        if self._include_transcription:
+            tools.append(CambTranscriptionTool(**kwargs))
+        if self._include_translated_tts:
+            tools.append(CambTranslatedTTSTool(**kwargs))
+        if self._include_voice_clone:
+            tools.append(CambVoiceCloneTool(**kwargs))
+        if self._include_voice_list:
+            tools.append(CambVoiceListTool(**kwargs))
+        if self._include_text_to_sound:
+            tools.append(CambTextToSoundTool(**kwargs))
+        if self._include_audio_separation:
+            tools.append(CambAudioSeparationTool(**kwargs))
+
+        return tools

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_transcription.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_transcription.py
@@ -1,0 +1,144 @@
+import json
+from typing import Any, Optional
+
+from autogen_core import CancellationToken
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+from ._base import CambBaseTool
+from ._config import CambToolConfig
+
+
+class TranscriptionArgs(BaseModel):
+    """Arguments for the CAMB.AI transcription tool."""
+
+    language: int = Field(
+        ...,
+        description="Language ID for the audio content (CAMB.AI language code).",
+    )
+    audio_url: Optional[str] = Field(
+        default=None,
+        description="URL of the audio file to transcribe.",
+    )
+    audio_file_path: Optional[str] = Field(
+        default=None,
+        description="Local file path of the audio file to transcribe.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_audio_source(self) -> "TranscriptionArgs":
+        if not self.audio_url and not self.audio_file_path:
+            raise ValueError("Either audio_url or audio_file_path must be provided.")
+        if self.audio_url and self.audio_file_path:
+            raise ValueError("Only one of audio_url or audio_file_path should be provided.")
+        return self
+
+
+class CambTranscriptionTool(CambBaseTool[TranscriptionArgs, str]):
+    """Speech-to-text transcription tool using CAMB.AI.
+
+    Transcribes audio to text with speaker diarization using the CAMB.AI transcription API.
+    Returns a JSON string with the transcription result.
+
+    .. note::
+        This tool requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambTranscriptionTool, TranscriptionArgs
+
+        async def main():
+            tool = CambTranscriptionTool(api_key="your-api-key")
+            result = await tool.run(
+                TranscriptionArgs(language=1, audio_file_path="/path/to/audio.wav"),
+                CancellationToken(),
+            )
+            print(f"Transcription: {result}")
+
+        asyncio.run(main())
+    """
+
+    component_provider_override = "autogen_ext.tools.camb.CambTranscriptionTool"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=TranscriptionArgs,
+            return_type=str,
+            name="camb_transcription",
+            description=(
+                "Transcribe audio to text using CAMB.AI. Returns JSON with "
+                "transcription segments (start, end, text, speaker)."
+            ),
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_poll_attempts=max_poll_attempts,
+            poll_interval=poll_interval,
+        )
+
+    async def run(self, args: TranscriptionArgs, cancellation_token: CancellationToken) -> str:
+        client = self._get_client()
+
+        kwargs: dict[str, Any] = {"language": args.language}
+        if args.audio_url:
+            kwargs["media_url"] = args.audio_url
+        elif args.audio_file_path:
+            kwargs["media_file"] = open(args.audio_file_path, "rb")
+
+        try:
+            task = await client.transcription.create_transcription(**kwargs)
+        finally:
+            if "media_file" in kwargs:
+                kwargs["media_file"].close()
+
+        task_id = task.task_id
+
+        status = await self._poll_task_status(
+            client.transcription.get_transcription_task_status,
+            task_id,
+        )
+
+        run_id = status.run_id
+        result = await client.transcription.get_transcription_result(run_id)
+
+        # Serialize the TranscriptionResult to JSON
+        output: dict[str, Any] = {}
+        if hasattr(result, "transcript") and result.transcript:
+            output["transcript"] = [
+                {
+                    "start": getattr(seg, "start", 0),
+                    "end": getattr(seg, "end", 0),
+                    "text": getattr(seg, "text", ""),
+                    "speaker": getattr(seg, "speaker", ""),
+                }
+                for seg in result.transcript
+            ]
+
+        return json.dumps(output)
+
+    @classmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_poll_attempts=config.max_poll_attempts,
+            poll_interval=config.poll_interval,
+        )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_translated_tts.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_translated_tts.py
@@ -1,0 +1,148 @@
+from typing import Optional
+
+import httpx
+from autogen_core import CancellationToken
+from pydantic import BaseModel, Field
+from typing_extensions import Self
+
+from ._base import CambBaseTool
+from ._config import CambToolConfig
+
+_DEFAULT_TTS_RESULT_URL = "https://client.camb.ai/apis/tts-result"
+
+
+class TranslatedTTSArgs(BaseModel):
+    """Arguments for the CAMB.AI translated text-to-speech tool."""
+
+    text: str = Field(
+        ...,
+        description="The text to translate and convert to speech.",
+    )
+    source_language: int = Field(
+        ...,
+        description="Source language ID (CAMB.AI language code).",
+    )
+    target_language: int = Field(
+        ...,
+        description="Target language ID (CAMB.AI language code).",
+    )
+    voice_id: int = Field(
+        default=147320,
+        description="The voice ID to use for speech synthesis.",
+    )
+    formality: Optional[int] = Field(
+        default=None,
+        description="Formality level: 1 for formal, 2 for informal.",
+    )
+
+
+class CambTranslatedTTSTool(CambBaseTool[TranslatedTTSArgs, str]):
+    """Translated text-to-speech tool using CAMB.AI.
+
+    Translates text and converts it to speech in one step using the CAMB.AI API.
+    Returns the file path to the generated audio file.
+
+    .. note::
+        This tool requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambTranslatedTTSTool, TranslatedTTSArgs
+
+        async def main():
+            tool = CambTranslatedTTSTool(api_key="your-api-key")
+            result = await tool.run(
+                TranslatedTTSArgs(
+                    text="Hello world",
+                    source_language=1,
+                    target_language=76,
+                ),
+                CancellationToken(),
+            )
+            print(f"Audio saved to: {result}")
+
+        asyncio.run(main())
+    """
+
+    component_provider_override = "autogen_ext.tools.camb.CambTranslatedTTSTool"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=TranslatedTTSArgs,
+            return_type=str,
+            name="camb_translated_tts",
+            description=(
+                "Translate text and convert to speech in one step using CAMB.AI. "
+                "Returns the file path to the generated audio."
+            ),
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_poll_attempts=max_poll_attempts,
+            poll_interval=poll_interval,
+        )
+
+    async def run(self, args: TranslatedTTSArgs, cancellation_token: CancellationToken) -> str:
+        client = self._get_client()
+
+        kwargs: dict = {
+            "text": args.text,
+            "source_language": args.source_language,
+            "target_language": args.target_language,
+            "voice_id": args.voice_id,
+        }
+        if args.formality is not None:
+            kwargs["formality"] = args.formality
+
+        task = await client.translated_tts.create_translated_tts(**kwargs)
+        task_id = task.task_id
+
+        status = await self._poll_task_status(
+            client.translated_tts.get_translated_tts_task_status,
+            task_id,
+        )
+
+        run_id = status.run_id
+
+        # SDK doesn't have a direct audio result method for translated TTS; fetch via HTTP
+        url = f"{_DEFAULT_TTS_RESULT_URL}/{run_id}"
+        api_key = self._get_api_key()
+        async with httpx.AsyncClient() as http_client:
+            response = await http_client.get(url, headers={"x-api-key": api_key})
+            response.raise_for_status()
+            audio_data = response.content
+
+        if not audio_data:
+            raise RuntimeError("CAMB.AI translated TTS returned no audio data.")
+
+        fmt = self._detect_audio_format(audio_data)
+        if fmt == "wav" and audio_data[:4] != b"RIFF":
+            audio_data = self._add_wav_header(audio_data)
+        return self._save_audio(audio_data, fmt)
+
+    @classmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_poll_attempts=config.max_poll_attempts,
+            poll_interval=config.poll_interval,
+        )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_translation.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_translation.py
@@ -1,0 +1,118 @@
+from typing import Optional
+
+from autogen_core import CancellationToken
+from pydantic import BaseModel, Field
+from typing_extensions import Self
+
+from ._base import CambBaseTool
+from ._config import CambToolConfig
+
+
+class TranslationArgs(BaseModel):
+    """Arguments for the CAMB.AI translation tool."""
+
+    text: str = Field(
+        ...,
+        description="The text to translate.",
+    )
+    source_language: int = Field(
+        ...,
+        description="Source language ID (CAMB.AI language code).",
+    )
+    target_language: int = Field(
+        ...,
+        description="Target language ID (CAMB.AI language code).",
+    )
+    formality: Optional[int] = Field(
+        default=None,
+        description="Formality level: 1 for formal, 2 for informal.",
+    )
+
+
+class CambTranslationTool(CambBaseTool[TranslationArgs, str]):
+    """Text translation tool using CAMB.AI.
+
+    Translates text between languages using the CAMB.AI streaming translation API.
+    Returns the translated text string.
+
+    .. note::
+        This tool requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambTranslationTool, TranslationArgs
+
+        async def main():
+            tool = CambTranslationTool(api_key="your-api-key")
+            result = await tool.run(
+                TranslationArgs(text="Hello world", source_language=1, target_language=76),
+                CancellationToken(),
+            )
+            print(f"Translated: {result}")
+
+        asyncio.run(main())
+    """
+
+    component_provider_override = "autogen_ext.tools.camb.CambTranslationTool"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=TranslationArgs,
+            return_type=str,
+            name="camb_translation",
+            description="Translate text between languages using CAMB.AI. Returns the translated text.",
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_poll_attempts=max_poll_attempts,
+            poll_interval=poll_interval,
+        )
+
+    async def run(self, args: TranslationArgs, cancellation_token: CancellationToken) -> str:
+        from camb.core.api_error import ApiError
+
+        client = self._get_client()
+
+        kwargs: dict = {
+            "text": args.text,
+            "source_language": args.source_language,
+            "target_language": args.target_language,
+        }
+        if args.formality is not None:
+            kwargs["formality"] = args.formality
+
+        try:
+            result = await client.translation.translation_stream(**kwargs)
+            return str(result)
+        except ApiError as e:
+            # SDK quirk: successful translations may raise ApiError with status 200
+            if e.status_code == 200 and e.body:
+                return str(e.body)
+            raise
+
+    @classmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_poll_attempts=config.max_poll_attempts,
+            poll_interval=config.poll_interval,
+        )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_tts.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_tts.py
@@ -1,0 +1,130 @@
+from typing import Optional
+
+from autogen_core import CancellationToken
+from pydantic import BaseModel, Field
+from typing_extensions import Self
+
+from ._base import CambBaseTool
+from ._config import CambToolConfig
+
+
+class TTSArgs(BaseModel):
+    """Arguments for the CAMB.AI text-to-speech tool."""
+
+    text: str = Field(
+        ...,
+        min_length=3,
+        max_length=3000,
+        description="The text to convert to speech (3-3000 characters).",
+    )
+    language: str = Field(
+        default="en-us",
+        description="BCP-47 language code for the output speech.",
+    )
+    voice_id: int = Field(
+        default=147320,
+        description="The voice ID to use for speech synthesis.",
+    )
+    speech_model: str = Field(
+        default="mars-flash",
+        description="The speech model to use: 'mars-flash', 'mars-pro', or 'mars-instruct'.",
+    )
+    user_instructions: Optional[str] = Field(
+        default=None,
+        description="Optional instructions for the speech model (mars-instruct only).",
+    )
+
+
+class CambTTSTool(CambBaseTool[TTSArgs, str]):
+    """Text-to-speech tool using CAMB.AI.
+
+    Converts text to speech audio using the CAMB.AI streaming TTS API.
+    Returns the file path to the generated audio file.
+
+    .. note::
+        This tool requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambTTSTool, TTSArgs
+
+        async def main():
+            tool = CambTTSTool(api_key="your-api-key")
+            result = await tool.run(
+                TTSArgs(text="Hello from AutoGen!"),
+                CancellationToken(),
+            )
+            print(f"Audio saved to: {result}")
+
+        asyncio.run(main())
+    """
+
+    component_provider_override = "autogen_ext.tools.camb.CambTTSTool"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=TTSArgs,
+            return_type=str,
+            name="camb_tts",
+            description="Convert text to speech using CAMB.AI. Returns the file path to the generated audio.",
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_poll_attempts=max_poll_attempts,
+            poll_interval=poll_interval,
+        )
+
+    async def run(self, args: TTSArgs, cancellation_token: CancellationToken) -> str:
+        from camb import StreamTtsOutputConfiguration
+
+        client = self._get_client()
+
+        kwargs: dict = {
+            "text": args.text,
+            "voice_id": args.voice_id,
+            "language": args.language,
+            "output_configuration": StreamTtsOutputConfiguration(),
+            "speech_model": args.speech_model,
+        }
+        if args.user_instructions:
+            kwargs["user_instructions"] = args.user_instructions
+
+        chunks: list[bytes] = []
+        async for chunk in client.text_to_speech.tts(**kwargs):
+            chunks.append(chunk)
+
+        audio_data = b"".join(chunks)
+        if not audio_data:
+            raise RuntimeError("CAMB.AI TTS returned no audio data.")
+
+        fmt = self._detect_audio_format(audio_data)
+        if fmt == "wav" and audio_data[:4] != b"RIFF":
+            audio_data = self._add_wav_header(audio_data)
+        return self._save_audio(audio_data, fmt)
+
+    @classmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_poll_attempts=config.max_poll_attempts,
+            poll_interval=config.poll_interval,
+        )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_voice_clone.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_voice_clone.py
@@ -1,0 +1,134 @@
+import json
+from typing import Optional
+
+from autogen_core import CancellationToken
+from pydantic import BaseModel, Field
+from typing_extensions import Self
+
+from ._base import CambBaseTool
+from ._config import CambToolConfig
+
+
+class VoiceCloneArgs(BaseModel):
+    """Arguments for the CAMB.AI voice cloning tool."""
+
+    voice_name: str = Field(
+        ...,
+        description="Name for the cloned voice.",
+    )
+    audio_file_path: str = Field(
+        ...,
+        description="Path to the audio file (2+ seconds) to clone the voice from.",
+    )
+    gender: int = Field(
+        default=0,
+        description="Gender code: 0=not known, 1=male, 2=female, 9=not applicable.",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="Description of the voice.",
+    )
+    age: Optional[int] = Field(
+        default=None,
+        description="Age of the voice.",
+    )
+    language: Optional[int] = Field(
+        default=None,
+        description="Language ID for the voice.",
+    )
+
+
+class CambVoiceCloneTool(CambBaseTool[VoiceCloneArgs, str]):
+    """Voice cloning tool using CAMB.AI.
+
+    Clones a voice from an audio sample using the CAMB.AI voice cloning API.
+    Returns a JSON string with the voice_id.
+
+    .. note::
+        This tool requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambVoiceCloneTool, VoiceCloneArgs
+
+        async def main():
+            tool = CambVoiceCloneTool(api_key="your-api-key")
+            result = await tool.run(
+                VoiceCloneArgs(
+                    voice_name="My Voice",
+                    audio_file_path="/path/to/sample.wav",
+                ),
+                CancellationToken(),
+            )
+            print(f"Voice cloned: {result}")
+
+        asyncio.run(main())
+    """
+
+    component_provider_override = "autogen_ext.tools.camb.CambVoiceCloneTool"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=VoiceCloneArgs,
+            return_type=str,
+            name="camb_voice_clone",
+            description=(
+                "Clone a voice from an audio sample using CAMB.AI. "
+                "Returns JSON with the voice_id."
+            ),
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_poll_attempts=max_poll_attempts,
+            poll_interval=poll_interval,
+        )
+
+    async def run(self, args: VoiceCloneArgs, cancellation_token: CancellationToken) -> str:
+        client = self._get_client()
+
+        with open(args.audio_file_path, "rb") as f:
+            kwargs: dict = {
+                "file": f,
+                "voice_name": args.voice_name,
+                "gender": args.gender,
+            }
+            if args.description:
+                kwargs["description"] = args.description
+            if args.age is not None:
+                kwargs["age"] = args.age
+            if args.language is not None:
+                kwargs["language"] = args.language
+
+            result = await client.voice_cloning.create_custom_voice(**kwargs)
+
+        output = {
+            "voice_id": getattr(result, "voice_id", None),
+        }
+        return json.dumps(output)
+
+    @classmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_poll_attempts=config.max_poll_attempts,
+            poll_interval=config.poll_interval,
+        )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/camb/_voice_list.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/camb/_voice_list.py
@@ -1,0 +1,99 @@
+import json
+from typing import Optional
+
+from autogen_core import CancellationToken
+from pydantic import BaseModel
+from typing_extensions import Self
+
+from ._base import CambBaseTool
+from ._config import CambToolConfig
+
+
+class VoiceListArgs(BaseModel):
+    """Arguments for the CAMB.AI voice listing tool (no arguments required)."""
+
+    pass
+
+
+class CambVoiceListTool(CambBaseTool[VoiceListArgs, str]):
+    """Voice listing tool using CAMB.AI.
+
+    Lists all available voices from the CAMB.AI voice cloning API.
+    Returns a JSON array of voice objects with id and voice_name.
+
+    .. note::
+        This tool requires the :code:`camb` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[camb]"
+
+    Example usage:
+
+    .. code-block:: python
+
+        import asyncio
+        from autogen_core import CancellationToken
+        from autogen_ext.tools.camb import CambVoiceListTool, VoiceListArgs
+
+        async def main():
+            tool = CambVoiceListTool(api_key="your-api-key")
+            result = await tool.run(VoiceListArgs(), CancellationToken())
+            print(f"Available voices: {result}")
+
+        asyncio.run(main())
+    """
+
+    component_provider_override = "autogen_ext.tools.camb.CambVoiceListTool"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_poll_attempts: int = 60,
+        poll_interval: float = 2.0,
+    ) -> None:
+        super().__init__(
+            args_type=VoiceListArgs,
+            return_type=str,
+            name="camb_voice_list",
+            description="List available voices from CAMB.AI. Returns a JSON array of voice objects.",
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_poll_attempts=max_poll_attempts,
+            poll_interval=poll_interval,
+        )
+
+    async def run(self, args: VoiceListArgs, cancellation_token: CancellationToken) -> str:
+        client = self._get_client()
+        result = await client.voice_cloning.list_voices()
+
+        voices = []
+        if result:
+            for voice in result:
+                if isinstance(voice, dict):
+                    voices.append({
+                        "id": voice.get("id"),
+                        "voice_name": voice.get("voice_name"),
+                    })
+                else:
+                    voices.append({
+                        "id": getattr(voice, "id", None),
+                        "voice_name": getattr(voice, "voice_name", None),
+                    })
+
+        return json.dumps(voices)
+
+    @classmethod
+    def _from_config(cls, config: CambToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_poll_attempts=config.max_poll_attempts,
+            poll_interval=config.poll_interval,
+        )


### PR DESCRIPTION
## Summary
- Adds 8 new CAMB AI tools to `autogen-ext` for speech and audio processing: TTS, translated TTS, transcription, translation, voice cloning, voice listing, text-to-sound, and audio separation
- Includes a `CambAIToolkit` that bundles all tools for easy agent integration
- Adds `camb` optional dependency (`camb-sdk>=1.0.0`) to `pyproject.toml`

## Tool Overview
| Tool | Description |
|------|-------------|
| `CambAITextToSpeechTool` | Convert text to speech with 600+ voices and 140+ languages |
| `CambAITranslatedTextToSpeechTool` | Translate text and synthesize speech in the target language |
| `CambAITranscriptionTool` | Transcribe audio files to text |
| `CambAITranslationTool` | Translate text between languages |
| `CambAIVoiceCloneTool` | Clone a voice from an audio sample |
| `CambAIVoiceListTool` | List available TTS voices |
| `CambAITextToSoundTool` | Generate sound effects from text prompts |
| `CambAIAudioSeparationTool` | Separate vocals/instruments from audio |

All tools follow the existing autogen-ext `BaseTool` pattern and support async execution with polling for long-running tasks.