### PR TITLE
feat: add RecipientNotFoundError exception for unregistered agent recipients

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -44,7 +44,7 @@ from ._serialization import JSON_DATA_CONTENT_TYPE, MessageSerializer, Serializa
 from ._subscription import Subscription
 from ._telemetry import EnvelopeMetadata, MessageRuntimeTracingConfig, TraceHelper, get_telemetry_envelope_metadata
 from ._topic import TopicId
-from .exceptions import MessageDroppedException
+from .exceptions import MessageDroppedException, RecipientNotFoundError
 
 logger = logging.getLogger("autogen_core")
 event_logger = logging.getLogger("autogen_core.events")
@@ -362,7 +362,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
         ):
             future = asyncio.get_event_loop().create_future()
             if recipient.type not in self._known_agent_names:
-                future.set_exception(Exception("Recipient not found"))
+                future.set_exception(RecipientNotFoundError(f"Recipient not found for {recipient}"))
                 return await future
 
             content = message.__dict__ if hasattr(message, "__dict__") else message

--- a/python/packages/autogen-core/src/autogen_core/exceptions.py
+++ b/python/packages/autogen-core/src/autogen_core/exceptions.py
@@ -1,4 +1,4 @@
-__all__ = ["CantHandleException", "UndeliverableException", "MessageDroppedException", "NotAccessibleError"]
+__all__ = ["CantHandleException", "UndeliverableException", "MessageDroppedException", "NotAccessibleError", "RecipientNotFoundError"]
 
 
 class CantHandleException(Exception):
@@ -15,3 +15,7 @@ class MessageDroppedException(Exception):
 
 class NotAccessibleError(Exception):
     """Tried to access a value that is not accessible. For example if it is remote cannot be accessed locally."""
+
+
+class RecipientNotFoundError(Exception):
+    """Raised when a message recipient is not found in the runtime."""

--- a/python/packages/autogen-core/tests/test_runtime.py
+++ b/python/packages/autogen-core/tests/test_runtime.py
@@ -16,6 +16,7 @@ from autogen_core import (
     type_subscription,
 )
 from autogen_core._default_subscription import default_subscription
+from autogen_core.exceptions import RecipientNotFoundError
 from autogen_test_utils import (
     CascadingAgent,
     CascadingMessageType,
@@ -348,6 +349,18 @@ async def test_event_handler_exception_propogates() -> None:
         await runtime.publish_message(MessageType(), topic_id=DefaultTopicId())
         await runtime.stop_when_idle()
 
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_recipient_not_found() -> None:
+    runtime = SingleThreadedAgentRuntime()
+    runtime.start()
+
+    with pytest.raises(RecipientNotFoundError, match="Recipient not found"):
+        await runtime.send_message(MessageType(), recipient=AgentId("nonexistent_agent", "default"))
+
+    await runtime.stop()
     await runtime.close()
 
 


### PR DESCRIPTION
## Why are these changes needed?

Currently, when `send_message()` is called with an unregistered `AgentId`, `SingleThreadedAgentRuntime` raises a generic `Exception("Recipient not found")`. This makes it impossible for users to specifically catch and handle this error without catching all exceptions.

This PR introduces a dedicated `RecipientNotFoundError` exception class that:
- Allows precise `except RecipientNotFoundError` handling
- Includes the recipient `AgentId` in the error message for easier debugging
- Follows the existing exception pattern in `autogen_core.exceptions` (`CantHandleException`, `UndeliverableException`, etc.)

## Related issue number

Closes #4964

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.