### PR TITLE
mcp: enforce strict-mode trust policy fail-closed defaults

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_actor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_actor.py
@@ -11,7 +11,7 @@ from mcp import types as mcp_types
 from mcp.client.session import ClientSession
 from mcp.shared.context import RequestContext
 
-from ._config import McpServerParams
+from ._config import McpServerParams, validate_mcp_trust_policy
 from ._host import McpSessionHost
 from ._session import create_mcp_server_session
 
@@ -49,6 +49,8 @@ class McpSessionActorConfig(BaseModel):
     """
 
     server_params: McpServerParams
+    strict_mode: bool = False
+    allow_untrusted: bool = False
 
 
 class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionActorConfig]):
@@ -74,9 +76,17 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionActorConfig]
 
     # model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def __init__(self, server_params: McpServerParams, host: McpSessionHost | None = None) -> None:
+    def __init__(
+        self,
+        server_params: McpServerParams,
+        host: McpSessionHost | None = None,
+        strict_mode: bool = False,
+        allow_untrusted: bool = False,
+    ) -> None:
         self.server_params: McpServerParams = server_params
         self._host = host
+        self._strict_mode = strict_mode
+        self._allow_untrusted = allow_untrusted
         self.name = "mcp_session_actor"
         self.description = "MCP session actor"
         self._command_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
@@ -92,6 +102,11 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionActorConfig]
 
     async def initialize(self) -> None:
         if not self._active:
+            validate_mcp_trust_policy(
+                self.server_params,
+                strict_mode=self._strict_mode,
+                allow_untrusted=self._allow_untrusted,
+            )
             self._active = True
             self._actor_task = asyncio.create_task(self._run_actor())
 
@@ -286,7 +301,11 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionActorConfig]
         Returns:
             McpSessionConfig: The configuration of the adapter.
         """
-        return McpSessionActorConfig(server_params=self.server_params)
+        return McpSessionActorConfig(
+            server_params=self.server_params,
+            strict_mode=self._strict_mode,
+            allow_untrusted=self._allow_untrusted,
+        )
 
     @classmethod
     def _from_config(cls, config: McpSessionActorConfig) -> Self:
@@ -299,4 +318,8 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionActorConfig]
         Returns:
             McpSessionActor: An instance of SseMcpToolAdapter.
         """
-        return cls(server_params=config.server_params)
+        return cls(
+            server_params=config.server_params,
+            strict_mode=config.strict_mode,
+            allow_untrusted=config.allow_untrusted,
+        )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_config.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_config.py
@@ -12,6 +12,7 @@ class StdioServerParams(StdioServerParameters):
     type: Literal["StdioServerParams"] = "StdioServerParams"
 
     read_timeout_seconds: float = 5
+    trusted: bool = False
 
 
 class SseServerParams(BaseModel):
@@ -23,6 +24,7 @@ class SseServerParams(BaseModel):
     headers: dict[str, Any] | None = None  # Optional headers to include in requests.
     timeout: float = 5  # HTTP timeout for regular operations.
     sse_read_timeout: float = 60 * 5  # Timeout for SSE read operations.
+    trusted: bool = False
 
 
 class StreamableHttpServerParams(BaseModel):
@@ -35,8 +37,26 @@ class StreamableHttpServerParams(BaseModel):
     timeout: float = 30.0  # HTTP timeout for regular operations in seconds.
     sse_read_timeout: float = 300.0  # Timeout for SSE read operations in seconds.
     terminate_on_close: bool = True
+    trusted: bool = False
 
 
 McpServerParams = Annotated[
     StdioServerParams | SseServerParams | StreamableHttpServerParams, Field(discriminator="type")
 ]
+
+
+def validate_mcp_trust_policy(
+    server_params: McpServerParams,
+    *,
+    strict_mode: bool,
+    allow_untrusted: bool,
+) -> None:
+    """Enforce fail-closed trust policy for MCP integrations in strict mode."""
+    if not strict_mode:
+        return
+    if server_params.trusted or allow_untrusted:
+        return
+    raise ValueError(
+        "Strict MCP trust mode rejected untrusted server configuration. "
+        "Set server_params.trusted=True or allow_untrusted=True."
+    )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_factory.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_factory.py
@@ -1,6 +1,12 @@
 from mcp import ClientSession
 
-from ._config import McpServerParams, SseServerParams, StdioServerParams, StreamableHttpServerParams
+from ._config import (
+    McpServerParams,
+    SseServerParams,
+    StdioServerParams,
+    StreamableHttpServerParams,
+    validate_mcp_trust_policy,
+)
 from ._session import create_mcp_server_session
 from ._sse import SseMcpToolAdapter
 from ._stdio import StdioMcpToolAdapter
@@ -10,6 +16,8 @@ from ._streamable_http import StreamableHttpMcpToolAdapter
 async def mcp_server_tools(
     server_params: McpServerParams,
     session: ClientSession | None = None,
+    strict_mode: bool = False,
+    allow_untrusted: bool = False,
 ) -> list[StdioMcpToolAdapter | SseMcpToolAdapter | StreamableHttpMcpToolAdapter]:
     """Creates a list of MCP tool adapters that can be used with AutoGen agents.
 
