### PR TITLE
feat: add MessageStore abstraction for group chat message threads

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/__init__.py
@@ -12,6 +12,7 @@ from ._group_chat._graph import (
     GraphFlow,
 )
 from ._group_chat._magentic_one import MagenticOneGroupChat
+from ._group_chat._message_store import InMemoryMessageStore, MessageStore
 from ._group_chat._round_robin_group_chat import RoundRobinGroupChat
 from ._group_chat._selector_group_chat import SelectorGroupChat
 from ._group_chat._swarm_group_chat import Swarm
@@ -27,4 +28,6 @@ __all__ = [
     "DiGraphNode",
     "DiGraphEdge",
     "GraphFlow",
+    "MessageStore",
+    "InMemoryMessageStore",
 ]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_message_store.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_message_store.py
@@ -1,0 +1,183 @@
+"""MessageStore abstraction for group chat message thread storage."""
+
+import time
+from abc import ABC, abstractmethod
+from datetime import timedelta
+from typing import Generic, List, Optional, Sequence, TypeVar
+
+T = TypeVar("T")
+
+
+class MessageStore(ABC, Generic[T]):
+    """Abstract base class for storing and retrieving message threads in group chat teams.
+
+    This abstraction allows different storage backends (in-memory, Redis, database, etc.)
+    to be plugged into a group chat team. Implementations can also provide policies such
+    as TTL-based expiration of stored messages.
+
+    Type Args:
+        T: The type of message stored in this store.
+
+    Example:
+
+        Creating a custom message store:
+
+        .. code-block:: python
+
+            from autogen_agentchat.teams import MessageStore
+
+
+            class MyMessageStore(MessageStore[str]):
+                def __init__(self) -> None:
+                    self._messages: list[str] = []
+
+                async def append(self, message: str) -> None:
+                    self._messages.append(message)
+
+                async def get_messages(self) -> list[str]:
+                    return list(self._messages)
+
+                async def clear(self) -> None:
+                    self._messages.clear()
+
+                async def count(self) -> int:
+                    return len(self._messages)
+
+    """
+
+    @abstractmethod
+    async def append(self, message: T) -> None:
+        """Append a message to the store.
+
+        Args:
+            message: The message to append.
+        """
+        ...
+
+    @abstractmethod
+    async def get_messages(self) -> Sequence[T]:
+        """Return all stored messages.
+
+        Returns:
+            A sequence of all messages currently in the store.
+        """
+        ...
+
+    @abstractmethod
+    async def clear(self) -> None:
+        """Clear all messages from the store."""
+        ...
+
+    @abstractmethod
+    async def count(self) -> int:
+        """Return the number of messages in the store.
+
+        Returns:
+            The number of messages currently in the store.
+        """
+        ...
+
+
+class InMemoryMessageStore(MessageStore[T]):
+    """In-memory implementation of :class:`MessageStore` with optional TTL-based expiration.
+
+    Messages are stored in a Python list. When a ``ttl`` is provided, any call to
+    :meth:`get_messages`, :meth:`count`, or :meth:`append` will first check
+    whether the TTL has expired and clear the store automatically if it has.
+
+    The TTL clock starts when the first message is appended after a clear (or on
+    initial use). Calling :meth:`clear` explicitly resets the TTL clock.
+
+    Args:
+        ttl: Optional time-to-live for the entire message thread. If set, the
+            stored messages are cleared automatically once this duration has
+            elapsed since the first message was appended.
+
+    Example:
+
+        .. code-block:: python
+
+            import asyncio
+            from datetime import timedelta
+            from autogen_agentchat.teams import InMemoryMessageStore
+
+
+            async def main() -> None:
+                store: InMemoryMessageStore[str] = InMemoryMessageStore(ttl=timedelta(seconds=10))
+                await store.append("hello")
+                await store.append("world")
+                print(await store.count())   # 2
+                print(await store.get_messages())  # ['hello', 'world']
+                await store.clear()
+                print(await store.count())   # 0
+
+
+            asyncio.run(main())
+
+    """
+
+    def __init__(self, ttl: Optional[timedelta] = None) -> None:
+        self._messages: List[T] = []
+        self._ttl = ttl
+        # Monotonic timestamp (seconds) of when the first message was appended
+        # after the last clear. None means the store is empty / never been used.
+        self._started_at: Optional[float] = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_expired(self) -> bool:
+        """Return True if the TTL has elapsed since the first message was stored."""
+        if self._ttl is None or self._started_at is None:
+            return False
+        return (time.monotonic() - self._started_at) >= self._ttl.total_seconds()
+
+    def _evict_if_expired(self) -> None:
+        """Clear the store in-place when the TTL has been exceeded."""
+        if self._is_expired():
+            self._messages.clear()
+            self._started_at = None
+
+    # ------------------------------------------------------------------
+    # MessageStore interface
+    # ------------------------------------------------------------------
+
+    async def append(self, message: T) -> None:
+        """Append a message to the store.
+
+        If the TTL has already expired the store is cleared before the new
+        message is appended, effectively restarting the TTL window.
+
+        Args:
+            message: The message to append.
+        """
+        self._evict_if_expired()
+        if self._started_at is None:
+            # Record the monotonic time of the first message in this window.
+            self._started_at = time.monotonic()
+        self._messages.append(message)
+
+    async def get_messages(self) -> Sequence[T]:
+        """Return all stored messages, automatically evicting expired messages.
+
+        Returns:
+            A sequence of messages. The sequence is empty if the store has
+            expired or no messages have been appended yet.
+        """
+        self._evict_if_expired()
+        return list(self._messages)
+
+    async def clear(self) -> None:
+        """Clear all messages from the store and reset the TTL clock."""
+        self._messages.clear()
+        self._started_at = None
+
+    async def count(self) -> int:
+        """Return the number of messages currently in the store.
+
+        Returns:
+            The number of messages. Returns 0 if the store has expired.
+        """
+        self._evict_if_expired()
+        return len(self._messages)

