### PR TITLE
feat: add auto-retry with exponential backoff for chat completion clients

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import os
+import random
 import re
 import warnings
 from asyncio import Task
@@ -51,7 +52,7 @@ from autogen_core.models import (
     validate_model_info,
 )
 from autogen_core.tools import Tool, ToolSchema
-from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI
+from openai import NOT_GIVEN, APIStatusError, AsyncAzureOpenAI, AsyncOpenAI
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -99,6 +100,9 @@ create_kwargs = set(completion_create_params.CompletionCreateParamsBase.__annota
 # Only single choice allowed
 disallowed_create_args = set(["stream", "messages", "function_call", "functions", "n"])
 required_create_args: Set[str] = set(["model"])
+
+DEFAULT_RETRY_MAX_ATTEMPTS = 3
+DEFAULT_RETRY_ON_ERROR_CODES = [429, 500, 502, 503, 504, 424]
 
 USER_AGENT_HEADER_NAME = "User-Agent"
 
@@ -439,6 +443,8 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         model_info: Optional[ModelInfo] = None,
         add_name_prefixes: bool = False,
         include_name_in_message: bool = True,
+        retry_max_attempts: Optional[int] = None,
+        retry_on_error_codes: Optional[List[int]] = None,
     ):
         self._client = client
         self._add_name_prefixes = add_name_prefixes
@@ -482,6 +488,10 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         self._create_args = create_args
         self._total_usage = RequestUsage(prompt_tokens=0, completion_tokens=0)
         self._actual_usage = RequestUsage(prompt_tokens=0, completion_tokens=0)
+        self._retry_max_attempts = retry_max_attempts if retry_max_attempts is not None else DEFAULT_RETRY_MAX_ATTEMPTS
+        self._retry_on_error_codes = (
+            retry_on_error_codes if retry_on_error_codes is not None else list(DEFAULT_RETRY_ON_ERROR_CODES)
+        )
 
     @classmethod
     def create_from_config(cls, config: Dict[str, Any]) -> ChatCompletionClient:
@@ -677,31 +687,43 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             json_output,
             extra_create_args,
         )
-        future: Union[Task[ParsedChatCompletion[BaseModel]], Task[ChatCompletion]]
-        if create_params.response_format is not None:
-            # Use beta client if response_format is not None
-            future = asyncio.ensure_future(
-                self._client.beta.chat.completions.parse(
-                    messages=create_params.messages,
-                    tools=(create_params.tools if len(create_params.tools) > 0 else NOT_GIVEN),
-                    response_format=create_params.response_format,
-                    **create_params.create_args,
-                )
-            )
-        else:
-            # Use the regular client
-            future = asyncio.ensure_future(
-                self._client.chat.completions.create(
-                    messages=create_params.messages,
-                    stream=False,
-                    tools=(create_params.tools if len(create_params.tools) > 0 else NOT_GIVEN),
-                    **create_params.create_args,
-                )
-            )
 
-        if cancellation_token is not None:
-            cancellation_token.link_future(future)
-        result: Union[ParsedChatCompletion[BaseModel], ChatCompletion] = await future
+        result: Union[ParsedChatCompletion[BaseModel], ChatCompletion]
+        for _retry_attempt in range(self._retry_max_attempts):
+            try:
+                future: Union[Task[ParsedChatCompletion[BaseModel]], Task[ChatCompletion]]
+                if create_params.response_format is not None:
+                    future = asyncio.ensure_future(
+                        self._client.beta.chat.completions.parse(
+                            messages=create_params.messages,
+                            tools=(create_params.tools if len(create_params.tools) > 0 else NOT_GIVEN),
+                            response_format=create_params.response_format,
+                            **create_params.create_args,
+                        )
+                    )
+                else:
+                    future = asyncio.ensure_future(
+                        self._client.chat.completions.create(
+                            messages=create_params.messages,
+                            stream=False,
+                            tools=(create_params.tools if len(create_params.tools) > 0 else NOT_GIVEN),
+                            **create_params.create_args,
+                        )
+                    )
+
+                if cancellation_token is not None:
+                    cancellation_token.link_future(future)
+                result = await future
+                break
+            except APIStatusError as e:
+                if e.status_code not in self._retry_on_error_codes or _retry_attempt == self._retry_max_attempts - 1:
+                    raise
+                wait = (2**_retry_attempt) + random.uniform(0, 1)
+                trace_logger.warning(
+                    f"API call failed with status {e.status_code}, retrying "
+                    f"(attempt {_retry_attempt + 1}/{self._retry_max_attempts}) after {wait:.1f}s"
+                )
+                await asyncio.sleep(wait)
         if create_params.response_format is not None:
             result = cast(ParsedChatCompletion[Any], result)
 
