### PR TITLE
Use collision-resistant request IDs in gRPC worker runtime

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py
@@ -245,6 +245,7 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
         self._running = False
         self._pending_requests: Dict[str, Future[Any]] = {}
         self._pending_requests_lock = asyncio.Lock()
+        self._request_id_prefix = str(uuid.uuid4())
         self._next_request_id = 0
         self._host_connection: HostConnection | None = None
         self._background_tasks: Set[Task[Any]] = set()
@@ -507,7 +508,7 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
     async def _get_new_request_id(self) -> str:
         async with self._pending_requests_lock:
             self._next_request_id += 1
-            return str(self._next_request_id)
+            return f"{self._request_id_prefix}-{self._next_request_id}"
 
     async def _process_request(self, request: agent_worker_pb2.RpcRequest) -> None:
         assert self._host_connection is not None

--- a/python/packages/autogen-ext/tests/test_worker_runtime.py
+++ b/python/packages/autogen-ext/tests/test_worker_runtime.py
@@ -34,6 +34,21 @@ from autogen_test_utils import (
 from .protos.serialization_test_pb2 import ProtoMessage
 
 
+@pytest.mark.asyncio
+async def test_request_ids_are_collision_resistant_per_runtime() -> None:
+    runtime = GrpcWorkerAgentRuntime(host_address="localhost:50050")
+
+    request_id_1 = await runtime._get_new_request_id()
+    request_id_2 = await runtime._get_new_request_id()
+
+    prefix_1, sequence_1 = request_id_1.rsplit("-", 1)
+    prefix_2, sequence_2 = request_id_2.rsplit("-", 1)
+
+    assert prefix_1 == prefix_2
+    assert sequence_1 == "1"
+    assert sequence_2 == "2"
+
+
 @pytest.mark.grpc
 @pytest.mark.asyncio
 async def test_agent_types_must_be_unique_single_worker() -> None:


### PR DESCRIPTION
## Problem
Sequential numeric request IDs in the gRPC worker runtime are collision-prone across runtime instances and can corrupt request/result correlation in concurrent environments.

## Why now
Issue #7270 calls out request ID collision risk and asks for stronger runtime correlation guarantees.

## What changed
- Added a per-runtime UUID prefix for request IDs.
- Updated request ID generation to combine runtime-unique prefix with monotonic sequence.
- Added regression test ensuring deterministic per-runtime sequencing with collision-resistant prefixing.

## Validation
- `uv run --project python pytest python/packages/autogen-ext/tests/test_worker_runtime.py -k request_ids_are_collision_resistant_per_runtime` (pass)

Refs #7270
