### PR TITLE
feat: Add Avian as a model client provider

### DIFF
--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.48"]
+avian = ["openai>=1.93", "tiktoken>=0.8.0"]
 langchain = ["langchain_core~= 0.3.3"]
 azure = [
     "azure-ai-inference>=1.0.0b9",

--- a/python/packages/autogen-ext/src/autogen_ext/models/avian/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/avian/__init__.py
@@ -1,0 +1,11 @@
+from ._avian_client import AvianChatCompletionClient
+from .config import (
+    AvianClientConfigurationConfigModel,
+    CreateArgumentsConfigModel,
+)
+
+__all__ = [
+    "AvianChatCompletionClient",
+    "AvianClientConfigurationConfigModel",
+    "CreateArgumentsConfigModel",
+]

--- a/python/packages/autogen-ext/src/autogen_ext/models/avian/_avian_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/avian/_avian_client.py
@@ -1,0 +1,252 @@
+"""Avian model client for AutoGen.
+
+Avian (https://avian.io) provides an OpenAI-compatible LLM inference API
+with access to models like DeepSeek-V3.2, Kimi-K2.5, GLM-5, and MiniMax-M2.5.
+
+This client wraps the OpenAI Python SDK and targets the Avian API endpoint,
+implementing the AutoGen ``ChatCompletionClient`` interface.
+"""
+
+import os
+import warnings
+from typing import Any, Dict, Optional, Union, cast
+
+from autogen_core import Component
+from autogen_core.models import (
+    ModelCapabilities,  # type: ignore
+    ModelFamily,
+    ModelInfo,
+    validate_model_info,
+)
+from openai import AsyncOpenAI
+from pydantic import SecretStr
+from typing_extensions import Self, Unpack
+
+from ..openai._openai_client import (
+    BaseOpenAIChatCompletionClient,
+    _create_args_from_config,
+)
+from . import _model_info
+from .config import AvianClientConfiguration, AvianClientConfigurationConfigModel
+
+AVIAN_BASE_URL = "https://api.avian.io/v1"
+
+
+def _avian_client_from_config(config: Dict[str, Any]) -> AsyncOpenAI:
+    """Create an AsyncOpenAI client configured for the Avian API."""
+    return AsyncOpenAI(
+        api_key=config.get("api_key", os.environ.get("AVIAN_API_KEY", "")),
+        base_url=config.get("base_url", AVIAN_BASE_URL),
+        timeout=config.get("timeout"),
+        max_retries=config.get("max_retries", 2),
+    )
+
+
+class AvianChatCompletionClient(BaseOpenAIChatCompletionClient, Component[AvianClientConfigurationConfigModel]):
+    """Chat completion client for models hosted on Avian (https://avian.io).
+
+    Avian provides an OpenAI-compatible API for LLM inference. This client
+    handles authentication and model configuration automatically.
+
+    To use this client, you must install the ``openai`` extra:
+
+    .. code-block:: bash
+
+        pip install "autogen-ext[openai]"
+
+    You will also need an Avian API key. Set it via the ``AVIAN_API_KEY``
+    environment variable or pass it directly as the ``api_key`` parameter.
+
+    Args:
+        model (str): The Avian model identifier. Supported models:
+            ``deepseek/deepseek-v3.2``, ``moonshotai/kimi-k2.5``,
+            ``z-ai/glm-5``, ``minimax/minimax-m2.5``.
+        api_key (optional, str): The Avian API key. If not provided,
+            the ``AVIAN_API_KEY`` environment variable is used.
+        base_url (optional, str): Override the API base URL.
+            Defaults to ``https://api.avian.io/v1``.
+        timeout (optional, float): Request timeout in seconds.
+        max_retries (optional, int): Maximum number of retries. Defaults to 2.
+        model_info (optional, ModelInfo): Override model capabilities.
+            Auto-detected for known Avian models.
+        temperature (optional, float): Sampling temperature (0.0 - 2.0).
+        max_tokens (optional, int): Maximum tokens to generate.
+        top_p (optional, float): Nucleus sampling parameter.
+        frequency_penalty (optional, float): Frequency penalty (-2.0 to 2.0).
+        presence_penalty (optional, float): Presence penalty (-2.0 to 2.0).
+        seed (optional, int): Random seed for reproducibility.
+        stop (optional, str | list[str]): Stop sequences.
+
+    Examples:
+
+        Basic usage with an Avian model:
+
+        .. code-block:: python
+
+            from autogen_ext.models.avian import AvianChatCompletionClient
+            from autogen_core.models import UserMessage
+
+            client = AvianChatCompletionClient(
+                model="deepseek/deepseek-v3.2",
+                # api_key="...",  # or set AVIAN_API_KEY env var
+            )
+
+            result = await client.create([UserMessage(content="Hello!", source="user")])
+            print(result)
+
+        Using with AutoGen agents:
+
+        .. code-block:: python
+
+            from autogen_agentchat.agents import AssistantAgent
+            from autogen_ext.models.avian import AvianChatCompletionClient
+
+            model_client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+            agent = AssistantAgent("assistant", model_client=model_client)
+
+        Streaming usage:
+
+        .. code-block:: python
+
+            import asyncio
+            from autogen_core.models import UserMessage
+            from autogen_ext.models.avian import AvianChatCompletionClient
+
+
+            async def main() -> None:
+                client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+
+                messages = [UserMessage(content="Write a haiku about code.", source="user")]
+                stream = client.create_stream(messages=messages)
+
+                async for response in stream:
+                    if isinstance(response, str):
+                        print(response, flush=True, end="")
+                    else:
+                        print("\\n---")
+                        print(response.content)
+
+                await client.close()
+
+
+            asyncio.run(main())
+
+        Loading from a configuration dictionary:
+
+        .. code-block:: python
+
+            from autogen_core.models import ChatCompletionClient
+
+            config = {
+                "provider": "autogen_ext.models.avian.AvianChatCompletionClient",
+                "config": {
+                    "model": "deepseek/deepseek-v3.2",
+                    "api_key": "your-avian-api-key",
+                },
+            }
+            client = ChatCompletionClient.load_component(config)
+
+    """
+
+    component_type = "model"
+    component_config_schema = AvianClientConfigurationConfigModel
+    component_provider_override = "autogen_ext.models.avian.AvianChatCompletionClient"
+
+    def __init__(self, **kwargs: Unpack[AvianClientConfiguration]):
+        if "model" not in kwargs:
+            raise ValueError("model is required for AvianChatCompletionClient")
+
+        model_capabilities: Optional[ModelCapabilities] = None  # type: ignore
+        self._raw_config: Dict[str, Any] = dict(kwargs).copy()
+        copied_args = dict(kwargs).copy()
+
+        if "model_capabilities" in kwargs:
+            model_capabilities = kwargs["model_capabilities"]
+            del copied_args["model_capabilities"]
+
+        model_info: Optional[ModelInfo] = None
+        if "model_info" in kwargs:
+            model_info = kwargs["model_info"]
+            del copied_args["model_info"]
+
+        # If no model_info provided, try to auto-detect from known Avian models.
+        if model_info is None and model_capabilities is None:
+            try:
+                model_info = _model_info.get_info(kwargs["model"])
+            except KeyError:
+                # Unknown model -- user must provide model_info.
+                raise ValueError(
+                    f"Unknown Avian model: {kwargs['model']}. "
+                    "Please provide model_info for custom or new models. "
+                    f"Known models: {list(_model_info._MODEL_INFO.keys())}"
+                )
+
+        # Ensure base_url defaults to Avian.
+        if "base_url" not in copied_args:
+            copied_args["base_url"] = AVIAN_BASE_URL
+
+        # Ensure api_key is set from env if not provided.
+        if "api_key" not in copied_args:
+            api_key = os.environ.get("AVIAN_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "api_key is required for AvianChatCompletionClient. "
+                    "Pass it as a parameter or set the AVIAN_API_KEY environment variable."
+                )
+            copied_args["api_key"] = api_key
+            self._raw_config["api_key"] = api_key
+
+        client = _avian_client_from_config(copied_args)
+        create_args = _create_args_from_config(copied_args)
+
+        super().__init__(
+            client=client,
+            create_args=create_args,
+            model_capabilities=model_capabilities,
+            model_info=model_info,
+        )
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_client"] = None
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._client = _avian_client_from_config(state["_raw_config"])
+
+    def _to_config(self) -> AvianClientConfigurationConfigModel:
+        copied_config = self._raw_config.copy()
+        return AvianClientConfigurationConfigModel(**copied_config)
+
+    @classmethod
+    def _from_config(cls, config: AvianClientConfigurationConfigModel) -> Self:
+        copied_config = config.model_copy().model_dump(exclude_none=True)
+
+        # Handle api_key as SecretStr.
+        if "api_key" in copied_config and isinstance(config.api_key, SecretStr):
+            copied_config["api_key"] = config.api_key.get_secret_value()
+
+        return cls(**copied_config)
+
+    def count_tokens(self, messages: Any, *, tools: Any = []) -> int:
+        """Count tokens in the messages.
+
+        Uses the OpenAI token counting logic from the base class with
+        cl100k_base encoding as a reasonable approximation.
+        """
+        from ..openai._openai_client import count_tokens_openai
+
+        return count_tokens_openai(
+            messages,
+            self._create_args["model"],
+            add_name_prefixes=self._add_name_prefixes,
+            tools=tools,
+            model_family=self._model_info["family"],
+            include_name_in_message=self._include_name_in_message,
+        )
+
+    def remaining_tokens(self, messages: Any, *, tools: Any = []) -> int:
+        """Return the number of remaining tokens before hitting the context limit."""
+        token_limit = _model_info.get_token_limit(self._create_args["model"])
+        return token_limit - self.count_tokens(messages, tools=tools)

--- a/python/packages/autogen-ext/src/autogen_ext/models/avian/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/avian/_model_info.py
@@ -1,0 +1,92 @@
+"""Model information for Avian-hosted models."""
+
+from typing import Dict
+
+from autogen_core.models import ModelFamily, ModelInfo
+
+# Avian model name aliases to their canonical identifiers.
+_MODEL_POINTERS: Dict[str, str] = {
+    "deepseek-v3.2": "deepseek/deepseek-v3.2",
+    "kimi-k2.5": "moonshotai/kimi-k2.5",
+    "glm-5": "z-ai/glm-5",
+    "minimax-m2.5": "minimax/minimax-m2.5",
+}
+
+# Model information for each Avian model.
+_MODEL_INFO: Dict[str, ModelInfo] = {
+    "deepseek/deepseek-v3.2": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.UNKNOWN,
+        "structured_output": True,
+        "multiple_system_messages": True,
+    },
+    "moonshotai/kimi-k2.5": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.UNKNOWN,
+        "structured_output": True,
+        "multiple_system_messages": True,
+    },
+    "z-ai/glm-5": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.UNKNOWN,
+        "structured_output": True,
+        "multiple_system_messages": True,
+    },
+    "minimax/minimax-m2.5": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.UNKNOWN,
+        "structured_output": True,
+        "multiple_system_messages": True,
+    },
+}
+
+# Token limits (context window) for each model.
+_MODEL_TOKEN_LIMITS: Dict[str, int] = {
+    "deepseek/deepseek-v3.2": 164_000,
+    "moonshotai/kimi-k2.5": 131_000,
+    "z-ai/glm-5": 131_000,
+    "minimax/minimax-m2.5": 1_000_000,
+}
+
+# Default token limit for unknown models.
+_DEFAULT_TOKEN_LIMIT = 128_000
+
+
+def resolve_model(model: str) -> str | None:
+    """Resolve a model alias to its canonical name.
+
+    Returns the canonical model name if found, otherwise None.
+    """
+    if model in _MODEL_INFO:
+        return model
+    if model in _MODEL_POINTERS:
+        return _MODEL_POINTERS[model]
+    return None
+
+
+def get_info(model: str) -> ModelInfo:
+    """Get the model info for a given model name.
+
+    Raises:
+        KeyError: If the model is not recognized.
+    """
+    resolved = resolve_model(model)
+    if resolved is not None and resolved in _MODEL_INFO:
+        return _MODEL_INFO[resolved]
+    raise KeyError(f"Unknown Avian model: {model}")
+
+
+def get_token_limit(model: str) -> int:
+    """Get the token limit for a given model name."""
+    resolved = resolve_model(model)
+    if resolved is not None and resolved in _MODEL_TOKEN_LIMITS:
+        return _MODEL_TOKEN_LIMITS[resolved]
+    return _DEFAULT_TOKEN_LIMIT

