### PR TITLE
feat(agentchat): add get_thread() method to BaseGroupChat

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -27,6 +27,8 @@ from ...messages import (
 from ...state import TeamState
 from ._chat_agent_container import ChatAgentContainer
 from ._events import (
+    GroupChatGetThread,
+    GroupChatGetThreadResponse,
     GroupChatPause,
     GroupChatReset,
     GroupChatResume,
@@ -744,6 +746,72 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
             GroupChatResume(),
             recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
         )
+
+    async def get_thread(self) -> List[BaseAgentEvent | BaseChatMessage]:
+        """Get the current message thread from the group chat manager.
+
+        This method returns a list of all messages exchanged between participants
+        in the group chat so far. It can be called while the team is running or
+        after it has completed.
+
+        Returns:
+            List[BaseAgentEvent | BaseChatMessage]: A list of messages in the
+                current thread, in the order they were exchanged.
+
+        Raises:
+            RuntimeError: If the team has not been initialized.
+
+        Example using the :class:`~autogen_agentchat.teams.RoundRobinGroupChat` team:
+
+        .. code-block:: python
+
+            import asyncio
+            from autogen_agentchat.agents import AssistantAgent
+            from autogen_agentchat.conditions import MaxMessageTermination
+            from autogen_agentchat.teams import RoundRobinGroupChat
+            from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+
+            async def main() -> None:
+                model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+                agent1 = AssistantAgent("Assistant1", model_client=model_client)
+                agent2 = AssistantAgent("Assistant2", model_client=model_client)
+                termination = MaxMessageTermination(3)
+                team = RoundRobinGroupChat([agent1, agent2], termination_condition=termination)
+                result = await team.run(task="Count from 1 to 10, respond one at a time.")
+
+                # Get the message thread.
+                thread = await team.get_thread()
+                for message in thread:
+                    print(message)
+
+
+            asyncio.run(main())
+        """
+
+        if not self._initialized:
+            raise RuntimeError(
+                "The group chat has not been initialized. It must be run at least once before getting the thread."
+            )
+
+        started_runtime = False
+        if self._embedded_runtime and not self._is_running:
+            assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+            self._runtime.start()
+            started_runtime = True
+
+        try:
+            response = await self._runtime.send_message(
+                GroupChatGetThread(),
+                recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
+            )
+            assert isinstance(response, GroupChatGetThreadResponse)
+            return list(response.messages)
+        finally:
+            if started_runtime:
+                assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+                await self._runtime.stop_when_idle()
 
     async def save_state(self) -> Mapping[str, Any]:
         """Save the state of the group chat team.

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -9,6 +9,8 @@ from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory, SelectS
 from ._events import (
     GroupChatAgentResponse,
     GroupChatError,
+    GroupChatGetThread,
+    GroupChatGetThreadResponse,
     GroupChatMessage,
     GroupChatPause,
     GroupChatRequestPublish,
@@ -284,6 +286,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
     async def handle_resume(self, message: GroupChatResume, ctx: MessageContext) -> None:
         """Resume the group chat manager. This is a no-op in the base class."""
         pass
+
+    @rpc
+    async def handle_get_thread(self, message: GroupChatGetThread, ctx: MessageContext) -> GroupChatGetThreadResponse:
+        """Handle a request to get the current message thread."""
+        return GroupChatGetThreadResponse(messages=list(self._message_thread))
 
     @abstractmethod
     async def validate_group_state(self, messages: List[BaseChatMessage] | None) -> None:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
@@ -106,6 +106,19 @@ class GroupChatResume(BaseModel):
     ...
 
 
+class GroupChatGetThread(BaseModel):
+    """A request to get the current message thread from the group chat manager."""
+
+    ...
+
+
+class GroupChatGetThreadResponse(BaseModel):
+    """A response containing the current message thread."""
+
+    messages: List[SerializeAsAny[BaseAgentEvent | BaseChatMessage]]
+    """The list of messages in the current thread."""
+
+
 class GroupChatError(BaseModel):
     """A message indicating that an error occurred in the group chat."""
 

--- a/python/packages/autogen-agentchat/tests/test_group_chat_get_thread.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat_get_thread.py
@@ -1,0 +1,96 @@
+import asyncio
+from typing import AsyncGenerator, Sequence
+
+import pytest
+import pytest_asyncio
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.base import Response
+from autogen_agentchat.conditions import MaxMessageTermination
+from autogen_agentchat.messages import BaseChatMessage, TextMessage
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_core import AgentRuntime, CancellationToken, SingleThreadedAgentRuntime
+
+
+class _EchoAgent(BaseChatAgent):
+    """A simple echo agent for testing."""
+
+    def __init__(self, name: str, description: str) -> None:
+        super().__init__(name, description)
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        if len(messages) > 0:
+            assert isinstance(messages[0], TextMessage)
+            return Response(chat_message=TextMessage(content=messages[0].content, source=self.name))
+        return Response(chat_message=TextMessage(content="echo", source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass
+
+
+@pytest_asyncio.fixture(params=["single_threaded", "embedded"])  # type: ignore
+async def runtime(request: pytest.FixtureRequest) -> AsyncGenerator[AgentRuntime | None, None]:
+    if request.param == "single_threaded":
+        runtime = SingleThreadedAgentRuntime()
+        runtime.start()
+        yield runtime
+        await runtime.stop()
+    elif request.param == "embedded":
+        yield None
+
+
+@pytest.mark.asyncio
+async def test_get_thread_after_run(runtime: AgentRuntime | None) -> None:
+    """Test that get_thread returns the message thread after a run."""
+    agent1 = _EchoAgent("agent1", "echo agent 1")
+    agent2 = _EchoAgent("agent2", "echo agent 2")
+    termination = MaxMessageTermination(3)
+    team = RoundRobinGroupChat([agent1, agent2], termination_condition=termination, runtime=runtime)
+
+    result = await team.run(task="Hello")
+
+    # Get the thread after the run.
+    thread = await team.get_thread()
+
+    # The thread should contain the task message plus agent responses.
+    assert len(thread) > 0
+    # The first message should be the task.
+    assert isinstance(thread[0], TextMessage)
+    assert thread[0].content == "Hello"
+    # The thread length should match the result messages (minus the stop message if any).
+    chat_messages = [m for m in result.messages if not isinstance(m, type(None))]
+    assert len(thread) == len(chat_messages)
+
+
+@pytest.mark.asyncio
+async def test_get_thread_empty_after_reset(runtime: AgentRuntime | None) -> None:
+    """Test that get_thread returns an empty list after reset."""
+    agent1 = _EchoAgent("agent1", "echo agent 1")
+    termination = MaxMessageTermination(2)
+    team = RoundRobinGroupChat([agent1], termination_condition=termination, runtime=runtime)
+
+    await team.run(task="Hello")
+
+    # Thread should have messages.
+    thread = await team.get_thread()
+    assert len(thread) > 0
+
+    # Reset the team.
+    await team.reset()
+
+    # Thread should now be empty.
+    thread = await team.get_thread()
+    assert len(thread) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_thread_not_initialized(runtime: AgentRuntime | None) -> None:
+    """Test that get_thread raises an error if the team has not been initialized."""
+    agent1 = _EchoAgent("agent1", "echo agent 1")
+    team = RoundRobinGroupChat([agent1], runtime=runtime)
+
+    with pytest.raises(RuntimeError, match="not been initialized"):
+        await team.get_thread()


### PR DESCRIPTION
## Why are these changes needed?

Currently, the message thread is stored internally in `BaseGroupChatManager._message_thread` but is not accessible from the public API. Users need a way to:
- Inspect conversation progress during or after a group chat run
- Debug multi-agent interactions by examining message history
- Display chat history in UIs or monitoring dashboards
- Access the full message thread without relying on `run_stream()`

## Related Issue(s)

- closes #6085

## Changes

**`_events.py`**: Added `GroupChatGetThread` RPC request event and `GroupChatGetThreadResponse` response model containing the serialized message list.

**`_base_group_chat_manager.py`**:
- Imported new event types
- Added `handle_get_thread()` RPC handler that returns a copy of `self._message_thread`

**`_base_group_chat.py`**:
- Imported new event types
- Added public `async def get_thread()` method with full documentation and usage example
- Handles both embedded and external runtime modes (starts/stops embedded runtime when team is not running)
- Validates team initialization before sending RPC

**`test_group_chat_get_thread.py`**: Added three test cases covering:
- `test_get_thread_after_run`: Verifies thread contains correct messages after `run()`
- `test_get_thread_empty_after_reset`: Verifies thread is empty after `reset()`
- `test_get_thread_not_initialized`: Verifies `RuntimeError` when team not initialized

All tests run with both `single_threaded` and `embedded` runtime modes (6 tests total, all passing).

## Implementation Details

The implementation follows the existing RPC communication pattern used by `reset()`, `pause()`, and `resume()`:
1. `BaseGroupChat.get_thread()` sends a `GroupChatGetThread` RPC message to the manager
2. `BaseGroupChatManager.handle_get_thread()` returns `GroupChatGetThreadResponse` with the current `_message_thread`
3. The response is deserialized and returned as `List[BaseAgentEvent | BaseChatMessage]`

For embedded runtime support, `get_thread()` temporarily starts the runtime if the team is not currently running (same pattern as `reset()`).

## Usage Example

```python
from autogen_agentchat.agents import AssistantAgent
from autogen_agentchat.conditions import MaxMessageTermination
from autogen_agentchat.teams import RoundRobinGroupChat
from autogen_ext.models.openai import OpenAIChatCompletionClient

async def main():
    model_client = OpenAIChatCompletionClient(model="gpt-4o")
    agent1 = AssistantAgent("Assistant1", model_client=model_client)
    agent2 = AssistantAgent("Assistant2", model_client=model_client)
    termination = MaxMessageTermination(3)
    team = RoundRobinGroupChat([agent1, agent2], termination_condition=termination)

    result = await team.run(task="Count from 1 to 10, respond one at a time.")

    # Get message history (new feature!)
    thread = await team.get_thread()
    for msg in thread:
        print(f"{msg.source}: {msg.content}")
```