--- a/python/packages/autogen-agentchat/tests/test_message_store.py
+++ b/python/packages/autogen-agentchat/tests/test_message_store.py
@@ -1,0 +1,248 @@
+"""Tests for MessageStore abstraction and InMemoryMessageStore implementation."""
+
+import asyncio
+import time
+from datetime import timedelta
+from typing import Sequence
+
+import pytest
+from autogen_agentchat.teams import InMemoryMessageStore, MessageStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StringStore(MessageStore[str]):
+    """Minimal concrete subclass of MessageStore used to verify the ABC contract."""
+
+    def __init__(self) -> None:
+        self._data: list[str] = []
+
+    async def append(self, message: str) -> None:
+        self._data.append(message)
+
+    async def get_messages(self) -> Sequence[str]:
+        return list(self._data)
+
+    async def clear(self) -> None:
+        self._data.clear()
+
+    async def count(self) -> int:
+        return len(self._data)
+
+
+# ---------------------------------------------------------------------------
+# Abstract interface tests (via concrete subclass)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_store_is_abstract() -> None:
+    """MessageStore cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        MessageStore()  # type: ignore[abstract]
+
+
+@pytest.mark.asyncio
+async def test_custom_concrete_store_append_and_get() -> None:
+    store = _StringStore()
+    await store.append("hello")
+    await store.append("world")
+    messages = await store.get_messages()
+    assert list(messages) == ["hello", "world"]
+
+
+@pytest.mark.asyncio
+async def test_custom_concrete_store_count() -> None:
+    store = _StringStore()
+    assert await store.count() == 0
+    await store.append("a")
+    assert await store.count() == 1
+    await store.append("b")
+    assert await store.count() == 2
+
+
+@pytest.mark.asyncio
+async def test_custom_concrete_store_clear() -> None:
+    store = _StringStore()
+    await store.append("a")
+    await store.append("b")
+    await store.clear()
+    assert await store.count() == 0
+    assert list(await store.get_messages()) == []
+
+
+# ---------------------------------------------------------------------------
+# InMemoryMessageStore – basic behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_starts_empty() -> None:
+    store: InMemoryMessageStore[str] = InMemoryMessageStore()
+    assert await store.count() == 0
+    assert list(await store.get_messages()) == []
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_append_and_get() -> None:
+    store: InMemoryMessageStore[str] = InMemoryMessageStore()
+    await store.append("msg1")
+    await store.append("msg2")
+    await store.append("msg3")
+    messages = list(await store.get_messages())
+    assert messages == ["msg1", "msg2", "msg3"]
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_count() -> None:
+    store: InMemoryMessageStore[int] = InMemoryMessageStore()
+    for i in range(5):
+        await store.append(i)
+    assert await store.count() == 5
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_clear() -> None:
+    store: InMemoryMessageStore[str] = InMemoryMessageStore()
+    await store.append("a")
+    await store.append("b")
+    await store.clear()
+    assert await store.count() == 0
+    assert list(await store.get_messages()) == []
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_append_after_clear() -> None:
+    """Appending after a clear should work as if the store is fresh."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore()
+    await store.append("first")
+    await store.clear()
+    await store.append("second")
+    assert await store.count() == 1
+    assert list(await store.get_messages()) == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_get_messages_returns_snapshot() -> None:
+    """get_messages() should return a copy; mutations must not affect internal state."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore()
+    await store.append("a")
+    snapshot = list(await store.get_messages())
+    snapshot.append("extra")
+    # Internal state is unchanged.
+    assert await store.count() == 1
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_generic_type() -> None:
+    """InMemoryMessageStore should work with arbitrary types, not just strings."""
+
+    class _Msg:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    store: InMemoryMessageStore[_Msg] = InMemoryMessageStore()
+    await store.append(_Msg(1))
+    await store.append(_Msg(2))
+    msgs = list(await store.get_messages())
+    assert len(msgs) == 2
+    assert msgs[0].value == 1
+    assert msgs[1].value == 2
+
+
+# ---------------------------------------------------------------------------
+# InMemoryMessageStore – TTL behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_no_ttl_does_not_expire() -> None:
+    """Without a TTL the store should retain messages indefinitely."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore()
+    await store.append("persistent")
+    # Sleep a small amount to confirm nothing is quietly being cleared.
+    await asyncio.sleep(0.05)
+    assert await store.count() == 1
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_ttl_expires_on_get_messages() -> None:
+    """After the TTL elapses, get_messages() should return an empty sequence."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore(ttl=timedelta(milliseconds=50))
+    await store.append("soon-gone")
+    assert await store.count() == 1
+    # Wait for expiry.
+    await asyncio.sleep(0.1)
+    messages = list(await store.get_messages())
+    assert messages == []
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_ttl_expires_on_count() -> None:
+    """After the TTL elapses, count() should return 0."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore(ttl=timedelta(milliseconds=50))
+    await store.append("soon-gone")
+    await asyncio.sleep(0.1)
+    assert await store.count() == 0
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_ttl_restarts_after_expiry_append() -> None:
+    """Appending after TTL expiry should restart the window with the new message."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore(ttl=timedelta(milliseconds=50))
+    await store.append("first-window")
+    await asyncio.sleep(0.1)
+    # After expiry, appending should start a fresh window.
+    await store.append("second-window")
+    assert await store.count() == 1
+    assert list(await store.get_messages()) == ["second-window"]
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_ttl_not_expired_yet() -> None:
+    """Messages should still be present before the TTL has elapsed."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore(ttl=timedelta(seconds=60))
+    await store.append("still-alive")
+    assert await store.count() == 1
+    assert list(await store.get_messages()) == ["still-alive"]
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_clear_resets_ttl_clock() -> None:
+    """Calling clear() should reset the TTL clock so the next append starts fresh."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore(ttl=timedelta(seconds=60))
+    await store.append("msg")
+    await store.clear()
+    # Internal _started_at must be None after clear.
+    assert store._started_at is None
+    await store.append("new-msg")
+    assert await store.count() == 1
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_ttl_multiple_appends_same_window() -> None:
+    """All messages appended within a TTL window should be returned together."""
+    store: InMemoryMessageStore[str] = InMemoryMessageStore(ttl=timedelta(seconds=60))
+    await store.append("a")
+    await store.append("b")
+    await store.append("c")
+    messages = list(await store.get_messages())
+    assert messages == ["a", "b", "c"]
+    assert await store.count() == 3
+
+
+# ---------------------------------------------------------------------------
+# Import smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_exports_from_teams_package() -> None:
+    """MessageStore and InMemoryMessageStore must be importable from autogen_agentchat.teams."""
+    from autogen_agentchat.teams import InMemoryMessageStore as IMS
+    from autogen_agentchat.teams import MessageStore as MS
+
+    assert MS is MessageStore
+    assert IMS is InMemoryMessageStore


### PR DESCRIPTION
## Summary

Implements the `MessageStore` abstraction requested in #6227.

- Adds `MessageStore[T]` — a generic ABC with four async methods: `append`, `get_messages`, `clear`, and `count`.
- Adds `InMemoryMessageStore[T]` — a concrete in-memory implementation backed by a Python list, with optional TTL-based expiration (messages are cleared automatically when the TTL elapses).
- Exports both classes from `autogen_agentchat.teams` so users can import them directly and plug custom implementations into their own group chat managers.
- Adds `tests/test_message_store.py` with 19 tests covering the ABC contract, all `InMemoryMessageStore` operations, and TTL expiry behaviour.

## Design decisions

| Decision | Rationale |
|---|---|
| Generic `T` type parameter | Message stores should work with any message type, not just `BaseAgentEvent \| BaseChatMessage`. This keeps the ABC reusable outside group chat contexts too. |
| `timedelta` TTL parameter | Mirrors the standard library and makes the intent obvious at the call site (`ttl=timedelta(minutes=30)` vs raw seconds). |
| TTL eviction is lazy (on read/write) | Avoids background threads/tasks; the store stays purely synchronous internally, which keeps it safe inside the existing `asyncio`-based group chat managers. |
| TTL clock starts on first `append` after clear | Ensures the window is anchored to actual usage, not object construction time. |
| `get_messages()` returns a copy | Prevents callers from accidentally mutating internal state through the returned sequence. |

## Files changed

```
python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_message_store.py  (new)
python/packages/autogen-agentchat/src/autogen_agentchat/teams/__init__.py                    (MessageStore, InMemoryMessageStore exported)
python/packages/autogen-agentchat/tests/test_message_store.py                                (new, 19 tests, all passing)
```

## Test plan

- [x] `python3 -m pytest tests/test_message_store.py -v` — 19/19 passed
- [x] `python3 -m pytest tests/test_termination_condition.py tests/test_messages.py tests/test_events.py -v` — 26/26 passed (no regressions)

Closes #6227

🤖 Generated with [Claude Code](https://claude.ai/claude-code)