@@ -1086,17 +1108,32 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         create_args: Dict[str, Any],
         cancellation_token: Optional[CancellationToken],
     ) -> AsyncGenerator[ChatCompletionChunk, None]:
-        stream_future = asyncio.ensure_future(
-            self._client.chat.completions.create(
-                messages=oai_messages,
-                stream=True,
-                tools=tool_params if len(tool_params) > 0 else NOT_GIVEN,
-                **create_args,
-            )
-        )
-        if cancellation_token is not None:
-            cancellation_token.link_future(stream_future)
-        stream = await stream_future
+        # Retry only the initial stream creation, not individual chunk reads.
+        stream = None
+        for _retry_attempt in range(self._retry_max_attempts):
+            try:
+                stream_future = asyncio.ensure_future(
+                    self._client.chat.completions.create(
+                        messages=oai_messages,
+                        stream=True,
+                        tools=tool_params if len(tool_params) > 0 else NOT_GIVEN,
+                        **create_args,
+                    )
+                )
+                if cancellation_token is not None:
+                    cancellation_token.link_future(stream_future)
+                stream = await stream_future
+                break
+            except APIStatusError as e:
+                if e.status_code not in self._retry_on_error_codes or _retry_attempt == self._retry_max_attempts - 1:
+                    raise
+                wait = (2**_retry_attempt) + random.uniform(0, 1)
+                trace_logger.warning(
+                    f"Stream API call failed with status {e.status_code}, retrying "
+                    f"(attempt {_retry_attempt + 1}/{self._retry_max_attempts}) after {wait:.1f}s"
+                )
+                await asyncio.sleep(wait)
+        assert stream is not None
         while True:
             try:
                 chunk_future = asyncio.ensure_future(anext(stream))
@@ -1115,29 +1152,48 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         response_format: Optional[Type[BaseModel]],
         cancellation_token: Optional[CancellationToken],
     ) -> AsyncGenerator[ChatCompletionChunk, None]:
-        async with self._client.beta.chat.completions.stream(
-            messages=oai_messages,
-            tools=tool_params if len(tool_params) > 0 else NOT_GIVEN,
-            response_format=(response_format if response_format is not None else NOT_GIVEN),
-            **create_args_no_response_format,
-        ) as stream:
-            while True:
-                try:
-                    event_future = asyncio.ensure_future(anext(stream))
-                    if cancellation_token is not None:
-                        cancellation_token.link_future(event_future)
-                    event = await event_future
+        for _retry_attempt in range(self._retry_max_attempts):
+            chunks_yielded = False
+            try:
+                async with self._client.beta.chat.completions.stream(
+                    messages=oai_messages,
+                    tools=tool_params if len(tool_params) > 0 else NOT_GIVEN,
+                    response_format=(response_format if response_format is not None else NOT_GIVEN),
+                    **create_args_no_response_format,
+                ) as stream:
+                    while True:
+                        try:
+                            event_future = asyncio.ensure_future(anext(stream))
+                            if cancellation_token is not None:
+                                cancellation_token.link_future(event_future)
+                            event = await event_future
 
