### PR TITLE
feat: implement dump_component/load_component for AzureAIChatCompletionClient

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/__init__.py
@@ -1,4 +1,4 @@
 from ._azure_ai_client import AzureAIChatCompletionClient
-from .config import AzureAIChatCompletionClientConfig
+from .config import AzureAIChatCompletionClientConfig, AzureAIChatCompletionClientConfigModel
 
-__all__ = ["AzureAIChatCompletionClient", "AzureAIChatCompletionClientConfig"]
+__all__ = ["AzureAIChatCompletionClient", "AzureAIChatCompletionClientConfig", "AzureAIChatCompletionClientConfigModel"]

--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
@@ -5,7 +5,7 @@ from asyncio import Task
 from inspect import getfullargspec
 from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Union, cast
 
-from autogen_core import EVENT_LOGGER_NAME, CancellationToken, FunctionCall, Image
+from autogen_core import EVENT_LOGGER_NAME, CancellationToken, Component, FunctionCall, Image
 from autogen_core.logging import LLMCallEvent, LLMStreamEndEvent, LLMStreamStartEvent
 from autogen_core.models import (
     AssistantMessage,
@@ -54,12 +54,14 @@ from azure.ai.inference.models import (
 from azure.ai.inference.models import (
     UserMessage as AzureUserMessage,
 )
-from pydantic import BaseModel
+from azure.core.credentials import AzureKeyCredential
+from pydantic import BaseModel, SecretStr
 from typing_extensions import AsyncGenerator, Unpack
 
 from autogen_ext.models.azure.config import (
     GITHUB_MODELS_ENDPOINT,
     AzureAIChatCompletionClientConfig,
+    AzureAIChatCompletionClientConfigModel,
 )
 
 from .._utils.parse_r1_content import parse_r1_content
@@ -178,7 +180,7 @@ def assert_valid_name(name: str) -> str:
     return name
 
 
-class AzureAIChatCompletionClient(ChatCompletionClient):
+class AzureAIChatCompletionClient(ChatCompletionClient, Component[AzureAIChatCompletionClientConfigModel]):
     """
     Chat completion client for models hosted on Azure AI Foundry or GitHub Models.
     See `here <https://learn.microsoft.com/en-us/azure/ai-studio/reference/reference-model-inference-chat-completions>`_ for more info.
@@ -287,7 +289,12 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
 
     """
 
+    component_type = "model"
+    component_config_schema = AzureAIChatCompletionClientConfigModel
+    component_provider_override = "autogen_ext.models.azure.AzureAIChatCompletionClient"
+
     def __init__(self, **kwargs: Unpack[AzureAIChatCompletionClientConfig]):
+        self._raw_config: Dict[str, Any] = dict(kwargs).copy()
         config = self._validate_config(kwargs)  # type: ignore
         self._model_info = config["model_info"]  # type: ignore
         self._client = self._create_client(config)
@@ -599,6 +606,35 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
         self.add_usage(usage)
 
         yield result
+
+    def _to_config(self) -> AzureAIChatCompletionClientConfigModel:
+        copied_config: Dict[str, Any] = {}
+        for k, v in self._raw_config.items():
+            if k == "credential":
+                if isinstance(v, AzureKeyCredential):
+                    copied_config["api_key"] = v.key
+                else:
+                    raise ValueError(
+                        "Only AzureKeyCredential is supported for component serialization. "
+                        "AsyncTokenCredential cannot be serialized."
+                    )
+            elif k in ("tools", "tool_choice"):
+                # These are runtime-only Azure SDK objects, skip them.
+                continue
+            else:
+                copied_config[k] = v
+        return AzureAIChatCompletionClientConfigModel(**copied_config)
+
+    @classmethod
+    def _from_config(cls, config: AzureAIChatCompletionClientConfigModel) -> "AzureAIChatCompletionClient":
+        copied_config = config.model_copy().model_dump(exclude_none=True)
+        if "api_key" in copied_config:
+            api_key = (
+                config.api_key.get_secret_value() if isinstance(config.api_key, SecretStr) else copied_config["api_key"]
+            )
+            copied_config["credential"] = AzureKeyCredential(api_key)
+            del copied_config["api_key"]
+        return cls(**copied_config)
 
     async def close(self) -> None:
         await self._client.close()

--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/config/__init__.py
@@ -8,6 +8,7 @@ from azure.ai.inference.models import (
 )
 from azure.core.credentials import AzureKeyCredential
 from azure.core.credentials_async import AsyncTokenCredential
+from pydantic import BaseModel, SecretStr
 
 GITHUB_MODELS_ENDPOINT = "https://models.github.ai/inference"
 
@@ -44,3 +45,21 @@ class AzureAICreateArguments(TypedDict, total=False):
 
 class AzureAIChatCompletionClientConfig(AzureAIClientArguments, AzureAICreateArguments):
     pass
+
+
+class AzureAIChatCompletionClientConfigModel(BaseModel):
+    """Pydantic config model for AzureAIChatCompletionClient serialization."""
+
+    endpoint: str
+    api_key: SecretStr | None = None
+    model_info: ModelInfo
+    model: str | None = None
+    frequency_penalty: float | None = None
+    presence_penalty: float | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    response_format: Literal["text", "json_object"] | None = None
+    stop: List[str] | None = None
+    seed: int | None = None
+    model_extras: Dict[str, Any] | None = None

--- a/python/packages/autogen-ext/tests/models/test_azure_ai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_azure_ai_model_client.py
@@ -9,8 +9,6 @@ import pytest
 from autogen_core import CancellationToken, FunctionCall, Image
 from autogen_core.models import CreateResult, ModelFamily, UserMessage
 from autogen_core.tools import FunctionTool
-from autogen_ext.models.azure import AzureAIChatCompletionClient
-from autogen_ext.models.azure.config import GITHUB_MODELS_ENDPOINT
 from azure.ai.inference.aio import (
     ChatCompletionsClient,
 )
@@ -29,6 +27,9 @@ from azure.ai.inference.models import (
     FunctionCall as AzureFunctionCall,
 )
 from azure.core.credentials import AzureKeyCredential
+
+from autogen_ext.models.azure import AzureAIChatCompletionClient
+from autogen_ext.models.azure.config import GITHUB_MODELS_ENDPOINT
 
 
 async def _mock_create_stream(*args: Any, **kwargs: Any) -> AsyncGenerator[StreamingChatCompletionsUpdate, None]:
@@ -973,3 +974,114 @@ async def test_azure_ai_tool_choice_specific_tool_streaming(
     assert final_result.content[0].name == "process_text"
     assert final_result.content[0].arguments == '{"input": "hello"}'
     assert final_result.thought == "Let me process this for you."
+
+
+@pytest.mark.asyncio
+async def test_azure_ai_dump_component_and_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that AzureAIChatCompletionClient supports dump_component and load_component round-trip."""
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+
+    def mock_new(cls: Type[ChatCompletionsClient], *args: Any, **kwargs: Any) -> MagicMock:
+        return mock_client
+
+    monkeypatch.setattr(ChatCompletionsClient, "__new__", mock_new)
+
+    client = AzureAIChatCompletionClient(
+        endpoint="https://test.azure.com",
+        credential=AzureKeyCredential("test-api-key"),
+        model="test-model",
+        model_info={
+            "json_output": True,
+            "function_calling": True,
+            "vision": False,
+            "family": "unknown",
+            "structured_output": False,
+        },
+        temperature=0.7,
+        max_tokens=100,
+    )
+
+    config = client.dump_component()
+    assert config is not None
+    # API key should not appear in plain text
+    assert "test-api-key" not in str(config)
+    serialized = config.model_dump_json()
+    assert "test-api-key" not in serialized
+
+    # Round-trip: load from dumped config
+
+    client2 = AzureAIChatCompletionClient.load_component(config)
+    assert client2 is not None
+    assert client2.model_info["json_output"] is True
+    assert client2.model_info["function_calling"] is True
+
+
+@pytest.mark.asyncio
+async def test_azure_ai_dump_component_preserves_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that dump_component preserves all configuration fields."""
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+
+    def mock_new(cls: Type[ChatCompletionsClient], *args: Any, **kwargs: Any) -> MagicMock:
+        return mock_client
+
+    monkeypatch.setattr(ChatCompletionsClient, "__new__", mock_new)
+
+    client = AzureAIChatCompletionClient(
+        endpoint="https://test.azure.com",
+        credential=AzureKeyCredential("my-key"),
+        model="phi-4",
+        model_info={
+            "json_output": False,
+            "function_calling": False,
+            "vision": False,
+            "family": "unknown",
+            "structured_output": False,
+        },
+        temperature=0.5,
+        seed=42,
+        stop=["END"],
+    )
+
+    config = client.dump_component()
+    config_dict = config.model_dump()
+    inner = config_dict["config"]
+    assert inner["endpoint"] == "https://test.azure.com"
+    assert inner["model"] == "phi-4"
+    assert inner["temperature"] == 0.5
+    assert inner["seed"] == 42
+    assert inner["stop"] == ["END"]
+
+
+@pytest.mark.asyncio
+async def test_azure_ai_load_component_via_chat_completion_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that AzureAIChatCompletionClient can be loaded via ChatCompletionClient.load_component()."""
+    from autogen_core.models import ChatCompletionClient
+
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+
+    def mock_new(cls: Type[ChatCompletionsClient], *args: Any, **kwargs: Any) -> MagicMock:
+        return mock_client
+
+    monkeypatch.setattr(ChatCompletionsClient, "__new__", mock_new)
+
+    config = {
+        "provider": "autogen_ext.models.azure.AzureAIChatCompletionClient",
+        "config": {
+            "endpoint": "https://test.azure.com",
+            "api_key": "test-key",
+            "model": "phi-4",
+            "model_info": {
+                "json_output": False,
+                "function_calling": False,
+                "vision": False,
+                "family": "unknown",
+                "structured_output": False,
+            },
+        },
+    }
+
+    client = ChatCompletionClient.load_component(config)
+    assert isinstance(client, AzureAIChatCompletionClient)


### PR DESCRIPTION
## Why are these changes needed?

`AzureAIChatCompletionClient` inherits from `ChatCompletionClient` → `ComponentBase` → `ComponentToConfig`, but does not implement `_to_config()` or `_from_config()`. This causes `dump_component()` to raise `NotImplementedError`, which is inconsistent with other model clients like `OpenAIChatCompletionClient` and `AzureOpenAIChatCompletionClient`.

This PR adds full component serialization support:
- `AzureAIChatCompletionClientConfigModel` Pydantic config model with `SecretStr` for API key protection
- `_to_config()`: serializes `AzureKeyCredential` → `SecretStr`, skips non-serializable runtime objects (`tools`, `tool_choice`)
- `_from_config()`: reconstructs `AzureKeyCredential` from `SecretStr`, passes config to constructor
- `component_type`, `component_config_schema`, `component_provider_override` class attributes
- Stored `_raw_config` in `__init__` for round-trip fidelity

## Related issue number

Closes #6992

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.