### PR TITLE
feat: add structured output support for AzureAIChatCompletionClient

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
@@ -38,6 +38,7 @@ from azure.ai.inference.models import (
     ImageContentItem,
     ImageDetailLevel,
     ImageUrl,
+    JsonSchemaFormat,
     StreamingChatChoiceUpdate,
     StreamingChatCompletionsUpdate,
     TextContentItem,
@@ -284,6 +285,28 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
         if __name__ == "__main__":
             asyncio.run(main())
 
+    Structured output is supported by passing a Pydantic model class to the ``json_output`` parameter
+    of :meth:`create` or :meth:`create_stream`. The model's JSON schema will be sent to the API,
+    and the response content will be a JSON string conforming to the schema.
+
+    .. code-block:: python
+
+        from pydantic import BaseModel
+
+
+        class CityInfo(BaseModel):
+            name: str
+            population: int
+
+
+        result = await client.create(
+            [UserMessage(content="What is the capital of France?", source="user")],
+            json_output=CityInfo,
+        )
+        city = CityInfo.model_validate_json(result.content)
+
+    .. versionadded:: 0.7.6
+        Structured output support via ``json_output`` parameter with Pydantic model classes.
 
     """
 
@@ -344,11 +367,17 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
             if self.model_info["json_output"] is False and json_output is True:
                 raise ValueError("Model does not support JSON output")
 
-            if isinstance(json_output, type):
-                # TODO: we should support this in the future.
-                raise ValueError("Structured output is not currently supported for AzureAIChatCompletionClient")
-
-            if json_output is True and "response_format" not in create_args:
+            if isinstance(json_output, type) and issubclass(json_output, BaseModel):
+                if self.model_info.get("structured_output") is False:
+                    raise ValueError("Model does not support structured output")
+                # Convert Pydantic model to JsonSchemaFormat for the Azure AI SDK.
+                schema = json_output.model_json_schema()
+                create_args["response_format"] = JsonSchemaFormat(
+                    name=json_output.__name__,
+                    schema=schema,
+                    strict=True,
+                )
+            elif json_output is True and "response_format" not in create_args:
                 create_args["response_format"] = "json_object"
 
         if self.model_info["json_output"] is False and json_output is True:

--- a/python/packages/autogen-ext/tests/models/test_azure_ai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_azure_ai_model_client.py
@@ -29,6 +29,7 @@ from azure.ai.inference.models import (
     FunctionCall as AzureFunctionCall,
 )
 from azure.core.credentials import AzureKeyCredential
+from pydantic import BaseModel
 
 
 async def _mock_create_stream(*args: Any, **kwargs: Any) -> AsyncGenerator[StreamingChatCompletionsUpdate, None]:
@@ -973,3 +974,186 @@ async def test_azure_ai_tool_choice_specific_tool_streaming(
     assert final_result.content[0].name == "process_text"
     assert final_result.content[0].arguments == '{"input": "hello"}'
     assert final_result.thought == "Let me process this for you."
+
+
+async def _mock_create_structured_output(
+    *args: Any, **kwargs: Any
+) -> ChatCompletions | AsyncGenerator[StreamingChatCompletionsUpdate, None]:
+    stream = kwargs.get("stream", False)
+    json_content = '{"name": "Paris", "population": 2161000}'
+
+    if not stream:
+        await asyncio.sleep(0.1)
+        return ChatCompletions(
+            id="id",
+            created=datetime.now(),
+            model="model",
+            choices=[
+                ChatChoice(
+                    index=0, finish_reason="stop", message=ChatResponseMessage(content=json_content, role="assistant")
+                )
+            ],
+            usage=CompletionsUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+    else:
+        # Stream the JSON content in chunks
+        chunks = ['{"name":', ' "Paris",', ' "population":', " 2161000}"]
+
+        async def _gen() -> AsyncGenerator[StreamingChatCompletionsUpdate, None]:
+            for chunk_content in chunks:
+                await asyncio.sleep(0.1)
+                yield StreamingChatCompletionsUpdate(
+                    id="id",
+                    choices=[
+                        StreamingChatChoiceUpdate(
+                            index=0,
+                            finish_reason="stop" if chunk_content == chunks[-1] else None,
+                            delta=StreamingChatResponseMessageUpdate(role="assistant", content=chunk_content),
+                        )
+                    ],
+                    created=datetime.now(),
+                    model="model",
+                    usage=CompletionsUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+                )
+
+        return _gen()
+
+
+class CityInfo(BaseModel):
+    name: str
+    population: int
+
+
+def _create_mock_client(monkeypatch: pytest.MonkeyPatch, mock_complete: Any) -> None:
+    """Helper to mock ChatCompletionsClient using __new__ to avoid test isolation issues."""
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    mock_client.complete = mock_complete
+
+    def mock_new(cls: Type[ChatCompletionsClient], *args: Any, **kwargs: Any) -> MagicMock:
+        return mock_client
+
+    monkeypatch.setattr(ChatCompletionsClient, "__new__", mock_new)
+
+
+@pytest.mark.asyncio
+async def test_structured_output_create(monkeypatch: pytest.MonkeyPatch) -> None:
+    _create_mock_client(monkeypatch, _mock_create_structured_output)
+    client = AzureAIChatCompletionClient(
+        endpoint="endpoint",
+        credential=AzureKeyCredential("api_key"),
+        model_info={
+            "json_output": True,
+            "function_calling": False,
+            "vision": False,
+            "family": "unknown",
+            "structured_output": True,
+        },
+        model="model",
+    )
+
+    messages = [UserMessage(content="What is the capital of France?", source="user")]
+    result = await client.create(messages, json_output=CityInfo)
+
+    assert isinstance(result.content, str)
+    parsed = CityInfo.model_validate_json(result.content)
+    assert parsed.name == "Paris"
+    assert parsed.population == 2161000
+
+
+@pytest.mark.asyncio
+async def test_structured_output_create_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    _create_mock_client(monkeypatch, _mock_create_structured_output)
+    client = AzureAIChatCompletionClient(
+        endpoint="endpoint",
+        credential=AzureKeyCredential("api_key"),
+        model_info={
+            "json_output": True,
+            "function_calling": False,
+            "vision": False,
+            "family": "unknown",
+            "structured_output": True,
+        },
+        model="model",
+    )
+
+    messages = [UserMessage(content="What is the capital of France?", source="user")]
+    chunks: list[str | CreateResult] = []
+    async for chunk in client.create_stream(messages, json_output=CityInfo):
+        chunks.append(chunk)
+
+    final_result = chunks[-1]
+    assert isinstance(final_result, CreateResult)
+    assert isinstance(final_result.content, str)
+    parsed = CityInfo.model_validate_json(final_result.content)
+    assert parsed.name == "Paris"
+    assert parsed.population == 2161000
+
+
+@pytest.mark.asyncio
+async def test_structured_output_not_supported(monkeypatch: pytest.MonkeyPatch) -> None:
+    _create_mock_client(monkeypatch, _mock_create)
+    client = AzureAIChatCompletionClient(
+        endpoint="endpoint",
+        credential=AzureKeyCredential("api_key"),
+        model_info={
+            "json_output": False,
+            "function_calling": False,
+            "vision": False,
+            "family": "unknown",
+            "structured_output": False,
+        },
+        model="model",
+    )
+
+    messages = [UserMessage(content="What is the capital of France?", source="user")]
+    with pytest.raises(ValueError, match="Model does not support structured output"):
+        await client.create(messages, json_output=CityInfo)
+
+
+@pytest.mark.asyncio
+async def test_structured_output_response_format_kwarg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that structured output sets the response_format to JsonSchemaFormat."""
+    from azure.ai.inference.models import JsonSchemaFormat
+
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _capture_create(*args: Any, **kwargs: Any) -> ChatCompletions:
+        captured_kwargs.update(kwargs)
+        return ChatCompletions(
+            id="id",
+            created=datetime.now(),
+            model="model",
+            choices=[
+                ChatChoice(
+                    index=0,
+                    finish_reason="stop",
+                    message=ChatResponseMessage(content='{"name": "Paris", "population": 2161000}', role="assistant"),
+                )
+            ],
+            usage=CompletionsUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+
+    _create_mock_client(monkeypatch, _capture_create)
+    client = AzureAIChatCompletionClient(
+        endpoint="endpoint",
+        credential=AzureKeyCredential("api_key"),
+        model_info={
+            "json_output": True,
+            "function_calling": False,
+            "vision": False,
+            "family": "unknown",
+            "structured_output": True,
+        },
+        model="model",
+    )
+
+    messages = [UserMessage(content="What is the capital of France?", source="user")]
+    await client.create(messages, json_output=CityInfo)
+
+    assert "response_format" in captured_kwargs
+    rf = captured_kwargs["response_format"]
+    assert isinstance(rf, JsonSchemaFormat)
+    assert rf["name"] == "CityInfo"
+    assert rf["strict"] is True
+    assert "properties" in rf["schema"]


### PR DESCRIPTION
## Why are these changes needed?

`AzureAIChatCompletionClient` currently supports `json_output=True` for unstructured JSON responses, but does not support passing a Pydantic `BaseModel` class for structured output with schema validation. The OpenAI client already supports this via `response_format` with `JsonSchemaFormat`.

This PR adds structured output support to `AzureAIChatCompletionClient`:
- When `json_output` is a Pydantic `BaseModel` subclass, convert it to a `JsonSchemaFormat` object and pass it as `response_format` to the Azure AI Inference SDK
- Raise `ValueError` if the model does not support structured output (`model_info["structured_output"] is False`)
- Includes comprehensive tests for create, stream, unsupported model, and response_format verification

Example usage:
```python
from pydantic import BaseModel

class CityInfo(BaseModel):
    name: str
    population: int
    country: str

result = await client.create(messages=messages, json_output=CityInfo)
```

## Related issue number

Closes #5957

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.