@@ -194,6 +202,12 @@ async def mcp_server_tools(
 
     For more examples and detailed usage, see the samples directory in the package repository.
     """
+    validate_mcp_trust_policy(
+        server_params,
+        strict_mode=strict_mode,
+        allow_untrusted=allow_untrusted,
+    )
+
     if session is None:
         async with create_mcp_server_session(server_params) as temp_session:
             await temp_session.initialize()

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
@@ -30,7 +30,13 @@ from mcp.types import (
 )
 
 from ._actor import McpSessionActor
-from ._config import McpServerParams, SseServerParams, StdioServerParams, StreamableHttpServerParams
+from ._config import (
+    McpServerParams,
+    SseServerParams,
+    StdioServerParams,
+    StreamableHttpServerParams,
+    validate_mcp_trust_policy,
+)
 from ._host import McpSessionHost
 
 
@@ -38,6 +44,8 @@ class McpWorkbenchConfig(BaseModel):
     server_params: McpServerParams
     tool_overrides: Dict[str, ToolOverride] = Field(default_factory=dict)
     host: ComponentModel | Dict[str, Any] | None = None
+    strict_mode: bool = False
+    allow_untrusted: bool = False
 
 
 class McpWorkbenchState(BaseModel):
@@ -241,9 +249,19 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
         server_params: McpServerParams,
         tool_overrides: Optional[Dict[str, ToolOverride]] = None,
         host: McpSessionHost | None = None,
+        strict_mode: bool = False,
+        allow_untrusted: bool = False,
     ) -> None:
         self._server_params = server_params
         self._tool_overrides = tool_overrides or {}
+        self._strict_mode = strict_mode
+        self._allow_untrusted = allow_untrusted
+
+        validate_mcp_trust_policy(
+            self._server_params,
+            strict_mode=self._strict_mode,
+            allow_untrusted=self._allow_untrusted,
+        )
 
         # Build reverse mapping from override names to original names for call_tool
         self._override_name_to_original: Dict[str, str] = {}
@@ -467,7 +485,12 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
             return  # Already initialized, no need to start again
 
         if isinstance(self._server_params, (StdioServerParams, SseServerParams, StreamableHttpServerParams)):
-            self._actor = McpSessionActor(self._server_params, host=self._host)
+            self._actor = McpSessionActor(
+                self._server_params,
+                host=self._host,
+                strict_mode=self._strict_mode,
+                allow_untrusted=self._allow_untrusted,
+            )
             await self._actor.initialize()
             self._actor_loop = asyncio.get_event_loop()
         else:
@@ -493,7 +516,11 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
     def _to_config(self) -> McpWorkbenchConfig:
         host_config = self._host.dump_component() if self._host else None
         return McpWorkbenchConfig(
-            server_params=self._server_params, tool_overrides=self._tool_overrides, host=host_config
+            server_params=self._server_params,
+            tool_overrides=self._tool_overrides,
+            host=host_config,
+            strict_mode=self._strict_mode,
+            allow_untrusted=self._allow_untrusted,
         )
 
     @classmethod
@@ -501,7 +528,13 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
         host = None
         if config.host is not None:
             host = McpSessionHost.load_component(config.host)
-        return cls(server_params=config.server_params, tool_overrides=config.tool_overrides, host=host)
+        return cls(
+            server_params=config.server_params,
+            tool_overrides=config.tool_overrides,
+            host=host,
+            strict_mode=config.strict_mode,
+            allow_untrusted=config.allow_untrusted,
+        )
 
     def __del__(self) -> None:
         # Ensure the actor is stopped when the workbench is deleted

--- a/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
@@ -302,6 +302,36 @@ async def test_adapter_from_factory(
 
 
 @pytest.mark.asyncio
+async def test_mcp_server_tools_strict_mode_rejects_untrusted(sample_server_params: StdioServerParams) -> None:
+    """Factory should fail closed for untrusted configs in strict mode."""
+    with pytest.raises(ValueError, match="Strict MCP trust mode rejected untrusted server configuration"):
+        await mcp_server_tools(server_params=sample_server_params, strict_mode=True)
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_tools_strict_mode_allows_explicit_opt_in(
+    sample_tool: Tool,
+    sample_server_params: StdioServerParams,
+    mock_session: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory should allow explicit untrusted opt-in in strict mode."""
+    mock_context = AsyncMock()
+    mock_context.__aenter__.return_value = mock_session
+    monkeypatch.setattr(
+        "autogen_ext.tools.mcp._factory.create_mcp_server_session",
+        lambda *args, **kwargs: mock_context,  # type: ignore
+    )
+    mock_session.list_tools.return_value.tools = [sample_tool]
+    tools = await mcp_server_tools(
+        server_params=sample_server_params,
+        strict_mode=True,
+        allow_untrusted=True,
+    )
+    assert len(tools) == 1
+
+
+@pytest.mark.asyncio
 async def test_adapter_from_factory_existing_session(
     sample_tool: Tool,
     sample_server_params: StdioServerParams,

--- a/python/packages/autogen-ext/tests/tools/test_mcp_workbench_warnings_and_errors.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_workbench_warnings_and_errors.py
@@ -29,6 +29,31 @@ def mock_actor() -> AsyncMock:
     return AsyncMock()
 
 
+def test_strict_mode_rejects_untrusted_server_params(sample_server_params: StdioServerParams) -> None:
+    """Strict mode should fail closed unless trust is explicit."""
+    with pytest.raises(ValueError, match="Strict MCP trust mode rejected untrusted server configuration"):
+        McpWorkbench(server_params=sample_server_params, strict_mode=True)
+
+
+def test_strict_mode_allows_explicit_trust() -> None:
+    """Strict mode should allow server params marked as trusted."""
+    workbench = McpWorkbench(
+        server_params=StdioServerParams(command="echo", args=["test"], trusted=True),
+        strict_mode=True,
+    )
+    assert isinstance(workbench, McpWorkbench)
+
+
+def test_strict_mode_allows_explicit_untrusted_opt_in(sample_server_params: StdioServerParams) -> None:
+    """Strict mode should allow explicit untrusted opt-in."""
+    workbench = McpWorkbench(
+        server_params=sample_server_params,
+        strict_mode=True,
+        allow_untrusted=True,
+    )
+    assert isinstance(workbench, McpWorkbench)
+
+
 @pytest.mark.asyncio
 async def test_list_tools_actor_none_after_start(sample_server_params: StdioServerParams) -> None:
     """Test list_tools when actor is None after start attempt - covers line 274."""


### PR DESCRIPTION
## Problem
MCP integrations can be configured without explicit trust boundaries, which allows permissive behavior in sensitive environments.

## Why Now
AutoGen documentation already warns to use trusted MCP servers; strict runtime contracts should enforce that guidance.

## What Changed
- Added explicit trust metadata and strict validation path in MCP server params.
- Added strict fail-closed policy enforcement helper (`validate_mcp_trust_policy`).
- Wired strict policy through:
  - `mcp_server_tools(..., strict_mode, allow_untrusted)`
  - `McpWorkbench(..., strict_mode, allow_untrusted)` config/state serialization
  - `McpSessionActor` initialization/config serialization
- Added focused tests for strict rejection and explicit opt-in allow paths.

## Validation
- `uv run --extra mcp pytest tests/tools/test_mcp_workbench_warnings_and_errors.py tests/tools/test_mcp_tools.py -q` ✅
- `uv run --extra mcp ruff check src/autogen_ext/tools/mcp/_config.py src/autogen_ext/tools/mcp/_factory.py src/autogen_ext/tools/mcp/_workbench.py src/autogen_ext/tools/mcp/_actor.py tests/tools/test_mcp_workbench_warnings_and_errors.py tests/tools/test_mcp_tools.py` ✅

Refs #7266