### PR TITLE
fix: normalize message roles for strict alternating APIs (DeepSeek R1, Mistral)

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -33,6 +33,7 @@ from autogen_core.models import (
     FunctionExecutionResult,
     FunctionExecutionResultMessage,
     LLMMessage,
+    ModelFamily,
     SystemMessage,
 )
 from autogen_core.tools import BaseTool, FunctionTool, StaticStreamWorkbench, ToolResult, Workbench
@@ -57,7 +58,7 @@ from ..messages import (
     ToolCallSummaryMessage,
 )
 from ..state import AssistantAgentState
-from ..utils import remove_images
+from ..utils import ensure_alternating_roles, remove_images
 from ._base_chat_agent import BaseChatAgent
 
 event_logger = logging.getLogger(EVENT_LOGGER_NAME)
@@ -1640,11 +1641,32 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
 
     @staticmethod
     def _get_compatible_context(model_client: ChatCompletionClient, messages: List[LLMMessage]) -> Sequence[LLMMessage]:
-        """Ensure that the messages are compatible with the underlying client, by removing images if needed."""
-        if model_client.model_info["vision"]:
-            return messages
-        else:
-            return remove_images(messages)
+        """Ensure that the messages are compatible with the underlying client.
+
+        Applies the following transformations in order:
+
+        1. Remove images for models that do not support vision input.
+        2. Merge consecutive same-role messages for models that require strictly
+           alternating user-assistant roles (e.g. DeepSeek R1, Mistral).  The
+           check respects both the explicit ``strict_alternating_roles`` field in
+           :py:class:`~autogen_core.models.ModelInfo` and the family-based
+           heuristic provided by
+           :py:meth:`~autogen_core.models.ModelFamily.requires_strict_alternating_roles`.
+        """
+        result: List[LLMMessage] = list(messages)
+
+        if not model_client.model_info["vision"]:
+            result = list(remove_images(result))
+
+        model_info = model_client.model_info
+        needs_alternation: bool = model_info.get(
+            "strict_alternating_roles",
+            ModelFamily.requires_strict_alternating_roles(model_info["family"]),
+        )
+        if needs_alternation:
+            result = ensure_alternating_roles(result)
+
+        return result
 
     def _to_config(self) -> AssistantAgentConfig:
         """Convert the assistant agent to a declarative config."""

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/utils/__init__.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/utils/__init__.py
@@ -2,6 +2,6 @@
 This module implements various utilities common to AgentChat agents and teams.
 """
 
-from ._utils import content_to_str, remove_images
+from ._utils import content_to_str, ensure_alternating_roles, remove_images
 
-__all__ = ["content_to_str", "remove_images"]
+__all__ = ["content_to_str", "ensure_alternating_roles", "remove_images"]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/utils/_utils.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/utils/_utils.py
@@ -1,7 +1,7 @@
 from typing import List, Union
 
 from autogen_core import FunctionCall, Image
-from autogen_core.models import FunctionExecutionResult, LLMMessage, UserMessage
+from autogen_core.models import AssistantMessage, FunctionExecutionResult, LLMMessage, SystemMessage, UserMessage
 from pydantic import BaseModel
 
 # Type aliases for convenience
@@ -42,3 +42,118 @@ def remove_images(messages: List[LLMMessage]) -> List[LLMMessage]:
         else:
             str_messages.append(message)
     return str_messages
+
+
+def _merge_llm_messages(first: LLMMessage, second: LLMMessage) -> LLMMessage:
+    """Merge two LLMMessages of the same type into one by concatenating their content.
+
+    Only :py:class:`~autogen_core.models.UserMessage` and
+    :py:class:`~autogen_core.models.AssistantMessage` may be merged; callers are
+    responsible for ensuring both messages have the same type.
+
+    Args:
+        first: The earlier message whose ``source`` is preserved in the merged result.
+        second: The later message whose content is appended.
+
+    Returns:
+        A new message of the same type with the combined content.
+    """
+    if isinstance(first, UserMessage) and isinstance(second, UserMessage):
+        content1 = content_to_str(first.content) if isinstance(first.content, list) else first.content
+        content2 = content_to_str(second.content) if isinstance(second.content, list) else second.content
+        return UserMessage(content=f"{content1}\n\n{content2}", source=first.source)
+
+    if isinstance(first, AssistantMessage) and isinstance(second, AssistantMessage):
+        if isinstance(first.content, str) and isinstance(second.content, str):
+            merged_thought: Union[str, None] = None
+            if first.thought and second.thought:
+                merged_thought = f"{first.thought}\n\n{second.thought}"
+            elif first.thought:
+                merged_thought = first.thought
+            elif second.thought:
+                merged_thought = second.thought
+            return AssistantMessage(
+                content=f"{first.content}\n\n{second.content}",
+                source=first.source,
+                thought=merged_thought,
+            )
+        if isinstance(first.content, list) and isinstance(second.content, list):
+            # Both are lists of FunctionCall — concatenate the calls.
+            return AssistantMessage(
+                content=list(first.content) + list(second.content),
+                source=first.source,
+                thought=first.thought,
+            )
+        # Mixed content types (one string, one FunctionCall list) — convert both to str.
+        return AssistantMessage(
+            content=f"{str(first.content)}\n\n{str(second.content)}",
+            source=first.source,
+            thought=first.thought,
+        )
+
+    # Fallback — should not be reached with well-typed inputs.
+    return first
+
+
+def ensure_alternating_roles(messages: List[LLMMessage]) -> List[LLMMessage]:
+    """Normalize a message list so that user and assistant roles strictly alternate.
+
+    Some model APIs (e.g. DeepSeek R1, Mistral) return a ``400`` error when they
+    receive consecutive messages with the same role.  This function resolves such
+    violations by *merging* consecutive same-role messages into a single message
+    whose content is the concatenation of the originals, separated by a blank line.
+
+    :py:class:`~autogen_core.models.SystemMessage` objects are treated as
+    transparent: they pass through unchanged and are *not* considered when
+    determining role adjacency.
+
+    Args:
+        messages: The original message list, which may contain consecutive
+            same-role messages.
+
+    Returns:
+        A new list where no two consecutive non-system messages share the same
+        role.  The input list is not modified.
+
+    Example::
+
+        >>> from autogen_core.models import UserMessage, AssistantMessage
+        >>> msgs = [
+        ...     UserMessage(content="Hello", source="user"),
+        ...     UserMessage(content="World", source="user"),
+        ...     AssistantMessage(content="Hi there", source="assistant"),
+        ... ]
+        >>> result = ensure_alternating_roles(msgs)
+        >>> len(result)
+        2
+        >>> result[0].content
+        'Hello\\n\\nWorld'
+    """
+    if not messages:
+        return messages
+
+    result: List[LLMMessage] = []
+
+    for msg in messages:
+        if isinstance(msg, SystemMessage):
+            result.append(msg)
+            continue
+
+        # Find the last non-system message already in the result list.
+        last_non_system: Union[LLMMessage, None] = None
+        last_non_system_idx: int = -1
+        for idx in range(len(result) - 1, -1, -1):
+            if not isinstance(result[idx], SystemMessage):
+                last_non_system = result[idx]
+                last_non_system_idx = idx
+                break
+
+        if last_non_system is None:
+            result.append(msg)
+        elif type(msg) is type(last_non_system):
+            # Same role — merge into the existing entry.
+            result[last_non_system_idx] = _merge_llm_messages(last_non_system, msg)
+        else:
+            result.append(msg)
+
+    return result

--- a/python/packages/autogen-agentchat/tests/test_utils.py
+++ b/python/packages/autogen-agentchat/tests/test_utils.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import pytest
-from autogen_agentchat.utils import remove_images
+from autogen_agentchat.utils import ensure_alternating_roles, remove_images
 from autogen_core import Image
 from autogen_core.models import AssistantMessage, LLMMessage, SystemMessage, UserMessage
 
@@ -34,3 +34,114 @@ async def test_remove_images() -> None:
 
     # Check that the image was removed.
     assert result[1].content == "User.1\n<image>"
+
+
+# ---------------------------------------------------------------------------
+# Tests for ensure_alternating_roles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_alternating_roles_already_alternating() -> None:
+    """Already-alternating messages must be returned unchanged."""
+    messages: List[LLMMessage] = [
+        UserMessage(content="User.1", source="user"),
+        AssistantMessage(content="Assistant.1", source="assistant"),
+        UserMessage(content="User.2", source="user"),
+        AssistantMessage(content="Assistant.2", source="assistant"),
+    ]
+
+    result = ensure_alternating_roles(messages)
+
+    assert len(result) == 4
+    assert result[0].content == "User.1"
+    assert result[1].content == "Assistant.1"
+    assert result[2].content == "User.2"
+    assert result[3].content == "Assistant.2"
+
+
+@pytest.mark.asyncio
+async def test_ensure_alternating_roles_consecutive_user_messages() -> None:
+    """Two consecutive user messages must be merged into one."""
+    messages: List[LLMMessage] = [
+        UserMessage(content="User.1", source="user"),
+        UserMessage(content="User.2", source="user"),
+        AssistantMessage(content="Assistant.1", source="assistant"),
+    ]
+
+    result = ensure_alternating_roles(messages)
+
+    assert len(result) == 2
+    assert isinstance(result[0], UserMessage)
+    assert result[0].content == "User.1\n\nUser.2"
+    assert isinstance(result[1], AssistantMessage)
+    assert result[1].content == "Assistant.1"
+
+
+@pytest.mark.asyncio
+async def test_ensure_alternating_roles_consecutive_assistant_messages() -> None:
+    """Two consecutive assistant messages must be merged into one."""
+    messages: List[LLMMessage] = [
+        UserMessage(content="User.1", source="user"),
+        AssistantMessage(content="Assistant.1", source="assistant"),
+        AssistantMessage(content="Assistant.2", source="assistant"),
+        UserMessage(content="User.2", source="user"),
+    ]
+
+    result = ensure_alternating_roles(messages)
+
+    assert len(result) == 3
+    assert isinstance(result[0], UserMessage)
+    assert result[0].content == "User.1"
+    assert isinstance(result[1], AssistantMessage)
+    assert result[1].content == "Assistant.1\n\nAssistant.2"
+    assert isinstance(result[2], UserMessage)
+    assert result[2].content == "User.2"
+
+
+@pytest.mark.asyncio
+async def test_ensure_alternating_roles_three_consecutive_same_role() -> None:
+    """Three consecutive same-role messages must all be merged into one."""
+    messages: List[LLMMessage] = [
+        UserMessage(content="A", source="user"),
+        UserMessage(content="B", source="user"),
+        UserMessage(content="C", source="user"),
+        AssistantMessage(content="X", source="assistant"),
+        AssistantMessage(content="Y", source="assistant"),
+    ]
+
+    result = ensure_alternating_roles(messages)
+
+    assert len(result) == 2
+    assert isinstance(result[0], UserMessage)
+    assert result[0].content == "A\n\nB\n\nC"
+    assert isinstance(result[1], AssistantMessage)
+    assert result[1].content == "X\n\nY"
+
+
+@pytest.mark.asyncio
+async def test_ensure_alternating_roles_system_messages_preserved() -> None:
+    """SystemMessages must pass through unchanged and not affect role adjacency detection."""
+    messages: List[LLMMessage] = [
+        SystemMessage(content="System prompt"),
+        UserMessage(content="User.1", source="user"),
+        UserMessage(content="User.2", source="user"),
+        AssistantMessage(content="Assistant.1", source="assistant"),
+    ]
+
+    result = ensure_alternating_roles(messages)
+
+    assert len(result) == 3
+    assert isinstance(result[0], SystemMessage)
+    assert result[0].content == "System prompt"
+    assert isinstance(result[1], UserMessage)
+    assert result[1].content == "User.1\n\nUser.2"
+    assert isinstance(result[2], AssistantMessage)
+    assert result[2].content == "Assistant.1"
+
+
+@pytest.mark.asyncio
+async def test_ensure_alternating_roles_empty_list() -> None:
+    """An empty message list must be returned as-is."""
+    result = ensure_alternating_roles([])
+    assert result == []

--- a/python/packages/autogen-core/src/autogen_core/models/_model_client.py
+++ b/python/packages/autogen-core/src/autogen_core/models/_model_client.py
@@ -153,6 +153,16 @@ class ModelFamily:
             ModelFamily.PIXTRAL,
         )
 
+    @staticmethod
+    def requires_strict_alternating_roles(family: str) -> bool:
+        """Check if the model family requires strict alternating user-assistant roles.
+
+        Some model APIs (e.g., DeepSeek R1, Mistral) reject message sequences with
+        consecutive messages from the same role. This method identifies such model
+        families so callers can apply the appropriate message normalization.
+        """
+        return family == ModelFamily.R1 or ModelFamily.is_mistral(family)
+
 
 @deprecated("Use the ModelInfo class instead ModelCapabilities.")
 class ModelCapabilities(TypedDict, total=False):
@@ -180,6 +190,10 @@ class ModelInfo(TypedDict, total=False):
     """True if the model supports structured output, otherwise False. This is different to json_output."""
     multiple_system_messages: Optional[bool]
     """True if the model supports multiple, non-consecutive system messages, otherwise False."""
+    strict_alternating_roles: Optional[bool]
+    """True if the model requires strict alternating user-assistant roles. When True,
+    consecutive messages with the same role will be merged before sending to the model.
+    If not set, :py:meth:`ModelFamily.requires_strict_alternating_roles` is used for detection."""
 
 
 def validate_model_info(model_info: ModelInfo) -> None:


### PR DESCRIPTION
## Summary

Some model APIs (DeepSeek R1, Mistral) reject requests that contain consecutive messages with the same role:

```
openai.BadRequestError: Error code: 400 - {'error': {'message': 'deepseek-reasoner does not support
successive user or assistant messages ... You should interleave the user/assistant messages ...'}}
```

This PR fixes the issue by normalising the message sequence inside `AssistantAgent` before it reaches the model client, as requested in #5965.

## Changes

### `autogen-core` — `ModelFamily` + `ModelInfo`
- Added `ModelFamily.requires_strict_alternating_roles(family)` — returns `True` for `R1` and all Mistral family variants.
- Added optional `strict_alternating_roles: Optional[bool]` field to `ModelInfo` so users can override family-based detection per model client instance.

### `autogen-agentchat` — new utility
- Added `ensure_alternating_roles(messages)` in `autogen_agentchat.utils`.  
  Walks the message list and **merges** consecutive same-role messages (joined by `\n\n`), preserving all content. `SystemMessage` objects are transparent to the role-adjacency check.
- Added private `_merge_llm_messages(first, second)` helper that handles `UserMessage`, `AssistantMessage` (string content, `FunctionCall` list, mixed), and thought-chain merging.

### `AssistantAgent._get_compatible_context()`
- Refactored from a single vision-removal step to a two-step pipeline:
  1. Remove images if the model lacks vision support (existing behaviour).
  2. Apply `ensure_alternating_roles()` if `model_info["strict_alternating_roles"]` is set **or** `ModelFamily.requires_strict_alternating_roles()` returns `True` for the model's family.

### Tests (`tests/test_utils.py`)
Six new `@pytest.mark.asyncio` tests for `ensure_alternating_roles`:
- Already-alternating messages — returned unchanged.
- Two consecutive user messages — merged.
- Two consecutive assistant messages — merged.
- Three consecutive same-role messages — all merged into one.
- System messages preserved and transparent to role detection.
- Empty list returned as-is.

## Design decisions

**Merge rather than inject.** The issue mentions both injection of an empty message and concatenation. Merging preserves all original content without polluting the history with empty or placeholder messages.

**Agent level, not model-client level.** Applied in `AssistantAgent._get_compatible_context()` as directed by the maintainer in the issue discussion.

**Explicit override via `strict_alternating_roles` in `ModelInfo`.** Users who run Mistral or DeepSeek R1 variants behind a proxy that does *not* enforce this restriction can set `strict_alternating_roles=False` to skip normalisation; conversely, unknown model families that do enforce it can opt in with `strict_alternating_roles=True`.

Closes #5965