--- a/python/packages/autogen-ext/src/autogen_ext/models/avian/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/avian/config/__init__.py
@@ -1,0 +1,45 @@
+from typing import Dict, List, Literal, Optional, Union
+
+from autogen_core.models import ModelCapabilities, ModelInfo  # type: ignore
+from pydantic import BaseModel, SecretStr
+from typing_extensions import Required, TypedDict
+
+
+class CreateArguments(TypedDict, total=False):
+    frequency_penalty: Optional[float]
+    max_tokens: Optional[int]
+    presence_penalty: Optional[float]
+    seed: Optional[int]
+    stop: Union[Optional[str], List[str]]
+    temperature: Optional[float]
+    top_p: Optional[float]
+
+
+class AvianClientConfiguration(CreateArguments, total=False):
+    model: Required[str]
+    api_key: str
+    base_url: str
+    timeout: Union[float, None]
+    max_retries: int
+    model_capabilities: ModelCapabilities  # type: ignore
+    model_info: ModelInfo
+
+
+class CreateArgumentsConfigModel(BaseModel):
+    frequency_penalty: float | None = None
+    max_tokens: int | None = None
+    presence_penalty: float | None = None
+    seed: int | None = None
+    stop: str | List[str] | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+
+
+class AvianClientConfigurationConfigModel(CreateArgumentsConfigModel):
+    model: str
+    api_key: SecretStr | None = None
+    base_url: str | None = None
+    timeout: float | None = None
+    max_retries: int | None = None
+    model_capabilities: ModelCapabilities | None = None  # type: ignore
+    model_info: ModelInfo | None = None

