### PR TITLE
scripts: add deterministic CI check-state classifier

### DIFF
--- a/scripts/ci_state_classifier.py
+++ b/scripts/ci_state_classifier.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Classify GitHub check states into deterministic triage categories."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+_PENDING = {"pending", "queued", "in_progress", "requested", "waiting"}
+_FAILED = {"failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale"}
+_POLICY = {
+    "resource not accessible by integration",
+    "insufficient permission",
+    "insufficient permissions",
+    "not authorized",
+    "forbidden",
+    "cla",
+}
+
+
+def classify(checks: list[dict[str, Any]]) -> str:
+    if not checks:
+        return "no checks"
+
+    policy_blocked = False
+    failed = False
+    pending = False
+
+    for check in checks:
+        status = str(check.get("status", "")).lower()
+        conclusion = str(check.get("conclusion", "")).lower()
+        summary = " ".join(
+            str(check.get(key, "")) for key in ("name", "context", "details", "title", "summary", "text")
+        ).lower()
+
+        if any(marker in summary for marker in _POLICY):
+            policy_blocked = True
+
+        if status in _PENDING:
+            pending = True
+        if conclusion in _FAILED:
+            failed = True
+
+    if policy_blocked:
+        return "policy-blocked"
+    if failed:
+        return "failed"
+    if pending:
+        return "pending"
+    return "passed"
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    checks = payload if isinstance(payload, list) else payload.get("checks", [])
+    print(json.dumps({"state": classify(checks)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_ci_state_classifier.py
+++ b/scripts/test_ci_state_classifier.py
@@ -1,0 +1,22 @@
+import unittest
+
+from ci_state_classifier import classify
+
+
+class ClassifierTests(unittest.TestCase):
+    def test_no_checks(self):
+        self.assertEqual(classify([]), "no checks")
+
+    def test_pending(self):
+        self.assertEqual(classify([{"status": "in_progress"}]), "pending")
+
+    def test_failed(self):
+        self.assertEqual(classify([{"conclusion": "failure"}]), "failed")
+
+    def test_policy_blocked_wins(self):
+        checks = [{"conclusion": "failure", "summary": "Resource not accessible by integration"}]
+        self.assertEqual(classify(checks), "policy-blocked")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
CI outcomes are interpreted manually and inconsistently across workflows, including no-check and policy-blocked cases.

## Why now
This is active operator friction in current workflows and needs deterministic behavior for repeatable triage/replay.

## What changed
Added a small Python classifier utility plus unit tests to normalize states into failed/pending/no checks/policy-blocked/passed.

## Validation
- python3 -m unittest test_ci_state_classifier.py (pass)

Refs #7261