-                    if event.type == "chunk":
-                        chunk = event.chunk
-                        yield chunk
-                    # We don't handle other event types from the beta client stream.
-                    # As the other event types are auxiliary to the chunk event.
-                    # See: https://github.com/openai/openai-python/blob/main/helpers.md#chat-completions-events.
-                    # Once the beta client is stable, we can move all the logic to the beta client.
-                    # Then we can consider handling other event types which may simplify the code overall.
-                except StopAsyncIteration:
-                    break
+                            if event.type == "chunk":
+                                chunk = event.chunk
+                                chunks_yielded = True
+                                yield chunk
+                            # We don't handle other event types from the beta client stream.
+                            # As the other event types are auxiliary to the chunk event.
+                            # See: https://github.com/openai/openai-python/blob/main/helpers.md#chat-completions-events.
+                            # Once the beta client is stable, we can move all the logic to the beta client.
+                            # Then we can consider handling other event types which may simplify the code overall.
+                        except StopAsyncIteration:
+                            break
+                return  # Stream completed successfully
+            except APIStatusError as e:
+                # Don't retry if we've already yielded chunks (partial data sent to consumer).
+                if (
+                    chunks_yielded
+                    or e.status_code not in self._retry_on_error_codes
+                    or _retry_attempt == self._retry_max_attempts - 1
+                ):
+                    raise
+                wait = (2**_retry_attempt) + random.uniform(0, 1)
+                trace_logger.warning(
+                    f"Beta stream API call failed with status {e.status_code}, retrying "
+                    f"(attempt {_retry_attempt + 1}/{self._retry_max_attempts}) after {wait:.1f}s"
+                )
+                await asyncio.sleep(wait)
 
     async def close(self) -> None:
         await self._client.close()
@@ -1261,6 +1317,10 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
             in user message parameters sent to the OpenAI API. Defaults to True. Set to False
             for model providers that don't support the `name` field (e.g., Groq).
         stream_options (optional, dict): Additional options for streaming. Currently only `include_usage` is supported.
+        retry_max_attempts (optional, int): Maximum number of retry attempts for transient API errors.
+            Uses exponential backoff with jitter between retries. Defaults to 3.
+        retry_on_error_codes (optional, list[int]): HTTP status codes that trigger an automatic retry.
+            Defaults to [429, 500, 502, 503, 504, 424].
 
     Examples:
 
@@ -1463,6 +1523,9 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
         if "include_name_in_message" in kwargs:
             include_name_in_message = kwargs["include_name_in_message"]
 
+        retry_max_attempts: Optional[int] = kwargs.get("retry_max_attempts")  # type: ignore[assignment]
+        retry_on_error_codes: Optional[List[int]] = kwargs.get("retry_on_error_codes")  # type: ignore[assignment]
+
         # Special handling for Gemini model.
         assert "model" in copied_args and isinstance(copied_args["model"], str)
         if copied_args["model"].startswith("gemini-"):
@@ -1491,6 +1554,8 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
             model_info=model_info,
             add_name_prefixes=add_name_prefixes,
             include_name_in_message=include_name_in_message,
+            retry_max_attempts=retry_max_attempts,
+            retry_on_error_codes=retry_on_error_codes,
         )
 
     def __getstate__(self) -> Dict[str, Any]:
@@ -1602,6 +1667,10 @@ class AzureOpenAIChatCompletionClient(
             in user message parameters sent to the OpenAI API. Defaults to True. Set to False
             for model providers that don't support the `name` field (e.g., Groq).
         stream_options (optional, dict): Additional options for streaming. Currently only `include_usage` is supported.
+        retry_max_attempts (optional, int): Maximum number of retry attempts for transient API errors.
+            Uses exponential backoff with jitter between retries. Defaults to 3.
+        retry_on_error_codes (optional, list[int]): HTTP status codes that trigger an automatic retry.
+            Defaults to [429, 500, 502, 503, 504, 424].
 
 
     To use the client, you need to provide your deployment name, Azure Cognitive Services endpoint, and api version.
@@ -1697,6 +1766,9 @@ class AzureOpenAIChatCompletionClient(
         if "include_name_in_message" in kwargs:
             include_name_in_message = kwargs["include_name_in_message"]
 
+        retry_max_attempts: Optional[int] = kwargs.get("retry_max_attempts")  # type: ignore[assignment]
+        retry_on_error_codes: Optional[List[int]] = kwargs.get("retry_on_error_codes")  # type: ignore[assignment]
+
         client = _azure_openai_client_from_config(copied_args)
         create_args = _create_args_from_config(copied_args)
         self._raw_config: Dict[str, Any] = copied_args
@@ -1707,6 +1779,8 @@ class AzureOpenAIChatCompletionClient(
             model_info=model_info,
             add_name_prefixes=add_name_prefixes,
             include_name_in_message=include_name_in_message,
+            retry_max_attempts=retry_max_attempts,
+            retry_on_error_codes=retry_on_error_codes,
         )
 
     def __getstate__(self) -> Dict[str, Any]:

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -74,6 +74,10 @@ class BaseOpenAIClientConfiguration(CreateArguments, total=False):
     include_name_in_message: bool
     """Whether to include the 'name' field in user message parameters. Defaults to True. Set to False for providers that don't support the 'name' field."""
     default_headers: Dict[str, str] | None
+    retry_max_attempts: int
+    """Maximum number of retry attempts for transient API errors. Defaults to 3."""
+    retry_on_error_codes: List[int]
+    """HTTP status codes that trigger a retry. Defaults to [429, 500, 502, 503, 504, 424]."""
 
 
 # See OpenAI docs for explanation of these parameters
@@ -120,6 +124,10 @@ class BaseOpenAIClientConfigurationConfigModel(CreateArgumentsConfigModel):
     add_name_prefixes: bool | None = None
     include_name_in_message: bool | None = None
     default_headers: Dict[str, str] | None = None
+    retry_max_attempts: int | None = None
+    """Maximum number of retry attempts for transient API errors. Defaults to 3."""
+    retry_on_error_codes: List[int] | None = None
+    """HTTP status codes that trigger a retry. Defaults to [429, 500, 502, 503, 504, 424]."""
 
 
 # See OpenAI docs for explanation of these parameters

--- a/python/packages/autogen-ext/tests/models/test_openai_retry.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_retry.py
@@ -1,0 +1,327 @@
+"""Tests for auto-retry with exponential backoff in OpenAI chat completion clients."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from autogen_core.models import UserMessage
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.models.openai._openai_client import (
+    DEFAULT_RETRY_MAX_ATTEMPTS,
+    DEFAULT_RETRY_ON_ERROR_CODES,
+    BaseOpenAIChatCompletionClient,
+)
+from openai import APIStatusError
+from openai.types.chat.chat_completion import ChatCompletion, Choice
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.completion_usage import CompletionUsage
+
+
+def _make_chat_completion(content: str = "Hello") -> ChatCompletion:
+    return ChatCompletion(
+        id="test-id",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=content),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o",
+        object="chat.completion",
+        usage=CompletionUsage(completion_tokens=10, prompt_tokens=5, total_tokens=15),
+    )
+
+
+def _make_api_status_error(status_code: int) -> APIStatusError:
+    response = httpx.Response(status_code=status_code, request=httpx.Request("POST", "https://api.openai.com"))
+    return APIStatusError(message=f"Error {status_code}", response=response, body=None)
+
+
+@pytest.mark.asyncio
+async def test_retry_defaults() -> None:
+    """Test that retry defaults are correctly set."""
+    mock_client = MagicMock()
+    client = BaseOpenAIChatCompletionClient(
+        client=mock_client,
+        create_args={"model": "gpt-4o"},
+        model_info={
+            "vision": False,
+            "function_calling": False,
+            "json_output": False,
+            "family": "unknown",
+            "structured_output": False,
+            "multiple_system_messages": True,
+        },
+    )
+    assert client._retry_max_attempts == DEFAULT_RETRY_MAX_ATTEMPTS  # noqa: SLF001
+    assert client._retry_on_error_codes == DEFAULT_RETRY_ON_ERROR_CODES  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_retry_custom_config() -> None:
+    """Test that custom retry config is applied."""
+    mock_client = MagicMock()
+    client = BaseOpenAIChatCompletionClient(
+        client=mock_client,
+        create_args={"model": "gpt-4o"},
+        model_info={
+            "vision": False,
+            "function_calling": False,
+            "json_output": False,
+            "family": "unknown",
+            "structured_output": False,
+            "multiple_system_messages": True,
+        },
+        retry_max_attempts=5,
+        retry_on_error_codes=[429, 503],
+    )
+    assert client._retry_max_attempts == 5  # noqa: SLF001
+    assert client._retry_on_error_codes == [429, 503]  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_create_retries_on_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that create retries on 429 status code."""
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test")
+
+    mock_create = AsyncMock(
+        side_effect=[
+            _make_api_status_error(429),
+            _make_chat_completion("Success after retry"),
+        ]
+    )
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with patch("autogen_ext.models.openai._openai_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.create(
+                messages=[UserMessage(content="Hello", source="user")],
+            )
+
+    assert result.content == "Success after retry"
+    assert mock_create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_retries_on_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that create retries on 500 status code."""
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test")
+
+    mock_create = AsyncMock(
+        side_effect=[
+            _make_api_status_error(500),
+            _make_api_status_error(502),
+            _make_chat_completion("Success after retries"),
+        ]
+    )
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with patch("autogen_ext.models.openai._openai_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.create(
+                messages=[UserMessage(content="Hello", source="user")],
+            )
+
+    assert result.content == "Success after retries"
+    assert mock_create.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_create_raises_after_max_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that create raises after exhausting all retry attempts."""
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test")
+
+    mock_create = AsyncMock(
+        side_effect=[
+            _make_api_status_error(429),
+            _make_api_status_error(429),
+            _make_api_status_error(429),
+        ]
+    )
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with patch("autogen_ext.models.openai._openai_client.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(APIStatusError) as exc_info:
+                await client.create(
+                    messages=[UserMessage(content="Hello", source="user")],
+                )
+
+    assert exc_info.value.status_code == 429
+    assert mock_create.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_create_no_retry_on_non_retryable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that create does not retry on non-retryable status codes (e.g., 401)."""
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test")
+
+    mock_create = AsyncMock(side_effect=_make_api_status_error(401))
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with pytest.raises(APIStatusError) as exc_info:
+            await client.create(
+                messages=[UserMessage(content="Hello", source="user")],
+            )
+
+    assert exc_info.value.status_code == 401
+    assert mock_create.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_create_retries_on_424(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that create retries on 424 (Failed Dependency) status code."""
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test")
+
+    mock_create = AsyncMock(
+        side_effect=[
+            _make_api_status_error(424),
+            _make_chat_completion("Success after 424 retry"),
+        ]
+    )
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with patch("autogen_ext.models.openai._openai_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.create(
+                messages=[UserMessage(content="Hello", source="user")],
+            )
+
+    assert result.content == "Success after 424 retry"
+    assert mock_create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_retry_with_custom_max_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that custom retry_max_attempts is honored via OpenAIChatCompletionClient."""
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test", retry_max_attempts=2)
+
+    mock_create = AsyncMock(
+        side_effect=[
+            _make_api_status_error(500),
+            _make_api_status_error(500),
+        ]
+    )
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with patch("autogen_ext.models.openai._openai_client.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(APIStatusError):
+                await client.create(
+                    messages=[UserMessage(content="Hello", source="user")],
+                )
+
+    # Should only try 2 times (custom max_attempts=2)
+    assert mock_create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_retry_with_custom_error_codes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that custom retry_on_error_codes is honored."""
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test", retry_on_error_codes=[418])
+
+    mock_create = AsyncMock(
+        side_effect=[
+            _make_api_status_error(418),
+            _make_chat_completion("I'm a teapot, but recovered"),
+        ]
+    )
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with patch("autogen_ext.models.openai._openai_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.create(
+                messages=[UserMessage(content="Hello", source="user")],
+            )
+
+    assert result.content == "I'm a teapot, but recovered"
+    assert mock_create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_exponential_backoff_timing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that exponential backoff sleep is called with increasing delays."""
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test")
+
+    mock_create = AsyncMock(
+        side_effect=[
+            _make_api_status_error(500),
+            _make_api_status_error(500),
+            _make_chat_completion("OK"),
+        ]
+    )
+
+    sleep_calls: list[float] = []
+
+    async def mock_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with patch("autogen_ext.models.openai._openai_client.asyncio.sleep", side_effect=mock_sleep):
+            await client.create(
+                messages=[UserMessage(content="Hello", source="user")],
+            )
+
+    assert len(sleep_calls) == 2
+    # First retry: 2^0 + jitter (1.0 to 2.0)
+    assert 1.0 <= sleep_calls[0] <= 2.0
+    # Second retry: 2^1 + jitter (2.0 to 3.0)
+    assert 2.0 <= sleep_calls[1] <= 3.0
+
+
+@pytest.mark.asyncio
+async def test_stream_retries_on_transient_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that create_stream retries the initial stream creation on transient errors."""
+    from openai.types.chat.chat_completion_chunk import ChatCompletionChunk, ChoiceDelta
+    from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test")
+
+    # Create a mock stream that yields one chunk then stops
+    chunk = ChatCompletionChunk(
+        id="test",
+        choices=[
+            ChunkChoice(
+                delta=ChoiceDelta(content="Hello", role="assistant"),
+                finish_reason="stop",
+                index=0,
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o",
+        object="chat.completion.chunk",
+        usage=CompletionUsage(completion_tokens=5, prompt_tokens=3, total_tokens=8),
+    )
+
+    async def mock_stream_gen() -> None:
+        yield chunk
+
+    mock_stream = mock_stream_gen()
+
+    # First call raises 500, second call returns the stream
+    call_count = 0
+
+    async def mock_create(**kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise _make_api_status_error(500)
+        return mock_stream
+
+    with monkeypatch.context() as mp:
+        mp.setattr(client._client.chat.completions, "create", mock_create)
+        with patch("autogen_ext.models.openai._openai_client.asyncio.sleep", new_callable=AsyncMock):
+            collected = []
+            async for item in client.create_stream(
+                messages=[UserMessage(content="Hello", source="user")],
+            ):
+                collected.append(item)
+
+    assert call_count == 2
+    # Should have the text chunk and the final CreateResult
+    assert len(collected) >= 1


### PR DESCRIPTION
## Why are these changes needed?

When OpenAI/Azure API calls fail with transient errors (429 rate limit, 500/502/503/504 server errors, 424 dependency failures), users currently need to implement their own retry logic. This is error-prone and duplicated across projects.

This PR adds built-in retry support to `OpenAIChatCompletionClient` and `AzureOpenAIChatCompletionClient`:

- **Exponential backoff with jitter**: Wait time = `2^attempt + random(0, 1)` seconds
- **Configurable parameters**:
  - `retry_max_attempts` (default: 3) — maximum retry attempts
  - `retry_on_error_codes` (default: `[429, 500, 502, 503, 504, 424]`) — HTTP status codes that trigger retry
- **Stream-safe**: Tracks whether chunks have been yielded to the consumer; does not retry after partial data has been sent (avoids data corruption)
- **Non-intrusive**: Zero behavior change when retries are not triggered; default config matches common best practices

Includes 11 comprehensive tests covering: default/custom config, various error codes, max retries exhaustion, non-retryable errors, exponential backoff timing verification, and stream retry behavior.

## Related issue number

Closes #3632

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.