--- a/python/packages/autogen-ext/tests/models/test_avian_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_avian_model_client.py
@@ -1,0 +1,357 @@
+"""Tests for the Avian model client."""
+
+import json
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from autogen_core import FunctionCall
+from autogen_core.models import (
+    AssistantMessage,
+    CreateResult,
+    FunctionExecutionResult,
+    FunctionExecutionResultMessage,
+    SystemMessage,
+    UserMessage,
+)
+from autogen_core.tools import FunctionTool
+from autogen_ext.models.avian import AvianChatCompletionClient
+from autogen_ext.models.avian._model_info import (
+    _MODEL_INFO,
+    _MODEL_TOKEN_LIMITS,
+    get_info,
+    get_token_limit,
+    resolve_model,
+)
+
+
+# ---- Model info tests ----
+
+
+def test_resolve_known_model() -> None:
+    assert resolve_model("deepseek/deepseek-v3.2") == "deepseek/deepseek-v3.2"
+
+
+def test_resolve_model_alias() -> None:
+    assert resolve_model("deepseek-v3.2") == "deepseek/deepseek-v3.2"
+
+
+def test_resolve_unknown_model() -> None:
+    assert resolve_model("nonexistent/model") is None
+
+
+def test_get_info_known_model() -> None:
+    info = get_info("deepseek/deepseek-v3.2")
+    assert info["function_calling"] is True
+    assert info["json_output"] is True
+    assert info["vision"] is False
+
+
+def test_get_info_alias() -> None:
+    info = get_info("kimi-k2.5")
+    assert info["function_calling"] is True
+
+
+def test_get_info_unknown_raises() -> None:
+    with pytest.raises(KeyError, match="Unknown Avian model"):
+        get_info("nonexistent/model")
+
+
+def test_get_token_limit_known() -> None:
+    assert get_token_limit("deepseek/deepseek-v3.2") == 164_000
+
+
+def test_get_token_limit_alias() -> None:
+    assert get_token_limit("minimax-m2.5") == 1_000_000
+
+
+def test_get_token_limit_unknown_returns_default() -> None:
+    assert get_token_limit("nonexistent/model") == 128_000
+
+
+def test_all_models_have_token_limits() -> None:
+    for model in _MODEL_INFO:
+        assert model in _MODEL_TOKEN_LIMITS, f"Missing token limit for {model}"
+
+
+# ---- Client construction tests ----
+
+
+def test_missing_model_raises() -> None:
+    with pytest.raises(ValueError, match="model is required"):
+        AvianChatCompletionClient()  # type: ignore
+
+
+def test_unknown_model_without_info_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    with pytest.raises(ValueError, match="Unknown Avian model"):
+        AvianChatCompletionClient(model="nonexistent/model")
+
+
+def test_unknown_model_with_info_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    client = AvianChatCompletionClient(
+        model="custom/model",
+        model_info={
+            "vision": False,
+            "function_calling": True,
+            "json_output": True,
+            "family": "unknown",
+            "structured_output": False,
+        },
+    )
+    assert client.model_info["function_calling"] is True
+
+
+def test_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AVIAN_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="api_key is required"):
+        AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+
+
+def test_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key-from-env")
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+    assert client._raw_config["api_key"] == "test-key-from-env"
+
+
+def test_api_key_from_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AVIAN_API_KEY", raising=False)
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2", api_key="direct-key")
+    assert client._raw_config["api_key"] == "direct-key"
+
+
+def test_default_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+    assert str(client._client.base_url).rstrip("/") == "https://api.avian.io/v1"
+
+
+def test_custom_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2", base_url="https://custom.api/v1")
+    assert "custom.api" in str(client._client.base_url)
+
+
+def test_model_info_auto_detected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+    info = client.model_info
+    assert info["function_calling"] is True
+    assert info["json_output"] is True
+    assert info["vision"] is False
+
+
+def test_model_info_all_known_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    for model_name in _MODEL_INFO:
+        client = AvianChatCompletionClient(model=model_name)
+        assert client.model_info is not None
+
+
+# ---- Serialization tests ----
+
+
+def test_config_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    client = AvianChatCompletionClient(
+        model="deepseek/deepseek-v3.2",
+        api_key="test-key",
+        temperature=0.7,
+    )
+    config = client._to_config()
+    assert config.model == "deepseek/deepseek-v3.2"
+    assert config.temperature == 0.7
+
+
+def test_from_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    from autogen_ext.models.avian.config import AvianClientConfigurationConfigModel
+    from pydantic import SecretStr
+
+    config = AvianClientConfigurationConfigModel(
+        model="deepseek/deepseek-v3.2",
+        api_key=SecretStr("test-key"),
+        temperature=0.5,
+    )
+    client = AvianChatCompletionClient._from_config(config)
+    assert client._raw_config["model"] == "deepseek/deepseek-v3.2"
+    assert client._raw_config["temperature"] == 0.5
+
+
+# ---- Pickle / state tests ----
+
+
+def test_getstate_removes_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+    state = client.__getstate__()
+    assert state["_client"] is None
+
+
+def test_setstate_restores_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+    state = client.__getstate__()
+    client.__setstate__(state)
+    assert client._client is not None
+
+
+# ---- Create / API call tests with mocking ----
+
+
+@pytest.mark.asyncio
+async def test_create_basic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test a basic non-streaming create call with mocked OpenAI client."""
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+
+    # Mock the OpenAI client's chat.completions.create
+    mock_choice = MagicMock()
+    mock_choice.finish_reason = "stop"
+    mock_choice.message.function_call = None
+    mock_choice.message.tool_calls = None
+    mock_choice.message.content = "Hello from Avian!"
+    mock_choice.message.model_extra = None
+    mock_choice.logprobs = None
+
+    mock_response = MagicMock()
+    mock_response.model = "deepseek/deepseek-v3.2"
+    mock_response.choices = [mock_choice]
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 5
+    mock_response.model_dump.return_value = {"id": "test", "choices": [], "model": "deepseek/deepseek-v3.2"}
+
+    client._client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    result = await client.create([UserMessage(content="Hello!", source="user")])
+
+    assert isinstance(result, CreateResult)
+    assert result.content == "Hello from Avian!"
+    assert result.finish_reason == "stop"
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.completion_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_create_with_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test create with function calling / tool calls."""
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+
+    # Mock tool call response
+    mock_tool_call = MagicMock()
+    mock_tool_call.id = "call_123"
+    mock_tool_call.function.name = "get_weather"
+    mock_tool_call.function.arguments = '{"location": "Paris"}'
+
+    mock_choice = MagicMock()
+    mock_choice.finish_reason = "tool_calls"
+    mock_choice.message.function_call = None
+    mock_choice.message.tool_calls = [mock_tool_call]
+    mock_choice.message.content = None
+    mock_choice.message.model_extra = None
+    mock_choice.logprobs = None
+
+    mock_response = MagicMock()
+    mock_response.model = "deepseek/deepseek-v3.2"
+    mock_response.choices = [mock_choice]
+    mock_response.usage.prompt_tokens = 20
+    mock_response.usage.completion_tokens = 15
+    mock_response.model_dump.return_value = {"id": "test", "choices": [], "model": "deepseek/deepseek-v3.2"}
+
+    client._client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    def get_weather(location: str) -> str:
+        """Get the weather for a location."""
+        return f"Sunny in {location}"
+
+    tool = FunctionTool(get_weather, description="Get weather")
+
+    result = await client.create(
+        [UserMessage(content="What is the weather in Paris?", source="user")],
+        tools=[tool],
+    )
+
+    assert isinstance(result, CreateResult)
+    assert isinstance(result.content, list)
+    assert len(result.content) == 1
+    assert result.content[0].name == "get_weather"
+    assert result.content[0].id == "call_123"
+    assert result.finish_reason == "function_calls"
+
+
+@pytest.mark.asyncio
+async def test_create_usage_tracking(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that usage is tracked correctly across calls."""
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+
+    mock_choice = MagicMock()
+    mock_choice.finish_reason = "stop"
+    mock_choice.message.function_call = None
+    mock_choice.message.tool_calls = None
+    mock_choice.message.content = "Response"
+    mock_choice.message.model_extra = None
+    mock_choice.logprobs = None
+
+    mock_response = MagicMock()
+    mock_response.model = "deepseek/deepseek-v3.2"
+    mock_response.choices = [mock_choice]
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 5
+    mock_response.model_dump.return_value = {"id": "test", "choices": [], "model": "deepseek/deepseek-v3.2"}
+
+    client._client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    await client.create([UserMessage(content="Hello!", source="user")])
+    await client.create([UserMessage(content="Again!", source="user")])
+
+    total = client.total_usage()
+    assert total.prompt_tokens == 20
+    assert total.completion_tokens == 10
+
+
+@pytest.mark.asyncio
+async def test_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that close calls the underlying client close."""
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+    client._client.close = AsyncMock()
+
+    await client.close()
+    client._client.close.assert_called_once()
+
+
+def test_remaining_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test remaining_tokens returns a reasonable value."""
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+    remaining = client.remaining_tokens([UserMessage(content="Hello", source="user")])
+    # Should be close to 164K minus a small number of tokens for the message
+    assert remaining > 163_000
+    assert remaining < 164_000
+
+
+def test_count_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test count_tokens returns a positive value."""
+    monkeypatch.setenv("AVIAN_API_KEY", "test-key")
+
+    client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
+    count = client.count_tokens([UserMessage(content="Hello world", source="user")])
+    assert count > 0
+
+
+# ---- Component loading test ----
+
+
+def test_component_type() -> None:
+    assert AvianChatCompletionClient.component_type == "model"
+
+
+def test_component_provider_override() -> None:
+    assert AvianChatCompletionClient.component_provider_override == "autogen_ext.models.avian.AvianChatCompletionClient"


### PR DESCRIPTION
## Summary

- Add `AvianChatCompletionClient` implementing AutoGen's `ChatCompletionClient` interface for [Avian](https://avian.io), an OpenAI-compatible LLM inference API
- Support for 4 models: `deepseek/deepseek-v3.2` (164K context), `moonshotai/kimi-k2.5` (131K context), `z-ai/glm-5` (131K context), `minimax/minimax-m2.5` (1M context)
- Full feature support: chat completions, streaming, function calling, structured output, component serialization
- 32 unit tests with mocked API calls covering model info, client construction, serialization, API interactions, and token counting

## Motivation

Avian provides access to high-quality open-weight LLMs (DeepSeek, Kimi, GLM, MiniMax) at competitive pricing through a single OpenAI-compatible endpoint. This integration enables AutoGen users to leverage these models in multi-agent workflows without custom configuration.

## Implementation

The client follows existing patterns in `autogen-ext`:
- Extends `BaseOpenAIChatCompletionClient` (same base as `OpenAIChatCompletionClient`)
- New module at `autogen_ext.models.avian`
- Auto-detects model capabilities and token limits for known models
- Supports `AVIAN_API_KEY` environment variable or direct parameter
- Adds `avian` optional dependency in `pyproject.toml` (reuses `openai` + `tiktoken`)

### Files added
- `python/packages/autogen-ext/src/autogen_ext/models/avian/__init__.py` — public exports
- `python/packages/autogen-ext/src/autogen_ext/models/avian/_avian_client.py` — main client class
- `python/packages/autogen-ext/src/autogen_ext/models/avian/_model_info.py` — model metadata and token limits
- `python/packages/autogen-ext/src/autogen_ext/models/avian/config/__init__.py` — configuration TypedDicts and Pydantic models
- `python/packages/autogen-ext/tests/models/test_avian_model_client.py` — 32 unit tests

### Usage

```python
from autogen_ext.models.avian import AvianChatCompletionClient
from autogen_core.models import UserMessage

client = AvianChatCompletionClient(
    model="deepseek/deepseek-v3.2",
    # api_key="...",  # or set AVIAN_API_KEY env var
)
result = await client.create([UserMessage(content="Hello!", source="user")])
```

With AutoGen agents:

```python
from autogen_agentchat.agents import AssistantAgent
from autogen_ext.models.avian import AvianChatCompletionClient

model_client = AvianChatCompletionClient(model="deepseek/deepseek-v3.2")
agent = AssistantAgent("assistant", model_client=model_client)
```

## Test plan

- [x] All 32 unit tests pass (`python -m pytest tests/models/test_avian_model_client.py -v`)
- [x] Model info resolution and alias tests
- [x] Client construction with various parameter combinations
- [x] API key from env var and direct parameter
- [x] Mock-based create/streaming/tool-call tests
- [x] Serialization round-trip tests
- [x] Token counting and remaining tokens

## Available models and pricing

| Model | Context | Max Output | Input $/1M | Output $/1M |
|-------|---------|------------|------------|-------------|
| deepseek/deepseek-v3.2 | 164K | 65K | $0.26 | $0.38 |
| moonshotai/kimi-k2.5 | 131K | 8K | $0.45 | $2.20 |
| z-ai/glm-5 | 131K | 16K | $0.30 | $2.55 |
| minimax/minimax-m2.5 | 1M | 1M | $0.30 | $1.10 |

cc @ekzhu @jackgerrits