### PR TITLE
fix: improve import error messages by chaining original exception (#4605)

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/memory/canvas/_text_canvas.py
+++ b/python/packages/autogen-ext/src/autogen_ext/memory/canvas/_text_canvas.py
@@ -3,8 +3,11 @@ from typing import Any, Dict, List, Union
 
 try:  # pragma: no cover
     from unidiff import PatchSet
-except ModuleNotFoundError:  # pragma: no cover
+
+    _unidiff_import_error: Exception | None = None
+except ModuleNotFoundError as e:  # pragma: no cover
     PatchSet = None  # type: ignore
+    _unidiff_import_error = e
 
 from ._canvas import BaseCanvas
 
@@ -150,7 +153,7 @@ class TextCanvas(BaseCanvas):
         if PatchSet is None:
             raise ImportError(
                 "The 'unidiff' package is required for patch application. Install with 'pip install unidiff'."
-            )
+            ) from _unidiff_import_error
 
         patch = PatchSet(patch_data)
         # Our canvas stores exactly one file per patch operation so we

--- a/python/packages/autogen-ext/src/autogen_ext/tools/azure/_ai_search.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/azure/_ai_search.py
@@ -154,11 +154,12 @@ class EmbeddingProviderMixin:
                 from openai import AsyncAzureOpenAI
 
                 from azure.identity import DefaultAzureCredential
-            except ImportError:
+            except ImportError as e:
                 raise ImportError(
                     "Azure OpenAI SDK is required for client-side embedding generation. "
+                    f"Original error: {e}\n"
                     "Please install it with: uv add openai azure-identity"
-                ) from None
+                ) from e
 
             api_key = getattr(search_config, "openai_api_key", None)
             api_version = getattr(search_config, "openai_api_version", "2023-11-01")
@@ -193,11 +194,12 @@ class EmbeddingProviderMixin:
         elif embedding_provider.lower() == "openai":
             try:
                 from openai import AsyncOpenAI
-            except ImportError:
+            except ImportError as e:
                 raise ImportError(
                     "OpenAI SDK is required for client-side embedding generation. "
+                    f"Original error: {e}\n"
                     "Please install it with: uv add openai"
-                ) from None
+                ) from e
 
             api_key = getattr(search_config, "openai_api_key", None)
             openai_client = AsyncOpenAI(api_key=api_key)


### PR DESCRIPTION
## Summary

Fixes #4605 — improves import error diagnostics in `autogen-ext` by preserving the original exception rather than suppressing it.

**Changes:**
- `tools/azure/_ai_search.py`: capture `ImportError as e` and raise `from e` (instead of `from None`) for both `azure_openai` and `openai` embedding provider paths; also includes the original error text in the message so users see the root cause (e.g. missing sub-dependency like `azure-identity`)
- `memory/canvas/_text_canvas.py`: store the `ModuleNotFoundError` at import time and chain it when the deferred `ImportError` is raised at the call site

**Before:**
```
ImportError: Azure OpenAI SDK is required for client-side embedding generation. Please install it with: uv add openai azure-identity
```

**After:**
```
ImportError: Azure OpenAI SDK is required for client-side embedding generation. Original error: No module named 'azure.identity'
Please install it with: uv add openai azure-identity
```

## Test plan
- [ ] Uninstall `openai` and verify the error message includes the original `ModuleNotFoundError` text
- [ ] Uninstall `azure-identity` and verify the error message shows the specific missing module
- [ ] Uninstall `unidiff` and call `apply_patch()` — verify chained exception is visible in traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)