### PR TITLE
fix(mcp): preserve non-ASCII text in JSON serialization

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -194,4 +194,4 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
             else:
                 return {}
 
-        return json.dumps([serialize_item(item) for item in value])
+        return json.dumps([serialize_item(item) for item in value], ensure_ascii=False)

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_host/_elicitation.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_host/_elicitation.py
@@ -82,7 +82,7 @@ class StreamElicitor(Elicitor):
                 prompt = "\n".join(
                     [
                         "Input Schema:",
-                        json.dumps(params.requestedSchema, indent=2),
+                        json.dumps(params.requestedSchema, indent=2, ensure_ascii=False),
                         "Please enter a JSON string following the above schema: ",
                     ]
                 )


### PR DESCRIPTION
json.dumps calls in MCP tool serialization were missing ensure_ascii=False, causing non-ASCII text (Japanese, CJK, etc.) to be escaped into \uXXXX sequences. This makes tool output unreadable when non-ASCII content is involved. Two call sites fixed in [_base.py](http://_vscodecontentref_/8) and _elicitation.py. Fixes #6995