### PR TITLE
docs: add llms.txt generation for AgentChat documentation

### DIFF
--- a/python/docs/src/conf.py
+++ b/python/docs/src/conf.py
@@ -85,6 +85,7 @@ html_title = "AutoGen"
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+html_extra_path = ["llms.txt", "llms-full.txt"]
 html_css_files = ["custom.css"]
 
 add_module_names = False

--- a/python/docs/src/llms-full.txt
+++ b/python/docs/src/llms-full.txt
@@ -1,0 +1,6869 @@
+# AutoGen Documentation
+
+---
+
+## AgentChat
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/index.html
+
+# AgentChat
+
+AgentChat is a high-level API for building multi-agent applications.
+It is built on top of the [`autogen-core`](../core-user-guide/index.md) package.
+For beginner users, AgentChat is the recommended starting point.
+For advanced users, [`autogen-core`](../core-user-guide/index.md)'s event-driven
+programming model provides more flexibility and control over the underlying components.
+
+AgentChat provides intuitive defaults, such as **Agents** with preset
+behaviors and **Teams** with predefined [multi-agent design patterns](../core-user-guide/design-patterns/intro.md).
+
+::::{grid} 2 2 2 2
+:gutter: 3
+
+:::{grid-item-card} {fas}`download;pst-color-primary` Installation
+:link: ./installation.html
+:link-alt: Installation: How to install AgentChat
+
+How to install AgentChat
+:::
+
+:::{grid-item-card} {fas}`rocket;pst-color-primary` Quickstart
+:link: ./quickstart.html
+:link-alt: Quickstart: Build your first agent
+
+Build your first agent
+:::
+
+:::{grid-item-card} {fas}`school;pst-color-primary` Tutorial
+:link: ./tutorial/index.html
+:link-alt: Tutorial: Step-by-step guide to using AgentChat, learn about agents, teams, and more
+
+Step-by-step guide to using AgentChat, learn about agents, teams, and more
+:::
+
+:::{grid-item-card} {fas}`wrench;pst-color-primary` Custom Agents
+:link: ./custom-agents.html
+:link-alt: Custom Agents: Create your own agents with custom behaviors
+
+Create your own agents with custom behaviors
+:::
+
+:::{grid-item-card} {fas}`sitemap;pst-color-primary` Selector Group Chat
+:link: ./selector-group-chat.html
+:link-alt: Selector Group Chat: Multi-agent coordination through a shared context and centralized, customizable selector
+
+Multi-agent coordination through a shared context and centralized, customizable selector
+:::
+
+:::{grid-item-card} {fas}`dove;pst-color-primary` Swarm
+:link: ./swarm.html
+:link-alt: Swarm: Multi-agent coordination through a shared context and localized, tool-based selector
+
+Multi-agent coordination through a shared context and localized, tool-based selector
+:::
+
+:::{grid-item-card} {fas}`book;pst-color-primary` Magentic-One
+:link: ./magentic-one.html
+:link-alt: Magentic-One: Get started with Magentic-One
+
+Get started with Magentic-One
+:::
+
+:::{grid-item-card} {fas}`sitemap;pst-color-primary` GraphFlow (Workflow)
+:link: ./graph-flow.html
+:link-alt: GraphFlow: Multi-agent workflows through a directed graph of agents.
+
+Multi-agent workflows through a directed graph of agents.
+:::
+
+:::{grid-item-card} {fas}`brain;pst-color-primary` Memory
+:link: ./memory.html
+:link-alt: Memory: Add memory capabilities to your agents
+
+Add memory capabilities to your agents
+:::
+
+:::{grid-item-card} {fas}`file;pst-color-primary` Logging
+:link: ./logging.html
+:link-alt: Logging: Log traces and internal messages
+
+Log traces and internal messages
+:::
+
+:::{grid-item-card} {fas}`save;pst-color-primary` Serialize Components
+:link: ./serialize-components.html
+:link-alt: Serialize Components: Serialize and deserialize components
+
+Serialize and deserialize components
+:::
+
+:::{grid-item-card} {fas}`code;pst-color-primary` Examples
+:link: ./examples/index.html
+:link-alt: Examples: Sample code and use cases
+
+Sample code and use cases
+:::
+
+:::{grid-item-card} {fas}`truck-moving;pst-color-primary` Migration Guide
+:link: ./migration-guide.html
+:link-alt: Migration Guide: How to migrate from AutoGen 0.2.x to 0.4.x.
+
+How to migrate from AutoGen 0.2.x to 0.4.x.
+:::
+::::
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+installation
+quickstart
+migration-guide
+```
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+:caption: Tutorial
+
+tutorial/index
+tutorial/models
+tutorial/messages
+tutorial/agents
+tutorial/teams
+tutorial/human-in-the-loop
+tutorial/termination
+tutorial/state
+
+```
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+:caption: Advanced
+
+custom-agents
+selector-group-chat
+swarm
+magentic-one
+graph-flow
+memory
+logging
+serialize-components
+tracing
+
+```
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+:caption: More
+
+examples/index
+```
+
+
+---
+
+## Custom Agents
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/custom-agents.html
+
+# Custom Agents
+
+You may have agents with behaviors that do not fall into a preset. 
+In such cases, you can build custom agents.
+
+All agents in AgentChat inherit from {py:class}`~autogen_agentchat.agents.BaseChatAgent` 
+class and implement the following abstract methods and attributes:
+
+- {py:meth}`~autogen_agentchat.agents.BaseChatAgent.on_messages`: The abstract method that defines the behavior of the agent in response to messages. This method is called when the agent is asked to provide a response in {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run`. It returns a {py:class}`~autogen_agentchat.base.Response` object.
+- {py:meth}`~autogen_agentchat.agents.BaseChatAgent.on_reset`: The abstract method that resets the agent to its initial state. This method is called when the agent is asked to reset itself.
+- {py:attr}`~autogen_agentchat.agents.BaseChatAgent.produced_message_types`: The list of possible {py:class}`~autogen_agentchat.messages.BaseChatMessage` message types the agent can produce in its response.
+
+Optionally, you can implement the the {py:meth}`~autogen_agentchat.agents.BaseChatAgent.on_messages_stream` method to stream messages as they are generated by the agent.
+This method is called by {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run_stream` to stream messages.
+If this method is not implemented, the agent
+uses the default implementation of {py:meth}`~autogen_agentchat.agents.BaseChatAgent.on_messages_stream`
+that calls the {py:meth}`~autogen_agentchat.agents.BaseChatAgent.on_messages` method and
+yields all messages in the response.
+
+## CountDownAgent
+
+In this example, we create a simple agent that counts down from a given number to zero,
+and produces a stream of messages with the current count.
+
+```python
+from typing import AsyncGenerator, List, Sequence
+
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import BaseAgentEvent, BaseChatMessage, TextMessage
+from autogen_core import CancellationToken
+
+
+class CountDownAgent(BaseChatAgent):
+    def __init__(self, name: str, count: int = 3):
+        super().__init__(name, "A simple agent that counts down.")
+        self._count = count
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        # Calls the on_messages_stream.
+        response: Response | None = None
+        async for message in self.on_messages_stream(messages, cancellation_token):
+            if isinstance(message, Response):
+                response = message
+        assert response is not None
+        return response
+
+    async def on_messages_stream(
+        self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken
+    ) -> AsyncGenerator[BaseAgentEvent | BaseChatMessage | Response, None]:
+        inner_messages: List[BaseAgentEvent | BaseChatMessage] = []
+        for i in range(self._count, 0, -1):
+            msg = TextMessage(content=f"{i}...", source=self.name)
+            inner_messages.append(msg)
+            yield msg
+        # The response is returned at the end of the stream.
+        # It contains the final message and all the inner messages.
+        yield Response(chat_message=TextMessage(content="Done!", source=self.name), inner_messages=inner_messages)
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass
+
+
+async def run_countdown_agent() -> None:
+    # Create a countdown agent.
+    countdown_agent = CountDownAgent("countdown")
+
+    # Run the agent with a given task and stream the response.
+    async for message in countdown_agent.on_messages_stream([], CancellationToken()):
+        if isinstance(message, Response):
+            print(message.chat_message)
+        else:
+            print(message)
+
+
+# Use asyncio.run(run_countdown_agent()) when running in a script.
+await run_countdown_agent()
+```
+
+## ArithmeticAgent
+
+In this example, we create an agent class that can perform simple arithmetic operations
+on a given integer. Then, we will use different instances of this agent class
+in a {py:class}`~autogen_agentchat.teams.SelectorGroupChat`
+to transform a given integer into another integer by applying a sequence of arithmetic operations.
+
+The `ArithmeticAgent` class takes an `operator_func` that takes an integer and returns an integer,
+after applying an arithmetic operation to the integer.
+In its `on_messages` method, it applies the `operator_func` to the integer in the input message,
+and returns a response with the result.
+
+```python
+from typing import Callable, Sequence
+
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.base import Response
+from autogen_agentchat.conditions import MaxMessageTermination
+from autogen_agentchat.messages import BaseChatMessage
+from autogen_agentchat.teams import SelectorGroupChat
+from autogen_agentchat.ui import Console
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+
+class ArithmeticAgent(BaseChatAgent):
+    def __init__(self, name: str, description: str, operator_func: Callable[[int], int]) -> None:
+        super().__init__(name, description=description)
+        self._operator_func = operator_func
+        self._message_history: List[BaseChatMessage] = []
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        # Update the message history.
+        # NOTE: it is possible the messages is an empty list, which means the agent was selected previously.
+        self._message_history.extend(messages)
+        # Parse the number in the last message.
+        assert isinstance(self._message_history[-1], TextMessage)
+        number = int(self._message_history[-1].content)
+        # Apply the operator function to the number.
+        result = self._operator_func(number)
+        # Create a new message with the result.
+        response_message = TextMessage(content=str(result), source=self.name)
+        # Update the message history.
+        self._message_history.append(response_message)
+        # Return the response.
+        return Response(chat_message=response_message)
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass
+```
+
+```{note}
+The `on_messages` method may be called with an empty list of messages, in which
+case it means the agent was called previously and is now being called again,
+without any new messages from the caller. So it is important to keep a history
+of the previous messages received by the agent, and use that history to generate
+the response.
+```
+
+Now we can create a {py:class}`~autogen_agentchat.teams.SelectorGroupChat` with 5 instances of `ArithmeticAgent`:
+
+- one that adds 1 to the input integer,
+- one that subtracts 1 from the input integer,
+- one that multiplies the input integer by 2,
+- one that divides the input integer by 2 and rounds down to the nearest integer, and
+- one that returns the input integer unchanged.
+
+We then create a {py:class}`~autogen_agentchat.teams.SelectorGroupChat` with these agents,
+and set the appropriate selector settings:
+
+- allow the same agent to be selected consecutively to allow for repeated operations, and
+- customize the selector prompt to tailor the model's response to the specific task.
+
+```python
+async def run_number_agents() -> None:
+    # Create agents for number operations.
+    add_agent = ArithmeticAgent("add_agent", "Adds 1 to the number.", lambda x: x + 1)
+    multiply_agent = ArithmeticAgent("multiply_agent", "Multiplies the number by 2.", lambda x: x * 2)
+    subtract_agent = ArithmeticAgent("subtract_agent", "Subtracts 1 from the number.", lambda x: x - 1)
+    divide_agent = ArithmeticAgent("divide_agent", "Divides the number by 2 and rounds down.", lambda x: x // 2)
+    identity_agent = ArithmeticAgent("identity_agent", "Returns the number as is.", lambda x: x)
+
+    # The termination condition is to stop after 10 messages.
+    termination_condition = MaxMessageTermination(10)
+
+    # Create a selector group chat.
+    selector_group_chat = SelectorGroupChat(
+        [add_agent, multiply_agent, subtract_agent, divide_agent, identity_agent],
+        model_client=OpenAIChatCompletionClient(model="gpt-4o"),
+        termination_condition=termination_condition,
+        allow_repeated_speaker=True,  # Allow the same agent to speak multiple times, necessary for this task.
+        selector_prompt=(
+            "Available roles:\n{roles}\nTheir job descriptions:\n{participants}\n"
+            "Current conversation history:\n{history}\n"
+            "Please select the most appropriate role for the next message, and only return the role name."
+        ),
+    )
+
+    # Run the selector group chat with a given task and stream the response.
+    task: List[BaseChatMessage] = [
+        TextMessage(content="Apply the operations to turn the given number into 25.", source="user"),
+        TextMessage(content="10", source="user"),
+    ]
+    stream = selector_group_chat.run_stream(task=task)
+    await Console(stream)
+
+
+# Use asyncio.run(run_number_agents()) when running in a script.
+await run_number_agents()
+```
+
+From the output, we can see that the agents have successfully transformed the input integer
+from 10 to 25 by choosing appropriate agents that apply the arithmetic operations in sequence.
+
+## Using Custom Model Clients in Custom Agents
+
+One of the key features of the {py:class}`~autogen_agentchat.agents.AssistantAgent` preset in AgentChat is that it takes a `model_client` argument and can use it in responding to messages. However, in some cases, you may want your agent to use a custom model client that is not currently supported (see [supported model clients](https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/components/model-clients.html)) or custom model behaviours. 
+
+You can accomplish this with a custom agent that implements *your custom model client*.
+
+In the example below, we will walk through an example of a custom agent that uses the [Google Gemini SDK](https://github.com/googleapis/python-genai) directly to respond to messages.
+
+> **Note:** You will need to install the [Google Gemini SDK](https://github.com/googleapis/python-genai) to run this example. You can install it using the following command: 
+
+```bash
+pip install google-genai
+``` 
+
+```python
+# !pip install google-genai
+import os
+from typing import AsyncGenerator, Sequence
+
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import BaseAgentEvent, BaseChatMessage
+from autogen_core import CancellationToken
+from autogen_core.model_context import UnboundedChatCompletionContext
+from autogen_core.models import AssistantMessage, RequestUsage, UserMessage
+from google import genai
+from google.genai import types
+
+
+class GeminiAssistantAgent(BaseChatAgent):
+    def __init__(
+        self,
+        name: str,
+        description: str = "An agent that provides assistance with ability to use tools.",
+        model: str = "gemini-1.5-flash-002",
+        api_key: str = os.environ["GEMINI_API_KEY"],
+        system_message: str
+        | None = "You are a helpful assistant that can respond to messages. Reply with TERMINATE when the task has been completed.",
+    ):
+        super().__init__(name=name, description=description)
+        self._model_context = UnboundedChatCompletionContext()
+        self._model_client = genai.Client(api_key=api_key)
+        self._system_message = system_message
+        self._model = model
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        final_response = None
+        async for message in self.on_messages_stream(messages, cancellation_token):
+            if isinstance(message, Response):
+                final_response = message
+
+        if final_response is None:
+            raise AssertionError("The stream should have returned the final result.")
+
+        return final_response
+
+    async def on_messages_stream(
+        self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken
+    ) -> AsyncGenerator[BaseAgentEvent | BaseChatMessage | Response, None]:
+        # Add messages to the model context
+        for msg in messages:
+            await self._model_context.add_message(msg.to_model_message())
+
+        # Get conversation history
+        history = [
+            (msg.source if hasattr(msg, "source") else "system")
+            + ": "
+            + (msg.content if isinstance(msg.content, str) else "")
+            + "\n"
+            for msg in await self._model_context.get_messages()
+        ]
+        # Generate response using Gemini
+        response = self._model_client.models.generate_content(
+            model=self._model,
+            contents=f"History: {history}\nGiven the history, please provide a response",
+            config=types.GenerateContentConfig(
+                system_instruction=self._system_message,
+                temperature=0.3,
+            ),
+        )
+
+        # Create usage metadata
+        usage = RequestUsage(
+            prompt_tokens=response.usage_metadata.prompt_token_count,
+            completion_tokens=response.usage_metadata.candidates_token_count,
+        )
+
+        # Add response to model context
+        await self._model_context.add_message(AssistantMessage(content=response.text, source=self.name))
+
+        # Yield the final response
+        yield Response(
+            chat_message=TextMessage(content=response.text, source=self.name, models_usage=usage),
+            inner_messages=[],
+        )
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        """Reset the assistant by clearing the model context."""
+        await self._model_context.clear()
+```
+
+```python
+gemini_assistant = GeminiAssistantAgent("gemini_assistant")
+await Console(gemini_assistant.run_stream(task="What is the capital of New York?"))
+```
+
+In the example above, we have chosen to provide `model`, `api_key` and `system_message` as arguments - you can choose to provide any other arguments that are required by the model client you are using or fits with your application design. 
+
+Now, let us explore how to use this custom agent as part of a team in AgentChat.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+
+model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+
+# Create the primary agent.
+primary_agent = AssistantAgent(
+    "primary",
+    model_client=model_client,
+    system_message="You are a helpful AI assistant.",
+)
+
+# Create a critic agent based on our new GeminiAssistantAgent.
+gemini_critic_agent = GeminiAssistantAgent(
+    "gemini_critic",
+    system_message="Provide constructive feedback. Respond with 'APPROVE' to when your feedbacks are addressed.",
+)
+
+
+# Define a termination condition that stops the task if the critic approves or after 10 messages.
+termination = TextMentionTermination("APPROVE") | MaxMessageTermination(10)
+
+# Create a team with the primary and critic agents.
+team = RoundRobinGroupChat([primary_agent, gemini_critic_agent], termination_condition=termination)
+
+await Console(team.run_stream(task="Write a Haiku poem with 4 lines about the fall season."))
+await model_client.close()
+```
+
+In section above, we show several very important concepts:
+- We have developed a custom agent that uses the Google Gemini SDK to respond to messages. 
+- We show that this custom agent can be used as part of the broader AgentChat ecosystem - in this case as a participant in a {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` as long as it inherits from {py:class}`~autogen_agentchat.agents.BaseChatAgent`.
+
+
+## Making the Custom Agent Declarative 
+
+Autogen provides a [Component](https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/framework/component-config.html) interface for making the configuration of components serializable to a declarative format. This is useful for saving and loading configurations, and for sharing configurations with others. 
+
+We accomplish this by inheriting from the `Component` class and implementing the `_from_config` and `_to_config` methods.
+The declarative class can be serialized to a JSON format using the `dump_component` method, and deserialized from a JSON format using the `load_component` method.
+
+```python
+import os
+from typing import AsyncGenerator, Sequence
+
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import BaseAgentEvent, BaseChatMessage
+from autogen_core import CancellationToken, Component
+from pydantic import BaseModel
+from typing_extensions import Self
+
+
+class GeminiAssistantAgentConfig(BaseModel):
+    name: str
+    description: str = "An agent that provides assistance with ability to use tools."
+    model: str = "gemini-1.5-flash-002"
+    system_message: str | None = None
+
+
+class GeminiAssistantAgent(BaseChatAgent, Component[GeminiAssistantAgentConfig]):  # type: ignore[no-redef]
+    component_config_schema = GeminiAssistantAgentConfig
+    # component_provider_override = "mypackage.agents.GeminiAssistantAgent"
+
+    def __init__(
+        self,
+        name: str,
+        description: str = "An agent that provides assistance with ability to use tools.",
+        model: str = "gemini-1.5-flash-002",
+        api_key: str = os.environ["GEMINI_API_KEY"],
+        system_message: str
+        | None = "You are a helpful assistant that can respond to messages. Reply with TERMINATE when the task has been completed.",
+    ):
+        super().__init__(name=name, description=description)
+        self._model_context = UnboundedChatCompletionContext()
+        self._model_client = genai.Client(api_key=api_key)
+        self._system_message = system_message
+        self._model = model
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        final_response = None
+        async for message in self.on_messages_stream(messages, cancellation_token):
+            if isinstance(message, Response):
+                final_response = message
+
+        if final_response is None:
+            raise AssertionError("The stream should have returned the final result.")
+
+        return final_response
+
+    async def on_messages_stream(
+        self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken
+    ) -> AsyncGenerator[BaseAgentEvent | BaseChatMessage | Response, None]:
+        # Add messages to the model context
+        for msg in messages:
+            await self._model_context.add_message(msg.to_model_message())
+
+        # Get conversation history
+        history = [
+            (msg.source if hasattr(msg, "source") else "system")
+            + ": "
+            + (msg.content if isinstance(msg.content, str) else "")
+            + "\n"
+            for msg in await self._model_context.get_messages()
+        ]
+
+        # Generate response using Gemini
+        response = self._model_client.models.generate_content(
+            model=self._model,
+            contents=f"History: {history}\nGiven the history, please provide a response",
+            config=types.GenerateContentConfig(
+                system_instruction=self._system_message,
+                temperature=0.3,
+            ),
+        )
+
+        # Create usage metadata
+        usage = RequestUsage(
+            prompt_tokens=response.usage_metadata.prompt_token_count,
+            completion_tokens=response.usage_metadata.candidates_token_count,
+        )
+
+        # Add response to model context
+        await self._model_context.add_message(AssistantMessage(content=response.text, source=self.name))
+
+        # Yield the final response
+        yield Response(
+            chat_message=TextMessage(content=response.text, source=self.name, models_usage=usage),
+            inner_messages=[],
+        )
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        """Reset the assistant by clearing the model context."""
+        await self._model_context.clear()
+
+    @classmethod
+    def _from_config(cls, config: GeminiAssistantAgentConfig) -> Self:
+        return cls(
+            name=config.name, description=config.description, model=config.model, system_message=config.system_message
+        )
+
+    def _to_config(self) -> GeminiAssistantAgentConfig:
+        return GeminiAssistantAgentConfig(
+            name=self.name,
+            description=self.description,
+            model=self._model,
+            system_message=self._system_message,
+        )
+```
+
+Now that we have the required methods implemented, we can now load and dump the custom agent to and from a JSON format, and then load the agent from the JSON format.
+ 
+ > Note: You should set the `component_provider_override` class variable to the full path of the module containing the custom agent class e.g., (`mypackage.agents.GeminiAssistantAgent`). This is used by   `load_component` method to determine how to instantiate the class. 
+ 
+
+```python
+gemini_assistant = GeminiAssistantAgent("gemini_assistant")
+config = gemini_assistant.dump_component()
+print(config.model_dump_json(indent=2))
+loaded_agent = GeminiAssistantAgent.load_component(config)
+print(loaded_agent)
+```
+
+## Next Steps 
+
+So far, we have seen how to create custom agents, add custom model clients to agents, and make custom agents declarative. There are a few ways in which this basic sample can be extended:
+
+- Extend the Gemini model client to handle function calling similar to the {py:class}`~autogen_agentchat.agents.AssistantAgent` class. https://ai.google.dev/gemini-api/docs/function-calling  
+- Implement a package with a custom agent and experiment with using its declarative format in a tool like [AutoGen Studio](https://microsoft.github.io/autogen/stable/user-guide/autogenstudio-user-guide/index.html).
+
+---
+
+## Company Research
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/examples/company-research.html
+
+# Company Research 
+
+
+Conducting company research, or competitive analysis, is a critical part of any business strategy. In this notebook, we will demonstrate how to create a team of agents to address this task. While there are many ways to translate a task into an agentic implementation, we will explore a sequential approach. We will create agents corresponding to steps in the research process and give them tools to perform their tasks.
+
+- **Search Agent**: Searches the web for information about a company. Will have access to a search engine API tool to retrieve search results.
+- **Stock Analysis Agent**: Retrieves the company's stock information from a financial data API, computes basic statistics (current price, 52-week high, 52-week low, etc.), and generates a plot of the stock price year-to-date, saving it to a file. Will have access to a financial data API tool to retrieve stock information.
+- **Report Agent**: Generates a report based on the information collected by the search and stock analysis agents. 
+
+First, let's import the necessary modules.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_core.tools import FunctionTool
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+```
+
+## Defining Tools 
+
+Next, we will define the tools that the agents will use to perform their tasks. We will create a `google_search` that uses the Google Search API to search the web for information about a company. We will also create a  `analyze_stock` function that uses the `yfinance` library to retrieve stock information for a company. 
+
+Finally, we will wrap these functions into a `FunctionTool` class that will allow us to use them as tools in our agents. 
+
+Note: The `google_search` function requires an API key to work. You can create a `.env` file in the same directory as this notebook and add your API key as 
+
+```
+GOOGLE_SEARCH_ENGINE_ID =xxx
+GOOGLE_API_KEY=xxx 
+``` 
+
+Also install required libraries 
+
+```
+pip install yfinance matplotlib pytz numpy pandas python-dotenv requests bs4
+```
+
+```python
+#!pip install yfinance matplotlib pytz numpy pandas python-dotenv requests bs4
+
+
+def google_search(query: str, num_results: int = 2, max_chars: int = 500) -> list:  # type: ignore[type-arg]
+    import os
+    import time
+
+    import requests
+    from bs4 import BeautifulSoup
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    api_key = os.getenv("GOOGLE_API_KEY")
+    search_engine_id = os.getenv("GOOGLE_SEARCH_ENGINE_ID")
+
+    if not api_key or not search_engine_id:
+        raise ValueError("API key or Search Engine ID not found in environment variables")
+
+    url = "https://customsearch.googleapis.com/customsearch/v1"
+    params = {"key": str(api_key), "cx": str(search_engine_id), "q": str(query), "num": str(num_results)}
+
+    response = requests.get(url, params=params)
+
+    if response.status_code != 200:
+        print(response.json())
+        raise Exception(f"Error in API request: {response.status_code}")
+
+    results = response.json().get("items", [])
+
+    def get_page_content(url: str) -> str:
+        try:
+            response = requests.get(url, timeout=10)
+            soup = BeautifulSoup(response.content, "html.parser")
+            text = soup.get_text(separator=" ", strip=True)
+            words = text.split()
+            content = ""
+            for word in words:
+                if len(content) + len(word) + 1 > max_chars:
+                    break
+                content += " " + word
+            return content.strip()
+        except Exception as e:
+            print(f"Error fetching {url}: {str(e)}")
+            return ""
+
+    enriched_results = []
+    for item in results:
+        body = get_page_content(item["link"])
+        enriched_results.append(
+            {"title": item["title"], "link": item["link"], "snippet": item["snippet"], "body": body}
+        )
+        time.sleep(1)  # Be respectful to the servers
+
+    return enriched_results
+
+
+def analyze_stock(ticker: str) -> dict:  # type: ignore[type-arg]
+    import os
+    from datetime import datetime, timedelta
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+    import yfinance as yf
+    from pytz import timezone  # type: ignore
+
+    stock = yf.Ticker(ticker)
+
+    # Get historical data (1 year of data to ensure we have enough for 200-day MA)
+    end_date = datetime.now(timezone("UTC"))
+    start_date = end_date - timedelta(days=365)
+    hist = stock.history(start=start_date, end=end_date)
+
+    # Ensure we have data
+    if hist.empty:
+        return {"error": "No historical data available for the specified ticker."}
+
+    # Compute basic statistics and additional metrics
+    current_price = stock.info.get("currentPrice", hist["Close"].iloc[-1])
+    year_high = stock.info.get("fiftyTwoWeekHigh", hist["High"].max())
+    year_low = stock.info.get("fiftyTwoWeekLow", hist["Low"].min())
+
+    # Calculate 50-day and 200-day moving averages
+    ma_50 = hist["Close"].rolling(window=50).mean().iloc[-1]
+    ma_200 = hist["Close"].rolling(window=200).mean().iloc[-1]
+
+    # Calculate YTD price change and percent change
+    ytd_start = datetime(end_date.year, 1, 1, tzinfo=timezone("UTC"))
+    ytd_data = hist.loc[ytd_start:]  # type: ignore[misc]
+    if not ytd_data.empty:
+        price_change = ytd_data["Close"].iloc[-1] - ytd_data["Close"].iloc[0]
+        percent_change = (price_change / ytd_data["Close"].iloc[0]) * 100
+    else:
+        price_change = percent_change = np.nan
+
+    # Determine trend
+    if pd.notna(ma_50) and pd.notna(ma_200):
+        if ma_50 > ma_200:
+            trend = "Upward"
+        elif ma_50 < ma_200:
+            trend = "Downward"
+        else:
+            trend = "Neutral"
+    else:
+        trend = "Insufficient data for trend analysis"
+
+    # Calculate volatility (standard deviation of daily returns)
+    daily_returns = hist["Close"].pct_change().dropna()
+    volatility = daily_returns.std() * np.sqrt(252)  # Annualized volatility
+
+    # Create result dictionary
+    result = {
+        "ticker": ticker,
+        "current_price": current_price,
+        "52_week_high": year_high,
+        "52_week_low": year_low,
+        "50_day_ma": ma_50,
+        "200_day_ma": ma_200,
+        "ytd_price_change": price_change,
+        "ytd_percent_change": percent_change,
+        "trend": trend,
+        "volatility": volatility,
+    }
+
+    # Convert numpy types to Python native types for better JSON serialization
+    for key, value in result.items():
+        if isinstance(value, np.generic):
+            result[key] = value.item()
+
+    # Generate plot
+    plt.figure(figsize=(12, 6))
+    plt.plot(hist.index, hist["Close"], label="Close Price")
+    plt.plot(hist.index, hist["Close"].rolling(window=50).mean(), label="50-day MA")
+    plt.plot(hist.index, hist["Close"].rolling(window=200).mean(), label="200-day MA")
+    plt.title(f"{ticker} Stock Price (Past Year)")
+    plt.xlabel("Date")
+    plt.ylabel("Price ($)")
+    plt.legend()
+    plt.grid(True)
+
+    # Save plot to file
+    os.makedirs("coding", exist_ok=True)
+    plot_file_path = f"coding/{ticker}_stockprice.png"
+    plt.savefig(plot_file_path)
+    print(f"Plot saved as {plot_file_path}")
+    result["plot_file_path"] = plot_file_path
+
+    return result
+```
+
+```python
+google_search_tool = FunctionTool(
+    google_search, description="Search Google for information, returns results with a snippet and body content"
+)
+stock_analysis_tool = FunctionTool(analyze_stock, description="Analyze stock data and generate a plot")
+```
+
+## Defining Agents
+
+Next, we will define the agents that will perform the tasks. We will create a `search_agent` that searches the web for information about a company,  a `stock_analysis_agent` that retrieves stock information for a company, and a `report_agent` that generates a report based on the information collected by the other agents. 
+
+```python
+model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+search_agent = AssistantAgent(
+    name="Google_Search_Agent",
+    model_client=model_client,
+    tools=[google_search_tool],
+    description="Search Google for information, returns top 2 results with a snippet and body content",
+    system_message="You are a helpful AI assistant. Solve tasks using your tools.",
+)
+
+stock_analysis_agent = AssistantAgent(
+    name="Stock_Analysis_Agent",
+    model_client=model_client,
+    tools=[stock_analysis_tool],
+    description="Analyze stock data and generate a plot",
+    system_message="Perform data analysis.",
+)
+
+report_agent = AssistantAgent(
+    name="Report_Agent",
+    model_client=model_client,
+    description="Generate a report based the search and results of stock analysis",
+    system_message="You are a helpful assistant that can generate a comprehensive report on a given topic based on search and stock analysis. When you done with generating the report, reply with TERMINATE.",
+)
+```
+
+## Creating the Team
+
+Finally, let's create a team of the three agents and set them to work on researching a company.
+
+```python
+team = RoundRobinGroupChat([stock_analysis_agent, search_agent, report_agent], max_turns=3)
+```
+
+We use `max_turns=3` to limit the number of turns to exactly the same number of agents in the team. This effectively makes the agents work in a sequential manner.
+
+```python
+stream = team.run_stream(task="Write a financial report on American airlines")
+await Console(stream)
+
+await model_client.close()
+```
+
+---
+
+## Examples
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/examples/index.html
+
+# Examples
+
+A list of examples to help you get started with AgentChat.
+
+:::::{grid} 2 2 2 3
+
+::::{grid-item-card} Travel Planning
+:img-top: ../../../images/example-travel.jpeg
+:img-alt: travel planning example
+:link: ./travel-planning.html
+:link-alt: travel planning: Generating a travel plan using multiple agents.
+
+^^^
+Generating a travel plan using multiple agents.
+
+::::
+
+::::{grid-item-card} Company Research
+:img-top: ../../../images/example-company.jpg
+:img-alt: company research example
+:link: ./company-research.html
+:link-alt: company research: Generating a company research report using multiple agents with tools.
+
+^^^
+Generating a company research report using multiple agents with tools.
+
+::::
+
+::::{grid-item-card} Literature Review
+:img-top: ../../../images/example-literature.jpg
+:img-alt: literature review example
+:link: ./literature-review.html
+:link-alt: literature review: Generating a literature review using agents with tools.
+
+^^^
+Generating a literature review using agents with tools.
+
+::::
+
+:::::
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+travel-planning
+company-research
+literature-review
+
+```
+
+
+---
+
+## Literature Review
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/examples/literature-review.html
+
+# Literature Review
+
+A common task while exploring a new topic is to conduct a literature review. In this example we will explore how a multi-agent team can be configured to conduct a _simple_ literature review.
+
+- **Arxiv Search Agent**: Use the Arxiv API to search for papers related to a given topic and return results.
+- **Google Search Agent**: Use the Google Search api to find papers related to a given topic and return results.
+- **Report Agent**: Generate a report based on the information collected by the arxviv search and Google search agents.
+
+
+First, let us import the necessary modules. 
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_core.tools import FunctionTool
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+```
+
+## Defining Tools 
+
+Next, we will define the tools that the agents will use to perform their tasks. In this case we will define a simple function `search_arxiv` that will use the `arxiv` library to search for papers related to a given topic.  
+
+Finally, we will wrap the functions into a `FunctionTool` class that will allow us to use it as a tool in the agents. 
+
+Note: You will need to set the appropriate environment variables for tools as needed.
+
+Also install required libraries: 
+
+```bash
+!pip install arxiv
+```
+
+```python
+def google_search(query: str, num_results: int = 2, max_chars: int = 500) -> list:  # type: ignore[type-arg]
+    import os
+    import time
+
+    import requests
+    from bs4 import BeautifulSoup
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    api_key = os.getenv("GOOGLE_API_KEY")
+    search_engine_id = os.getenv("GOOGLE_SEARCH_ENGINE_ID")
+
+    if not api_key or not search_engine_id:
+        raise ValueError("API key or Search Engine ID not found in environment variables")
+
+    url = "https://www.googleapis.com/customsearch/v1"
+    params = {"key": api_key, "cx": search_engine_id, "q": query, "num": num_results}
+
+    response = requests.get(url, params=params)  # type: ignore[arg-type]
+
+    if response.status_code != 200:
+        print(response.json())
+        raise Exception(f"Error in API request: {response.status_code}")
+
+    results = response.json().get("items", [])
+
+    def get_page_content(url: str) -> str:
+        try:
+            response = requests.get(url, timeout=10)
+            soup = BeautifulSoup(response.content, "html.parser")
+            text = soup.get_text(separator=" ", strip=True)
+            words = text.split()
+            content = ""
+            for word in words:
+                if len(content) + len(word) + 1 > max_chars:
+                    break
+                content += " " + word
+            return content.strip()
+        except Exception as e:
+            print(f"Error fetching {url}: {str(e)}")
+            return ""
+
+    enriched_results = []
+    for item in results:
+        body = get_page_content(item["link"])
+        enriched_results.append(
+            {"title": item["title"], "link": item["link"], "snippet": item["snippet"], "body": body}
+        )
+        time.sleep(1)  # Be respectful to the servers
+
+    return enriched_results
+
+
+def arxiv_search(query: str, max_results: int = 2) -> list:  # type: ignore[type-arg]
+    """
+    Search Arxiv for papers and return the results including abstracts.
+    """
+    import arxiv
+
+    client = arxiv.Client()
+    search = arxiv.Search(query=query, max_results=max_results, sort_by=arxiv.SortCriterion.Relevance)
+
+    results = []
+    for paper in client.results(search):
+        results.append(
+            {
+                "title": paper.title,
+                "authors": [author.name for author in paper.authors],
+                "published": paper.published.strftime("%Y-%m-%d"),
+                "abstract": paper.summary,
+                "pdf_url": paper.pdf_url,
+            }
+        )
+
+    # # Write results to a file
+    # with open('arxiv_search_results.json', 'w') as f:
+    #     json.dump(results, f, indent=2)
+
+    return results
+```
+
+```python
+google_search_tool = FunctionTool(
+    google_search, description="Search Google for information, returns results with a snippet and body content"
+)
+arxiv_search_tool = FunctionTool(
+    arxiv_search, description="Search Arxiv for papers related to a given topic, including abstracts"
+)
+```
+
+## Defining Agents 
+
+Next, we will define the agents that will perform the tasks. 
+
+```python
+model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+
+google_search_agent = AssistantAgent(
+    name="Google_Search_Agent",
+    tools=[google_search_tool],
+    model_client=model_client,
+    description="An agent that can search Google for information, returns results with a snippet and body content",
+    system_message="You are a helpful AI assistant. Solve tasks using your tools.",
+)
+
+arxiv_search_agent = AssistantAgent(
+    name="Arxiv_Search_Agent",
+    tools=[arxiv_search_tool],
+    model_client=model_client,
+    description="An agent that can search Arxiv for papers related to a given topic, including abstracts",
+    system_message="You are a helpful AI assistant. Solve tasks using your tools. Specifically, you can take into consideration the user's request and craft a search query that is most likely to return relevant academi papers.",
+)
+
+
+report_agent = AssistantAgent(
+    name="Report_Agent",
+    model_client=model_client,
+    description="Generate a report based on a given topic",
+    system_message="You are a helpful assistant. Your task is to synthesize data extracted into a high quality literature review including CORRECT references. You MUST write a final report that is formatted as a literature review with CORRECT references.  Your response should end with the word 'TERMINATE'",
+)
+```
+
+## Creating the Team 
+
+Finally, we will create a team of agents and configure them to perform the tasks.
+
+```python
+termination = TextMentionTermination("TERMINATE")
+team = RoundRobinGroupChat(
+    participants=[google_search_agent, arxiv_search_agent, report_agent], termination_condition=termination
+)
+```
+
+```python
+await Console(
+    team.run_stream(
+        task="Write a literature review on no code tools for building multi agent ai systems",
+    )
+)
+
+await model_client.close()
+```
+
+---
+
+## Travel Planning
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/examples/travel-planning.html
+
+# Travel Planning 
+
+In this example, we'll walk through the process of creating a sophisticated travel planning system using AgentChat. Our travel planner will utilize multiple AI agents, each with a specific role, to collaboratively create a comprehensive travel itinerary.  
+
+First, let us import the necessary modules.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+```
+
+### Defining Agents 
+
+In the next section we will define the agents that will be used in the travel planning team.
+
+```python
+model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+planner_agent = AssistantAgent(
+    "planner_agent",
+    model_client=model_client,
+    description="A helpful assistant that can plan trips.",
+    system_message="You are a helpful assistant that can suggest a travel plan for a user based on their request.",
+)
+
+local_agent = AssistantAgent(
+    "local_agent",
+    model_client=model_client,
+    description="A local assistant that can suggest local activities or places to visit.",
+    system_message="You are a helpful assistant that can suggest authentic and interesting local activities or places to visit for a user and can utilize any context information provided.",
+)
+
+language_agent = AssistantAgent(
+    "language_agent",
+    model_client=model_client,
+    description="A helpful assistant that can provide language tips for a given destination.",
+    system_message="You are a helpful assistant that can review travel plans, providing feedback on important/critical tips about how best to address language or communication challenges for the given destination. If the plan already includes language tips, you can mention that the plan is satisfactory, with rationale.",
+)
+
+travel_summary_agent = AssistantAgent(
+    "travel_summary_agent",
+    model_client=model_client,
+    description="A helpful assistant that can summarize the travel plan.",
+    system_message="You are a helpful assistant that can take in all of the suggestions and advice from the other agents and provide a detailed final travel plan. You must ensure that the final plan is integrated and complete. YOUR FINAL RESPONSE MUST BE THE COMPLETE PLAN. When the plan is complete and all perspectives are integrated, you can respond with TERMINATE.",
+)
+```
+
+```python
+termination = TextMentionTermination("TERMINATE")
+group_chat = RoundRobinGroupChat(
+    [planner_agent, local_agent, language_agent, travel_summary_agent], termination_condition=termination
+)
+await Console(group_chat.run_stream(task="Plan a 3 day trip to Nepal."))
+
+await model_client.close()
+```
+
+---
+
+## GraphFlow (Workflows)
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/graph-flow.html
+
+# GraphFlow (Workflows)
+
+In this section you'll learn how to create an _multi-agent workflow_ using {py:class}`~autogen_agentchat.teams.GraphFlow`, or simply "flow" for short.
+It uses structured execution and precisely controls how agents interact to accomplish a task.
+
+We'll first show you how to create and run a flow. We'll then explain how to observe and debug flow behavior, 
+and discuss important operations for managing execution.
+
+AutoGen AgentChat provides a team for directed graph execution:
+
+- {py:class}`~autogen_agentchat.teams.GraphFlow`: A team that follows a {py:class}`~autogen_agentchat.teams.DiGraph`
+to control the execution flow between agents. 
+Supports sequential, parallel, conditional, and looping behaviors.
+
+```{note}
+**When should you use {py:class}`~autogen_agentchat.teams.GraphFlow`?**
+
+Use Graph when you need strict control over the order in which agents act, or when different outcomes must lead to different next steps.
+Start with a simple team such as {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` or {py:class}`~autogen_agentchat.teams.SelectorGroupChat`
+if ad-hoc conversation flow is sufficient. 
+Transition to a structured workflow when your task requires deterministic control,
+conditional branching, or handling complex multi-step processes with cycles.
+```
+
+> **Warning:** {py:class}`~autogen_agentchat.teams.GraphFlow` is an **experimental feature**. 
+Its API, behavior, and capabilities are **subject to change** in future releases.
+
+## Creating and Running a Flow
+
+{py:class}`~autogen_agentchat.teams.DiGraphBuilder` is a fluent utility that lets you easily construct execution graphs for workflows. It supports building:
+
+- Sequential chains
+- Parallel fan-outs
+- Conditional branching
+- Loops with safe exit conditions
+
+Each node in the graph represents an agent, and edges define the allowed execution paths. Edges can optionally have conditions based on agent messages.
+
+### Sequential Flow
+
+We will begin by creating a simple workflow where a **writer** drafts a paragraph and a **reviewer** provides feedback. This graph terminates after the reviewer comments on the writer. 
+
+Note, the flow automatically computes all the source and leaf nodes of the graph and the execution starts at all the source nodes in the graph and completes execution when no nodes are left to execute.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import DiGraphBuilder, GraphFlow
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Create an OpenAI model client
+client = OpenAIChatCompletionClient(model="gpt-4.1-nano")
+
+# Create the writer agent
+writer = AssistantAgent("writer", model_client=client, system_message="Draft a short paragraph on climate change.")
+
+# Create the reviewer agent
+reviewer = AssistantAgent("reviewer", model_client=client, system_message="Review the draft and suggest improvements.")
+
+# Build the graph
+builder = DiGraphBuilder()
+builder.add_node(writer).add_node(reviewer)
+builder.add_edge(writer, reviewer)
+
+# Build and validate the graph
+graph = builder.build()
+
+# Create the flow
+flow = GraphFlow([writer, reviewer], graph=graph)
+```
+
+```python
+# Use `asyncio.run(...)` and wrap the below in a async function when running in a script.
+stream = flow.run_stream(task="Write a short paragraph about climate change.")
+async for event in stream:  # type: ignore
+    print(event)
+# Use Console(flow.run_stream(...)) for better formatting in console.
+```
+
+### Parallel Flow with Join
+
+We now create a slightly more complex flow:
+
+- A **writer** drafts a paragraph.
+- Two **editors** independently edit for grammar and style (parallel fan-out).
+- A **final reviewer** consolidates their edits (join).
+
+Execution starts at the **writer**, fans out to **editor1** and **editor2** simultaneously, and then both feed into the **final reviewer**.
+
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import DiGraphBuilder, GraphFlow
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Create an OpenAI model client
+client = OpenAIChatCompletionClient(model="gpt-4.1-nano")
+
+# Create the writer agent
+writer = AssistantAgent("writer", model_client=client, system_message="Draft a short paragraph on climate change.")
+
+# Create two editor agents
+editor1 = AssistantAgent("editor1", model_client=client, system_message="Edit the paragraph for grammar.")
+
+editor2 = AssistantAgent("editor2", model_client=client, system_message="Edit the paragraph for style.")
+
+# Create the final reviewer agent
+final_reviewer = AssistantAgent(
+    "final_reviewer",
+    model_client=client,
+    system_message="Consolidate the grammar and style edits into a final version.",
+)
+
+# Build the workflow graph
+builder = DiGraphBuilder()
+builder.add_node(writer).add_node(editor1).add_node(editor2).add_node(final_reviewer)
+
+# Fan-out from writer to editor1 and editor2
+builder.add_edge(writer, editor1)
+builder.add_edge(writer, editor2)
+
+# Fan-in both editors into final reviewer
+builder.add_edge(editor1, final_reviewer)
+builder.add_edge(editor2, final_reviewer)
+
+# Build and validate the graph
+graph = builder.build()
+
+# Create the flow
+flow = GraphFlow(
+    participants=builder.get_participants(),
+    graph=graph,
+)
+
+# Run the workflow
+await Console(flow.run_stream(task="Write a short paragraph about climate change."))
+```
+
+## Message Filtering
+
+### Execution Graph vs. Message Graph
+
+In {py:class}`~autogen_agentchat.teams.GraphFlow`, the **execution graph** is defined using 
+{py:class}`~autogen_agentchat.teams.DiGraph`, which controls the order in which agents execute.
+However, the execution graph does not control what messages an agent receives from other agents.
+By default, all messages are sent to all agents in the graph.
+
+**Message filtering** is a separate feature that allows you to filter the messages
+received by each agent and limiting their model context to only the relevant information.
+The set of message filters defines the **message graph** in the flow.
+
+Specifying the message graph can help with:
+- Reduce hallucinations
+- Control memory load
+- Focus agents only on relevant information
+
+You can use {py:class}`~autogen_agentchat.agents.MessageFilterAgent` together with {py:class}`~autogen_agentchat.agents.MessageFilterConfig` and {py:class}`~autogen_agentchat.agents.PerSourceFilter` to define these rules.
+
+```python
+from autogen_agentchat.agents import AssistantAgent, MessageFilterAgent, MessageFilterConfig, PerSourceFilter
+from autogen_agentchat.teams import DiGraphBuilder, GraphFlow
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Model client
+client = OpenAIChatCompletionClient(model="gpt-4.1-nano")
+
+# Create agents
+researcher = AssistantAgent(
+    "researcher", model_client=client, system_message="Summarize key facts about climate change."
+)
+analyst = AssistantAgent("analyst", model_client=client, system_message="Review the summary and suggest improvements.")
+presenter = AssistantAgent(
+    "presenter", model_client=client, system_message="Prepare a presentation slide based on the final summary."
+)
+
+# Apply message filtering
+filtered_analyst = MessageFilterAgent(
+    name="analyst",
+    wrapped_agent=analyst,
+    filter=MessageFilterConfig(per_source=[PerSourceFilter(source="researcher", position="last", count=1)]),
+)
+
+filtered_presenter = MessageFilterAgent(
+    name="presenter",
+    wrapped_agent=presenter,
+    filter=MessageFilterConfig(per_source=[PerSourceFilter(source="analyst", position="last", count=1)]),
+)
+
+# Build the flow
+builder = DiGraphBuilder()
+builder.add_node(researcher).add_node(filtered_analyst).add_node(filtered_presenter)
+builder.add_edge(researcher, filtered_analyst).add_edge(filtered_analyst, filtered_presenter)
+
+# Create the flow
+flow = GraphFlow(
+    participants=builder.get_participants(),
+    graph=builder.build(),
+)
+
+# Run the flow
+await Console(flow.run_stream(task="Summarize key facts about climate change."))
+```
+
+## 🔁 Advanced Example: Conditional Loop + Filtered Summary
+
+This example demonstrates:
+
+- A loop between generator and reviewer (which exits when reviewer says "APPROVE")
+- A summarizer agent that only sees the first user input and the last reviewer message
+
+
+```python
+from autogen_agentchat.agents import AssistantAgent, MessageFilterAgent, MessageFilterConfig, PerSourceFilter
+from autogen_agentchat.teams import (
+    DiGraphBuilder,
+    GraphFlow,
+)
+from autogen_agentchat.conditions import MaxMessageTermination
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+
+# Agents
+generator = AssistantAgent("generator", model_client=model_client, system_message="Generate a list of creative ideas.")
+reviewer = AssistantAgent(
+    "reviewer",
+    model_client=model_client,
+    system_message="Review ideas and provide feedbacks, or just 'APPROVE' for final approval.",
+)
+summarizer_core = AssistantAgent(
+    "summary", model_client=model_client, system_message="Summarize the user request and the final feedback."
+)
+
+# Filtered summarizer
+filtered_summarizer = MessageFilterAgent(
+    name="summary",
+    wrapped_agent=summarizer_core,
+    filter=MessageFilterConfig(
+        per_source=[
+            PerSourceFilter(source="user", position="first", count=1),
+            PerSourceFilter(source="reviewer", position="last", count=1),
+        ]
+    ),
+)
+
+# Build graph with conditional loop
+builder = DiGraphBuilder()
+builder.add_node(generator).add_node(reviewer).add_node(filtered_summarizer)
+builder.add_edge(generator, reviewer)
+builder.add_edge(reviewer, filtered_summarizer, condition=lambda msg: "APPROVE" in msg.to_model_text())
+builder.add_edge(reviewer, generator, condition=lambda msg: "APPROVE" not in msg.to_model_text())
+builder.set_entry_point(generator)  # Set entry point to generator. Required if there are no source nodes.
+graph = builder.build()
+
+termination_condition = MaxMessageTermination(10)
+
+# Create the flow
+flow = GraphFlow(
+    participants=builder.get_participants(),
+    graph=graph,
+    termination_condition=termination_condition
+)
+
+# Run the flow and pretty print the output in the console
+await Console(flow.run_stream(task="Brainstorm ways to reduce plastic waste."))
+```
+
+## 🔁 Advanced Example: Cycles With Activation Group Examples
+
+The following examples demonstrate how to use `activation_group` and `activation_condition` to handle complex dependency patterns in cyclic graphs, especially when multiple paths lead to the same target node.
+
+### Example 1: Loop with Multiple Paths - "All" Activation (A→B→C→B)
+
+In this scenario, we have A → B → C → B, where B has two incoming edges (from A and from C). By default, B requires **all** its dependencies to be satisfied before executing.
+
+This example shows a review loop where both the initial input (A) and the feedback (C) must be processed before B can execute again.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import DiGraphBuilder, GraphFlow
+from autogen_agentchat.conditions import MaxMessageTermination
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Model client
+client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+
+# Create agents for A→B→C→B→E scenario
+agent_a = AssistantAgent("A", model_client=client, system_message="Start the process and provide initial input.")
+agent_b = AssistantAgent(
+    "B",
+    model_client=client,
+    system_message="Process input from A or feedback from C. Say 'CONTINUE' if it's from A or 'STOP' if it's from C.",
+)
+agent_c = AssistantAgent("C", model_client=client, system_message="Review B's output and provide feedback.")
+agent_e = AssistantAgent("E", model_client=client, system_message="Finalize the process.")
+
+# Build the graph with activation groups
+builder = DiGraphBuilder()
+builder.add_node(agent_a).add_node(agent_b).add_node(agent_c).add_node(agent_e)
+
+# A → B (initial path)
+builder.add_edge(agent_a, agent_b, activation_group="initial")
+
+# B → C
+builder.add_edge(agent_b, agent_c, condition="CONTINUE")
+
+# C → B (loop back - different activation group)
+builder.add_edge(agent_c, agent_b, activation_group="feedback")
+
+# B → E (exit condition)
+builder.add_edge(agent_b, agent_e, condition="STOP")
+
+termination_condition = MaxMessageTermination(10)
+# Build and create flow
+graph = builder.build()
+flow = GraphFlow(participants=[agent_a, agent_b, agent_c, agent_e], graph=graph, termination_condition=termination_condition)
+
+print("=== Example 1: A→B→C→B with 'All' Activation ===")
+print("B will exit when it receives a message from C")
+# await Console(flow.run_stream(task="Start a review process for a document."))
+```
+
+### Example 2: Loop with Multiple Paths - "Any" Activation (A→B→(C1,C2)→B)
+
+In this more complex scenario, we have A → B → (C1, C2) → B, where:
+- B fans out to both C1 and C2 in parallel
+- Both C1 and C2 feed back to B 
+- B uses "any" activation, meaning it executes as soon as **either** C1 or C2 completes
+
+This is useful for scenarios where you want the fastest response to trigger the next step.
+
+
+```python
+# Create agents for A→B→(C1,C2)→B scenario
+agent_a2 = AssistantAgent("A", model_client=client, system_message="Initiate a task that needs parallel processing.")
+agent_b2 = AssistantAgent(
+    "B",
+    model_client=client,
+    system_message="Coordinate parallel tasks. Say 'PROCESS' to start parallel work or 'DONE' to finish.",
+)
+agent_c1 = AssistantAgent("C1", model_client=client, system_message="Handle task type 1. Say 'C1_COMPLETE' when done.")
+agent_c2 = AssistantAgent("C2", model_client=client, system_message="Handle task type 2. Say 'C2_COMPLETE' when done.")
+agent_e = AssistantAgent("E", model_client=client, system_message="Finalize the process.")
+
+# Build the graph with "any" activation
+builder2 = DiGraphBuilder()
+builder2.add_node(agent_a2).add_node(agent_b2).add_node(agent_c1).add_node(agent_c2).add_node(agent_e)
+
+# A → B (initial)
+builder2.add_edge(agent_a2, agent_b2)
+
+# B → C1 and B → C2 (parallel fan-out)
+builder2.add_edge(agent_b2, agent_c1, condition="PROCESS")
+builder2.add_edge(agent_b2, agent_c2, condition="PROCESS")
+
+# B → E (exit condition)
+builder2.add_edge(agent_b2, agent_e, condition=lambda msg: "DONE" in msg.to_model_text())
+
+# C1 → B and C2 → B (both in same activation group with "any" condition)
+builder2.add_edge(
+    agent_c1, agent_b2, activation_group="loop_back_group", activation_condition="any", condition="C1_COMPLETE"
+)
+
+builder2.add_edge(
+    agent_c2, agent_b2, activation_group="loop_back_group", activation_condition="any", condition="C2_COMPLETE"
+)
+
+# Build and create flow
+graph2 = builder2.build()
+flow2 = GraphFlow(participants=[agent_a2, agent_b2, agent_c1, agent_c2, agent_e], graph=graph2)
+
+print("=== Example 2: A→B→(C1,C2)→B with 'Any' Activation ===")
+print("B will execute as soon as EITHER C1 OR C2 completes (whichever finishes first)")
+# await Console(flow2.run_stream(task="Start a parallel processing task."))
+```
+
+### Example 3: Mixed Activation Groups
+
+This example shows how different activation groups can coexist in the same graph. We have a scenario where:
+- Node D receives inputs from multiple sources with different activation requirements
+- Some dependencies use "all" activation (must wait for all inputs)
+- Other dependencies use "any" activation (proceed on first input)
+
+This pattern is useful for complex workflows where different types of dependencies have different urgency levels.
+
+
+```python
+# Create agents for mixed activation scenario
+agent_a3 = AssistantAgent("A", model_client=client, system_message="Provide critical input that must be processed.")
+agent_b3 = AssistantAgent("B", model_client=client, system_message="Provide secondary critical input.")
+agent_c3 = AssistantAgent("C", model_client=client, system_message="Provide optional quick input.")
+agent_d3 = AssistantAgent("D", model_client=client, system_message="Process inputs based on different priority levels.")
+
+# Build graph with mixed activation groups
+builder3 = DiGraphBuilder()
+builder3.add_node(agent_a3).add_node(agent_b3).add_node(agent_c3).add_node(agent_d3)
+
+# Critical inputs that must ALL be present (activation_group="critical", activation_condition="all")
+builder3.add_edge(agent_a3, agent_d3, activation_group="critical", activation_condition="all")
+builder3.add_edge(agent_b3, agent_d3, activation_group="critical", activation_condition="all")
+
+# Optional input that can trigger execution on its own (activation_group="optional", activation_condition="any")
+builder3.add_edge(agent_c3, agent_d3, activation_group="optional", activation_condition="any")
+
+# Build and create flow
+graph3 = builder3.build()
+flow3 = GraphFlow(participants=[agent_a3, agent_b3, agent_c3, agent_d3], graph=graph3)
+
+print("=== Example 3: Mixed Activation Groups ===")
+print("D will execute when:")
+print("- BOTH A AND B complete (critical group with 'all' activation), OR")
+print("- C completes (optional group with 'any' activation)")
+print("This allows for both required dependencies and fast-path triggers.")
+# await Console(flow3.run_stream(task="Process inputs with mixed priority levels."))
+```
+
+### Key Takeaways for Activation Groups
+
+1. **`activation_group`**: Groups edges that point to the same target node, allowing you to define different dependency patterns.
+
+2. **`activation_condition`**: 
+   - `"all"` (default): Target node waits for ALL edges in the group to be satisfied
+   - `"any"`: Target node executes as soon as ANY edge in the group is satisfied
+
+3. **Use Cases**:
+   - **Cycles with multiple entry points**: Different activation groups prevent conflicts
+   - **Priority-based execution**: Mix "all" and "any" conditions for different urgency levels  
+   - **Parallel processing with early termination**: Use "any" to proceed with the fastest result
+
+4. **Best Practices**:
+   - Use descriptive group names (`"critical"`, `"optional"`, `"feedback"`, etc.)
+   - Keep activation conditions consistent within the same group
+   - Test your graph logic with different execution paths
+
+These patterns enable sophisticated workflow control while maintaining clear, understandable execution semantics.
+
+---
+
+## Installation
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/installation.html
+
+# Installation
+
+## Create a Virtual Environment (optional)
+
+When installing AgentChat locally, we recommend using a virtual environment for the installation. This will ensure that the dependencies for AgentChat are isolated from the rest of your system.
+
+``````{tab-set}
+
+`````{tab-item} venv
+
+Create and activate:
+
+Linux/Mac:
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Windows command-line:
+```batch
+# The command may be `python3` instead of `python` depending on your setup
+python -m venv .venv
+.venv\Scripts\activate.bat
+```
+
+To deactivate later, run:
+
+```bash
+deactivate
+```
+
+`````
+
+`````{tab-item} conda
+
+[Install Conda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html) if you have not already.
+
+
+Create and activate:
+
+```bash
+conda create -n autogen python=3.12
+conda activate autogen
+```
+
+To deactivate later, run:
+
+```bash
+conda deactivate
+```
+
+
+`````
+
+
+
+``````
+
+## Install Using pip
+
+Install the `autogen-agentchat` package using pip:
+
+```bash
+
+pip install -U "autogen-agentchat"
+```
+
+```{note}
+Python 3.10 or later is required.
+```
+
+## Install OpenAI for Model Client
+
+To use the OpenAI and Azure OpenAI models, you need to install the following
+extensions:
+
+```bash
+pip install "autogen-ext[openai]"
+```
+
+If you are using Azure OpenAI with AAD authentication, you need to install the following:
+
+```bash
+pip install "autogen-ext[azure]"
+```
+
+
+---
+
+## Logging
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/logging.html
+
+# Logging
+
+AutoGen uses Python's built-in [`logging`](https://docs.python.org/3/library/logging.html) module.
+
+To enable logging for AgentChat, you can use the following code:
+
+```python
+import logging
+
+from autogen_agentchat import EVENT_LOGGER_NAME, TRACE_LOGGER_NAME
+
+logging.basicConfig(level=logging.WARNING)
+
+# For trace logging.
+trace_logger = logging.getLogger(TRACE_LOGGER_NAME)
+trace_logger.addHandler(logging.StreamHandler())
+trace_logger.setLevel(logging.DEBUG)
+
+# For structured message logging, such as low-level messages between agents.
+event_logger = logging.getLogger(EVENT_LOGGER_NAME)
+event_logger.addHandler(logging.StreamHandler())
+event_logger.setLevel(logging.DEBUG)
+```
+
+To enable additional logs such as model client calls and agent runtime events,
+please refer to the [Core Logging Guide](../core-user-guide/framework/logging.md).
+
+---
+
+## Magentic-One
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/magentic-one.html
+
+# Magentic-One
+
+[Magentic-One](https://aka.ms/magentic-one-blog) is a generalist multi-agent system for solving open-ended web and file-based tasks across a variety of domains. It represents a significant step forward for multi-agent systems, achieving competitive performance on a number of agentic benchmarks (see the [technical report](https://arxiv.org/abs/2411.04468) for full details).
+
+When originally released in [November 2024](https://aka.ms/magentic-one-blog) Magentic-One was [implemented directly on the `autogen-core` library](https://github.com/microsoft/autogen/tree/v0.4.4/python/packages/autogen-magentic-one). We have now ported Magentic-One to use `autogen-agentchat`, providing a more modular and easier to use interface.
+
+To this end, the Magentic-One orchestrator {py:class}`~autogen_agentchat.teams.MagenticOneGroupChat` is now simply an AgentChat team, supporting all standard AgentChat agents and features. Likewise, Magentic-One's {py:class}`~autogen_ext.agents.web_surfer.MultimodalWebSurfer`, {py:class}`~autogen_ext.agents.file_surfer.FileSurfer`, and {py:class}`~autogen_ext.agents.magentic_one.MagenticOneCoderAgent` agents are now broadly available as AgentChat agents, to be used in any AgentChat workflows.
+
+Lastly, there is a helper class, {py:class}`~autogen_ext.teams.magentic_one.MagenticOne`, which bundles all of this together as it was in the paper with minimal configuration.
+
+Find additional information about Magentic-one in our [blog post](https://aka.ms/magentic-one-blog) and [technical report](https://arxiv.org/abs/2411.04468).
+
+![Autogen Magentic-One example](../../images/autogen-magentic-one-example.png)
+
+**Example**: The figure above illustrates Magentic-One multi-agent team completing a complex task from the GAIA benchmark. Magentic-One's Orchestrator agent creates a plan, delegates tasks to other agents, and tracks progress towards the goal, dynamically revising the plan as needed. The Orchestrator can delegate tasks to a FileSurfer agent to read and handle files, a WebSurfer agent to operate a web browser, or a Coder or Computer Terminal agent to write or execute code, respectively.
+
+```{caution}
+Using Magentic-One involves interacting with a digital world designed for humans, which carries inherent risks. To minimize these risks, consider the following precautions:
+
+1. **Use Containers**: Run all tasks in docker containers to isolate the agents and prevent direct system attacks.
+2. **Virtual Environment**: Use a virtual environment to run the agents and prevent them from accessing sensitive data.
+3. **Monitor Logs**: Closely monitor logs during and after execution to detect and mitigate risky behavior.
+4. **Human Oversight**: Run the examples with a human in the loop to supervise the agents and prevent unintended consequences.
+5. **Limit Access**: Restrict the agents' access to the internet and other resources to prevent unauthorized actions.
+6. **Safeguard Data**: Ensure that the agents do not have access to sensitive data or resources that could be compromised. Do not share sensitive information with the agents.
+Be aware that agents may occasionally attempt risky actions, such as recruiting humans for help or accepting cookie agreements without human involvement. Always ensure agents are monitored and operate within a controlled environment to prevent unintended consequences. Moreover, be cautious that Magentic-One may be susceptible to prompt injection attacks from webpages.
+```
+
+## Getting started
+
+Install the required packages:
+
+```bash
+pip install "autogen-agentchat" "autogen-ext[magentic-one,openai]"
+
+# If using the MultimodalWebSurfer, you also need to install playwright dependencies:
+playwright install --with-deps chromium
+```
+
+If you haven't done so already, go through the AgentChat tutorial to learn about the concepts of AgentChat.
+
+Then, you can try swapping out a {py:class}`autogen_agentchat.teams.SelectorGroupChat` with {py:class}`~autogen_agentchat.teams.MagenticOneGroupChat`.
+
+For example:
+
+```python
+import asyncio
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import MagenticOneGroupChat
+from autogen_agentchat.ui import Console
+
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+    assistant = AssistantAgent(
+        "Assistant",
+        model_client=model_client,
+    )
+    team = MagenticOneGroupChat([assistant], model_client=model_client)
+    await Console(team.run_stream(task="Provide a different proof for Fermat's Last Theorem"))
+    await model_client.close()
+
+
+asyncio.run(main())
+```
+
+To use a different model, see [Models](./tutorial/models.ipynb) for more information.
+
+Or, use the Magentic-One agents in a team:
+
+```{caution}
+The example code may download files from the internet, execute code, and interact with web pages. Ensure you are in a safe environment before running the example code.
+```
+
+```python
+import asyncio
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_agentchat.teams import MagenticOneGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.agents.web_surfer import MultimodalWebSurfer
+# from autogen_ext.agents.file_surfer import FileSurfer
+# from autogen_ext.agents.magentic_one import MagenticOneCoderAgent
+# from autogen_agentchat.agents import CodeExecutorAgent
+# from autogen_ext.code_executors.local import LocalCommandLineCodeExecutor
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+    surfer = MultimodalWebSurfer(
+        "WebSurfer",
+        model_client=model_client,
+    )
+
+    team = MagenticOneGroupChat([surfer], model_client=model_client)
+    await Console(team.run_stream(task="What is the UV index in Melbourne today?"))
+
+    # # Note: you can also use  other agents in the team
+    # team = MagenticOneGroupChat([surfer, file_surfer, coder, terminal], model_client=model_client)
+    # file_surfer = FileSurfer( "FileSurfer",model_client=model_client)
+    # coder = MagenticOneCoderAgent("Coder",model_client=model_client)
+    # terminal = CodeExecutorAgent("ComputerTerminal",code_executor=LocalCommandLineCodeExecutor())
+
+
+asyncio.run(main())
+```
+
+Or, use the {py:class}`~autogen_ext.teams.magentic_one.MagenticOne` helper class
+with all the agents bundled together:
+
+```python
+import asyncio
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.teams.magentic_one import MagenticOne
+from autogen_agentchat.ui import Console
+from autogen_agentchat.agents import ApprovalRequest, ApprovalResponse
+
+
+def approval_func(request: ApprovalRequest) -> ApprovalResponse:
+    """Simple approval function that requests user input before code execution."""
+    print(f"Code to execute:\n{request.code}")
+    user_input = input("Do you approve this code execution? (y/n): ").strip().lower()
+    if user_input == 'y':
+        return ApprovalResponse(approved=True, reason="User approved the code execution")
+    else:
+        return ApprovalResponse(approved=False, reason="User denied the code execution")
+
+
+async def example_usage():
+    client = OpenAIChatCompletionClient(model="gpt-4o")
+    # Enable code execution approval for security
+    m1 = MagenticOne(client=client, approval_func=approval_func)
+    task = "Write a Python script to fetch data from an API."
+    result = await Console(m1.run_stream(task=task))
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(example_usage())
+```
+
+## Architecture
+
+![Autogen Magentic-One architecture](../../images/autogen-magentic-one-agents.png)
+
+Magentic-One work is based on a multi-agent architecture where a lead Orchestrator agent is responsible for high-level planning, directing other agents and tracking task progress. The Orchestrator begins by creating a plan to tackle the task, gathering needed facts and educated guesses in a Task Ledger that is maintained. At each step of its plan, the Orchestrator creates a Progress Ledger where it self-reflects on task progress and checks whether the task is completed. If the task is not yet completed, it assigns one of Magentic-One other agents a subtask to complete. After the assigned agent completes its subtask, the Orchestrator updates the Progress Ledger and continues in this way until the task is complete. If the Orchestrator finds that progress is not being made for enough steps, it can update the Task Ledger and create a new plan. This is illustrated in the figure above; the Orchestrator work is thus divided into an outer loop where it updates the Task Ledger and an inner loop to update the Progress Ledger.
+
+Overall, Magentic-One consists of the following agents:
+
+- Orchestrator: the lead agent responsible for task decomposition and planning, directing other agents in executing subtasks, tracking overall progress, and taking corrective actions as needed
+- WebSurfer: This is an LLM-based agent that is proficient in commanding and managing the state of a Chromium-based web browser. With each incoming request, the WebSurfer performs an action on the browser then reports on the new state of the web page The action space of the WebSurfer includes navigation (e.g. visiting a URL, performing a web search); web page actions (e.g., clicking and typing); and reading actions (e.g., summarizing or answering questions). The WebSurfer relies on the accessibility tree of the browser and on set-of-marks prompting to perform its actions.
+- FileSurfer: This is an LLM-based agent that commands a markdown-based file preview application to read local files of most types. The FileSurfer can also perform common navigation tasks such as listing the contents of directories and navigating a folder structure.
+- Coder: This is an LLM-based agent specialized through its system prompt for writing code, analyzing information collected from the other agents, or creating new artifacts.
+- ComputerTerminal: Finally, ComputerTerminal provides the team with access to a console shell where the Coder’s programs can be executed, and where new programming libraries can be installed.
+
+Together, Magentic-One’s agents provide the Orchestrator with the tools and capabilities that it needs to solve a broad variety of open-ended problems, as well as the ability to autonomously adapt to, and act in, dynamic and ever-changing web and file-system environments.
+
+While the default multimodal LLM we use for all agents is GPT-4o, Magentic-One is model agnostic and can incorporate heterogonous models to support different capabilities or meet different cost requirements when getting tasks done. For example, it can use different LLMs and SLMs and their specialized versions to power different agents. We recommend a strong reasoning model for the Orchestrator agent such as GPT-4o. In a different configuration of Magentic-One, we also experiment with using OpenAI o1-preview for the outer loop of the Orchestrator and for the Coder, while other agents continue to use GPT-4o.
+
+## Citation
+
+```
+
+@misc{fourney2024magenticonegeneralistmultiagentsolving,
+      title={Magentic-One: A Generalist Multi-Agent System for Solving Complex Tasks},
+      author={Adam Fourney and Gagan Bansal and Hussein Mozannar and Cheng Tan and Eduardo Salinas and Erkang and Zhu and Friederike Niedtner and Grace Proebsting and Griffin Bassman and Jack Gerrits and Jacob Alber and Peter Chang and Ricky Loynd and Robert West and Victor Dibia and Ahmed Awadallah and Ece Kamar and Rafah Hosn and Saleema Amershi},
+      year={2024},
+      eprint={2411.04468},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      url={https://arxiv.org/abs/2411.04468},
+}
+
+```
+
+
+---
+
+## Initialize user memory
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/memory.html
+
+## Memory and RAG
+
+There are several use cases where it is valuable to maintain a _store_ of useful facts that can be intelligently added to the context of the agent just before a specific step. The typically use case here is a RAG pattern where a query is used to retrieve relevant information from a database that is then added to the agent's context.
+
+
+AgentChat provides a {py:class}`~autogen_core.memory.Memory` protocol that can be extended to provide this functionality.  The key methods are `query`, `update_context`,  `add`, `clear`, and `close`. 
+
+- `add`: add new entries to the memory store
+- `query`: retrieve relevant information from the memory store 
+- `update_context`: mutate an agent's internal `model_context` by adding the retrieved information (used in the {py:class}`~autogen_agentchat.agents.AssistantAgent` class) 
+- `clear`: clear all entries from the memory store
+- `close`: clean up any resources used by the memory store  
+
+
+## ListMemory Example
+
+{py:class}`~autogen_core.memory.ListMemory` is provided as an example implementation of the {py:class}`~autogen_core.memory.Memory` protocol. It is a simple list-based memory implementation that maintains memories in chronological order, appending the most recent memories to the model's context. The implementation is designed to be straightforward and predictable, making it easy to understand and debug.
+In the following example, we will use ListMemory to maintain a memory bank of user preferences and demonstrate how it can be used to provide consistent context for agent responses over time.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_core.memory import ListMemory, MemoryContent, MemoryMimeType
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+```
+
+```python
+# Initialize user memory
+user_memory = ListMemory()
+
+# Add user preferences to memory
+await user_memory.add(MemoryContent(content="The weather should be in metric units", mime_type=MemoryMimeType.TEXT))
+
+await user_memory.add(MemoryContent(content="Meal recipe must be vegan", mime_type=MemoryMimeType.TEXT))
+
+
+async def get_weather(city: str, units: str = "imperial") -> str:
+    if units == "imperial":
+        return f"The weather in {city} is 73 °F and Sunny."
+    elif units == "metric":
+        return f"The weather in {city} is 23 °C and Sunny."
+    else:
+        return f"Sorry, I don't know the weather in {city}."
+
+
+assistant_agent = AssistantAgent(
+    name="assistant_agent",
+    model_client=OpenAIChatCompletionClient(
+        model="gpt-4o-2024-08-06",
+    ),
+    tools=[get_weather],
+    memory=[user_memory],
+)
+```
+
+```python
+# Run the agent with a task.
+stream = assistant_agent.run_stream(task="What is the weather in New York?")
+await Console(stream)
+```
+
+We can inspect that the `assistant_agent` model_context is actually updated with the retrieved memory entries.  The `transform` method is used to format the retrieved memory entries into a string that can be used by the agent.  In this case, we simply concatenate the content of each memory entry into a single string.
+
+```python
+await assistant_agent._model_context.get_messages()
+```
+
+We see above that the weather is returned in Centigrade as stated in the user preferences. 
+
+Similarly, assuming we ask a separate question about generating a meal plan, the agent is able to retrieve relevant information from the memory store and provide a personalized (vegan) response.
+
+```python
+stream = assistant_agent.run_stream(task="Write brief meal recipe with broth")
+await Console(stream)
+```
+
+## Custom Memory Stores (Vector DBs, etc.)
+
+You can build on the `Memory` protocol to implement more complex memory stores. For example, you could implement a custom memory store that uses a vector database to store and retrieve information, or a memory store that uses a machine learning model to generate personalized responses based on the user's preferences etc.
+
+Specifically, you will need to overload the `add`, `query` and `update_context`  methods to implement the desired functionality and pass the memory store to your agent.
+
+
+Currently the following example memory stores are available as part of the {py:class}`~autogen_ext` extensions package.
+
+- `autogen_ext.memory.chromadb.ChromaDBVectorMemory`: A memory store that uses a vector database to store and retrieve information.
+
+- `autogen_ext.memory.chromadb.SentenceTransformerEmbeddingFunctionConfig`: A configuration class for the SentenceTransformer embedding function used by the `ChromaDBVectorMemory` store. Note that other embedding functions such as `autogen_ext.memory.openai.OpenAIEmbeddingFunctionConfig` can also be used with the `ChromaDBVectorMemory` store.
+
+- `autogen_ext.memory.redis.RedisMemory`: A memory store that uses a Redis vector database to store and retrieve information.
+
+
+```python
+import tempfile
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_core.memory import MemoryContent, MemoryMimeType
+from autogen_ext.memory.chromadb import (
+    ChromaDBVectorMemory,
+    PersistentChromaDBVectorMemoryConfig,
+    SentenceTransformerEmbeddingFunctionConfig,
+)
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Use a temporary directory for ChromaDB persistence
+with tempfile.TemporaryDirectory() as tmpdir:
+    chroma_user_memory = ChromaDBVectorMemory(
+        config=PersistentChromaDBVectorMemoryConfig(
+            collection_name="preferences",
+            persistence_path=tmpdir,  # Use the temp directory here
+            k=2,  # Return top k results
+            score_threshold=0.4,  # Minimum similarity score
+            embedding_function_config=SentenceTransformerEmbeddingFunctionConfig(
+                model_name="all-MiniLM-L6-v2"  # Use default model for testing
+            ),
+        )
+    )
+    # Add user preferences to memory
+    await chroma_user_memory.add(
+        MemoryContent(
+            content="The weather should be in metric units",
+            mime_type=MemoryMimeType.TEXT,
+            metadata={"category": "preferences", "type": "units"},
+        )
+    )
+
+    await chroma_user_memory.add(
+        MemoryContent(
+            content="Meal recipe must be vegan",
+            mime_type=MemoryMimeType.TEXT,
+            metadata={"category": "preferences", "type": "dietary"},
+        )
+    )
+
+    model_client = OpenAIChatCompletionClient(
+        model="gpt-4o",
+    )
+
+    # Create assistant agent with ChromaDB memory
+    assistant_agent = AssistantAgent(
+        name="assistant_agent",
+        model_client=model_client,
+        tools=[get_weather],
+        memory=[chroma_user_memory],
+    )
+
+    stream = assistant_agent.run_stream(task="What is the weather in New York?")
+    await Console(stream)
+
+    await model_client.close()
+    await chroma_user_memory.close()
+```
+
+Note that you can also serialize the ChromaDBVectorMemory and save it to disk.
+
+```python
+chroma_user_memory.dump_component().model_dump_json()
+```
+
+### Redis Memory
+You can perform the same persistent memory storage using Redis. Note, you will need to have a running Redis instance to connect to.
+
+See {py:class}`~autogen_ext.memory.redis.RedisMemory` for instructions to run Redis locally or via Docker.
+
+```python
+from logging import WARNING, getLogger
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_core.memory import MemoryContent, MemoryMimeType
+from autogen_ext.memory.redis import RedisMemory, RedisMemoryConfig
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+logger = getLogger()
+logger.setLevel(WARNING)
+
+# Initailize Redis memory
+redis_memory = RedisMemory(
+    config=RedisMemoryConfig(
+        redis_url="redis://localhost:6379",
+        index_name="chat_history",
+        prefix="memory",
+    )
+)
+
+# Add user preferences to memory
+await redis_memory.add(
+    MemoryContent(
+        content="The weather should be in metric units",
+        mime_type=MemoryMimeType.TEXT,
+        metadata={"category": "preferences", "type": "units"},
+    )
+)
+
+await redis_memory.add(
+    MemoryContent(
+        content="Meal recipe must be vegan",
+        mime_type=MemoryMimeType.TEXT,
+        metadata={"category": "preferences", "type": "dietary"},
+    )
+)
+
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+)
+
+# Create assistant agent with ChromaDB memory
+assistant_agent = AssistantAgent(
+    name="assistant_agent",
+    model_client=model_client,
+    tools=[get_weather],
+    memory=[redis_memory],
+)
+
+stream = assistant_agent.run_stream(task="What is the weather in New York?")
+await Console(stream)
+
+await model_client.close()
+await redis_memory.close()
+```
+
+## RAG Agent: Putting It All Together
+
+The RAG (Retrieval Augmented Generation) pattern which is common in building AI systems encompasses two distinct phases:
+
+1. **Indexing**: Loading documents, chunking them, and storing them in a vector database
+2. **Retrieval**: Finding and using relevant chunks during conversation runtime
+
+In our previous examples, we manually added items to memory and passed them to our agents. In practice, the indexing process is usually automated and based on much larger document sources like product documentation, internal files, or knowledge bases.
+
+> Note: The quality of a RAG system is dependent on the quality of the chunking and retrieval process (models, embeddings, etc.). You may need to experiement with more advanced chunking and retrieval models to get the best results.
+
+### Building a Simple RAG Agent
+
+To begin, let's create a simple document indexer that we will used to load documents, chunk them, and store them in a `ChromaDBVectorMemory` memory store. 
+
+```python
+import re
+from typing import List
+
+import aiofiles
+import aiohttp
+from autogen_core.memory import Memory, MemoryContent, MemoryMimeType
+
+
+class SimpleDocumentIndexer:
+    """Basic document indexer for AutoGen Memory."""
+
+    def __init__(self, memory: Memory, chunk_size: int = 1500) -> None:
+        self.memory = memory
+        self.chunk_size = chunk_size
+
+    async def _fetch_content(self, source: str) -> str:
+        """Fetch content from URL or file."""
+        if source.startswith(("http://", "https://")):
+            async with aiohttp.ClientSession() as session:
+                async with session.get(source) as response:
+                    return await response.text()
+        else:
+            async with aiofiles.open(source, "r", encoding="utf-8") as f:
+                return await f.read()
+
+    def _strip_html(self, text: str) -> str:
+        """Remove HTML tags and normalize whitespace."""
+        text = re.sub(r"<[^>]*>", " ", text)
+        text = re.sub(r"\s+", " ", text)
+        return text.strip()
+
+    def _split_text(self, text: str) -> List[str]:
+        """Split text into fixed-size chunks."""
+        chunks: list[str] = []
+        # Just split text into fixed-size chunks
+        for i in range(0, len(text), self.chunk_size):
+            chunk = text[i : i + self.chunk_size]
+            chunks.append(chunk.strip())
+        return chunks
+
+    async def index_documents(self, sources: List[str]) -> int:
+        """Index documents into memory."""
+        total_chunks = 0
+
+        for source in sources:
+            try:
+                content = await self._fetch_content(source)
+
+                # Strip HTML if content appears to be HTML
+                if "<" in content and ">" in content:
+                    content = self._strip_html(content)
+
+                chunks = self._split_text(content)
+
+                for i, chunk in enumerate(chunks):
+                    await self.memory.add(
+                        MemoryContent(
+                            content=chunk, mime_type=MemoryMimeType.TEXT, metadata={"source": source, "chunk_index": i}
+                        )
+                    )
+
+                total_chunks += len(chunks)
+
+            except Exception as e:
+                print(f"Error indexing {source}: {str(e)}")
+
+        return total_chunks
+```
+
+
+ 
+Now let's use our indexer with ChromaDBVectorMemory to build a complete RAG agent:
+
+
+```python
+import os
+from pathlib import Path
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_ext.memory.chromadb import ChromaDBVectorMemory, PersistentChromaDBVectorMemoryConfig
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Initialize vector memory
+
+rag_memory = ChromaDBVectorMemory(
+    config=PersistentChromaDBVectorMemoryConfig(
+        collection_name="autogen_docs",
+        persistence_path=os.path.join(str(Path.home()), ".chromadb_autogen"),
+        k=3,  # Return top 3 results
+        score_threshold=0.4,  # Minimum similarity score
+    )
+)
+
+await rag_memory.clear()  # Clear existing memory
+
+
+# Index AutoGen documentation
+async def index_autogen_docs() -> None:
+    indexer = SimpleDocumentIndexer(memory=rag_memory)
+    sources = [
+        "https://raw.githubusercontent.com/microsoft/autogen/main/README.md",
+        "https://microsoft.github.io/autogen/dev/user-guide/agentchat-user-guide/tutorial/agents.html",
+        "https://microsoft.github.io/autogen/dev/user-guide/agentchat-user-guide/tutorial/teams.html",
+        "https://microsoft.github.io/autogen/dev/user-guide/agentchat-user-guide/tutorial/termination.html",
+    ]
+    chunks: int = await indexer.index_documents(sources)
+    print(f"Indexed {chunks} chunks from {len(sources)} AutoGen documents")
+
+
+await index_autogen_docs()
+```
+
+```python
+# Create our RAG assistant agent
+rag_assistant = AssistantAgent(
+    name="rag_assistant", model_client=OpenAIChatCompletionClient(model="gpt-4o"), memory=[rag_memory]
+)
+
+# Ask questions about AutoGen
+stream = rag_assistant.run_stream(task="What is AgentChat?")
+await Console(stream)
+
+# Remember to close the memory when done
+await rag_memory.close()
+```
+
+This implementation provides a RAG agent that can answer questions based on AutoGen documentation. When a question is asked, the Memory system  retrieves relevant chunks and adds them to the context, enabling the assistant to generate informed responses.
+
+For production systems, you might want to:
+1. Implement more sophisticated chunking strategies
+2. Add metadata filtering capabilities
+3. Customize the retrieval scoring
+4. Optimize embedding models for your specific domain
+
+
+## Mem0Memory Example
+
+`autogen_ext.memory.mem0.Mem0Memory` provides integration with `Mem0.ai`'s memory system. It supports both cloud-based and local backends, offering advanced memory capabilities for agents. The implementation handles proper retrieval and context updating, making it suitable for production environments.
+
+In the following example, we'll demonstrate how to use `Mem0Memory` to maintain persistent memories across conversations:
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_core.memory import MemoryContent, MemoryMimeType
+from autogen_ext.memory.mem0 import Mem0Memory
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Initialize Mem0 cloud memory (requires API key)
+# For local deployment, use is_cloud=False with appropriate config
+mem0_memory = Mem0Memory(
+    is_cloud=True,
+    limit=5,  # Maximum number of memories to retrieve
+)
+
+# Add user preferences to memory
+await mem0_memory.add(
+    MemoryContent(
+        content="The weather should be in metric units",
+        mime_type=MemoryMimeType.TEXT,
+        metadata={"category": "preferences", "type": "units"},
+    )
+)
+
+await mem0_memory.add(
+    MemoryContent(
+        content="Meal recipe must be vegan",
+        mime_type=MemoryMimeType.TEXT,
+        metadata={"category": "preferences", "type": "dietary"},
+    )
+)
+
+# Create assistant with mem0 memory
+assistant_agent = AssistantAgent(
+    name="assistant_agent",
+    model_client=OpenAIChatCompletionClient(
+        model="gpt-4o-2024-08-06",
+    ),
+    tools=[get_weather],
+    memory=[mem0_memory],
+)
+
+# Ask about the weather
+stream = assistant_agent.run_stream(task="What are my dietary preferences?")
+await Console(stream)
+```
+
+The example above demonstrates how Mem0Memory can be used with an assistant agent. The memory integration ensures that:
+
+1. All agent interactions are stored in Mem0 for future reference
+2. Relevant memories (like user preferences) are automatically retrieved and added to the context
+3. The agent can maintain consistent behavior based on stored memories
+
+Mem0Memory is particularly useful for:
+- Long-running agent deployments that need persistent memory
+- Applications requiring enhanced privacy controls
+- Teams wanting unified memory management across agents
+- Use cases needing advanced memory filtering and analytics
+
+Just like ChromaDBVectorMemory, you can serialize Mem0Memory configurations:
+
+```python
+# Serialize the memory configuration
+config_json = mem0_memory.dump_component().model_dump_json()
+print(f"Memory config JSON: {config_json[:100]}...")
+```
+
+---
+
+## Migration Guide for v0.2 to v0.4
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/migration-guide.html
+
+# Migration Guide for v0.2 to v0.4
+
+This is a migration guide for users of the `v0.2.*` versions of `autogen-agentchat`
+to the `v0.4` version, which introduces a new set of APIs and features.
+The `v0.4` version contains breaking changes. Please read this guide carefully.
+We still maintain the `v0.2` version in the `0.2` branch; however,
+we highly recommend you upgrade to the `v0.4` version.
+
+```{note}
+We no longer have admin access to the `pyautogen` PyPI package, and
+the releases from that package are no longer from Microsoft since version 0.2.34.
+To continue use the `v0.2` version of AutoGen, install it using `autogen-agentchat~=0.2`.
+Please read our [clarification statement](https://github.com/microsoft/autogen/discussions/4217) regarding forks.
+```
+
+## What is `v0.4`?
+
+Since the release of AutoGen in 2023, we have intensively listened to our community and users from small startups and large enterprises, gathering much feedback. Based on that feedback, we built AutoGen `v0.4`, a from-the-ground-up rewrite adopting an asynchronous, event-driven architecture to address issues such as observability, flexibility, interactive control, and scale.
+
+The `v0.4` API is layered:
+the [Core API](../core-user-guide/index.md) is the foundation layer offering a scalable, event-driven actor framework for creating agentic workflows;
+the [AgentChat API](./index.md) is built on Core, offering a task-driven, high-level framework for building interactive agentic applications. It is a replacement for AutoGen `v0.2`.
+
+Most of this guide focuses on `v0.4`'s AgentChat API; however, you can also build your own high-level framework using just the Core API.
+
+## New to AutoGen?
+
+Jump straight to the [AgentChat Tutorial](./tutorial/models.ipynb) to get started with `v0.4`.
+
+## What's in this guide?
+
+We provide a detailed guide on how to migrate your existing codebase from `v0.2` to `v0.4`.
+
+See each feature below for detailed information on how to migrate.
+
+- [Migration Guide for v0.2 to v0.4](#migration-guide-for-v02-to-v04)
+  - [What is `v0.4`?](#what-is-v04)
+  - [New to AutoGen?](#new-to-autogen)
+  - [What's in this guide?](#whats-in-this-guide)
+  - [Model Client](#model-client)
+    - [Use component config](#use-component-config)
+    - [Use model client class directly](#use-model-client-class-directly)
+  - [Model Client for OpenAI-Compatible APIs](#model-client-for-openai-compatible-apis)
+  - [Model Client Cache](#model-client-cache)
+  - [Assistant Agent](#assistant-agent)
+  - [Multi-Modal Agent](#multi-modal-agent)
+  - [User Proxy](#user-proxy)
+  - [RAG Agent](#rag-agent)
+  - [Conversable Agent and Register Reply](#conversable-agent-and-register-reply)
+  - [Save and Load Agent State](#save-and-load-agent-state)
+  - [Two-Agent Chat](#two-agent-chat)
+  - [Tool Use](#tool-use)
+  - [Chat Result](#chat-result)
+  - [Conversion between v0.2 and v0.4 Messages](#conversion-between-v02-and-v04-messages)
+  - [Group Chat](#group-chat)
+  - [Group Chat with Resume](#group-chat-with-resume)
+  - [Save and Load Group Chat State](#save-and-load-group-chat-state)
+  - [Group Chat with Tool Use](#group-chat-with-tool-use)
+  - [Group Chat with Custom Selector (Stateflow)](#group-chat-with-custom-selector-stateflow)
+  - [Nested Chat](#nested-chat)
+  - [Sequential Chat](#sequential-chat)
+  - [GPTAssistantAgent](#gptassistantagent)
+  - [Long Context Handling](#long-context-handling)
+  - [Observability and Control](#observability-and-control)
+  - [Code Executors](#code-executors)
+
+The following features currently in `v0.2`
+will be provided in the future releases of `v0.4.*` versions:
+
+- Model Client Cost [#4835](https://github.com/microsoft/autogen/issues/4835)
+- Teachable Agent
+- RAG Agent
+
+We will update this guide when the missing features become available.
+
+## Model Client
+
+In `v0.2` you configure the model client as follows, and create the `OpenAIWrapper` object.
+
+```python
+from autogen.oai import OpenAIWrapper
+
+config_list = [
+    {"model": "gpt-4o", "api_key": "sk-xxx"},
+    {"model": "gpt-4o-mini", "api_key": "sk-xxx"},
+]
+
+model_client = OpenAIWrapper(config_list=config_list)
+```
+
+> **Note**: In AutoGen 0.2, the OpenAI client would try configs in the list until one worked. 0.4 instead expects a specfic model configuration to be chosen.
+
+In `v0.4`, we offer two ways to create a model client.
+
+### Use component config
+
+AutoGen 0.4 has a [generic component configuration system](../core-user-guide/framework/component-config.ipynb). Model clients are a great use case for this. See below for how to create an OpenAI chat completion client.
+
+```python
+
+from autogen_core.models import ChatCompletionClient
+
+config = {
+    "provider": "OpenAIChatCompletionClient",
+    "config": {
+        "model": "gpt-4o",
+        "api_key": "sk-xxx" # os.environ["...']
+    }
+}
+
+model_client = ChatCompletionClient.load_component(config)
+```
+
+### Use model client class directly
+
+Open AI:
+
+```python
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(model="gpt-4o", api_key="sk-xxx")
+```
+
+Azure OpenAI:
+
+```python
+from autogen_ext.models.openai import AzureOpenAIChatCompletionClient
+
+model_client = AzureOpenAIChatCompletionClient(
+    azure_deployment="gpt-4o",
+    azure_endpoint="https://<your-endpoint>.openai.azure.com/",
+    model="gpt-4o",
+    api_version="2024-09-01-preview",
+    api_key="sk-xxx",
+)
+```
+
+Read more on {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient`.
+
+## Model Client for OpenAI-Compatible APIs
+
+You can use a the `OpenAIChatCompletionClient` to connect to an OpenAI-Compatible API,
+but you need to specify the `base_url` and `model_info`.
+
+```python
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+custom_model_client = OpenAIChatCompletionClient(
+    model="custom-model-name",
+    base_url="https://custom-model.com/reset/of/the/path",
+    api_key="placeholder",
+    model_info={
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": "unknown",
+        "structured_output": True,
+    },
+)
+```
+
+> **Note**: We don't test all the OpenAI-Compatible APIs, and many of them
+> works differently from the OpenAI API even though they may claim to suppor it.
+> Please test them before using them.
+
+Read about [Model Clients](./tutorial/models.ipynb)
+in AgentChat Tutorial and more detailed information on [Core API Docs](../core-user-guide/components/model-clients.ipynb)
+
+Support for other hosted models will be added in the future.
+
+## Model Client Cache
+
+In `v0.2`, you can set the cache seed through the `cache_seed` parameter in the LLM config.
+The cache is enabled by default.
+
+```python
+llm_config = {
+    "config_list": [{"model": "gpt-4o", "api_key": "sk-xxx"}],
+    "seed": 42,
+    "temperature": 0,
+    "cache_seed": 42,
+}
+```
+
+In `v0.4`, the cache is not enabled by default, to use it you need to use a
+{py:class}`~autogen_ext.models.cache.ChatCompletionCache` wrapper around the model client.
+
+You can use a {py:class}`~autogen_ext.cache_store.diskcache.DiskCacheStore` or {py:class}`~autogen_ext.cache_store.redis.RedisStore` to store the cache.
+
+```bash
+pip install -U "autogen-ext[openai, diskcache, redis]"
+```
+
+Here's an example of using `diskcache` for local caching:
+
+```python
+import asyncio
+import tempfile
+
+from autogen_core.models import UserMessage
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.models.cache import ChatCompletionCache, CHAT_CACHE_VALUE_TYPE
+from autogen_ext.cache_store.diskcache import DiskCacheStore
+from diskcache import Cache
+
+
+async def main():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Initialize the original client
+        openai_model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+        # Then initialize the CacheStore, in this case with diskcache.Cache.
+        # You can also use redis like:
+        # from autogen_ext.cache_store.redis import RedisStore
+        # import redis
+        # redis_instance = redis.Redis()
+        # cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
+        cache_store = DiskCacheStore[CHAT_CACHE_VALUE_TYPE](Cache(tmpdirname))
+        cache_client = ChatCompletionCache(openai_model_client, cache_store)
+
+        response = await cache_client.create([UserMessage(content="Hello, how are you?", source="user")])
+        print(response)  # Should print response from OpenAI
+        response = await cache_client.create([UserMessage(content="Hello, how are you?", source="user")])
+        print(response)  # Should print cached response
+        await openai_model_client.close()
+
+
+asyncio.run(main())
+```
+
+## Assistant Agent
+
+In `v0.2`, you create an assistant agent as follows:
+
+```python
+from autogen.agentchat import AssistantAgent
+
+llm_config = {
+    "config_list": [{"model": "gpt-4o", "api_key": "sk-xxx"}],
+    "seed": 42,
+    "temperature": 0,
+}
+
+assistant = AssistantAgent(
+    name="assistant",
+    system_message="You are a helpful assistant.",
+    llm_config=llm_config,
+)
+```
+
+In `v0.4`, it is similar, but you need to specify `model_client` instead of `llm_config`.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(model="gpt-4o", api_key="sk-xxx", seed=42, temperature=0)
+
+assistant = AssistantAgent(
+    name="assistant",
+    system_message="You are a helpful assistant.",
+    model_client=model_client,
+)
+```
+
+However, the usage is somewhat different. In `v0.4`, instead of calling `assistant.send`,
+you call `assistant.on_messages` or `assistant.on_messages_stream` to handle incoming messages.
+Furthermore, the `on_messages` and `on_messages_stream` methods are asynchronous,
+and the latter returns an async generator to stream the inner thoughts of the agent.
+
+Here is how you can call the assistant agent in `v0.4` directly, continuing from the above example:
+
+```python
+import asyncio
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.agents import AssistantAgent
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", seed=42, temperature=0)
+
+    assistant = AssistantAgent(
+        name="assistant",
+        system_message="You are a helpful assistant.",
+        model_client=model_client,
+    )
+
+    cancellation_token = CancellationToken()
+    response = await assistant.on_messages([TextMessage(content="Hello!", source="user")], cancellation_token)
+    print(response)
+
+    await model_client.close()
+
+asyncio.run(main())
+```
+
+The {py:class}`~autogen_core.CancellationToken` can be used to cancel the request asynchronously
+when you call `cancellation_token.cancel()`, which will cause the `await`
+on the `on_messages` call to raise a `CancelledError`.
+
+Read more on [Agent Tutorial](./tutorial/agents.ipynb)
+and {py:class}`~autogen_agentchat.agents.AssistantAgent`.
+
+## Multi-Modal Agent
+
+The {py:class}`~autogen_agentchat.agents.AssistantAgent` in `v0.4` supports multi-modal inputs if the model client supports it.
+The `vision` capability of the model client is used to determine if the agent supports multi-modal inputs.
+
+```python
+import asyncio
+from pathlib import Path
+from autogen_agentchat.messages import MultiModalMessage
+from autogen_agentchat.agents import AssistantAgent
+from autogen_core import CancellationToken, Image
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", seed=42, temperature=0)
+
+    assistant = AssistantAgent(
+        name="assistant",
+        system_message="You are a helpful assistant.",
+        model_client=model_client,
+    )
+
+    cancellation_token = CancellationToken()
+    message = MultiModalMessage(
+        content=["Here is an image:", Image.from_file(Path("test.png"))],
+        source="user",
+    )
+    response = await assistant.on_messages([message], cancellation_token)
+    print(response)
+
+    await model_client.close()
+
+asyncio.run(main())
+```
+
+## User Proxy
+
+In `v0.2`, you create a user proxy as follows:
+
+```python
+from autogen.agentchat import UserProxyAgent
+
+user_proxy = UserProxyAgent(
+    name="user_proxy",
+    human_input_mode="NEVER",
+    max_consecutive_auto_reply=10,
+    code_execution_config=False,
+    llm_config=False,
+)
+```
+
+This user proxy would take input from the user through console, and would terminate
+if the incoming message ends with "TERMINATE".
+
+In `v0.4`, a user proxy is simply an agent that takes user input only, there is no
+other special configuration needed. You can create a user proxy as follows:
+
+```python
+from autogen_agentchat.agents import UserProxyAgent
+
+user_proxy = UserProxyAgent("user_proxy")
+```
+
+See {py:class}`~autogen_agentchat.agents.UserProxyAgent`
+for more details and how to customize the input function with timeout.
+
+## RAG Agent
+
+In `v0.2`, there was the concept of teachable agents as well as a RAG agents that could take a database config.
+
+```python
+teachable_agent = ConversableAgent(
+    name="teachable_agent",
+    llm_config=llm_config
+)
+
+# Instantiate a Teachability object. Its parameters are all optional.
+teachability = Teachability(
+    reset_db=False,
+    path_to_db_dir="./tmp/interactive/teachability_db"
+)
+
+teachability.add_to_agent(teachable_agent)
+```
+
+In `v0.4`, you can implement a RAG agent using the {py:class}`~autogen_core.memory.Memory` class. Specifically, you can define a memory store class, and pass that as a parameter to the assistant agent. See the [Memory](memory.ipynb) tutorial for more details.
+
+This clear separation of concerns allows you to implement a memory store that uses any database or storage system you want (you have to inherit from the `Memory` class) and use it with an assistant agent. The example below shows how to use a ChromaDB vector memory store with the assistant agent. In addition, your application logic should determine how and when to add content to the memory store. For example, you may choose to call `memory.add` for every response from the assistant agent or use a separate LLM call to determine if the content should be added to the memory store.
+
+```python
+
+# ...
+# example of a ChromaDBVectorMemory class
+chroma_user_memory = ChromaDBVectorMemory(
+    config=PersistentChromaDBVectorMemoryConfig(
+        collection_name="preferences",
+        persistence_path=os.path.join(str(Path.home()), ".chromadb_autogen"),
+        k=2,  # Return top  k results
+        score_threshold=0.4,  # Minimum similarity score
+    )
+)
+
+# you can add logic such as a document indexer that adds content to the memory store
+
+assistant_agent = AssistantAgent(
+    name="assistant_agent",
+    model_client=OpenAIChatCompletionClient(
+        model="gpt-4o",
+    ),
+    tools=[get_weather],
+    memory=[chroma_user_memory],
+)
+```
+
+## Conversable Agent and Register Reply
+
+In `v0.2`, you can create a conversable agent and register a reply function as follows:
+
+```python
+from typing import Any, Dict, List, Optional, Tuple, Union
+from autogen.agentchat import ConversableAgent
+
+llm_config = {
+    "config_list": [{"model": "gpt-4o", "api_key": "sk-xxx"}],
+    "seed": 42,
+    "temperature": 0,
+}
+
+conversable_agent = ConversableAgent(
+    name="conversable_agent",
+    system_message="You are a helpful assistant.",
+    llm_config=llm_config,
+    code_execution_config={"work_dir": "coding"},
+    human_input_mode="NEVER",
+    max_consecutive_auto_reply=10,
+)
+
+def reply_func(
+    recipient: ConversableAgent,
+    messages: Optional[List[Dict]] = None,
+    sender: Optional[Agent] = None,
+    config: Optional[Any] = None,
+) -> Tuple[bool, Union[str, Dict, None]]:
+    # Custom reply logic here
+    return True, "Custom reply"
+
+# Register the reply function
+conversable_agent.register_reply([ConversableAgent], reply_func, position=0)
+
+# NOTE: An async reply function will only be invoked with async send.
+```
+
+Rather than guessing what the `reply_func` does, all its parameters,
+and what the `position` should be, in `v0.4`, we can simply create a custom agent
+and implement the `on_messages`, `on_reset`, and `produced_message_types` methods.
+
+```python
+from typing import Sequence
+from autogen_core import CancellationToken
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.messages import TextMessage, BaseChatMessage
+from autogen_agentchat.base import Response
+
+class CustomAgent(BaseChatAgent):
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        return Response(chat_message=TextMessage(content="Custom reply", source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+```
+
+You can then use the custom agent in the same way as the {py:class}`~autogen_agentchat.agents.AssistantAgent`.
+See [Custom Agent Tutorial](custom-agents.ipynb)
+for more details.
+
+## Save and Load Agent State
+
+In `v0.2` there is no built-in way to save and load an agent's state: you need
+to implement it yourself by exporting the `chat_messages` attribute of `ConversableAgent`
+and importing it back through the `chat_messages` parameter.
+
+In `v0.4`, you can call `save_state` and `load_state` methods on agents to save and load their state.
+
+```python
+import asyncio
+import json
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.agents import AssistantAgent
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", seed=42, temperature=0)
+
+    assistant = AssistantAgent(
+        name="assistant",
+        system_message="You are a helpful assistant.",
+        model_client=model_client,
+    )
+
+    cancellation_token = CancellationToken()
+    response = await assistant.on_messages([TextMessage(content="Hello!", source="user")], cancellation_token)
+    print(response)
+
+    # Save the state.
+    state = await assistant.save_state()
+
+    # (Optional) Write state to disk.
+    with open("assistant_state.json", "w") as f:
+        json.dump(state, f)
+
+    # (Optional) Load it back from disk.
+    with open("assistant_state.json", "r") as f:
+        state = json.load(f)
+        print(state) # Inspect the state, which contains the chat history.
+
+    # Carry on the chat.
+    response = await assistant.on_messages([TextMessage(content="Tell me a joke.", source="user")], cancellation_token)
+    print(response)
+
+    # Load the state, resulting the agent to revert to the previous state before the last message.
+    await assistant.load_state(state)
+
+    # Carry on the same chat again.
+    response = await assistant.on_messages([TextMessage(content="Tell me a joke.", source="user")], cancellation_token)
+    # Close the connection to the model client.
+    await model_client.close()
+
+asyncio.run(main())
+```
+
+You can also call `save_state` and `load_state` on any teams, such as {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`
+to save and load the state of the entire team.
+
+## Two-Agent Chat
+
+In `v0.2`, you can create a two-agent chat for code execution as follows:
+
+```python
+from autogen.coding import LocalCommandLineCodeExecutor
+from autogen.agentchat import AssistantAgent, UserProxyAgent
+
+llm_config = {
+    "config_list": [{"model": "gpt-4o", "api_key": "sk-xxx"}],
+    "seed": 42,
+    "temperature": 0,
+}
+
+assistant = AssistantAgent(
+    name="assistant",
+    system_message="You are a helpful assistant. Write all code in python. Reply only 'TERMINATE' if the task is done.",
+    llm_config=llm_config,
+    is_termination_msg=lambda x: x.get("content", "").rstrip().endswith("TERMINATE"),
+)
+
+user_proxy = UserProxyAgent(
+    name="user_proxy",
+    human_input_mode="NEVER",
+    max_consecutive_auto_reply=10,
+    code_execution_config={"code_executor": LocalCommandLineCodeExecutor(work_dir="coding")},
+    llm_config=False,
+    is_termination_msg=lambda x: x.get("content", "").rstrip().endswith("TERMINATE"),
+)
+
+chat_result = user_proxy.initiate_chat(assistant, message="Write a python script to print 'Hello, world!'")
+# Intermediate messages are printed to the console directly.
+print(chat_result)
+```
+
+To get the same behavior in `v0.4`, you can use the {py:class}`~autogen_agentchat.agents.AssistantAgent`
+and {py:class}`~autogen_agentchat.agents.CodeExecutorAgent` together in a {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`.
+
+```python
+import asyncio
+from autogen_agentchat.agents import AssistantAgent, CodeExecutorAgent
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.conditions import TextMentionTermination, MaxMessageTermination
+from autogen_agentchat.ui import Console
+from autogen_ext.code_executors.local import LocalCommandLineCodeExecutor
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", seed=42, temperature=0)
+
+    assistant = AssistantAgent(
+        name="assistant",
+        system_message="You are a helpful assistant. Write all code in python. Reply only 'TERMINATE' if the task is done.",
+        model_client=model_client,
+    )
+
+    code_executor = CodeExecutorAgent(
+        name="code_executor",
+        code_executor=LocalCommandLineCodeExecutor(work_dir="coding"),
+    )
+
+    # The termination condition is a combination of text termination and max message termination, either of which will cause the chat to terminate.
+    termination = TextMentionTermination("TERMINATE") | MaxMessageTermination(10)
+
+    # The group chat will alternate between the assistant and the code executor.
+    group_chat = RoundRobinGroupChat([assistant, code_executor], termination_condition=termination)
+
+    # `run_stream` returns an async generator to stream the intermediate messages.
+    stream = group_chat.run_stream(task="Write a python script to print 'Hello, world!'")
+    # `Console` is a simple UI to display the stream.
+    await Console(stream)
+    
+    # Close the connection to the model client.
+    await model_client.close()
+
+asyncio.run(main())
+```
+
+## Tool Use
+
+In `v0.2`, to create a tool use chatbot, you must have two agents, one for calling the tool and one for executing the tool.
+You need to initiate a two-agent chat for every user request.
+
+```python
+from autogen.agentchat import AssistantAgent, UserProxyAgent, register_function
+
+llm_config = {
+    "config_list": [{"model": "gpt-4o", "api_key": "sk-xxx"}],
+    "seed": 42,
+    "temperature": 0,
+}
+
+tool_caller = AssistantAgent(
+    name="tool_caller",
+    system_message="You are a helpful assistant. You can call tools to help user.",
+    llm_config=llm_config,
+    max_consecutive_auto_reply=1, # Set to 1 so that we return to the application after each assistant reply as we are building a chatbot.
+)
+
+tool_executor = UserProxyAgent(
+    name="tool_executor",
+    human_input_mode="NEVER",
+    code_execution_config=False,
+    llm_config=False,
+)
+
+def get_weather(city: str) -> str:
+    return f"The weather in {city} is 72 degree and sunny."
+
+# Register the tool function to the tool caller and executor.
+register_function(get_weather, caller=tool_caller, executor=tool_executor)
+
+while True:
+    user_input = input("User: ")
+    if user_input == "exit":
+        break
+    chat_result = tool_executor.initiate_chat(
+        tool_caller,
+        message=user_input,
+        summary_method="reflection_with_llm", # To let the model reflect on the tool use, set to "last_msg" to return the tool call result directly.
+    )
+    print("Assistant:", chat_result.summary)
+```
+
+In `v0.4`, you really just need one agent -- the {py:class}`~autogen_agentchat.agents.AssistantAgent` -- to handle
+both the tool calling and tool execution.
+
+```python
+import asyncio
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.messages import TextMessage
+
+def get_weather(city: str) -> str: # Async tool is possible too.
+    return f"The weather in {city} is 72 degree and sunny."
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", seed=42, temperature=0)
+    assistant = AssistantAgent(
+        name="assistant",
+        system_message="You are a helpful assistant. You can call tools to help user.",
+        model_client=model_client,
+        tools=[get_weather],
+        reflect_on_tool_use=True, # Set to True to have the model reflect on the tool use, set to False to return the tool call result directly.
+    )
+    while True:
+        user_input = input("User: ")
+        if user_input == "exit":
+            break
+        response = await assistant.on_messages([TextMessage(content=user_input, source="user")], CancellationToken())
+        print("Assistant:", response.chat_message.to_text())
+    await model_client.close()
+
+asyncio.run(main())
+```
+
+When using tool-equipped agents inside a group chat such as
+{py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`,
+you simply do the same as above to add tools to the agents, and create a
+group chat with the agents.
+
+## Chat Result
+
+In `v0.2`, you get a `ChatResult` object from the `initiate_chat` method.
+For example:
+
+```python
+chat_result = tool_executor.initiate_chat(
+    tool_caller,
+    message=user_input,
+    summary_method="reflection_with_llm",
+)
+print(chat_result.summary) # Get LLM-reflected summary of the chat.
+print(chat_result.chat_history) # Get the chat history.
+print(chat_result.cost) # Get the cost of the chat.
+print(chat_result.human_input) # Get the human input solicited by the chat.
+```
+
+See [ChatResult Docs](https://microsoft.github.io/autogen/0.2/docs/reference/agentchat/chat#chatresult)
+for more details.
+
+In `v0.4`, you get a {py:class}`~autogen_agentchat.base.TaskResult` object from a `run` or `run_stream` method.
+The {py:class}`~autogen_agentchat.base.TaskResult` object contains the `messages` which is the message history
+of the chat, including both agents' private (tool calls, etc.) and public messages.
+
+There are some notable differences between {py:class}`~autogen_agentchat.base.TaskResult` and `ChatResult`:
+
+- The `messages` list in {py:class}`~autogen_agentchat.base.TaskResult` uses different message format than the `ChatResult.chat_history` list.
+- There is no `summary` field. It is up to the application to decide how to summarize the chat using the `messages` list.
+- `human_input` is not provided in the {py:class}`~autogen_agentchat.base.TaskResult` object, as the user input can be extracted from the `messages` list by filtering with the `source` field.
+- `cost` is not provided in the {py:class}`~autogen_agentchat.base.TaskResult` object, however, you can calculate the cost based on token usage. It would be a great community extension to add cost calculation. See [community extensions](../extensions-user-guide/discover.md).
+
+## Conversion between v0.2 and v0.4 Messages
+
+You can use the following conversion functions to convert between a v0.4 message in
+{py:attr}`autogen_agentchat.base.TaskResult.messages` and a v0.2 message in `ChatResult.chat_history`.
+
+```python
+from typing import Any, Dict, List, Literal
+
+from autogen_agentchat.messages import (
+    BaseAgentEvent,
+    BaseChatMessage,
+    HandoffMessage,
+    MultiModalMessage,
+    StopMessage,
+    TextMessage,
+    ToolCallExecutionEvent,
+    ToolCallRequestEvent,
+    ToolCallSummaryMessage,
+)
+from autogen_core import FunctionCall, Image
+from autogen_core.models import FunctionExecutionResult
+
+
+def convert_to_v02_message(
+    message: BaseAgentEvent | BaseChatMessage,
+    role: Literal["assistant", "user", "tool"],
+    image_detail: Literal["auto", "high", "low"] = "auto",
+) -> Dict[str, Any]:
+    """Convert a v0.4 AgentChat message to a v0.2 message.
+
+    Args:
+        message (BaseAgentEvent | BaseChatMessage): The message to convert.
+        role (Literal["assistant", "user", "tool"]): The role of the message.
+        image_detail (Literal["auto", "high", "low"], optional): The detail level of image content in multi-modal message. Defaults to "auto".
+
+    Returns:
+        Dict[str, Any]: The converted AutoGen v0.2 message.
+    """
+    v02_message: Dict[str, Any] = {}
+    if isinstance(message, TextMessage | StopMessage | HandoffMessage | ToolCallSummaryMessage):
+        v02_message = {"content": message.content, "role": role, "name": message.source}
+    elif isinstance(message, MultiModalMessage):
+        v02_message = {"content": [], "role": role, "name": message.source}
+        for modal in message.content:
+            if isinstance(modal, str):
+                v02_message["content"].append({"type": "text", "text": modal})
+            elif isinstance(modal, Image):
+                v02_message["content"].append(modal.to_openai_format(detail=image_detail))
+            else:
+                raise ValueError(f"Invalid multimodal message content: {modal}")
+    elif isinstance(message, ToolCallRequestEvent):
+        v02_message = {"tool_calls": [], "role": "assistant", "content": None, "name": message.source}
+        for tool_call in message.content:
+            v02_message["tool_calls"].append(
+                {
+                    "id": tool_call.id,
+                    "type": "function",
+                    "function": {"name": tool_call.name, "args": tool_call.arguments},
+                }
+            )
+    elif isinstance(message, ToolCallExecutionEvent):
+        tool_responses: List[Dict[str, str]] = []
+        for tool_result in message.content:
+            tool_responses.append(
+                {
+                    "tool_call_id": tool_result.call_id,
+                    "role": "tool",
+                    "content": tool_result.content,
+                }
+            )
+        content = "\n\n".join([response["content"] for response in tool_responses])
+        v02_message = {"tool_responses": tool_responses, "role": "tool", "content": content}
+    else:
+        raise ValueError(f"Invalid message type: {type(message)}")
+    return v02_message
+
+
+def convert_to_v04_message(message: Dict[str, Any]) -> BaseAgentEvent | BaseChatMessage:
+    """Convert a v0.2 message to a v0.4 AgentChat message."""
+    if "tool_calls" in message:
+        tool_calls: List[FunctionCall] = []
+        for tool_call in message["tool_calls"]:
+            tool_calls.append(
+                FunctionCall(
+                    id=tool_call["id"],
+                    name=tool_call["function"]["name"],
+                    arguments=tool_call["function"]["args"],
+                )
+            )
+        return ToolCallRequestEvent(source=message["name"], content=tool_calls)
+    elif "tool_responses" in message:
+        tool_results: List[FunctionExecutionResult] = []
+        for tool_response in message["tool_responses"]:
+            tool_results.append(
+                FunctionExecutionResult(
+                    call_id=tool_response["tool_call_id"],
+                    content=tool_response["content"],
+                    is_error=False,
+                    name=tool_response["name"],
+                )
+            )
+        return ToolCallExecutionEvent(source="tools", content=tool_results)
+    elif isinstance(message["content"], list):
+        content: List[str | Image] = []
+        for modal in message["content"]:  # type: ignore
+            if modal["type"] == "text":  # type: ignore
+                content.append(modal["text"])  # type: ignore
+            else:
+                content.append(Image.from_uri(modal["image_url"]["url"]))  # type: ignore
+        return MultiModalMessage(content=content, source=message["name"])
+    elif isinstance(message["content"], str):
+        return TextMessage(content=message["content"], source=message["name"])
+    else:
+        raise ValueError(f"Unable to convert message: {message}")
+```
+
+## Group Chat
+
+In `v0.2`, you need to create a `GroupChat` class and pass it into a
+`GroupChatManager`, and have a participant that is a user proxy to initiate the chat.
+For a simple scenario of a writer and a critic, you can do the following:
+
+```python
+from autogen.agentchat import AssistantAgent, GroupChat, GroupChatManager
+
+llm_config = {
+    "config_list": [{"model": "gpt-4o", "api_key": "sk-xxx"}],
+    "seed": 42,
+    "temperature": 0,
+}
+
+writer = AssistantAgent(
+    name="writer",
+    description="A writer.",
+    system_message="You are a writer.",
+    llm_config=llm_config,
+    is_termination_msg=lambda x: x.get("content", "").rstrip().endswith("APPROVE"),
+)
+
+critic = AssistantAgent(
+    name="critic",
+    description="A critic.",
+    system_message="You are a critic, provide feedback on the writing. Reply only 'APPROVE' if the task is done.",
+    llm_config=llm_config,
+)
+
+# Create a group chat with the writer and critic.
+groupchat = GroupChat(agents=[writer, critic], messages=[], max_round=12)
+
+# Create a group chat manager to manage the group chat, use round-robin selection method.
+manager = GroupChatManager(groupchat=groupchat, llm_config=llm_config, speaker_selection_method="round_robin")
+
+# Initiate the chat with the editor, intermediate messages are printed to the console directly.
+result = editor.initiate_chat(
+    manager,
+    message="Write a short story about a robot that discovers it has feelings.",
+)
+print(result.summary)
+```
+
+In `v0.4`, you can use the {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` to achieve the same behavior.
+
+```python
+import asyncio
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.conditions import TextMentionTermination
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", seed=42, temperature=0)
+
+    writer = AssistantAgent(
+        name="writer",
+        description="A writer.",
+        system_message="You are a writer.",
+        model_client=model_client,
+    )
+
+    critic = AssistantAgent(
+        name="critic",
+        description="A critic.",
+        system_message="You are a critic, provide feedback on the writing. Reply only 'APPROVE' if the task is done.",
+        model_client=model_client,
+    )
+
+    # The termination condition is a text termination, which will cause the chat to terminate when the text "APPROVE" is received.
+    termination = TextMentionTermination("APPROVE")
+
+    # The group chat will alternate between the writer and the critic.
+    group_chat = RoundRobinGroupChat([writer, critic], termination_condition=termination, max_turns=12)
+
+    # `run_stream` returns an async generator to stream the intermediate messages.
+    stream = group_chat.run_stream(task="Write a short story about a robot that discovers it has feelings.")
+    # `Console` is a simple UI to display the stream.
+    await Console(stream)
+    # Close the connection to the model client.
+    await model_client.close()
+
+asyncio.run(main())
+```
+
+For LLM-based speaker selection, you can use the {py:class}`~autogen_agentchat.teams.SelectorGroupChat` instead.
+See [Selector Group Chat Tutorial](./selector-group-chat.ipynb)
+and {py:class}`~autogen_agentchat.teams.SelectorGroupChat` for more details.
+
+> **Note**: In `v0.4`, you do not need to register functions on a user proxy to use tools
+> in a group chat. You can simply pass the tool functions to the {py:class}`~autogen_agentchat.agents.AssistantAgent` as shown in the [Tool Use](#tool-use) section.
+> The agent will automatically call the tools when needed.
+> If your tool doesn't output well formed response, you can use the `reflect_on_tool_use` parameter to have the model reflect on the tool use.
+
+## Group Chat with Resume
+
+In `v0.2`, group chat with resume is a bit complicated. You need to explicitly
+save the group chat messages and load them back when you want to resume the chat.
+See [Resuming Group Chat in v0.2](https://microsoft.github.io/autogen/0.2/docs/topics/groupchat/resuming_groupchat) for more details.
+
+In `v0.4`, you can simply call `run` or `run_stream` again with the same group chat object to resume the chat. To export and load the state, you can use
+`save_state` and `load_state` methods.
+
+```python
+import asyncio
+import json
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.conditions import TextMentionTermination
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+def create_team(model_client : OpenAIChatCompletionClient) -> RoundRobinGroupChat:
+    writer = AssistantAgent(
+        name="writer",
+        description="A writer.",
+        system_message="You are a writer.",
+        model_client=model_client,
+    )
+
+    critic = AssistantAgent(
+        name="critic",
+        description="A critic.",
+        system_message="You are a critic, provide feedback on the writing. Reply only 'APPROVE' if the task is done.",
+        model_client=model_client,
+    )
+
+    # The termination condition is a text termination, which will cause the chat to terminate when the text "APPROVE" is received.
+    termination = TextMentionTermination("APPROVE")
+
+    # The group chat will alternate between the writer and the critic.
+    group_chat = RoundRobinGroupChat([writer, critic], termination_condition=termination)
+
+    return group_chat
+
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", seed=42, temperature=0)
+    # Create team.
+    group_chat = create_team(model_client)
+
+    # `run_stream` returns an async generator to stream the intermediate messages.
+    stream = group_chat.run_stream(task="Write a short story about a robot that discovers it has feelings.")
+    # `Console` is a simple UI to display the stream.
+    await Console(stream)
+
+    # Save the state of the group chat and all participants.
+    state = await group_chat.save_state()
+    with open("group_chat_state.json", "w") as f:
+        json.dump(state, f)
+
+    # Create a new team with the same participants configuration.
+    group_chat = create_team(model_client)
+
+    # Load the state of the group chat and all participants.
+    with open("group_chat_state.json", "r") as f:
+        state = json.load(f)
+    await group_chat.load_state(state)
+
+    # Resume the chat.
+    stream = group_chat.run_stream(task="Translate the story into Chinese.")
+    await Console(stream)
+
+    # Close the connection to the model client.
+    await model_client.close()
+
+asyncio.run(main())
+```
+
+## Save and Load Group Chat State
+
+In `v0.2`, you need to explicitly save the group chat messages and load them back when you want to resume the chat.
+
+In `v0.4`, you can simply call `save_state` and `load_state` methods on the group chat object.
+See [Group Chat with Resume](#group-chat-with-resume) for an example.
+
+## Group Chat with Tool Use
+
+In `v0.2` group chat, when tools are involved, you need to register the tool functions on a user proxy,
+and include the user proxy in the group chat. The tool calls made by other agents
+will be routed to the user proxy to execute.
+
+We have observed numerous issues with this approach, such as the the tool call
+routing not working as expected, and the tool call request and result cannot be
+accepted by models without support for function calling.
+
+In `v0.4`, there is no need to register the tool functions on a user proxy,
+as the tools are directly executed within the {py:class}`~autogen_agentchat.agents.AssistantAgent`,
+which publishes the response from the tool to the group chat.
+So the group chat manager does not need to be involved in routing tool calls.
+
+See [Selector Group Chat Tutorial](./selector-group-chat.ipynb) for an example
+of using tools in a group chat.
+
+## Group Chat with Custom Selector (Stateflow)
+
+In `v0.2` group chat, when the `speaker_selection_method` is set to a custom function,
+it can override the default selection method. This is useful for implementing
+a state-based selection method.
+For more details, see [Custom Sepaker Selection in v0.2](https://microsoft.github.io/autogen/0.2/docs/topics/groupchat/customized_speaker_selection).
+
+In `v0.4`, you can use the {py:class}`~autogen_agentchat.teams.SelectorGroupChat` with `selector_func` to achieve the same behavior.
+The `selector_func` is a function that takes the current message thread of the group chat
+and returns the next speaker's name. If `None` is returned, the LLM-based
+selection method will be used.
+
+Here is an example of using the state-based selection method to implement
+a web search/analysis scenario.
+
+```python
+import asyncio
+from typing import Sequence
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import MaxMessageTermination, TextMentionTermination
+from autogen_agentchat.messages import BaseAgentEvent, BaseChatMessage
+from autogen_agentchat.teams import SelectorGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Note: This example uses mock tools instead of real APIs for demonstration purposes
+def search_web_tool(query: str) -> str:
+    if "2006-2007" in query:
+        return """Here are the total points scored by Miami Heat players in the 2006-2007 season:
+        Udonis Haslem: 844 points
+        Dwayne Wade: 1397 points
+        James Posey: 550 points
+        ...
+        """
+    elif "2007-2008" in query:
+        return "The number of total rebounds for Dwayne Wade in the Miami Heat season 2007-2008 is 214."
+    elif "2008-2009" in query:
+        return "The number of total rebounds for Dwayne Wade in the Miami Heat season 2008-2009 is 398."
+    return "No data found."
+
+
+def percentage_change_tool(start: float, end: float) -> float:
+    return ((end - start) / start) * 100
+
+def create_team(model_client : OpenAIChatCompletionClient) -> SelectorGroupChat:
+    planning_agent = AssistantAgent(
+        "PlanningAgent",
+        description="An agent for planning tasks, this agent should be the first to engage when given a new task.",
+        model_client=model_client,
+        system_message="""
+        You are a planning agent.
+        Your job is to break down complex tasks into smaller, manageable subtasks.
+        Your team members are:
+            Web search agent: Searches for information
+            Data analyst: Performs calculations
+
+        You only plan and delegate tasks - you do not execute them yourself.
+
+        When assigning tasks, use this format:
+        1. <agent> : <task>
+
+        After all tasks are complete, summarize the findings and end with "TERMINATE".
+        """,
+    )
+
+    web_search_agent = AssistantAgent(
+        "WebSearchAgent",
+        description="A web search agent.",
+        tools=[search_web_tool],
+        model_client=model_client,
+        system_message="""
+        You are a web search agent.
+        Your only tool is search_tool - use it to find information.
+        You make only one search call at a time.
+        Once you have the results, you never do calculations based on them.
+        """,
+    )
+
+    data_analyst_agent = AssistantAgent(
+        "DataAnalystAgent",
+        description="A data analyst agent. Useful for performing calculations.",
+        model_client=model_client,
+        tools=[percentage_change_tool],
+        system_message="""
+        You are a data analyst.
+        Given the tasks you have been assigned, you should analyze the data and provide results using the tools provided.
+        """,
+    )
+
+    # The termination condition is a combination of text mention termination and max message termination.
+    text_mention_termination = TextMentionTermination("TERMINATE")
+    max_messages_termination = MaxMessageTermination(max_messages=25)
+    termination = text_mention_termination | max_messages_termination
+
+    # The selector function is a function that takes the current message thread of the group chat
+    # and returns the next speaker's name. If None is returned, the LLM-based selection method will be used.
+    def selector_func(messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> str | None:
+        if messages[-1].source != planning_agent.name:
+            return planning_agent.name # Always return to the planning agent after the other agents have spoken.
+        return None
+
+    team = SelectorGroupChat(
+        [planning_agent, web_search_agent, data_analyst_agent],
+        model_client=OpenAIChatCompletionClient(model="gpt-4o-mini"), # Use a smaller model for the selector.
+        termination_condition=termination,
+        selector_func=selector_func,
+    )
+    return team
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+    team = create_team(model_client)
+    task = "Who was the Miami Heat player with the highest points in the 2006-2007 season, and what was the percentage change in his total rebounds between the 2007-2008 and 2008-2009 seasons?"
+    await Console(team.run_stream(task=task))
+
+asyncio.run(main())
+```
+
+## Nested Chat
+
+Nested chat allows you to nest a whole team or another agent inside
+an agent. This is useful for creating a hierarchical structure of agents
+or "information silos", as the nested agents cannot communicate directly
+with other agents outside of the same group.
+
+In `v0.2`, nested chat is supported by using the `register_nested_chats` method
+on the `ConversableAgent` class.
+You need to specify the nested sequence of agents using dictionaries,
+See [Nested Chat in v0.2](https://microsoft.github.io/autogen/0.2/docs/tutorial/conversation-patterns#nested-chats)
+for more details.
+
+In `v0.4`, nested chat is an implementation detail of a custom agent.
+You can create a custom agent that takes a team or another agent as a parameter
+and implements the `on_messages` method to trigger the nested team or agent.
+It is up to the application to decide how to pass or transform the messages from
+and to the nested team or agent.
+
+The following example shows a simple nested chat that counts numbers.
+
+```python
+import asyncio
+from typing import Sequence
+from autogen_core import CancellationToken
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.messages import TextMessage, BaseChatMessage
+from autogen_agentchat.base import Response
+
+class CountingAgent(BaseChatAgent):
+    """An agent that returns a new number by adding 1 to the last number in the input messages."""
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        if len(messages) == 0:
+            last_number = 0 # Start from 0 if no messages are given.
+        else:
+            assert isinstance(messages[-1], TextMessage)
+            last_number = int(messages[-1].content) # Otherwise, start from the last number.
+        return Response(chat_message=TextMessage(content=str(last_number + 1), source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+class NestedCountingAgent(BaseChatAgent):
+    """An agent that increments the last number in the input messages
+    multiple times using a nested counting team."""
+    def __init__(self, name: str, counting_team: RoundRobinGroupChat) -> None:
+        super().__init__(name, description="An agent that counts numbers.")
+        self._counting_team = counting_team
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        # Run the inner team with the given messages and returns the last message produced by the team.
+        result = await self._counting_team.run(task=messages, cancellation_token=cancellation_token)
+        # To stream the inner messages, implement `on_messages_stream` and use that to implement `on_messages`.
+        assert isinstance(result.messages[-1], TextMessage)
+        return Response(chat_message=result.messages[-1], inner_messages=result.messages[len(messages):-1])
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        # Reset the inner team.
+        await self._counting_team.reset()
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+async def main() -> None:
+    # Create a team of two counting agents as the inner team.
+    counting_agent_1 = CountingAgent("counting_agent_1", description="An agent that counts numbers.")
+    counting_agent_2 = CountingAgent("counting_agent_2", description="An agent that counts numbers.")
+    counting_team = RoundRobinGroupChat([counting_agent_1, counting_agent_2], max_turns=5)
+    # Create a nested counting agent that takes the inner team as a parameter.
+    nested_counting_agent = NestedCountingAgent("nested_counting_agent", counting_team)
+    # Run the nested counting agent with a message starting from 1.
+    response = await nested_counting_agent.on_messages([TextMessage(content="1", source="user")], CancellationToken())
+    assert response.inner_messages is not None
+    for message in response.inner_messages:
+        print(message)
+    print(response.chat_message)
+
+asyncio.run(main())
+```
+
+You should see the following output:
+
+```bash
+source='counting_agent_1' models_usage=None content='2' type='TextMessage'
+source='counting_agent_2' models_usage=None content='3' type='TextMessage'
+source='counting_agent_1' models_usage=None content='4' type='TextMessage'
+source='counting_agent_2' models_usage=None content='5' type='TextMessage'
+source='counting_agent_1' models_usage=None content='6' type='TextMessage'
+```
+
+You can take a look at {py:class}`~autogen_agentchat.agents.SocietyOfMindAgent`
+for a more complex implementation.
+
+## Sequential Chat
+
+In `v0.2`, sequential chat is supported by using the `initiate_chats` function.
+It takes input a list of dictionary configurations for each step of the sequence.
+See [Sequential Chat in v0.2](https://microsoft.github.io/autogen/0.2/docs/tutorial/conversation-patterns#sequential-chats)
+for more details.
+
+Base on the feedback from the community, the `initiate_chats` function
+is too opinionated and not flexible enough to support the diverse set of scenarios that
+users want to implement. We often find users struggling to get the `initiate_chats` function
+to work when they can easily glue the steps together usign basic Python code.
+Therefore, in `v0.4`, we do not provide a built-in function for sequential chat in the AgentChat API.
+
+Instead, you can create an event-driven sequential workflow using the Core API,
+and use the other components provided the AgentChat API to implement each step of the workflow.
+See an example of sequential workflow in the [Core API Tutorial](../core-user-guide/design-patterns/sequential-workflow.ipynb).
+
+We recognize that the concept of workflow is at the heart of many applications,
+and we will provide more built-in support for workflows in the future.
+
+## GPTAssistantAgent
+
+In `v0.2`, `GPTAssistantAgent` is a special agent class that is backed by the OpenAI Assistant API.
+
+In `v0.4`, the equivalent is the {py:class}`~autogen_ext.agents.openai.OpenAIAssistantAgent` class.
+It supports the same set of features as the `GPTAssistantAgent` in `v0.2` with
+more such as customizable threads and file uploads.
+See {py:class}`~autogen_ext.agents.openai.OpenAIAssistantAgent` for more details.
+
+## Long Context Handling
+
+In `v0.2`, long context that overflows the model's context window can be handled
+by using the `transforms` capability that is added to an `ConversableAgent`
+after which is contructed.
+
+The feedbacks from our community has led us to believe this feature is essential
+and should be a built-in component of {py:class}`~autogen_agentchat.agents.AssistantAgent`, and can be used for
+every custom agent.
+
+In `v0.4`, we introduce the {py:class}`~autogen_core.model_context.ChatCompletionContext` base class that manages
+message history and provides a virtual view of the history. Applications can use
+built-in implementations such as {py:class}`~autogen_core.model_context.BufferedChatCompletionContext` to
+limit the message history sent to the model, or provide their own implementations
+that creates different virtual views.
+
+To use {py:class}`~autogen_core.model_context.BufferedChatCompletionContext` in an {py:class}`~autogen_agentchat.agents.AssistantAgent` in a chatbot scenario.
+
+```python
+import asyncio
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.agents import AssistantAgent
+from autogen_core import CancellationToken
+from autogen_core.model_context import BufferedChatCompletionContext
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", seed=42, temperature=0)
+
+    assistant = AssistantAgent(
+        name="assistant",
+        system_message="You are a helpful assistant.",
+        model_client=model_client,
+        model_context=BufferedChatCompletionContext(buffer_size=10), # Model can only view the last 10 messages.
+    )
+    while True:
+        user_input = input("User: ")
+        if user_input == "exit":
+            break
+        response = await assistant.on_messages([TextMessage(content=user_input, source="user")], CancellationToken())
+        print("Assistant:", response.chat_message.to_text())
+    
+    await model_client.close()
+
+asyncio.run(main())
+```
+
+In this example, the chatbot can only read the last 10 messages in the history.
+
+## Observability and Control
+
+In `v0.4` AgentChat, you can observe the agents by using the `on_messages_stream` method
+which returns an async generator to stream the inner thoughts and actions of the agent.
+For teams, you can use the `run_stream` method to stream the inner conversation among the agents in the team.
+Your application can use these streams to observe the agents and teams in real-time.
+
+Both the `on_messages_stream` and `run_stream` methods takes a {py:class}`~autogen_core.CancellationToken` as a parameter
+which can be used to cancel the output stream asynchronously and stop the agent or team.
+For teams, you can also use termination conditions to stop the team when a certain condition is met.
+See [Termination Condition Tutorial](./tutorial/termination.ipynb)
+for more details.
+
+Unlike the `v0.2` which comes with a special logging module, the `v0.4` API
+simply uses Python's `logging` module to log events such as model client calls.
+See [Logging](../core-user-guide/framework/logging.md)
+in the Core API documentation for more details.
+
+## Code Executors
+
+The code executors in `v0.2` and `v0.4` are nearly identical except
+the `v0.4` executors support async API. You can also use
+{py:class}`~autogen_core.CancellationToken` to cancel a code execution if it takes too long.
+See [Command Line Code Executors Tutorial](../core-user-guide/components/command-line-code-executors.ipynb)
+in the Core API documentation.
+
+We also added `ACADynamicSessionsCodeExecutor` that can use Azure Container Apps (ACA)
+dynamic sessions for code execution.
+See [ACA Dynamic Sessions Code Executor Docs](../extensions-user-guide/azure-container-code-executor.ipynb).
+
+
+---
+
+## Quickstart
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/quickstart.html
+
+# Quickstart
+
+Via AgentChat, you can build applications quickly using preset agents.
+To illustrate this, we will begin with creating a single agent that can
+use tools.
+
+First, we need to install the AgentChat and Extension packages.
+
+```python
+pip install -U "autogen-agentchat" "autogen-ext[openai,azure]"
+```
+
+This example uses an OpenAI model, however, you can use other models as well.
+Simply update the `model_client` with the desired model or model client class.
+
+To use Azure OpenAI models and AAD authentication,
+you can follow the instructions [here](./tutorial/models.ipynb#azure-openai).
+To use other models, see [Models](./tutorial/models.ipynb).
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Define a model client. You can use other model client that implements
+# the `ChatCompletionClient` interface.
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    # api_key="YOUR_API_KEY",
+)
+
+
+# Define a simple function tool that the agent can use.
+# For this example, we use a fake weather tool for demonstration purposes.
+async def get_weather(city: str) -> str:
+    """Get the weather for a given city."""
+    return f"The weather in {city} is 73 degrees and Sunny."
+
+
+# Define an AssistantAgent with the model, tool, system message, and reflection enabled.
+# The system message instructs the agent via natural language.
+agent = AssistantAgent(
+    name="weather_agent",
+    model_client=model_client,
+    tools=[get_weather],
+    system_message="You are a helpful assistant.",
+    reflect_on_tool_use=True,
+    model_client_stream=True,  # Enable streaming tokens from the model client.
+)
+
+
+# Run the agent and stream the messages to the console.
+async def main() -> None:
+    await Console(agent.run_stream(task="What is the weather in New York?"))
+    # Close the connection to the model client.
+    await model_client.close()
+
+
+# NOTE: if running this inside a Python script you'll need to use asyncio.run(main()).
+await main()
+```
+
+## What's Next?
+
+Now that you have a basic understanding of how to use a single agent, consider following the [tutorial](./tutorial/index.md) for a walkthrough on other features of AgentChat.
+
+---
+
+## Selector Group Chat
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/selector-group-chat.html
+
+# Selector Group Chat
+
+{py:class}`~autogen_agentchat.teams.SelectorGroupChat` implements a team where participants take turns broadcasting messages to all other members. A generative model (e.g., an LLM) selects the next speaker based on the shared context, enabling dynamic, context-aware collaboration.
+
+Key features include:
+
+- Model-based speaker selection
+- Configurable participant roles and descriptions
+- Prevention of consecutive turns by the same speaker (optional)
+- Customizable selection prompting
+- Customizable selection function to override the default model-based selection
+- Customizable candidate function to narrow-down the set of agents for selection using model
+
+```{note}
+{py:class}`~autogen_agentchat.teams.SelectorGroupChat` is a high-level API. For more control and customization, refer to the [Group Chat Pattern](../core-user-guide/design-patterns/group-chat.ipynb) in the Core API documentation to implement your own group chat logic.
+```
+
+## How Does it Work?
+
+{py:class}`~autogen_agentchat.teams.SelectorGroupChat` is a group chat similar to {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`,
+but with a model-based next speaker selection mechanism.
+When the team receives a task through {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` or {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run_stream`,
+the following steps are executed:
+
+1. The team analyzes the current conversation context, including the conversation history and participants' {py:attr}`~autogen_agentchat.base.ChatAgent.name` and {py:attr}`~autogen_agentchat.base.ChatAgent.description` attributes, to determine the next speaker using a model. By default, the team will not select the same speak consecutively unless it is the only agent available. This can be changed by setting `allow_repeated_speaker=True`. You can also override the model by providing a custom selection function.
+2. The team prompts the selected speaker agent to provide a response, which is then **broadcasted** to all other participants.
+3. The termination condition is checked to determine if the conversation should end, if not, the process repeats from step 1.
+4. When the conversation ends, the team returns the {py:class}`~autogen_agentchat.base.TaskResult` containing the conversation history from this task.
+
+Once the team finishes the task, the conversation context is kept within the team and all participants, so the next task can continue from the previous conversation context.
+You can reset the conversation context by calling {py:meth}`~autogen_agentchat.teams.BaseGroupChat.reset`.
+
+In this section, we will demonstrate how to use {py:class}`~autogen_agentchat.teams.SelectorGroupChat` with a simple example for a web search and data analysis task.
+
+## Example: Web Search/Analysis
+
+```python
+from typing import List, Sequence
+
+from autogen_agentchat.agents import AssistantAgent, UserProxyAgent
+from autogen_agentchat.conditions import MaxMessageTermination, TextMentionTermination
+from autogen_agentchat.messages import BaseAgentEvent, BaseChatMessage
+from autogen_agentchat.teams import SelectorGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+```
+
+### Agents
+
+![Selector Group Chat](selector-group-chat.svg)
+
+This system uses three specialized agents:
+
+- **Planning Agent**: The strategic coordinator that breaks down complex tasks into manageable subtasks. 
+- **Web Search Agent**: An information retrieval specialist that interfaces with the `search_web_tool`.
+- **Data Analyst Agent**: An agent specialist in performing calculations equipped with `percentage_change_tool`. 
+
+The tools `search_web_tool` and `percentage_change_tool` are external tools that the agents can use to perform their tasks.
+
+```python
+# Note: This example uses mock tools instead of real APIs for demonstration purposes
+def search_web_tool(query: str) -> str:
+    if "2006-2007" in query:
+        return """Here are the total points scored by Miami Heat players in the 2006-2007 season:
+        Udonis Haslem: 844 points
+        Dwayne Wade: 1397 points
+        James Posey: 550 points
+        ...
+        """
+    elif "2007-2008" in query:
+        return "The number of total rebounds for Dwayne Wade in the Miami Heat season 2007-2008 is 214."
+    elif "2008-2009" in query:
+        return "The number of total rebounds for Dwayne Wade in the Miami Heat season 2008-2009 is 398."
+    return "No data found."
+
+
+def percentage_change_tool(start: float, end: float) -> float:
+    return ((end - start) / start) * 100
+```
+
+Let's create the specialized agents using the {py:class}`~autogen_agentchat.agents.AssistantAgent` class.
+It is important to note that the agents' {py:attr}`~autogen_agentchat.base.ChatAgent.name` and {py:attr}`~autogen_agentchat.base.ChatAgent.description` attributes are used by the model to determine the next speaker,
+so it is recommended to provide meaningful names and descriptions.
+
+```python
+model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+planning_agent = AssistantAgent(
+    "PlanningAgent",
+    description="An agent for planning tasks, this agent should be the first to engage when given a new task.",
+    model_client=model_client,
+    system_message="""
+    You are a planning agent.
+    Your job is to break down complex tasks into smaller, manageable subtasks.
+    Your team members are:
+        WebSearchAgent: Searches for information
+        DataAnalystAgent: Performs calculations
+
+    You only plan and delegate tasks - you do not execute them yourself.
+
+    When assigning tasks, use this format:
+    1. <agent> : <task>
+
+    After all tasks are complete, summarize the findings and end with "TERMINATE".
+    """,
+)
+
+web_search_agent = AssistantAgent(
+    "WebSearchAgent",
+    description="An agent for searching information on the web.",
+    tools=[search_web_tool],
+    model_client=model_client,
+    system_message="""
+    You are a web search agent.
+    Your only tool is search_tool - use it to find information.
+    You make only one search call at a time.
+    Once you have the results, you never do calculations based on them.
+    """,
+)
+
+data_analyst_agent = AssistantAgent(
+    "DataAnalystAgent",
+    description="An agent for performing calculations.",
+    model_client=model_client,
+    tools=[percentage_change_tool],
+    system_message="""
+    You are a data analyst.
+    Given the tasks you have been assigned, you should analyze the data and provide results using the tools provided.
+    If you have not seen the data, ask for it.
+    """,
+)
+```
+
+```{note}
+By default, {py:class}`~autogen_agentchat.agents.AssistantAgent` returns the
+tool output as the response. If your tool does not return a well-formed
+string in natural language format, you may want to add a reflection step
+within the agent by setting `reflect_on_tool_use=True` when creating the agent.
+This will allow the agent to reflect on the tool output and provide a natural
+language response.
+```
+
+### Workflow
+
+1. The task is received by the {py:class}`~autogen_agentchat.teams.SelectorGroupChat` which, based on agent descriptions, selects the most appropriate agent to handle the initial task (typically the Planning Agent).
+
+2. The **Planning Agent** analyzes the task and breaks it down into subtasks, assigning each to the most appropriate agent using the format:
+   `<agent> : <task>`
+
+3. Based on the conversation context and agent descriptions, the {py:class}`~autogen_agent.teams.SelectorGroupChat` manager dynamically selects the next agent to handle their assigned subtask.
+
+4. The **Web Search Agent** performs searches one at a time, storing results in the shared conversation history.
+
+5. The **Data Analyst** processes the gathered information using available calculation tools when selected.
+
+6. The workflow continues with agents being dynamically selected until either:
+   - The Planning Agent determines all subtasks are complete and sends "TERMINATE"
+   - An alternative termination condition is met (e.g., a maximum number of messages)
+
+When defining your agents, make sure to include a helpful {py:attr}`~autogen_agentchat.base.ChatAgent.description` since this is used to decide which agent to select next.
+
+### Termination Conditions
+
+Let's use two termination conditions:
+{py:class}`~autogen_agentchat.conditions.TextMentionTermination` to end the conversation when the Planning Agent sends "TERMINATE",
+and {py:class}`~autogen_agentchat.conditions.MaxMessageTermination` to limit the conversation to 25 messages to avoid infinite loop.
+
+```python
+text_mention_termination = TextMentionTermination("TERMINATE")
+max_messages_termination = MaxMessageTermination(max_messages=25)
+termination = text_mention_termination | max_messages_termination
+```
+
+### Selector Prompt
+
+{py:class}`~autogen_agentchat.teams.SelectorGroupChat` uses a model to select
+the next speaker based on the conversation context.
+We will use a custom selector prompt to properly align with the workflow.
+
+```python
+selector_prompt = """Select an agent to perform task.
+
+{roles}
+
+Current conversation context:
+{history}
+
+Read the above conversation, then select an agent from {participants} to perform the next task.
+Make sure the planner agent has assigned tasks before other agents start working.
+Only select one agent.
+"""
+```
+
+The string variables available in the selector prompt are:
+- `{participants}`: The names of candidates for selection. The format is `["<name1>", "<name2>", ...]`.
+- `{roles}`: A newline-separated list of names and descriptions of the candidate agents. The format for each line is: `"<name> : <description>"`.
+- `{history}`: The conversation history formatted as a double newline separated of names and message content. The format for each message is: `"<name> : <message content>"`.
+
+```{tip}
+Try not to overload the model with too much instruction in the selector prompt.
+
+What is too much? It depends on the capabilities of the model you are using.
+For GPT-4o and equivalents, you can use a selector prompt with a condition for when each speaker should be selected.
+For smaller models such as Phi-4, you should keep the selector prompt as simple as possible
+such as the one used in this example.
+
+Generally, if you find yourself writing multiple conditions for each agent,
+it is a sign that you should consider using a custom selection function,
+or breaking down the task into smaller, sequential tasks to be handled by
+separate agents or teams.
+```
+
+### Running the Team
+
+Let's create the team with the agents, termination conditions, and custom selector prompt.
+
+```python
+team = SelectorGroupChat(
+    [planning_agent, web_search_agent, data_analyst_agent],
+    model_client=model_client,
+    termination_condition=termination,
+    selector_prompt=selector_prompt,
+    allow_repeated_speaker=True,  # Allow an agent to speak multiple turns in a row.
+)
+```
+
+Now we run the team with a task to find information about an NBA player.
+
+```python
+task = "Who was the Miami Heat player with the highest points in the 2006-2007 season, and what was the percentage change in his total rebounds between the 2007-2008 and 2008-2009 seasons?"
+```
+
+```python
+# Use asyncio.run(...) if you are running this in a script.
+await Console(team.run_stream(task=task))
+```
+
+As we can see, after the Web Search Agent conducts the necessary searches and the Data Analyst Agent completes the necessary calculations, we find that Dwayne Wade was the Miami Heat player with the highest points in the 2006-2007 season, and the percentage change in his total rebounds between the 2007-2008 and 2008-2009 seasons is 85.98%!
+
+## Custom Selector Function
+
+Often times we want better control over the selection process.
+To this end, we can set the `selector_func` argument with a custom selector function to override the default model-based selection.
+This allows us to implement more complex selection logic and state-based transitions.
+
+For instance, we want the Planning Agent to speak immediately after any specialized agent to check the progress.
+
+```{note}
+Returning `None` from the custom selector function will use the default model-based selection.
+``` 
+
+```{note}
+Custom selector functions are not [serialized](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/serialize-components.html) when `.dump_component()` is called on the SelectorGroupChat team . If you need to serialize team configurations with custom selector functions, consider implementing custom workflows and serialization logic.
+```
+
+```python
+def selector_func(messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> str | None:
+    if messages[-1].source != planning_agent.name:
+        return planning_agent.name
+    return None
+
+
+# Reset the previous team and run the chat again with the selector function.
+await team.reset()
+team = SelectorGroupChat(
+    [planning_agent, web_search_agent, data_analyst_agent],
+    model_client=model_client,
+    termination_condition=termination,
+    selector_prompt=selector_prompt,
+    allow_repeated_speaker=True,
+    selector_func=selector_func,
+)
+
+await Console(team.run_stream(task=task))
+```
+
+You can see from the conversation log that the Planning Agent always speaks immediately after the specialized agents.
+
+```{tip}
+Each participant agent only makes one step (executing tools, generating a response, etc.)
+on each turn. 
+If you want an {py:class}`~autogen_agentchat.agents.AssistantAgent` to repeat
+until it stop returning a {py:class}`~autogen_agentchat.messages.ToolCallSummaryMessage`
+when it has finished running all the tools it needs to run, you can do so by
+checking the last message and returning the agent if it is a
+{py:class}`~autogen_agentchat.messages.ToolCallSummaryMessage`.
+```
+
+## Custom Candidate Function
+
+One more possible requirement might be to automatically select the next speaker from a filtered list of agents.
+For this, we can set `candidate_func` parameter with a custom candidate function to filter down the list of potential agents for speaker selection for each turn of groupchat.
+
+This allow us to restrict speaker selection to a specific set of agents after a given agent.
+
+
+```{note}
+The `candidate_func` is only valid if `selector_func` is not set.
+Returning `None` or an empty list `[]` from the custom candidate function will raise a `ValueError`.
+```
+
+```python
+def candidate_func(messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> List[str]:
+    # keep planning_agent first one to plan out the tasks
+    if messages[-1].source == "user":
+        return [planning_agent.name]
+
+    # if previous agent is planning_agent and if it explicitely asks for web_search_agent
+    # or data_analyst_agent or both (in-case of re-planning or re-assignment of tasks)
+    # then return those specific agents
+    last_message = messages[-1]
+    if last_message.source == planning_agent.name:
+        participants = []
+        if web_search_agent.name in last_message.to_text():
+            participants.append(web_search_agent.name)
+        if data_analyst_agent.name in last_message.to_text():
+            participants.append(data_analyst_agent.name)
+        if participants:
+            return participants  # SelectorGroupChat will select from the remaining two agents.
+
+    # we can assume that the task is finished once the web_search_agent
+    # and data_analyst_agent have took their turns, thus we send
+    # in planning_agent to terminate the chat
+    previous_set_of_agents = set(message.source for message in messages)
+    if web_search_agent.name in previous_set_of_agents and data_analyst_agent.name in previous_set_of_agents:
+        return [planning_agent.name]
+
+    # if no-conditions are met then return all the agents
+    return [planning_agent.name, web_search_agent.name, data_analyst_agent.name]
+
+
+# Reset the previous team and run the chat again with the selector function.
+await team.reset()
+team = SelectorGroupChat(
+    [planning_agent, web_search_agent, data_analyst_agent],
+    model_client=model_client,
+    termination_condition=termination,
+    candidate_func=candidate_func,
+)
+
+await Console(team.run_stream(task=task))
+```
+
+You can see from the conversation log that the Planning Agent returns to conversation once the Web Search Agent and Data Analyst Agent took their turns and it finds that the task was not finished as expected so it called the WebSearchAgent again to get rebound values and then called DataAnalysetAgent to get the percentage change.
+
+## User Feedback
+
+We can add {py:class}`~autogen_agentchat.agents.UserProxyAgent` to the team to
+provide user feedback during a run.
+See [Human-in-the-Loop](./tutorial/human-in-the-loop.ipynb) for more details
+about {py:class}`~autogen_agentchat.agents.UserProxyAgent`.
+
+To use the {py:class}`~autogen_agentchat.agents.UserProxyAgent` in the 
+web search example, we simply add it to the team and update the selector function
+to always check for user feedback after the planning agent speaks.
+If the user responds with `"APPROVE"`, the conversation continues, otherwise,
+the planning agent tries again, until the user approves.
+
+```python
+user_proxy_agent = UserProxyAgent("UserProxyAgent", description="A proxy for the user to approve or disapprove tasks.")
+
+
+def selector_func_with_user_proxy(messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> str | None:
+    if messages[-1].source != planning_agent.name and messages[-1].source != user_proxy_agent.name:
+        # Planning agent should be the first to engage when given a new task, or check progress.
+        return planning_agent.name
+    if messages[-1].source == planning_agent.name:
+        if messages[-2].source == user_proxy_agent.name and "APPROVE" in messages[-1].content.upper():  # type: ignore
+            # User has approved the plan, proceed to the next agent.
+            return None
+        # Use the user proxy agent to get the user's approval to proceed.
+        return user_proxy_agent.name
+    if messages[-1].source == user_proxy_agent.name:
+        # If the user does not approve, return to the planning agent.
+        if "APPROVE" not in messages[-1].content.upper():  # type: ignore
+            return planning_agent.name
+    return None
+
+
+# Reset the previous agents and run the chat again with the user proxy agent and selector function.
+await team.reset()
+team = SelectorGroupChat(
+    [planning_agent, web_search_agent, data_analyst_agent, user_proxy_agent],
+    model_client=model_client,
+    termination_condition=termination,
+    selector_prompt=selector_prompt,
+    selector_func=selector_func_with_user_proxy,
+    allow_repeated_speaker=True,
+)
+
+await Console(team.run_stream(task=task))
+```
+
+Now, the user's feedback is incorporated into the conversation flow,
+and the user can approve or reject the planning agent's decisions.
+
+## Using Reasoning Models
+
+So far in the examples, we have used a `gpt-4o` model. Models like `gpt-4o`
+and `gemini-1.5-flash` are great at following instructions, so you can
+have relatively detailed instructions in the selector prompt for the team and the 
+system messages for each agent to guide their behavior.
+
+However, if you are using a reasoning model like `o3-mini`, you will need to
+keep the selector prompt and system messages as simple and to the point as possible.
+This is because the reasoning models are already good at coming up with their own 
+instructions given the context provided to them.
+
+This also means that we don't need a planning agent to break down the task
+anymore, since the {py:class}`~autogen_agentchat.teams.SelectorGroupChat` that
+uses a reasoning model can do that on its own.
+
+In the following example, we will use `o3-mini` as the model for the
+agents and the team, and we will not use a planning agent.
+Also, we are keeping the selector prompt and system messages as simple as possible.
+
+```python
+model_client = OpenAIChatCompletionClient(model="o3-mini")
+
+web_search_agent = AssistantAgent(
+    "WebSearchAgent",
+    description="An agent for searching information on the web.",
+    tools=[search_web_tool],
+    model_client=model_client,
+    system_message="""Use web search tool to find information.""",
+)
+
+data_analyst_agent = AssistantAgent(
+    "DataAnalystAgent",
+    description="An agent for performing calculations.",
+    model_client=model_client,
+    tools=[percentage_change_tool],
+    system_message="""Use tool to perform calculation. If you have not seen the data, ask for it.""",
+)
+
+user_proxy_agent = UserProxyAgent(
+    "UserProxyAgent",
+    description="A user to approve or disapprove tasks.",
+)
+
+selector_prompt = """Select an agent to perform task.
+
+{roles}
+
+Current conversation context:
+{history}
+
+Read the above conversation, then select an agent from {participants} to perform the next task.
+When the task is complete, let the user approve or disapprove the task.
+"""
+
+team = SelectorGroupChat(
+    [web_search_agent, data_analyst_agent, user_proxy_agent],
+    model_client=model_client,
+    termination_condition=termination,  # Use the same termination condition as before.
+    selector_prompt=selector_prompt,
+    allow_repeated_speaker=True,
+)
+```
+
+```python
+await Console(team.run_stream(task=task))
+```
+
+```{tip}
+For more guidance on how to prompt reasoning models, see the
+Azure AI Services Blog on [Prompt Engineering for OpenAI's O1 and O3-mini Reasoning Models](https://techcommunity.microsoft.com/blog/azure-ai-services-blog/prompt-engineering-for-openai%E2%80%99s-o1-and-o3-mini-reasoning-models/4374010)
+```
+
+---
+
+## Serializing Components
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/serialize-components.html
+
+# Serializing Components 
+
+AutoGen provides a  {py:class}`~autogen_core.Component` configuration class that defines behaviours  to serialize/deserialize component into declarative specifications. We can accomplish this by calling `.dump_component()` and `.load_component()` respectively. This is useful for debugging, visualizing, and even for sharing your work with others. In this notebook, we will demonstrate how to serialize multiple components to a declarative specification like a JSON file.  
+
+
+```{warning}
+
+ONLY LOAD COMPONENTS FROM TRUSTED SOURCES.
+
+With serilized components, each component implements the logic for how it is serialized and deserialized - i.e., how the declarative specification is generated and how it is converted back to an object. 
+
+In some cases, creating an object may include executing code (e.g., a serialized function). ONLY LOAD COMPONENTS FROM TRUSTED SOURCES. 
+ 
+```
+
+```{note}
+`selector_func` is not serializable and will be ignored during serialization and deserialization process.
+```
+
+ 
+### Termination Condition Example 
+
+In the example below, we will define termination conditions (a part of an agent team) in python, export this to a dictionary/json and also demonstrate how the termination condition object can be loaded from the dictionary/json. 
+ 
+
+```python
+from autogen_agentchat.conditions import MaxMessageTermination, StopMessageTermination
+
+max_termination = MaxMessageTermination(5)
+stop_termination = StopMessageTermination()
+
+or_termination = max_termination | stop_termination
+
+or_term_config = or_termination.dump_component()
+print("Config: ", or_term_config.model_dump_json())
+
+new_or_termination = or_termination.load_component(or_term_config)
+```
+
+## Agent Example 
+
+In the example below, we will define an agent in python, export this to a dictionary/json and also demonstrate how the agent object can be loaded from the dictionary/json.
+
+```python
+from autogen_agentchat.agents import AssistantAgent, UserProxyAgent
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Create an agent that uses the OpenAI GPT-4o model.
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    # api_key="YOUR_API_KEY",
+)
+agent = AssistantAgent(
+    name="assistant",
+    model_client=model_client,
+    handoffs=["flights_refunder", "user"],
+    # tools=[], # serializing tools is not yet supported
+    system_message="Use tools to solve tasks.",
+)
+user_proxy = UserProxyAgent(name="user")
+```
+
+```python
+user_proxy_config = user_proxy.dump_component()  # dump component
+print(user_proxy_config.model_dump_json())
+up_new = user_proxy.load_component(user_proxy_config)  # load component
+```
+
+```python
+agent_config = agent.dump_component()  # dump component
+print(agent_config.model_dump_json())
+agent_new = agent.load_component(agent_config)  # load component
+```
+
+A similar approach can be used to serialize the `MultiModalWebSurfer` agent.
+
+```python
+from autogen_ext.agents.web_surfer import MultimodalWebSurfer
+
+agent = MultimodalWebSurfer(
+    name="web_surfer",
+    model_client=model_client,
+    headless=False,
+)
+
+web_surfer_config = agent.dump_component()  # dump component
+print(web_surfer_config.model_dump_json())
+
+```
+
+## Team Example
+
+In the example below, we will define a team in python, export this to a dictionary/json and also demonstrate how the team object can be loaded from the dictionary/json.
+
+```python
+from autogen_agentchat.agents import AssistantAgent, UserProxyAgent
+from autogen_agentchat.conditions import MaxMessageTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Create an agent that uses the OpenAI GPT-4o model.
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    # api_key="YOUR_API_KEY",
+)
+agent = AssistantAgent(
+    name="assistant",
+    model_client=model_client,
+    handoffs=["flights_refunder", "user"],
+    # tools=[], # serializing tools is not yet supported
+    system_message="Use tools to solve tasks.",
+)
+
+team = RoundRobinGroupChat(participants=[agent], termination_condition=MaxMessageTermination(2))
+
+team_config = team.dump_component()  # dump component
+print(team_config.model_dump_json())
+
+await model_client.close()
+```
+
+---
+
+## Swarm
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/swarm.html
+
+# Swarm
+
+{py:class}`~autogen_agentchat.teams.Swarm` implements a team in which agents can hand off 
+task to other agents based on their capabilities. 
+It is a multi-agent design pattern first introduced by OpenAI in 
+[Swarm](https://github.com/openai/swarm).
+The key idea is to let agent delegate tasks to other agents using a special tool call, while
+all agents share the same message context.
+This enables agents to make local decisions about task planning, rather than
+relying on a central orchestrator such as in {py:class}`~autogen_agentchat.teams.SelectorGroupChat`.
+
+```{note}
+{py:class}`~autogen_agentchat.teams.Swarm` is a high-level API. If you need more
+control and customization that is not supported by this API, you can take a look
+at the [Handoff Pattern](../core-user-guide/design-patterns/handoffs.ipynb)
+in the Core API documentation and implement your own version of the Swarm pattern.
+```
+
+## How Does It Work?
+
+At its core, the {py:class}`~autogen_agentchat.teams.Swarm` team is a group chat
+where agents take turn to generate a response. 
+Similar to {py:class}`~autogen_agentchat.teams.SelectorGroupChat`
+and {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`, participant agents
+broadcast their responses so all agents share the same message context.
+
+Different from the other two group chat teams, at each turn,
+**the speaker agent is selected based on the most recent
+{py:class}`~autogen_agentchat.messages.HandoffMessage` message in the context.**
+This naturally requires each agent in the team to be able to generate
+{py:class}`~autogen_agentchat.messages.HandoffMessage` to signal
+which other agents that it hands off to.
+
+For {py:class}`~autogen_agentchat.agents.AssistantAgent`, you can set the
+`handoffs` argument to specify which agents it can hand off to. You can
+use {py:class}`~autogen_agentchat.base.Handoff` to customize the message
+content and handoff behavior.
+
+The overall process can be summarized as follows:
+
+1. Each agent has the ability to generate {py:class}`~autogen_agentchat.messages.HandoffMessage`
+   to signal which other agents it can hand off to. For {py:class}`~autogen_agentchat.agents.AssistantAgent`, this means setting the `handoffs` argument.
+2. When the team starts on a task, the first speaker agents operate on the task and make localized decision about whether to hand off and to whom.
+3. When an agent generates a {py:class}`~autogen_agentchat.messages.HandoffMessage`, the receiving agent takes over the task with the same message context.
+4. The process continues until a termination condition is met.
+
+```{note}
+The {py:class}`~autogen_agentchat.agents.AssistantAgent` uses the tool calling
+capability of the model to generate handoffs. This means that the model must
+support tool calling. If the model does parallel tool calling, multiple handoffs
+may be generated at the same time. This can lead to unexpected behavior.
+To avoid this, you can disable parallel tool calling by configuring the model
+client. For {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient`
+and {py:class}`~autogen_ext.models.openai.AzureOpenAIChatCompletionClient`,
+you can set `parallel_tool_calls=False` in the configuration.
+```
+
+In this section, we will show you two examples of how to use the {py:class}`~autogen_agentchat.teams.Swarm` team:
+
+1. A customer support team with human-in-the-loop handoff.
+2. An automonous team for content generation.
+
+## Customer Support Example
+
+![Customer Support](swarm_customer_support.svg)
+
+This system implements a flights refund scenario with two agents:
+
+- **Travel Agent**: Handles general travel and refund coordination.
+- **Flights Refunder**: Specializes in processing flight refunds with the `refund_flight` tool.
+
+Additionally, we let the user interact with the agents, when agents handoff to `"user"`.
+
+#### Workflow
+1. The **Travel Agent** initiates the conversation and evaluates the user's request.
+2. Based on the request:
+   - For refund-related tasks, the Travel Agent hands off to the **Flights Refunder**.
+   - For information needed from the customer, either agent can hand off to the `"user"`.
+3. The **Flights Refunder** processes refunds using the `refund_flight` tool when appropriate.
+4. If an agent hands off to the `"user"`, the team execution will stop and wait for the user to input a response.
+5. When the user provides input, it's sent back to the team as a {py:class}`~autogen_agentchat.messages.HandoffMessage`. This message is directed to the agent that originally requested user input.
+6. The process continues until the Travel Agent determines the task is complete and terminates the workflow.
+
+```python
+from typing import Any, Dict, List
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import HandoffTermination, TextMentionTermination
+from autogen_agentchat.messages import HandoffMessage
+from autogen_agentchat.teams import Swarm
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+```
+
+### Tools
+
+```python
+def refund_flight(flight_id: str) -> str:
+    """Refund a flight"""
+    return f"Flight {flight_id} refunded"
+```
+
+### Agents
+
+```python
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    # api_key="YOUR_API_KEY",
+)
+
+travel_agent = AssistantAgent(
+    "travel_agent",
+    model_client=model_client,
+    handoffs=["flights_refunder", "user"],
+    system_message="""You are a travel agent.
+    The flights_refunder is in charge of refunding flights.
+    If you need information from the user, you must first send your message, then you can handoff to the user.
+    Use TERMINATE when the travel planning is complete.""",
+)
+
+flights_refunder = AssistantAgent(
+    "flights_refunder",
+    model_client=model_client,
+    handoffs=["travel_agent", "user"],
+    tools=[refund_flight],
+    system_message="""You are an agent specialized in refunding flights.
+    You only need flight reference numbers to refund a flight.
+    You have the ability to refund a flight using the refund_flight tool.
+    If you need information from the user, you must first send your message, then you can handoff to the user.
+    When the transaction is complete, handoff to the travel agent to finalize.""",
+)
+```
+
+```python
+termination = HandoffTermination(target="user") | TextMentionTermination("TERMINATE")
+team = Swarm([travel_agent, flights_refunder], termination_condition=termination)
+```
+
+```python
+task = "I need to refund my flight."
+
+
+async def run_team_stream() -> None:
+    task_result = await Console(team.run_stream(task=task))
+    last_message = task_result.messages[-1]
+
+    while isinstance(last_message, HandoffMessage) and last_message.target == "user":
+        user_message = input("User: ")
+
+        task_result = await Console(
+            team.run_stream(task=HandoffMessage(source="user", target=last_message.source, content=user_message))
+        )
+        last_message = task_result.messages[-1]
+
+
+# Use asyncio.run(...) if you are running this in a script.
+await run_team_stream()
+await model_client.close()
+```
+
+## Stock Research Example
+
+![Stock Research](swarm_stock_research.svg)
+
+
+This system is designed to perform stock research tasks by leveraging four agents:
+
+- **Planner**: The central coordinator that delegates specific tasks to specialized agents based on their expertise. The planner ensures that each agent is utilized efficiently and oversees the overall workflow.
+- **Financial Analyst**: A specialized agent responsible for analyzing financial metrics and stock data using tools such as `get_stock_data`.
+- **News Analyst**: An agent focused on gathering and summarizing recent news articles relevant to the stock, using tools such as `get_news`.
+- **Writer**: An agent tasked with compiling the findings from the stock and news analysis into a cohesive final report.
+
+#### Workflow
+1. The **Planner** initiates the research process by delegating tasks to the appropriate agents in a step-by-step manner.
+2. Each agent performs its task independently and appends their work to the shared **message thread/history**. Rather than directly returning results to the planner, all agents contribute to and read from this shared message history. When agents generate their work using the LLM, they have access to this shared message history, which provides context and helps track the overall progress of the task.
+3. Once an agent completes its task, it hands off control back to the planner.
+4. The process continues until the planner determines that all necessary tasks have been completed and decides to terminate the workflow.
+
+### Tools
+
+```python
+async def get_stock_data(symbol: str) -> Dict[str, Any]:
+    """Get stock market data for a given symbol"""
+    return {"price": 180.25, "volume": 1000000, "pe_ratio": 65.4, "market_cap": "700B"}
+
+
+async def get_news(query: str) -> List[Dict[str, str]]:
+    """Get recent news articles about a company"""
+    return [
+        {
+            "title": "Tesla Expands Cybertruck Production",
+            "date": "2024-03-20",
+            "summary": "Tesla ramps up Cybertruck manufacturing capacity at Gigafactory Texas, aiming to meet strong demand.",
+        },
+        {
+            "title": "Tesla FSD Beta Shows Promise",
+            "date": "2024-03-19",
+            "summary": "Latest Full Self-Driving beta demonstrates significant improvements in urban navigation and safety features.",
+        },
+        {
+            "title": "Model Y Dominates Global EV Sales",
+            "date": "2024-03-18",
+            "summary": "Tesla's Model Y becomes best-selling electric vehicle worldwide, capturing significant market share.",
+        },
+    ]
+```
+
+```python
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    # api_key="YOUR_API_KEY",
+)
+
+planner = AssistantAgent(
+    "planner",
+    model_client=model_client,
+    handoffs=["financial_analyst", "news_analyst", "writer"],
+    system_message="""You are a research planning coordinator.
+    Coordinate market research by delegating to specialized agents:
+    - Financial Analyst: For stock data analysis
+    - News Analyst: For news gathering and analysis
+    - Writer: For compiling final report
+    Always send your plan first, then handoff to appropriate agent.
+    Always handoff to a single agent at a time.
+    Use TERMINATE when research is complete.""",
+)
+
+financial_analyst = AssistantAgent(
+    "financial_analyst",
+    model_client=model_client,
+    handoffs=["planner"],
+    tools=[get_stock_data],
+    system_message="""You are a financial analyst.
+    Analyze stock market data using the get_stock_data tool.
+    Provide insights on financial metrics.
+    Always handoff back to planner when analysis is complete.""",
+)
+
+news_analyst = AssistantAgent(
+    "news_analyst",
+    model_client=model_client,
+    handoffs=["planner"],
+    tools=[get_news],
+    system_message="""You are a news analyst.
+    Gather and analyze relevant news using the get_news tool.
+    Summarize key market insights from news.
+    Always handoff back to planner when analysis is complete.""",
+)
+
+writer = AssistantAgent(
+    "writer",
+    model_client=model_client,
+    handoffs=["planner"],
+    system_message="""You are a financial report writer.
+    Compile research findings into clear, concise reports.
+    Always handoff back to planner when writing is complete.""",
+)
+```
+
+```python
+# Define termination condition
+text_termination = TextMentionTermination("TERMINATE")
+termination = text_termination
+
+research_team = Swarm(
+    participants=[planner, financial_analyst, news_analyst, writer], termination_condition=termination
+)
+
+task = "Conduct market research for TSLA stock"
+await Console(research_team.run_stream(task=task))
+await model_client.close()
+```
+
+---
+
+## Tracing and Observability
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tracing.html
+
+# Tracing and Observability
+
+AutoGen has [built-in support for tracing](https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/framework/telemetry.html) and observability for collecting comprehensive records on the execution of your application. This feature is useful for debugging, performance analysis, and understanding the flow of your application.
+
+This capability is powered by the [OpenTelemetry](https://opentelemetry.io/) library, which means you can use any OpenTelemetry-compatible backend to collect and analyze traces.
+
+AutoGen follows the [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/) for tracing, for agents and tools.
+It also follows the [Semantic Conventions for GenAI Systems](https://opentelemetry.io/docs/specs/semconv/gen-ai/) currently under development.
+
+## Setup
+
+To begin, you need to install the OpenTelemetry Python package. You can do this using pip:
+
+```bash
+pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-grpc opentelemetry-instrumentation-openai
+```
+
+Once you have the SDK installed, the simplest way to set up tracing in AutoGen is to:
+
+1. Configure an OpenTelemetry tracer provider
+2. Set up an exporter to send traces to your backend
+3. Connect the tracer provider to the AutoGen runtime
+
+## Telemetry Backend
+
+To collect and view traces, you need to set up a telemetry backend. Several open-source options are available, including Jaeger, Zipkin. For this example, we will use Jaeger as our telemetry backend.
+
+For a quick start, you can run Jaeger locally using Docker:
+
+```bash
+docker run -d --name jaeger \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+This command starts a Jaeger instance that listens on port 16686 for the Jaeger UI and port 4317 for the OpenTelemetry collector. You can access the Jaeger UI at `http://localhost:16686`.
+
+## Tracing an AgentChat Team
+
+In the following section, we will review how to enable tracing with an AutoGen GroupChat team. The AutoGen runtime already supports open telemetry (automatically logging message metadata). To begin, we will create a tracing service that will be used to instrument the AutoGen runtime.  
+
+```python
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.openai import OpenAIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# Set up telemetry span exporter.
+otel_exporter = OTLPSpanExporter(endpoint="http://localhost:4317", insecure=True)
+span_processor = BatchSpanProcessor(otel_exporter)
+
+# Set up telemetry trace provider.
+tracer_provider = TracerProvider(resource=Resource({"service.name": "autogen-test-agentchat"}))
+tracer_provider.add_span_processor(span_processor)
+trace.set_tracer_provider(tracer_provider)
+
+# Instrument the OpenAI Python library
+OpenAIInstrumentor().instrument()
+
+# we will get reference this tracer later using its service name
+# tracer = trace.get_tracer("autogen-test-agentchat")
+```
+
+All of the code to create a [team](./tutorial/teams.ipynb) should already be familiar to you.
+
+```{note}
+AgentChat teams are run using the AutoGen Core's agent runtime.
+In turn, the runtime is already instrumented to log, see [Core Telemetry Guide](../core-user-guide/framework/telemetry.md).
+To disable the agent runtime telemetry, you can set the `trace_provider` to
+`opentelemetry.trace.NoOpTracerProvider` in the runtime constructor.
+
+Additionally, you can set the environment variable `AUTOGEN_DISABLE_RUNTIME_TRACING` to `true` to disable the agent runtime telemetry if you don't have access to the runtime constructor. For example, if you are using `ComponentConfig`.
+```
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import MaxMessageTermination, TextMentionTermination
+from autogen_agentchat.teams import SelectorGroupChat
+from autogen_agentchat.ui import Console
+from autogen_core import SingleThreadedAgentRuntime
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+
+def search_web_tool(query: str) -> str:
+    if "2006-2007" in query:
+        return """Here are the total points scored by Miami Heat players in the 2006-2007 season:
+        Udonis Haslem: 844 points
+        Dwayne Wade: 1397 points
+        James Posey: 550 points
+        ...
+        """
+    elif "2007-2008" in query:
+        return "The number of total rebounds for Dwayne Wade in the Miami Heat season 2007-2008 is 214."
+    elif "2008-2009" in query:
+        return "The number of total rebounds for Dwayne Wade in the Miami Heat season 2008-2009 is 398."
+    return "No data found."
+
+
+def percentage_change_tool(start: float, end: float) -> float:
+    return ((end - start) / start) * 100
+
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+    # Get a tracer with the default tracer provider.
+    tracer = trace.get_tracer("tracing-autogen-agentchat")
+
+    # Use the tracer to create a span for the main function.
+    with tracer.start_as_current_span("run_team"):
+        planning_agent = AssistantAgent(
+            "PlanningAgent",
+            description="An agent for planning tasks, this agent should be the first to engage when given a new task.",
+            model_client=model_client,
+            system_message="""
+            You are a planning agent.
+            Your job is to break down complex tasks into smaller, manageable subtasks.
+            Your team members are:
+                WebSearchAgent: Searches for information
+                DataAnalystAgent: Performs calculations
+
+            You only plan and delegate tasks - you do not execute them yourself.
+
+            When assigning tasks, use this format:
+            1. <agent> : <task>
+
+            After all tasks are complete, summarize the findings and end with "TERMINATE".
+            """,
+        )
+
+        web_search_agent = AssistantAgent(
+            "WebSearchAgent",
+            description="An agent for searching information on the web.",
+            tools=[search_web_tool],
+            model_client=model_client,
+            system_message="""
+            You are a web search agent.
+            Your only tool is search_tool - use it to find information.
+            You make only one search call at a time.
+            Once you have the results, you never do calculations based on them.
+            """,
+        )
+
+        data_analyst_agent = AssistantAgent(
+            "DataAnalystAgent",
+            description="An agent for performing calculations.",
+            model_client=model_client,
+            tools=[percentage_change_tool],
+            system_message="""
+            You are a data analyst.
+            Given the tasks you have been assigned, you should analyze the data and provide results using the tools provided.
+            If you have not seen the data, ask for it.
+            """,
+        )
+
+        text_mention_termination = TextMentionTermination("TERMINATE")
+        max_messages_termination = MaxMessageTermination(max_messages=25)
+        termination = text_mention_termination | max_messages_termination
+
+        selector_prompt = """Select an agent to perform task.
+
+        {roles}
+
+        Current conversation context:
+        {history}
+
+        Read the above conversation, then select an agent from {participants} to perform the next task.
+        Make sure the planner agent has assigned tasks before other agents start working.
+        Only select one agent.
+        """
+
+        task = "Who was the Miami Heat player with the highest points in the 2006-2007 season, and what was the percentage change in his total rebounds between the 2007-2008 and 2008-2009 seasons?"
+
+        runtime = SingleThreadedAgentRuntime(
+            tracer_provider=trace.NoOpTracerProvider(),  # Disable telemetry for runtime.
+        )
+        runtime.start()
+
+        team = SelectorGroupChat(
+            [planning_agent, web_search_agent, data_analyst_agent],
+            model_client=model_client,
+            termination_condition=termination,
+            selector_prompt=selector_prompt,
+            allow_repeated_speaker=True,
+            runtime=runtime,
+        )
+        await Console(team.run_stream(task=task))
+
+        await runtime.stop()
+
+    await model_client.close()
+
+
+# asyncio.run(main())
+```
+
+```python
+await main()
+```
+
+You can then use the Jaeger UI to view the traces collected from the application run above.  
+
+![Jaeger UI](jaeger.png)
+
+---
+
+## Agents
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html
+
+# Agents
+
+AutoGen AgentChat provides a set of preset Agents, each with variations in how an agent might respond to messages.
+All agents share the following attributes and methods:
+
+- {py:attr}`~autogen_agentchat.agents.BaseChatAgent.name`: The unique name of the agent.
+- {py:attr}`~autogen_agentchat.agents.BaseChatAgent.description`: The description of the agent in text.
+- {py:attr}`~autogen_agentchat.agents.BaseChatAgent.run`: The method that runs the agent given a task as a string or a list of messages, and returns a {py:class}`~autogen_agentchat.base.TaskResult`. **Agents are expected to be stateful and this method is expected to be called with new messages, not complete history**.
+- {py:attr}`~autogen_agentchat.agents.BaseChatAgent.run_stream`: Same as {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run` but returns an iterator of messages that subclass {py:class}`~autogen_agentchat.messages.BaseAgentEvent` or {py:class}`~autogen_agentchat.messages.BaseChatMessage` followed by a {py:class}`~autogen_agentchat.base.TaskResult` as the last item.
+
+See {py:mod}`autogen_agentchat.messages` for more information on AgentChat message types.
+
+## Assistant Agent
+
+{py:class}`~autogen_agentchat.agents.AssistantAgent` is a built-in agent that
+uses a language model and has the ability to use tools.
+
+```{warning}
+{py:class}`~autogen_agentchat.agents.AssistantAgent` is a "kitchen sink" agent
+for prototyping and educational purpose -- it is very general.
+Make sure you read the documentation and implementation to understand the design choices.
+Once you fully understand the design, you may want to implement your own agent.
+See [Custom Agent](../custom-agents.ipynb).
+```
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.messages import StructuredMessage
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+```
+
+```python
+# Define a tool that searches the web for information.
+# For simplicity, we will use a mock function here that returns a static string.
+async def web_search(query: str) -> str:
+    """Find information on the web"""
+    return "AutoGen is a programming framework for building multi-agent applications."
+
+
+# Create an agent that uses the OpenAI GPT-4o model.
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4.1-nano",
+    # api_key="YOUR_API_KEY",
+)
+agent = AssistantAgent(
+    name="assistant",
+    model_client=model_client,
+    tools=[web_search],
+    system_message="Use tools to solve tasks.",
+)
+```
+
+## Getting Result
+
+We can use the {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run` method to get the agent run on a given task.
+
+```python
+# Use asyncio.run(agent.run(...)) when running in a script.
+result = await agent.run(task="Find information on AutoGen")
+print(result.messages)
+```
+
+The call to the {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run` method
+returns a {py:class}`~autogen_agentchat.base.TaskResult`
+with the list of messages in the {py:attr}`~autogen_agentchat.base.TaskResult.messages` attribute,
+which stores the agent's "thought process" as well as the final response.
+
+```{note}
+It is important to note that {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run`
+will update the internal state of the agent -- it will add the messages to the agent's
+message history. You can also call {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run`
+without a task to get the agent to generate responses given its current state.
+```
+
+```{note}
+Unlike in v0.2 AgentChat, the tools are executed by the same agent directly within
+the same call to {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run`.
+By default, the agent will return the result of the tool call as the final response.
+```
+
+## Multi-Modal Input
+
+The {py:class}`~autogen_agentchat.agents.AssistantAgent` can handle multi-modal input
+by providing the input as a {py:class}`~autogen_agentchat.messages.MultiModalMessage`.
+
+```python
+from io import BytesIO
+
+import PIL
+import requests
+from autogen_agentchat.messages import MultiModalMessage
+from autogen_core import Image
+
+# Create a multi-modal message with random image and text.
+pil_image = PIL.Image.open(BytesIO(requests.get("https://picsum.photos/300/200").content))
+img = Image(pil_image)
+multi_modal_message = MultiModalMessage(content=["Can you describe the content of this image?", img], source="user")
+img
+```
+
+```python
+# Use asyncio.run(...) when running in a script.
+result = await agent.run(task=multi_modal_message)
+print(result.messages[-1].content)  # type: ignore
+```
+
+## Streaming Messages
+
+We can also stream each message as it is generated by the agent by using the
+{py:meth}`~autogen_agentchat.agents.BaseChatAgent.run_stream` method,
+and use {py:class}`~autogen_agentchat.ui.Console` to print the messages
+as they appear to the console.
+
+```python
+async def assistant_run_stream() -> None:
+    # Option 1: read each message from the stream (as shown in the previous example).
+    # async for message in agent.run_stream(task="Find information on AutoGen"):
+    #     print(message)
+
+    # Option 2: use Console to print all messages as they appear.
+    await Console(
+        agent.run_stream(task="Find information on AutoGen"),
+        output_stats=True,  # Enable stats printing.
+    )
+
+
+# Use asyncio.run(assistant_run_stream()) when running in a script.
+await assistant_run_stream()
+```
+
+The {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run_stream` method
+returns an asynchronous generator that yields each message generated by the agent,
+followed by a {py:class}`~autogen_agentchat.base.TaskResult` as the last item.
+
+From the messages, you can observe that the assistant agent utilized the `web_search` tool to
+gather information and responded based on the search results.
+
+## Using Tools and Workbench
+
+Large Language Models (LLMs) are typically limited to generating text or code responses. 
+However, many complex tasks benefit from the ability to use external tools that perform specific actions,
+such as fetching data from APIs or databases.
+
+To address this limitation, modern LLMs can now accept a list of available tool schemas 
+(descriptions of tools and their arguments) and generate a tool call message. 
+This capability is known as **Tool Calling** or **Function Calling** and 
+is becoming a popular pattern in building intelligent agent-based applications.
+Refer to the documentation from [OpenAI](https://platform.openai.com/docs/guides/function-calling) 
+and [Anthropic](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) for more information about tool calling in LLMs.
+
+In AgentChat, the {py:class}`~autogen_agentchat.agents.AssistantAgent` can use tools to perform specific actions.
+The `web_search` tool is one such tool that allows the assistant agent to search the web for information.
+A single custom tool can be a Python function or a subclass of the {py:class}`~autogen_core.tools.BaseTool`.
+
+On the other hand, a {py:class}`~autogen_core.tools.Workbench` is a collection of tools that share state and resources.
+
+```{note}
+For how to use model clients directly with tools and workbench, refer to the [Tools](../../core-user-guide/components/tools.ipynb)
+and [Workbench](../../core-user-guide/components/workbench.ipynb) sections
+in the Core User Guide.
+```
+
+By default, when {py:class}`~autogen_agentchat.agents.AssistantAgent` executes a tool,
+it will return the tool's output as a string in {py:class}`~autogen_agentchat.messages.ToolCallSummaryMessage` in its response.
+If your tool does not return a well-formed string in natural language, you
+can add a reflection step to have the model summarize the tool's output,
+by setting the `reflect_on_tool_use=True` parameter in the {py:class}`~autogen_agentchat.agents.AssistantAgent` constructor.
+
+### Built-in Tools and Workbench
+
+AutoGen Extension provides a set of built-in tools that can be used with the Assistant Agent.
+Head over to the [API documentation](../../../reference/index.md) for all the available tools
+under the `autogen_ext.tools` namespace. For example, you can find the following tools:
+
+- {py:mod}`~autogen_ext.tools.graphrag`: Tools for using GraphRAG index.
+- {py:mod}`~autogen_ext.tools.http`: Tools for making HTTP requests.
+- {py:mod}`~autogen_ext.tools.langchain`: Adaptor for using LangChain tools.
+- {py:mod}`~autogen_ext.tools.mcp`: Tools and workbench for using Model Chat Protocol (MCP) servers.
+
+### Function Tool
+
+The {py:class}`~autogen_agentchat.agents.AssistantAgent` automatically
+converts a Python function into a {py:class}`~autogen_core.tools.FunctionTool`
+which can be used as a tool by the agent and automatically generates the tool schema
+from the function signature and docstring.
+
+The `web_search_func` tool is an example of a function tool.
+The schema is automatically generated.
+
+```python
+from autogen_core.tools import FunctionTool
+
+
+# Define a tool using a Python function.
+async def web_search_func(query: str) -> str:
+    """Find information on the web"""
+    return "AutoGen is a programming framework for building multi-agent applications."
+
+
+# This step is automatically performed inside the AssistantAgent if the tool is a Python function.
+web_search_function_tool = FunctionTool(web_search_func, description="Find information on the web")
+# The schema is provided to the model during AssistantAgent's on_messages call.
+web_search_function_tool.schema
+```
+
+### Model Context Protocol (MCP) Workbench
+
+The {py:class}`~autogen_agentchat.agents.AssistantAgent` can also use tools that are
+served from a Model Context Protocol (MCP) server
+using {py:func}`~autogen_ext.tools.mcp.McpWorkbench`.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.messages import TextMessage
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.tools.mcp import McpWorkbench, StdioServerParams
+
+# Get the fetch tool from mcp-server-fetch.
+fetch_mcp_server = StdioServerParams(command="uvx", args=["mcp-server-fetch"])
+
+# Create an MCP workbench which provides a session to the mcp server.
+async with McpWorkbench(fetch_mcp_server) as workbench:  # type: ignore
+    # Create an agent that can use the fetch tool.
+    model_client = OpenAIChatCompletionClient(model="gpt-4.1-nano")
+    fetch_agent = AssistantAgent(
+        name="fetcher", model_client=model_client, workbench=workbench, reflect_on_tool_use=True
+    )
+
+    # Let the agent fetch the content of a URL and summarize it.
+    result = await fetch_agent.run(task="Summarize the content of https://en.wikipedia.org/wiki/Seattle")
+    assert isinstance(result.messages[-1], TextMessage)
+    print(result.messages[-1].content)
+
+    # Close the connection to the model client.
+    await model_client.close()
+```
+
+### Agent as a Tool
+
+Any {py:class}`~autogen_agentchat.agents.BaseChatAgent` can be used as a tool
+by wrapping it in a {py:class}`~autogen_agentchat.tools.AgentTool`.
+This allows for a dynamic, model-driven multi-agent workflow where
+the agent can call other agents as tools to solve tasks.
+
+### Parallel Tool Calls
+
+Some models support parallel tool calls, which can be useful for tasks that require multiple tools to be called simultaneously.
+By default, if the model client produces multiple tool calls, {py:class}`~autogen_agentchat.agents.AssistantAgent`
+will call the tools in parallel.
+
+You may want to disable parallel tool calls when the tools have side effects that may interfere with each other, or,
+when agent behavior needs to be consistent across different models.
+This should be done at the model client level.
+
+```{important}
+When using {py:class}`~autogen_agentchat.tools.AgentTool` or {py:class}`~autogen_agentchat.tools.TeamTool`,
+you **must** disable parallel tool calls to avoid concurrency issues.
+These tools cannot run concurrently as agents and teams maintain internal state
+that would conflict with parallel execution.
+```
+
+For {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` and {py:class}`~autogen_ext.models.openai.AzureOpenAIChatCompletionClient`,
+set `parallel_tool_calls=False` to disable parallel tool calls.
+
+```python
+model_client_no_parallel_tool_call = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    parallel_tool_calls=False,  # type: ignore
+)
+agent_no_parallel_tool_call = AssistantAgent(
+    name="assistant",
+    model_client=model_client_no_parallel_tool_call,
+    tools=[web_search],
+    system_message="Use tools to solve tasks.",
+)
+```
+
+### Tool Iterations
+
+One model call followed by one tool call or parallel tool calls
+is a single tool iteration.
+By default, the {py:class}`~autogen_agentchat.agents.AssistantAgent` will
+execute at most one iteration.
+
+The agent can be configured to execute multiple iterations until the model
+stops generating tool calls or the maximum number of iterations is reached.
+You can control the maximum number of iterations by setting the `max_tool_iterations` parameter
+in the {py:class}`~autogen_agentchat.agents.AssistantAgent` constructor.
+
+```python
+agent_loop = AssistantAgent(
+    name="assistant_loop",
+    model_client=model_client_no_parallel_tool_call,
+    tools=[web_search],
+    system_message="Use tools to solve tasks.",
+    max_tool_iterations=10,  # At most 10 iterations of tool calls before stopping the loop.
+)
+```
+
+## Structured Output
+
+Structured output allows models to return structured JSON text with pre-defined schema
+provided by the application. Different from JSON-mode, the schema can be provided
+as a [Pydantic BaseModel](https://docs.pydantic.dev/latest/concepts/models/)
+class, which can also be used to validate the output.
+
+Once you specify the base model class in the `output_content_type` parameter
+of the {py:class}`~autogen_agentchat.agents.AssistantAgent` constructor,
+the agent will respond with a {py:class}`~autogen_agentchat.messages.StructuredMessage`
+whose `content`'s type is the type of the base model class.
+
+This way, you can integrate agent's response directly into your application
+and use the model's output as a structured object.
+
+```{note}
+When the `output_content_type` is set, it by default requires the agent to reflect on the tool use
+and return the a structured output message based on the tool call result.
+You can disable this behavior by setting `reflect_on_tool_use=False` explictly.
+```
+
+Structured output is also useful for incorporating Chain-of-Thought
+reasoning in the agent's responses.
+See the example below for how to use structured output with the assistant agent.
+
+```python
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+# The response format for the agent as a Pydantic base model.
+class AgentResponse(BaseModel):
+    thoughts: str
+    response: Literal["happy", "sad", "neutral"]
+
+
+# Create an agent that uses the OpenAI GPT-4o model.
+model_client = OpenAIChatCompletionClient(model="gpt-4o")
+agent = AssistantAgent(
+    "assistant",
+    model_client=model_client,
+    system_message="Categorize the input as happy, sad, or neutral following the JSON format.",
+    # Define the output content type of the agent.
+    output_content_type=AgentResponse,
+)
+
+result = await Console(agent.run_stream(task="I am happy."))
+
+# Check the last message in the result, validate its type, and print the thoughts and response.
+assert isinstance(result.messages[-1], StructuredMessage)
+assert isinstance(result.messages[-1].content, AgentResponse)
+print("Thought: ", result.messages[-1].content.thoughts)
+print("Response: ", result.messages[-1].content.response)
+await model_client.close()
+```
+
+## Streaming Tokens
+
+You can stream the tokens generated by the model client by setting `model_client_stream=True`.
+This will cause the agent to yield {py:class}`~autogen_agentchat.messages.ModelClientStreamingChunkEvent` messages
+in {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run_stream`.
+
+The underlying model API must support streaming tokens for this to work.
+Please check with your model provider to see if this is supported.
+
+```python
+model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+streaming_assistant = AssistantAgent(
+    name="assistant",
+    model_client=model_client,
+    system_message="You are a helpful assistant.",
+    model_client_stream=True,  # Enable streaming tokens.
+)
+
+# Use an async function and asyncio.run() in a script.
+async for message in streaming_assistant.run_stream(task="Name two cities in South America"):  # type: ignore
+    print(message)
+```
+
+You can see the streaming chunks in the output above.
+The chunks are generated by the model client and are yielded by the agent as they are received.
+The final response, the concatenation of all the chunks, is yielded right after the last chunk.
+
+## Using Model Context
+
+{py:class}`~autogen_agentchat.agents.AssistantAgent` has a `model_context`
+parameter that can be used to pass in a {py:class}`~autogen_core.model_context.ChatCompletionContext`
+object. This allows the agent to use different model contexts, such as
+{py:class}`~autogen_core.model_context.BufferedChatCompletionContext` to
+limit the context sent to the model.
+
+By default, {py:class}`~autogen_agentchat.agents.AssistantAgent` uses
+the {py:class}`~autogen_core.model_context.UnboundedChatCompletionContext`
+which sends the full conversation history to the model. To limit the context
+to the last `n` messages, you can use the {py:class}`~autogen_core.model_context.BufferedChatCompletionContext`.
+To limit the context by token count, you can use the
+{py:class}`~autogen_core.model_context.TokenLimitedChatCompletionContext`.
+
+```python
+from autogen_core.model_context import BufferedChatCompletionContext
+
+# Create an agent that uses only the last 5 messages in the context to generate responses.
+agent = AssistantAgent(
+    name="assistant",
+    model_client=model_client,
+    tools=[web_search],
+    system_message="Use tools to solve tasks.",
+    model_context=BufferedChatCompletionContext(buffer_size=5),  # Only use the last 5 messages in the context.
+)
+```
+
+## Other Preset Agents
+
+The following preset agents are available:
+
+- {py:class}`~autogen_agentchat.agents.UserProxyAgent`: An agent that takes user input returns it as responses.
+- {py:class}`~autogen_agentchat.agents.CodeExecutorAgent`: An agent that can execute code.
+- {py:class}`~autogen_ext.agents.openai.OpenAIAssistantAgent`: An agent that is backed by an OpenAI Assistant, with ability to use custom tools.
+- {py:class}`~autogen_ext.agents.web_surfer.MultimodalWebSurfer`: A multi-modal agent that can search the web and visit web pages for information.
+- {py:class}`~autogen_ext.agents.file_surfer.FileSurfer`: An agent that can search and browse local files for information.
+- {py:class}`~autogen_ext.agents.video_surfer.VideoSurfer`: An agent that can watch videos for information.
+
+## Next Step
+
+Having explored the usage of the {py:class}`~autogen_agentchat.agents.AssistantAgent`, we can now proceed to the next section to learn about the teams feature in AgentChat.
+
+
+<!-- ## CodingAssistantAgent
+
+Generates responses (text and code) using an LLM upon receipt of a message. It takes a `system_message` argument that defines or sets the tone for how the agent's LLM should respond. 
+
+```python
+
+writing_assistant_agent = CodingAssistantAgent(
+    name="writing_assistant_agent",
+    system_message="You are a helpful assistant that solve tasks by generating text responses and code.",
+    model_client=model_client,
+)
+`
+
+We can explore or test the behavior of the agent by sending a message to it using the  {py:meth}`~autogen_agentchat.agents.BaseChatAgent.on_messages`  method. 
+
+```python
+result = await writing_assistant_agent.on_messages(
+    messages=[
+        TextMessage(content="What is the weather right now in France?", source="user"),
+    ],
+    cancellation_token=CancellationToken(),
+)
+print(result) -->
+
+---
+
+## Human-in-the-Loop
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/human-in-the-loop.html
+
+# Human-in-the-Loop
+
+In the previous section [Teams](./teams.ipynb), we have seen how to create, observe,
+and control a team of agents.
+This section will focus on how to interact with the team from your application,
+and provide human feedback to the team.
+
+There are two main ways to interact with the team from your application:
+
+1. During a team's run -- execution of {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` or {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run_stream`, provide feedback through a {py:class}`~autogen_agentchat.agents.UserProxyAgent`.
+2. Once the run terminates, provide feedback through input to the next call to {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` or {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run_stream`.
+
+We will cover both methods in this section.
+
+To jump straight to code samples on integration with web and UI frameworks, see the following links:
+- [AgentChat + FastAPI](https://github.com/microsoft/autogen/tree/main/python/samples/agentchat_fastapi)
+- [AgentChat + ChainLit](https://github.com/microsoft/autogen/tree/main/python/samples/agentchat_chainlit)
+- [AgentChat + Streamlit](https://github.com/microsoft/autogen/tree/main/python/samples/agentchat_streamlit)
+
+## Providing Feedback During a Run
+
+The {py:class}`~autogen_agentchat.agents.UserProxyAgent` is a special built-in agent
+that acts as a proxy for a user to provide feedback to the team.
+
+To use the {py:class}`~autogen_agentchat.agents.UserProxyAgent`, you can create an instance of it
+and include it in the team before running the team.
+The team will decide when to call the {py:class}`~autogen_agentchat.agents.UserProxyAgent`
+to ask for feedback from the user.
+
+For example in a {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` team, 
+the {py:class}`~autogen_agentchat.agents.UserProxyAgent` is called in the order
+in which it is passed to the team, while in a {py:class}`~autogen_agentchat.teams.SelectorGroupChat`
+team, the selector prompt or selector function determines when the 
+{py:class}`~autogen_agentchat.agents.UserProxyAgent` is called.
+
+The following diagram illustrates how you can use 
+{py:class}`~autogen_agentchat.agents.UserProxyAgent`
+to get feedback from the user during a team's run:
+
+![human-in-the-loop-user-proxy](./human-in-the-loop-user-proxy.svg)
+
+The bold arrows indicates the flow of control during a team's run:
+when the team calls the {py:class}`~autogen_agentchat.agents.UserProxyAgent`,
+it transfers the control to the application/user, and waits for the feedback;
+once the feedback is provided, the control is transferred back to the team
+and the team continues its execution.
+
+```{note}
+When {py:class}`~autogen_agentchat.agents.UserProxyAgent` is called during a run,
+it blocks the execution of the team until the user provides feedback or errors out.
+This will hold up the team's progress and put the team in an unstable state
+that cannot be saved or resumed.
+```
+
+Due to the blocking nature of this approach, it is recommended to use it only for short interactions
+that require immediate feedback from the user, such as asking for approval or disapproval
+with a button click, or an alert requiring immediate attention otherwise failing the task.
+
+Here is an example of how to use the {py:class}`~autogen_agentchat.agents.UserProxyAgent`
+in a {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` for a poetry generation task:
+
+```python
+from autogen_agentchat.agents import AssistantAgent, UserProxyAgent
+from autogen_agentchat.conditions import TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Create the agents.
+model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+assistant = AssistantAgent("assistant", model_client=model_client)
+user_proxy = UserProxyAgent("user_proxy", input_func=input)  # Use input() to get user input from console.
+
+# Create the termination condition which will end the conversation when the user says "APPROVE".
+termination = TextMentionTermination("APPROVE")
+
+# Create the team.
+team = RoundRobinGroupChat([assistant, user_proxy], termination_condition=termination)
+
+# Run the conversation and stream to the console.
+stream = team.run_stream(task="Write a 4-line poem about the ocean.")
+# Use asyncio.run(...) when running in a script.
+await Console(stream)
+await model_client.close()
+```
+
+From the console output, you can see the team solicited feedback from the user
+through `user_proxy` to approve the generated poem.
+
+You can provide your own input function to the {py:class}`~autogen_agentchat.agents.UserProxyAgent`
+to customize the feedback process.
+For example, when the team is running as a web service, you can use a custom
+input function to wait for message from a web socket connection.
+The following code snippet shows an example of custom input function
+when using the [FastAPI](https://fastapi.tiangolo.com/) web framework:
+
+```python
+@app.websocket("/ws/chat")
+async def chat(websocket: WebSocket):
+    await websocket.accept()
+
+    async def _user_input(prompt: str, cancellation_token: CancellationToken | None) -> str:
+        data = await websocket.receive_json() # Wait for user message from websocket.
+        message = TextMessage.model_validate(data) # Assume user message is a TextMessage.
+        return message.content
+    
+    # Create user proxy with custom input function
+    # Run the team with the user proxy
+    # ...
+```
+
+See the [AgentChat FastAPI sample](https://github.com/microsoft/autogen/blob/main/python/samples/agentchat_fastapi) for a complete example.
+
+For [ChainLit](https://github.com/Chainlit/chainlit) integration with {py:class}`~autogen_agentchat.agents.UserProxyAgent`,
+see the [AgentChat ChainLit sample](https://github.com/microsoft/autogen/blob/main/python/samples/agentchat_chainlit).
+
+## Providing Feedback to the Next Run
+
+Often times, an application or a user interacts with the team of agents in an interactive loop:
+the team runs until termination, 
+the application or user provides feedback, and the team runs again with the feedback.
+
+This approach is useful in a persisted session
+with asynchronous communication between the team and the application/user:
+Once a team finishes a run, the application saves the state of the team,
+puts it in a persistent storage, and resumes the team when the feedback arrives.
+
+```{note}
+For how to save and load the state of a team, please refer to [Managing State](./state.ipynb).
+This section will focus on the feedback mechanisms.
+```
+
+The following diagram illustrates the flow of control in this approach:
+
+![human-in-the-loop-termination](./human-in-the-loop-termination.svg)
+
+There are two ways to implement this approach:
+
+- Set the maximum number of turns so that the team always stops after the specified number of turns.
+- Use termination conditions such as {py:class}`~autogen_agentchat.conditions.TextMentionTermination` and {py:class}`~autogen_agentchat.conditions.HandoffTermination` to allow the team to decide when to stop and give control back, given the team's internal state.
+
+You can use both methods together to achieve your desired behavior.
+
+### Using Max Turns
+
+This method allows you to pause the team for user input by setting a maximum number of turns. For instance, you can configure the team to stop after the first agent responds by setting `max_turns` to 1. This is particularly useful in scenarios where continuous user engagement is required, such as in a chatbot.
+
+To implement this, set the `max_turns` parameter in the {py:meth}`~autogen_agentchat.teams.RoundRobinGroupChat` constructor.
+
+```python
+team = RoundRobinGroupChat([...], max_turns=1)
+```
+
+Once the team stops, the turn count will be reset. When you resume the team,
+it will start from 0 again. However, the team's internal state will be preserved,
+for example, the {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` will
+resume from the next agent in the list with the same conversation history.
+
+```{note}
+`max_turn` is specific to the team class and is currently only supported by
+{py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`, {py:class}`~autogen_agentchat.teams.SelectorGroupChat`, and {py:class}`~autogen_agentchat.teams.Swarm`.
+When used with termination conditions, the team will stop when either condition is met.
+```
+
+Here is an example of how to use `max_turns` in a {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` for a poetry generation task
+with a maximum of 1 turn:
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Create the agents.
+model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+assistant = AssistantAgent("assistant", model_client=model_client)
+
+# Create the team setting a maximum number of turns to 1.
+team = RoundRobinGroupChat([assistant], max_turns=1)
+
+task = "Write a 4-line poem about the ocean."
+while True:
+    # Run the conversation and stream to the console.
+    stream = team.run_stream(task=task)
+    # Use asyncio.run(...) when running in a script.
+    await Console(stream)
+    # Get the user response.
+    task = input("Enter your feedback (type 'exit' to leave): ")
+    if task.lower().strip() == "exit":
+        break
+await model_client.close()
+```
+
+You can see that the team stopped immediately after one agent responded.
+
+### Using Termination Conditions
+
+We have already seen several examples of termination conditions in the previous sections.
+In this section, we focus on {py:class}`~autogen_agentchat.conditions.HandoffTermination`
+which stops the team when an agent sends a {py:class}`~autogen_agentchat.messages.HandoffMessage` message.
+
+Let's create a team with a single {py:class}`~autogen_agentchat.agents.AssistantAgent` agent
+with a handoff setting, and run the team with a task that requires additional input from the user
+because the agent doesn't have relevant tools to continue processing the task.
+
+```{note}
+The model used with {py:class}`~autogen_agentchat.agents.AssistantAgent` must support tool call
+to use the handoff feature.
+```
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.base import Handoff
+from autogen_agentchat.conditions import HandoffTermination, TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Create an OpenAI model client.
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    # api_key="sk-...", # Optional if you have an OPENAI_API_KEY env variable set.
+)
+
+# Create a lazy assistant agent that always hands off to the user.
+lazy_agent = AssistantAgent(
+    "lazy_assistant",
+    model_client=model_client,
+    handoffs=[Handoff(target="user", message="Transfer to user.")],
+    system_message="If you cannot complete the task, transfer to user. Otherwise, when finished, respond with 'TERMINATE'.",
+)
+
+# Define a termination condition that checks for handoff messages.
+handoff_termination = HandoffTermination(target="user")
+# Define a termination condition that checks for a specific text mention.
+text_termination = TextMentionTermination("TERMINATE")
+
+# Create a single-agent team with the lazy assistant and both termination conditions.
+lazy_agent_team = RoundRobinGroupChat([lazy_agent], termination_condition=handoff_termination | text_termination)
+
+# Run the team and stream to the console.
+task = "What is the weather in New York?"
+await Console(lazy_agent_team.run_stream(task=task), output_stats=True)
+```
+
+You can see the team stopped due to the handoff message was detected.
+Let's continue the team by providing the information the agent needs.
+
+```python
+await Console(lazy_agent_team.run_stream(task="The weather in New York is sunny."))
+```
+
+You can see the team continued after the user provided the information.
+
+```{note}
+If you are using {py:class}`~autogen_agentchat.teams.Swarm` team with
+{py:class}`~autogen_agentchat.conditions.HandoffTermination` targeting user,
+to resume the team, you need to set the `task` to a {py:class}`~autogen_agentchat.messages.HandoffMessage`
+with the `target` set to the next agent you want to run.
+See [Swarm](../swarm.ipynb) for more details.
+```
+
+---
+
+## Introduction
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/index.html
+
+# Introduction
+
+This tutorial provides a step-by-step guide to using AgentChat.
+Make sure you have first followed the [installation instructions](../installation.md)
+to prepare your environment.
+
+At any point you are stuck, feel free to ask for help on
+[GitHub Discussions](https://github.com/microsoft/autogen/discussions)
+or [Discord](https://aka.ms/autogen-discord).
+
+```{note}
+If you are coming from AutoGen v0.2, please read the [migration guide](../migration-guide.md).
+```
+
+::::{grid} 2 2 2 2
+:gutter: 3
+
+:::{grid-item-card} {fas}`brain;pst-color-primary` Models
+:link: ./models.html
+:link-alt: Models: How to use LLM model clients
+
+How to use LLM model clients
+:::
+
+:::{grid-item-card} {fas}`envelope;pst-color-primary` Messages
+:link: ./messages.html
+:link-alt: Messages: Understand the message types
+
+Understand the message types
+:::
+
+:::{grid-item-card} {fas}`robot;pst-color-primary` Agents
+:link: ./agents.html
+:link-alt: Agents: Work with AgentChat agents and get started with autogen_agentchat.agents.AssistantAgent
+
+Work with AgentChat agents and get started with {py:class}`~autogen_agentchat.agents.AssistantAgent`
+:::
+
+:::{grid-item-card} {fas}`sitemap;pst-color-primary` Teams
+:link: ./teams.html
+:link-alt: Teams: Work with teams of agents and get started with autogen_agentchat.teams.RoundRobinGroupChat.
+
+Work with teams of agents and get started with {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`.
+:::
+
+:::{grid-item-card} {fas}`person-chalkboard;pst-color-primary` Human-in-the-Loop
+:link: ./human-in-the-loop.html
+:link-alt: Human-in-the-Loop: Best practices for providing feedback to a team
+
+Best practices for providing feedback to a team
+:::
+
+:::{grid-item-card} {fas}`circle-stop;pst-color-primary` Termination
+:link: ./termination.html
+:link-alt: Termination: Control a team using termination conditions
+
+Control a team using termination conditions
+:::
+
+:::{grid-item-card} {fas}`code;pst-color-primary` Custom Agents
+:link: ./custom-agents.html
+:link-alt: Custom Agents: Create your own agents
+
+Create your own agents
+:::
+
+:::{grid-item-card} {fas}`database;pst-color-primary` Managing State
+:link: ./state.html
+:link-alt: Managing State: Save and load agents and teams for persistent sessions
+
+Save and load agents and teams for persistent sessions
+:::
+::::
+
+
+---
+
+## Messages
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/messages.html
+
+# Messages
+
+In AutoGen AgentChat, _messages_ facilitate communication and information exchange with other agents, orchestrators, and applications. AgentChat supports various message types, each designed for specific purposes.
+
+## Types of Messages
+
+At a high level, messages in AgentChat can be categorized into two types: agent-agent messages and an agent's internal events and messages.
+
+### Agent-Agent Messages
+AgentChat supports many message types for agent-to-agent communication. They belong to subclasses of the base class {py:class}`~autogen_agentchat.messages.BaseChatMessage`. Concrete subclasses covers basic text and multimodal communication, such as {py:class}`~autogen_agentchat.messages.TextMessage` and {py:class}`~autogen_agentchat.messages.MultiModalMessage`.
+
+For example, the following code snippet demonstrates how to create a text message, which accepts a string content and a string source:
+
+```python
+from autogen_agentchat.messages import TextMessage
+
+text_message = TextMessage(content="Hello, world!", source="User")
+```
+
+Similarly, the following code snippet demonstrates how to create a multimodal message, which accepts
+a list of strings or {py:class}`~autogen_core.Image` objects:
+
+```python
+from io import BytesIO
+
+import requests
+from autogen_agentchat.messages import MultiModalMessage
+from autogen_core import Image as AGImage
+from PIL import Image
+
+pil_image = Image.open(BytesIO(requests.get("https://picsum.photos/300/200").content))
+img = AGImage(pil_image)
+multi_modal_message = MultiModalMessage(content=["Can you describe the content of this image?", img], source="User")
+img
+```
+
+The {py:class}`~autogen_agentchat.messages.TextMessage` and  {py:class}`~autogen_agentchat.messages.MultiModalMessage` we have created can be passed to agents directly via the {py:class}`~autogen_agentchat.base.ChatAgent.on_messages` method, or as tasks given to a team {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` method. Messages are also used in the responses of an agent. We will explain these in more detail in [Agents](./agents.ipynb) and [Teams](./teams.ipynb).
+
+### Internal Events
+
+AgentChat also supports the concept of `events` - messages that are internal to an agent. These messages are used to communicate events and information on actions _within_ the agent itself, and belong to subclasses of the base class {py:class}`~autogen_agentchat.messages.BaseAgentEvent`.
+
+Examples of these include {py:class}`~autogen_agentchat.messages.ToolCallRequestEvent`, which indicates that a request was made to call a tool, and {py:class}`~autogen_agentchat.messages.ToolCallExecutionEvent`, which contains the results of tool calls.
+
+Typically, events are created by the agent itself and are contained in the {py:attr}`~autogen_agentchat.base.Response.inner_messages` field of the {py:class}`~autogen_agentchat.base.Response` returned from {py:class}`~autogen_agentchat.base.ChatAgent.on_messages`. If you are building a custom agent and have events that you want to communicate to other entities (e.g., a UI), you can include these in the {py:attr}`~autogen_agentchat.base.Response.inner_messages` field of the {py:class}`~autogen_agentchat.base.Response`. We will show examples of this in [Custom Agents](../custom-agents.ipynb).
+
+
+You can read about the full set of messages supported in AgentChat in the {py:mod}`~autogen_agentchat.messages` module. 
+
+## Custom Message Types
+
+You can create custom message types by subclassing the base class {py:class}`~autogen_agentchat.messages.BaseChatMessage` or {py:class}`~autogen_agentchat.messages.BaseAgentEvent`. This allows you to define your own message formats and behaviors, tailored to your application. Custom message types are useful when you write custom agents.
+
+---
+
+## Models
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/models.html
+
+# Models
+
+In many cases, agents need access to LLM model services such as OpenAI, Azure OpenAI, or local models. Since there are many different providers with different APIs, `autogen-core` implements a protocol for model clients and `autogen-ext` implements a set of model clients for popular model services. AgentChat can use these model clients to interact with model services. 
+
+This section provides a quick overview of available model clients.
+For more details on how to use them directly, please refer to [Model Clients](../../core-user-guide/components/model-clients.ipynb) in the Core API documentation.
+
+```{note}
+See {py:class}`~autogen_ext.models.cache.ChatCompletionCache` for a caching wrapper to use with the following clients.
+```
+
+## Log Model Calls
+
+AutoGen uses standard Python logging module to log events like model calls and responses.
+The logger name is {py:attr}`autogen_core.EVENT_LOGGER_NAME`, and the event type is `LLMCall`.
+
+```python
+import logging
+
+from autogen_core import EVENT_LOGGER_NAME
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(EVENT_LOGGER_NAME)
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.INFO)
+```
+
+## OpenAI
+
+To access OpenAI models, install the `openai` extension, which allows you to use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient`.
+
+```python
+pip install "autogen-ext[openai]"
+```
+
+You will also need to obtain an [API key](https://platform.openai.com/account/api-keys) from OpenAI.
+
+```python
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+openai_model_client = OpenAIChatCompletionClient(
+    model="gpt-4o-2024-08-06",
+    # api_key="sk-...", # Optional if you have an OPENAI_API_KEY environment variable set.
+)
+```
+
+To test the model client, you can use the following code:
+
+```python
+from autogen_core.models import UserMessage
+
+result = await openai_model_client.create([UserMessage(content="What is the capital of France?", source="user")])
+print(result)
+await openai_model_client.close()
+```
+
+```{note}
+You can use this client with models hosted on OpenAI-compatible endpoints, however, we have not tested this functionality.
+See {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` for more information.
+```
+
+## Azure OpenAI
+
+Similarly, install the `azure` and `openai` extensions to use the {py:class}`~autogen_ext.models.openai.AzureOpenAIChatCompletionClient`.
+
+```python
+pip install "autogen-ext[openai,azure]"
+```
+
+To use the client, you need to provide your deployment id, Azure Cognitive Services endpoint, api version, and model capabilities.
+For authentication, you can either provide an API key or an Azure Active Directory (AAD) token credential.
+
+The following code snippet shows how to use AAD authentication.
+The identity used must be assigned the [Cognitive Services OpenAI User](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/role-based-access-control#cognitive-services-openai-user) role.
+
+```python
+from autogen_core.models import UserMessage
+from autogen_ext.auth.azure import AzureTokenProvider
+from autogen_ext.models.openai import AzureOpenAIChatCompletionClient
+from azure.identity import DefaultAzureCredential
+
+# Create the token provider
+token_provider = AzureTokenProvider(
+    DefaultAzureCredential(),
+    "https://cognitiveservices.azure.com/.default",
+)
+
+az_model_client = AzureOpenAIChatCompletionClient(
+    azure_deployment="{your-azure-deployment}",
+    model="{model-name, such as gpt-4o}",
+    api_version="2024-06-01",
+    azure_endpoint="https://{your-custom-endpoint}.openai.azure.com/",
+    azure_ad_token_provider=token_provider,  # Optional if you choose key-based authentication.
+    # api_key="sk-...", # For key-based authentication.
+)
+
+result = await az_model_client.create([UserMessage(content="What is the capital of France?", source="user")])
+print(result)
+await az_model_client.close()
+```
+
+See [here](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity#chat-completions) for how to use the Azure client directly or for more information.
+
+## Azure AI Foundry
+
+[Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-studio/) (previously known as Azure AI Studio) offers models hosted on Azure.
+To use those models, you use the {py:class}`~autogen_ext.models.azure.AzureAIChatCompletionClient`.
+
+You need to install the `azure` extra to use this client.
+
+```python
+pip install "autogen-ext[azure]"
+```
+
+Below is an example of using this client with the Phi-4 model from [GitHub Marketplace](https://github.com/marketplace/models).
+
+```python
+import os
+
+from autogen_core.models import UserMessage
+from autogen_ext.models.azure import AzureAIChatCompletionClient
+from azure.core.credentials import AzureKeyCredential
+
+client = AzureAIChatCompletionClient(
+    model="Phi-4",
+    endpoint="https://models.github.ai/inference",
+    # To authenticate with the model you will need to generate a personal access token (PAT) in your GitHub settings.
+    # Create your PAT token by following instructions here: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+    credential=AzureKeyCredential(os.environ["GITHUB_TOKEN"]),
+    model_info={
+        "json_output": False,
+        "function_calling": False,
+        "vision": False,
+        "family": "unknown",
+        "structured_output": False,
+    },
+)
+
+result = await client.create([UserMessage(content="What is the capital of France?", source="user")])
+print(result)
+await client.close()
+```
+
+## Anthropic (experimental)
+
+To use the {py:class}`~autogen_ext.models.anthropic.AnthropicChatCompletionClient`, you need to install the `anthropic` extra. Underneath, it uses the `anthropic` python sdk to access the models.
+You will also need to obtain an [API key](https://console.anthropic.com) from Anthropic.
+
+```python
+# !pip install -U "autogen-ext[anthropic]"
+```
+
+```python
+from autogen_core.models import UserMessage
+from autogen_ext.models.anthropic import AnthropicChatCompletionClient
+
+anthropic_client = AnthropicChatCompletionClient(model="claude-3-7-sonnet-20250219")
+result = await anthropic_client.create([UserMessage(content="What is the capital of France?", source="user")])
+print(result)
+await anthropic_client.close()
+```
+
+## Ollama (experimental)
+
+[Ollama](https://ollama.com/) is a local model server that can run models locally on your machine.
+
+```{note}
+Small local models are typically not as capable as larger models on the cloud.
+For some tasks they may not perform as well and the output may be suprising.
+```
+
+To use Ollama, install the `ollama` extension and use the {py:class}`~autogen_ext.models.ollama.OllamaChatCompletionClient`.
+
+```python
+pip install -U "autogen-ext[ollama]"
+```
+
+```python
+from autogen_core.models import UserMessage
+from autogen_ext.models.ollama import OllamaChatCompletionClient
+
+# Assuming your Ollama server is running locally on port 11434.
+ollama_model_client = OllamaChatCompletionClient(model="llama3.2")
+
+response = await ollama_model_client.create([UserMessage(content="What is the capital of France?", source="user")])
+print(response)
+await ollama_model_client.close()
+```
+
+## Gemini (experimental)
+
+Gemini currently offers [an OpenAI-compatible API (beta)](https://ai.google.dev/gemini-api/docs/openai).
+So you can use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with the Gemini API.
+
+```{note}
+While some model providers may offer OpenAI-compatible APIs, they may still have minor differences.
+For example, the `finish_reason` field may be different in the response.
+
+```
+
+```python
+from autogen_core.models import UserMessage
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(
+    model="gemini-1.5-flash-8b",
+    # api_key="GEMINI_API_KEY",
+)
+
+response = await model_client.create([UserMessage(content="What is the capital of France?", source="user")])
+print(response)
+await model_client.close()
+```
+
+Also, as Gemini adds new models, you may need to define the models capabilities via the model_info field. For example, to use `gemini-2.0-flash-lite` or a similar new model, you can use the following code:
+
+```python 
+from autogen_core.models import UserMessage
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_core.models import ModelInfo
+
+model_client = OpenAIChatCompletionClient(
+    model="gemini-2.0-flash-lite",
+    model_info=ModelInfo(vision=True, function_calling=True, json_output=True, family="unknown", structured_output=True)
+    # api_key="GEMINI_API_KEY",
+)
+
+response = await model_client.create([UserMessage(content="What is the capital of France?", source="user")])
+print(response)
+await model_client.close()
+```
+
+## Llama API (experimental)
+
+[Llama API](https://llama.developer.meta.com?utm_source=partner-autogen&utm_medium=readme) is the Meta's first party API offering. It currently offers an [OpenAI compatible endpoint](https://llama.developer.meta.com/docs/features/compatibility).
+So you can use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with the Llama API.
+
+This endpoint fully supports the following OpenAI client library features:
+* Chat completions
+* Model selection
+* Temperature/sampling
+* Streaming
+* Image understanding
+* Structured output (JSON mode)
+* Function calling (tools)
+
+```python
+from pathlib import Path
+
+from autogen_core import Image
+from autogen_core.models import UserMessage
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Text
+model_client = OpenAIChatCompletionClient(
+    model="Llama-4-Scout-17B-16E-Instruct-FP8",
+    # api_key="LLAMA_API_KEY"
+)
+
+response = await model_client.create([UserMessage(content="Write me a poem", source="user")])
+print(response)
+await model_client.close()
+
+# Image
+model_client = OpenAIChatCompletionClient(
+    model="Llama-4-Maverick-17B-128E-Instruct-FP8",
+    # api_key="LLAMA_API_KEY"
+)
+image = Image.from_file(Path("test.png"))
+
+response = await model_client.create([UserMessage(content=["What is in this image", image], source="user")])
+print(response)
+await model_client.close()
+```
+
+## Semantic Kernel Adapter
+
+The {py:class}`~autogen_ext.models.semantic_kernel.SKChatCompletionAdapter`
+allows you to use Semantic kernel model clients as a
+{py:class}`~autogen_core.models.ChatCompletionClient` by adapting them to the required interface.
+
+You need to install the relevant provider extras to use this adapter. 
+
+The list of extras that can be installed:
+
+- `semantic-kernel-anthropic`: Install this extra to use Anthropic models.
+- `semantic-kernel-google`: Install this extra to use Google Gemini models.
+- `semantic-kernel-ollama`: Install this extra to use Ollama models.
+- `semantic-kernel-mistralai`: Install this extra to use MistralAI models.
+- `semantic-kernel-aws`: Install this extra to use AWS models.
+- `semantic-kernel-hugging-face`: Install this extra to use Hugging Face models.
+
+For example, to use Anthropic models, you need to install `semantic-kernel-anthropic`.
+
+```python
+# pip install "autogen-ext[semantic-kernel-anthropic]"
+```
+
+To use this adapter, you need create a Semantic Kernel model client and pass it to the adapter.
+
+For example, to use the Anthropic model:
+
+```python
+import os
+
+from autogen_core.models import UserMessage
+from autogen_ext.models.semantic_kernel import SKChatCompletionAdapter
+from semantic_kernel import Kernel
+from semantic_kernel.connectors.ai.anthropic import AnthropicChatCompletion, AnthropicChatPromptExecutionSettings
+from semantic_kernel.memory.null_memory import NullMemory
+
+sk_client = AnthropicChatCompletion(
+    ai_model_id="claude-3-5-sonnet-20241022",
+    api_key=os.environ["ANTHROPIC_API_KEY"],
+    service_id="my-service-id",  # Optional; for targeting specific services within Semantic Kernel
+)
+settings = AnthropicChatPromptExecutionSettings(
+    temperature=0.2,
+)
+
+anthropic_model_client = SKChatCompletionAdapter(
+    sk_client, kernel=Kernel(memory=NullMemory()), prompt_settings=settings
+)
+
+# Call the model directly.
+model_result = await anthropic_model_client.create(
+    messages=[UserMessage(content="What is the capital of France?", source="User")]
+)
+print(model_result)
+await anthropic_model_client.close()
+```
+
+Read more about the [Semantic Kernel Adapter](../../../reference/python/autogen_ext.models.semantic_kernel.rst).
+
+---
+
+## Managing State
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/state.html
+
+# Managing State 
+
+So far, we have discussed how to build components in a multi-agent application - agents, teams, termination conditions. In many cases, it is useful to save the state of these components to disk and load them back later. This is particularly useful in a web application where stateless endpoints respond to requests and need to load the state of the application from persistent storage.
+
+In this notebook, we will discuss how to save and load the state of agents, teams, and termination conditions. 
+ 
+
+## Saving and Loading Agents
+
+We can get the state of an agent by calling {py:meth}`~autogen_agentchat.agents.AssistantAgent.save_state` method on 
+an {py:class}`~autogen_agentchat.agents.AssistantAgent`. 
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import MaxMessageTermination
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(model="gpt-4o-2024-08-06")
+
+assistant_agent = AssistantAgent(
+    name="assistant_agent",
+    system_message="You are a helpful assistant",
+    model_client=model_client,
+)
+
+# Use asyncio.run(...) when running in a script.
+response = await assistant_agent.on_messages(
+    [TextMessage(content="Write a 3 line poem on lake tangayika", source="user")], CancellationToken()
+)
+print(response.chat_message)
+await model_client.close()
+```
+
+```python
+agent_state = await assistant_agent.save_state()
+print(agent_state)
+```
+
+```python
+model_client = OpenAIChatCompletionClient(model="gpt-4o-2024-08-06")
+
+new_assistant_agent = AssistantAgent(
+    name="assistant_agent",
+    system_message="You are a helpful assistant",
+    model_client=model_client,
+)
+await new_assistant_agent.load_state(agent_state)
+
+# Use asyncio.run(...) when running in a script.
+response = await new_assistant_agent.on_messages(
+    [TextMessage(content="What was the last line of the previous poem you wrote", source="user")], CancellationToken()
+)
+print(response.chat_message)
+await model_client.close()
+```
+
+```{note}
+For {py:class}`~autogen_agentchat.agents.AssistantAgent`, its state consists of the model_context.
+If you write your own custom agent, consider overriding the {py:meth}`~autogen_agentchat.agents.BaseChatAgent.save_state` and {py:meth}`~autogen_agentchat.agents.BaseChatAgent.load_state` methods to customize the behavior. The default implementations save and load an empty state.
+```
+
+## Saving and Loading Teams 
+
+We can get the state of a team by calling `save_state` method on the team and load it back by calling `load_state` method on the team. 
+
+When we call `save_state` on a team, it saves the state of all the agents in the team.
+
+We will begin by creating a simple {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` team with a single agent and ask it to write a poem. 
+
+```python
+model_client = OpenAIChatCompletionClient(model="gpt-4o-2024-08-06")
+
+# Define a team.
+assistant_agent = AssistantAgent(
+    name="assistant_agent",
+    system_message="You are a helpful assistant",
+    model_client=model_client,
+)
+agent_team = RoundRobinGroupChat([assistant_agent], termination_condition=MaxMessageTermination(max_messages=2))
+
+# Run the team and stream messages to the console.
+stream = agent_team.run_stream(task="Write a beautiful poem 3-line about lake tangayika")
+
+# Use asyncio.run(...) when running in a script.
+await Console(stream)
+
+# Save the state of the agent team.
+team_state = await agent_team.save_state()
+```
+
+If we reset the team (simulating instantiation of the team),  and ask the question `What was the last line of the poem you wrote?`, we see that the team is unable to accomplish this as there is no reference to the previous run.
+
+```python
+await agent_team.reset()
+stream = agent_team.run_stream(task="What was the last line of the poem you wrote?")
+await Console(stream)
+```
+
+Next, we load the state of the team and ask the same question. We see that the team is able to accurately return the last line of the poem it wrote.
+
+```python
+print(team_state)
+
+# Load team state.
+await agent_team.load_state(team_state)
+stream = agent_team.run_stream(task="What was the last line of the poem you wrote?")
+await Console(stream)
+```
+
+## Persisting State (File or Database)
+
+In many cases, we may want to persist the state of the team to disk (or a database) and load it back later. State is a dictionary that can be serialized to a file or written to a database.
+
+```python
+import json
+
+## save state to disk
+
+with open("coding/team_state.json", "w") as f:
+    json.dump(team_state, f)
+
+## load state from disk
+with open("coding/team_state.json", "r") as f:
+    team_state = json.load(f)
+
+new_agent_team = RoundRobinGroupChat([assistant_agent], termination_condition=MaxMessageTermination(max_messages=2))
+await new_agent_team.load_state(team_state)
+stream = new_agent_team.run_stream(task="What was the last line of the poem you wrote?")
+await Console(stream)
+await model_client.close()
+```
+
+---
+
+## Teams
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/teams.html
+
+# Teams
+
+In this section you'll learn how to create a _multi-agent team_ (or simply team) using AutoGen. A team is a group of agents that work together to achieve a common goal.
+
+We'll first show you how to create and run a team. We'll then explain how to observe the team's behavior, which is crucial for debugging and understanding the team's performance, and common operations to control the team's behavior.
+
+
+AgentChat supports several team presets:
+
+- {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`: A team that runs a group chat with participants taking turns in a round-robin fashion (covered on this page). [Tutorial](#creating-a-team) 
+- {py:class}`~autogen_agentchat.teams.SelectorGroupChat`: A team that selects the next speaker using a ChatCompletion model after each message. [Tutorial](../selector-group-chat.ipynb)
+- {py:class}`~autogen_agentchat.teams.MagenticOneGroupChat`: A  generalist multi-agent system for solving open-ended web and file-based tasks across a variety of domains. [Tutorial](../magentic-one.md) 
+- {py:class}`~autogen_agentchat.teams.Swarm`: A team that uses {py:class}`~autogen_agentchat.messages.HandoffMessage` to signal transitions between agents. [Tutorial](../swarm.ipynb)
+
+```{note}
+
+**When should you use a team?**
+
+Teams are for complex tasks that require collaboration and diverse expertise.
+However, they also demand more scaffolding to steer compared to single agents.
+While AutoGen simplifies the process of working with teams, start with
+a single agent for simpler tasks, and transition to a multi-agent team when a single agent proves inadequate.
+Ensure that you have optimized your single agent with the appropriate tools
+and instructions before moving to a team-based approach.
+```
+
+## Creating a Team
+
+{py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` is a simple yet effective team configuration where all agents share the same context and take turns responding in a round-robin fashion. Each agent, during its turn, broadcasts its response to all other agents, ensuring that the entire team maintains a consistent context.
+
+We will begin by creating a team with two {py:class}`~autogen_agentchat.agents.AssistantAgent` and a {py:class}`~autogen_agentchat.conditions.TextMentionTermination` condition that stops the team when a specific word is detected in the agent's response.
+
+The two-agent team implements the _reflection_ pattern, a multi-agent design pattern where a critic agent evaluates the responses of a primary agent. Learn more about the reflection pattern using the [Core API](../../core-user-guide/design-patterns/reflection.ipynb).
+
+```python
+import asyncio
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.base import TaskResult
+from autogen_agentchat.conditions import ExternalTermination, TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# Create an OpenAI model client.
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o-2024-08-06",
+    # api_key="sk-...", # Optional if you have an OPENAI_API_KEY env variable set.
+)
+
+# Create the primary agent.
+primary_agent = AssistantAgent(
+    "primary",
+    model_client=model_client,
+    system_message="You are a helpful AI assistant.",
+)
+
+# Create the critic agent.
+critic_agent = AssistantAgent(
+    "critic",
+    model_client=model_client,
+    system_message="Provide constructive feedback. Respond with 'APPROVE' to when your feedbacks are addressed.",
+)
+
+# Define a termination condition that stops the task if the critic approves.
+text_termination = TextMentionTermination("APPROVE")
+
+# Create a team with the primary and critic agents.
+team = RoundRobinGroupChat([primary_agent, critic_agent], termination_condition=text_termination)
+```
+
+## Running a Team
+
+Let's call the {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` method
+to start the team with a task.
+
+```python
+# Use `asyncio.run(...)` when running in a script.
+result = await team.run(task="Write a short poem about the fall season.")
+print(result)
+```
+
+The team runs the agents until the termination condition was met.
+In this case, the team ran agents following a round-robin order until the the
+termination condition was met when the word "APPROVE" was detected in the
+agent's response.
+When the team stops, it returns a {py:class}`~autogen_agentchat.base.TaskResult` object with all the messages produced by the agents in the team.
+
+## Observing a Team
+
+Similar to the agent's {py:meth}`~autogen_agentchat.agents.BaseChatAgent.on_messages_stream` method, you can stream the team's messages while it is running by calling the {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run_stream` method. This method returns a generator that yields messages produced by the agents in the team as they are generated, with the final item being the {py:class}`~autogen_agentchat.base.TaskResult` object.
+
+```python
+# When running inside a script, use a async main function and call it from `asyncio.run(...)`.
+await team.reset()  # Reset the team for a new task.
+async for message in team.run_stream(task="Write a short poem about the fall season."):  # type: ignore
+    if isinstance(message, TaskResult):
+        print("Stop Reason:", message.stop_reason)
+    else:
+        print(message)
+```
+
+As demonstrated in the example above, you can determine the reason why the team stopped by checking the {py:attr}`~autogen_agentchat.base.TaskResult.stop_reason` attribute.
+
+The {py:meth}`~autogen_agentchat.ui.Console` method provides a convenient way to print messages to the console with proper formatting.
+
+
+```python
+await team.reset()  # Reset the team for a new task.
+await Console(team.run_stream(task="Write a short poem about the fall season."))  # Stream the messages to the console.
+```
+
+## Resetting a Team
+
+You can reset the team by calling the {py:meth}`~autogen_agentchat.teams.BaseGroupChat.reset` method. This method will clear the team's state, including all agents.
+It will call the each agent's {py:meth}`~autogen_agentchat.base.ChatAgent.on_reset` method to clear the agent's state.
+
+```python
+await team.reset()  # Reset the team for the next run.
+```
+
+It is usually a good idea to reset the team if the next task is not related to the previous task.
+However, if the next task is related to the previous task, you don't need to reset and you can instead
+resume the team.
+
+## Stopping a Team
+
+Apart from automatic termination conditions such as {py:class}`~autogen_agentchat.conditions.TextMentionTermination`
+that stops the team based on the internal state of the team, you can also stop the team
+from outside by using the {py:class}`~autogen_agentchat.conditions.ExternalTermination`.
+
+Calling {py:meth}`~autogen_agentchat.conditions.ExternalTermination.set` 
+on {py:class}`~autogen_agentchat.conditions.ExternalTermination` will stop
+the team when the current agent's turn is over.
+Thus, the team may not stop immediately.
+This allows the current agent to finish its turn and broadcast the final message to the team
+before the team stops, keeping the team's state consistent.
+
+```python
+# Create a new team with an external termination condition.
+external_termination = ExternalTermination()
+team = RoundRobinGroupChat(
+    [primary_agent, critic_agent],
+    termination_condition=external_termination | text_termination,  # Use the bitwise OR operator to combine conditions.
+)
+
+# Run the team in a background task.
+run = asyncio.create_task(Console(team.run_stream(task="Write a short poem about the fall season.")))
+
+# Wait for some time.
+await asyncio.sleep(0.1)
+
+# Stop the team.
+external_termination.set()
+
+# Wait for the team to finish.
+await run
+```
+
+From the ouput above, you can see the team stopped because the external termination condition was met,
+but the speaking agent was able to finish its turn before the team stopped.
+
+## Resuming a Team
+
+Teams are stateful and maintains the conversation history and context
+after each run, unless you reset the team.
+
+You can resume a team to continue from where it left off by calling the {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` or {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run_stream` method again
+without a new task.
+{py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` will continue from the next agent in the round-robin order.
+
+```python
+await Console(team.run_stream())  # Resume the team to continue the last task.
+```
+
+You can see the team resumed from where it left off in the output above,
+and the first message is from the next agent after the last agent that spoke
+before the team stopped.
+
+Let's resume the team again with a new task while keeping the context about the previous task.
+
+```python
+# The new task is to translate the same poem to Chinese Tang-style poetry.
+await Console(team.run_stream(task="将这首诗用中文唐诗风格写一遍。"))
+```
+
+## Aborting a Team
+
+You can abort a call to {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run` or {py:meth}`~autogen_agentchat.teams.BaseGroupChat.run_stream`
+during execution by setting a {py:class}`~autogen_core.CancellationToken` passed to the `cancellation_token` parameter.
+
+Different from stopping a team, aborting a team will immediately stop the team and raise a {py:class}`~asyncio.CancelledError` exception.
+
+```{note}
+The caller will get a {py:class}`~asyncio.CancelledError` exception when the team is aborted.
+```
+
+```python
+# Create a cancellation token.
+cancellation_token = CancellationToken()
+
+# Use another coroutine to run the team.
+run = asyncio.create_task(
+    team.run(
+        task="Translate the poem to Spanish.",
+        cancellation_token=cancellation_token,
+    )
+)
+
+# Cancel the run.
+cancellation_token.cancel()
+
+try:
+    result = await run  # This will raise a CancelledError.
+except asyncio.CancelledError:
+    print("Task was cancelled.")
+```
+
+## Single-Agent Team
+
+```{note}
+Starting with version 0.6.2, you can use {py:class}`~autogen_agentchat.agents.AssistantAgent`
+with `max_tool_iterations` to run the agent with multiple iterations
+of tool calls. So you may not need to use a single-agent team if you just 
+want to run the agent in a tool-calling loop.
+```
+
+Often, you may want to run a single agent in a team configuration.
+This is useful for running the {py:class}`~autogen_agentchat.agents.AssistantAgent` in a loop
+until a termination condition is met.
+
+This is different from running the {py:class}`~autogen_agentchat.agents.AssistantAgent` using
+its {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run` or {py:meth}`~autogen_agentchat.agents.BaseChatAgent.run_stream` method,
+which only runs the agent for one step and returns the result.
+See {py:class}`~autogen_agentchat.agents.AssistantAgent` for more details about a single step.
+
+Here is an example of running a single agent in a {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat` team configuration
+with a {py:class}`~autogen_agentchat.conditions.TextMessageTermination` condition.
+The task is to increment a number until it reaches 10 using a tool.
+The agent will keep calling the tool until the number reaches 10,
+and then it will return a final {py:class}`~autogen_agentchat.messages.TextMessage`
+which will stop the run.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import TextMessageTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    # api_key="sk-...", # Optional if you have an OPENAI_API_KEY env variable set.
+    # Disable parallel tool calls for this example.
+    parallel_tool_calls=False,  # type: ignore
+)
+
+
+# Create a tool for incrementing a number.
+def increment_number(number: int) -> int:
+    """Increment a number by 1."""
+    return number + 1
+
+
+# Create a tool agent that uses the increment_number function.
+looped_assistant = AssistantAgent(
+    "looped_assistant",
+    model_client=model_client,
+    tools=[increment_number],  # Register the tool.
+    system_message="You are a helpful AI assistant, use the tool to increment the number.",
+)
+
+# Termination condition that stops the task if the agent responds with a text message.
+termination_condition = TextMessageTermination("looped_assistant")
+
+# Create a team with the looped assistant agent and the termination condition.
+team = RoundRobinGroupChat(
+    [looped_assistant],
+    termination_condition=termination_condition,
+)
+
+# Run the team with a task and print the messages to the console.
+async for message in team.run_stream(task="Increment the number 5 to 10."):  # type: ignore
+    print(type(message).__name__, message)
+
+await model_client.close()
+```
+
+The key is to focus on the termination condition.
+In this example, we use a {py:class}`~autogen_agentchat.conditions.TextMessageTermination` condition
+that stops the team when the agent stop producing {py:class}`~autogen_agentchat.messages.ToolCallSummaryMessage`.
+The team will keep running until the agent produces a {py:class}`~autogen_agentchat.messages.TextMessage` with the final result.
+
+You can also use other termination conditions to control the agent.
+See [Termination Conditions](./termination.ipynb) for more details.
+
+---
+
+## Termination
+
+Source: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/termination.html
+
+# Termination 
+
+In the previous section, we explored how to define agents, and organize them into teams that can solve tasks. However, a run can go on forever, and in many cases, we need to know _when_ to stop them. This is the role of the termination condition.
+
+AgentChat supports several termination condition by providing a base {py:class}`~autogen_agentchat.base.TerminationCondition` class and several implementations that inherit from it.
+
+A termination condition is a callable that takes a sequence of {py:class}`~autogen_agentchat.messages.BaseAgentEvent` or {py:class}`~autogen_agentchat.messages.BaseChatMessage` objects **since the last time the condition was called**, and returns a {py:class}`~autogen_agentchat.messages.StopMessage` if the conversation should be terminated, or `None` otherwise.
+Once a termination condition has been reached, it must be reset by calling {py:meth}`~autogen_agentchat.base.TerminationCondition.reset` before it can be used again.
+
+Some important things to note about termination conditions: 
+- They are stateful but reset automatically after each run ({py:meth}`~autogen_agentchat.base.TaskRunner.run` or {py:meth}`~autogen_agentchat.base.TaskRunner.run_stream`) is finished.
+- They can be combined using the AND and OR operators.
+
+```{note}
+For group chat teams (i.e., {py:class}`~autogen_agentchat.teams.RoundRobinGroupChat`,
+{py:class}`~autogen_agentchat.teams.SelectorGroupChat`, and {py:class}`~autogen_agentchat.teams.Swarm`),
+the termination condition is called after each agent responds.
+While a response may contain multiple inner messages, the team calls its termination condition just once for all the messages from a single response.
+So the condition is called with the "delta sequence" of messages since the last time it was called.
+```
+
+Built-In Termination Conditions: 
+1. {py:class}`~autogen_agentchat.conditions.MaxMessageTermination`: Stops after a specified number of messages have been produced, including both agent and task messages.
+2. {py:class}`~autogen_agentchat.conditions.TextMentionTermination`: Stops when specific text or string is mentioned in a message (e.g., "TERMINATE").
+3. {py:class}`~autogen_agentchat.conditions.TokenUsageTermination`: Stops when a certain number of prompt or completion tokens are used. This requires the agents to report token usage in their messages.
+4. {py:class}`~autogen_agentchat.conditions.TimeoutTermination`: Stops after a specified duration in seconds.
+5. {py:class}`~autogen_agentchat.conditions.HandoffTermination`: Stops when a handoff to a specific target is requested. Handoff messages can be used to build patterns such as {py:class}`~autogen_agentchat.teams.Swarm`. This is useful when you want to pause the run and allow application or user to provide input when an agent hands off to them.
+6. {py:class}`~autogen_agentchat.conditions.SourceMatchTermination`: Stops after a specific agent responds.
+7. {py:class}`~autogen_agentchat.conditions.ExternalTermination`: Enables programmatic control of termination from outside the run. This is useful for UI integration (e.g., "Stop" buttons in chat interfaces).
+8. {py:class}`~autogen_agentchat.conditions.StopMessageTermination`: Stops when a {py:class}`~autogen_agentchat.messages.StopMessage` is produced by an agent.
+9. {py:class}`~autogen_agentchat.conditions.TextMessageTermination`: Stops when a {py:class}`~autogen_agentchat.messages.TextMessage` is produced by an agent.
+10. {py:class}`~autogen_agentchat.conditions.FunctionCallTermination`: Stops when a {py:class}`~autogen_agentchat.messages.ToolCallExecutionEvent` containing a {py:class}`~autogen_core.models.FunctionExecutionResult` with a matching name is produced by an agent.
+11. {py:class}`~autogen_agentchat.conditions.FunctionalTermination`: Stop when a function expression is evaluated to `True` on the last delta sequence of messages. This is useful for quickly create custom termination conditions that are not covered by the built-in ones.
+
+## Basic Usage
+
+To demonstrate the characteristics of termination conditions, we'll create a team consisting of two agents: a primary agent responsible for text generation and a critic agent that reviews and provides feedback on the generated text.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import MaxMessageTermination, TextMentionTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    temperature=1,
+    # api_key="sk-...", # Optional if you have an OPENAI_API_KEY env variable set.
+)
+
+# Create the primary agent.
+primary_agent = AssistantAgent(
+    "primary",
+    model_client=model_client,
+    system_message="You are a helpful AI assistant.",
+)
+
+# Create the critic agent.
+critic_agent = AssistantAgent(
+    "critic",
+    model_client=model_client,
+    system_message="Provide constructive feedback for every message. Respond with 'APPROVE' to when your feedbacks are addressed.",
+)
+```
+
+Let's explore how termination conditions automatically reset after each `run` or `run_stream` call, allowing the team to resume its conversation from where it left off.
+
+```python
+max_msg_termination = MaxMessageTermination(max_messages=3)
+round_robin_team = RoundRobinGroupChat([primary_agent, critic_agent], termination_condition=max_msg_termination)
+
+# Use asyncio.run(...) if you are running this script as a standalone script.
+await Console(round_robin_team.run_stream(task="Write a unique, Haiku about the weather in Paris"))
+```
+
+The conversation stopped after reaching the maximum message limit. Since the primary agent didn't get to respond to the feedback, let's continue the conversation.
+
+```python
+# Use asyncio.run(...) if you are running this script as a standalone script.
+await Console(round_robin_team.run_stream())
+```
+
+The team continued from where it left off, allowing the primary agent to respond to the feedback.
+
+## Combining Termination Conditions
+
+Let's show how termination conditions can be combined using the AND (`&`) and OR (`|`) operators to create more complex termination logic. For example, we'll create a team that stops either after 10 messages are generated or when the critic agent approves a message.
+
+
+```python
+max_msg_termination = MaxMessageTermination(max_messages=10)
+text_termination = TextMentionTermination("APPROVE")
+combined_termination = max_msg_termination | text_termination
+
+round_robin_team = RoundRobinGroupChat([primary_agent, critic_agent], termination_condition=combined_termination)
+
+# Use asyncio.run(...) if you are running this script as a standalone script.
+await Console(round_robin_team.run_stream(task="Write a unique, Haiku about the weather in Paris"))
+```
+
+The conversation stopped after the critic agent approved the message, although it could have also stopped if 10 messages were generated.
+
+Alternatively, if we want to stop the run only when both conditions are met, we can use the AND (`&`) operator.
+
+```python
+combined_termination = max_msg_termination & text_termination
+```
+
+## Custom Termination Condition
+
+The built-in termination conditions are sufficient for most use cases.
+However, there may be cases where you need to implement a custom termination condition that doesn't fit into the existing ones.
+You can do this by subclassing the {py:class}`~autogen_agentchat.base.TerminationCondition` class.
+
+In this example, we create a custom termination condition that stops the conversation when
+a specific function call is made.
+
+```python
+from typing import Sequence
+
+from autogen_agentchat.base import TerminatedException, TerminationCondition
+from autogen_agentchat.messages import BaseAgentEvent, BaseChatMessage, StopMessage, ToolCallExecutionEvent
+from autogen_core import Component
+from pydantic import BaseModel
+from typing_extensions import Self
+
+
+class FunctionCallTerminationConfig(BaseModel):
+    """Configuration for the termination condition to allow for serialization
+    and deserialization of the component.
+    """
+
+    function_name: str
+
+
+class FunctionCallTermination(TerminationCondition, Component[FunctionCallTerminationConfig]):
+    """Terminate the conversation if a FunctionExecutionResult with a specific name is received."""
+
+    component_config_schema = FunctionCallTerminationConfig
+    component_provider_override = "autogen_agentchat.conditions.FunctionCallTermination"
+    """The schema for the component configuration."""
+
+    def __init__(self, function_name: str) -> None:
+        self._terminated = False
+        self._function_name = function_name
+
+    @property
+    def terminated(self) -> bool:
+        return self._terminated
+
+    async def __call__(self, messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> StopMessage | None:
+        if self._terminated:
+            raise TerminatedException("Termination condition has already been reached")
+        for message in messages:
+            if isinstance(message, ToolCallExecutionEvent):
+                for execution in message.content:
+                    if execution.name == self._function_name:
+                        self._terminated = True
+                        return StopMessage(
+                            content=f"Function '{self._function_name}' was executed.",
+                            source="FunctionCallTermination",
+                        )
+        return None
+
+    async def reset(self) -> None:
+        self._terminated = False
+
+    def _to_config(self) -> FunctionCallTerminationConfig:
+        return FunctionCallTerminationConfig(
+            function_name=self._function_name,
+        )
+
+    @classmethod
+    def _from_config(cls, config: FunctionCallTerminationConfig) -> Self:
+        return cls(
+            function_name=config.function_name,
+        )
+```
+
+Let's use this new termination condition to stop the conversation when the critic agent approves a message
+using the `approve` function call.
+
+First we create a simple function that will be called when the critic agent approves a message.
+
+```python
+def approve() -> None:
+    """Approve the message when all feedbacks have been addressed."""
+    pass
+```
+
+Then we create the agents. The critic agent is equipped with the `approve` tool.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o",
+    temperature=1,
+    # api_key="sk-...", # Optional if you have an OPENAI_API_KEY env variable set.
+)
+
+# Create the primary agent.
+primary_agent = AssistantAgent(
+    "primary",
+    model_client=model_client,
+    system_message="You are a helpful AI assistant.",
+)
+
+# Create the critic agent with the approve function as a tool.
+critic_agent = AssistantAgent(
+    "critic",
+    model_client=model_client,
+    tools=[approve],  # Register the approve function as a tool.
+    system_message="Provide constructive feedback. Use the approve tool to approve when all feedbacks are addressed.",
+)
+```
+
+Now, we create the termination condition and the team.
+We run the team with the poem-writing task.
+
+```python
+function_call_termination = FunctionCallTermination(function_name="approve")
+round_robin_team = RoundRobinGroupChat([primary_agent, critic_agent], termination_condition=function_call_termination)
+
+# Use asyncio.run(...) if you are running this script as a standalone script.
+await Console(round_robin_team.run_stream(task="Write a unique, Haiku about the weather in Paris"))
+await model_client.close()
+```
+
+You can see that the conversation stopped when the critic agent approved the message using the `approve` function call.

--- a/python/docs/src/llms.txt
+++ b/python/docs/src/llms.txt
@@ -1,0 +1,35 @@
+# AutoGen
+
+> AutoGen is an open-source framework for building multi-agent AI applications.
+> It provides tools for creating agents that can collaborate, use tools, and solve
+> complex tasks through structured conversations.
+
+## AgentChat
+
+High-level API for building multi-agent applications
+
+- [AgentChat](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/index.html)
+- [Custom Agents](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/custom-agents.html)
+- [Company Research](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/examples/company-research.html)
+- [Examples](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/examples/index.html)
+- [Literature Review](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/examples/literature-review.html)
+- [Travel Planning](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/examples/travel-planning.html)
+- [GraphFlow (Workflows)](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/graph-flow.html)
+- [Installation](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/installation.html)
+- [Logging](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/logging.html)
+- [Magentic-One](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/magentic-one.html)
+- [Initialize user memory](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/memory.html)
+- [Migration Guide for v0.2 to v0.4](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/migration-guide.html)
+- [Quickstart](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/quickstart.html)
+- [Selector Group Chat](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/selector-group-chat.html)
+- [Serializing Components](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/serialize-components.html)
+- [Swarm](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/swarm.html)
+- [Tracing and Observability](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tracing.html)
+- [Agents](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/agents.html)
+- [Human-in-the-Loop](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/human-in-the-loop.html)
+- [Introduction](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/index.html)
+- [Messages](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/messages.html)
+- [Models](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/models.html)
+- [Managing State](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/state.html)
+- [Teams](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/teams.html)
+- [Termination](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/termination.html)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -126,6 +126,7 @@ docs-build = "sphinx-build docs/src docs/build"
 docs-serve = "sphinx-autobuild docs/src docs/build --watch packages/ --port 8000 --jobs auto"
 docs-check = "sphinx-build --fail-on-warning docs/src docs/build"
 docs-check-examples = "sphinx-build -b code_lint docs/src docs/build"
+generate-llms-txt = "python scripts/generate_llms_txt.py"
 
 gen-proto = [
     { cmd = "python -m grpc_tools.protoc --python_out=./packages/autogen-ext/src/autogen_ext/runtimes/grpc/protos --grpc_python_out=./packages/autogen-ext/src/autogen_ext/runtimes/grpc/protos --mypy_out=./packages/autogen-ext/src/autogen_ext/runtimes/grpc/protos --mypy_grpc_out=./packages/autogen-ext/src/autogen_ext/runtimes/grpc/protos --proto_path ../protos/ agent_worker.proto --proto_path ../protos/ cloudevent.proto" },

--- a/python/scripts/generate_llms_txt.py
+++ b/python/scripts/generate_llms_txt.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate llms.txt and llms-full.txt for AutoGen documentation.
+
+This script reads documentation source files (Markdown and Jupyter notebooks)
+and produces LLM-friendly text files following the llms.txt specification
+(https://llmstxt.org/).
+
+Usage:
+    python scripts/generate_llms_txt.py
+
+Output:
+    docs/src/llms.txt       - Structured index of documentation pages
+    docs/src/llms-full.txt  - Full concatenated documentation text
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+DOCS_SRC = Path(__file__).resolve().parent.parent / "docs" / "src"
+BASE_URL = "https://microsoft.github.io/autogen/stable"
+
+GUIDE_SECTIONS = [
+    {
+        "title": "AgentChat",
+        "description": "High-level API for building multi-agent applications",
+        "path": "user-guide/agentchat-user-guide",
+    },
+]
+
+
+def extract_notebook_text(path: Path) -> str:
+    """Extract markdown and code cells from a Jupyter notebook."""
+    with open(path, encoding="utf-8") as f:
+        nb = json.load(f)
+
+    parts: list[str] = []
+    for cell in nb.get("cells", []):
+        source = "".join(cell.get("source", []))
+        if not source.strip():
+            continue
+        if cell["cell_type"] == "markdown":
+            parts.append(source)
+        elif cell["cell_type"] == "code":
+            parts.append(f"```python\n{source}\n```")
+    return "\n\n".join(parts)
+
+
+def extract_markdown_text(path: Path) -> str:
+    """Read a markdown file, stripping front matter."""
+    text = path.read_text(encoding="utf-8")
+    # Strip YAML front matter
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            text = text[end + 3 :].lstrip("\n")
+    return text
+
+
+def get_title(text: str) -> str:
+    """Extract the first heading from text."""
+    for line in text.splitlines():
+        m = re.match(r"^#\s+(.+)", line)
+        if m:
+            # Strip MyST/Sphinx directives from title
+            title = m.group(1).strip()
+            title = re.sub(r"\{[^}]+\}`[^`]*`", "", title).strip()
+            return title
+    return ""
+
+
+def collect_docs(section_path: Path) -> list[tuple[Path, str]]:
+    """Collect all .md and .ipynb files in order, returning (path, text) pairs."""
+    results: list[tuple[Path, str]] = []
+
+    # Process index first if it exists
+    index = section_path / "index.md"
+    if index.exists():
+        results.append((index, extract_markdown_text(index)))
+
+    # Then all other files recursively, sorted for deterministic output
+    for path in sorted(section_path.rglob("*")):
+        if path == index:
+            continue
+        if path.suffix == ".md":
+            results.append((path, extract_markdown_text(path)))
+        elif path.suffix == ".ipynb":
+            results.append((path, extract_notebook_text(path)))
+
+    return results
+
+
+def make_url(section_url_path: str, file_path: Path, section_root: Path) -> str:
+    """Convert a file path to its documentation URL."""
+    rel = file_path.relative_to(section_root)
+    # Change extension to .html
+    url_path = str(rel.with_suffix(".html"))
+    return f"{BASE_URL}/{section_url_path}/{url_path}"
+
+
+def generate() -> None:
+    """Generate llms.txt and llms-full.txt."""
+    index_lines: list[str] = [
+        "# AutoGen",
+        "",
+        "> AutoGen is an open-source framework for building multi-agent AI applications.",
+        "> It provides tools for creating agents that can collaborate, use tools, and solve",
+        "> complex tasks through structured conversations.",
+        "",
+    ]
+    full_parts: list[str] = [
+        "# AutoGen Documentation\n",
+    ]
+
+    for section in GUIDE_SECTIONS:
+        section_root = DOCS_SRC / section["path"]
+        if not section_root.exists():
+            print(f"Warning: {section_root} not found, skipping", file=sys.stderr)
+            continue
+
+        index_lines.append(f"## {section['title']}")
+        index_lines.append("")
+        index_lines.append(f"{section['description']}")
+        index_lines.append("")
+
+        docs = collect_docs(section_root)
+        for path, text in docs:
+            title = get_title(text) or path.stem.replace("-", " ").title()
+            url = make_url(section["path"], path, section_root)
+            index_lines.append(f"- [{title}]({url})")
+
+            full_parts.append(f"---\n\n## {title}\n\nSource: {url}\n\n{text}\n")
+
+        index_lines.append("")
+
+    # Write index
+    llms_txt = DOCS_SRC / "llms.txt"
+    llms_txt.write_text("\n".join(index_lines), encoding="utf-8")
+    print(f"Generated {llms_txt}")
+
+    # Write full text
+    llms_full = DOCS_SRC / "llms-full.txt"
+    llms_full.write_text("\n".join(full_parts), encoding="utf-8")
+    print(f"Generated {llms_full}")
+
+
+if __name__ == "__main__":
+    generate()


### PR DESCRIPTION
## Why are these changes needed?

This adds support for the [llms.txt specification](https://llmstxt.org/) to make AutoGen documentation more accessible to LLMs and AI-powered tools.

A generation script reads the AgentChat user guide source files (Markdown and Jupyter notebooks) and produces:
- `llms.txt` — structured index with page titles and URLs
- `llms-full.txt` — full concatenated documentation text

The script can be run locally with `poe generate-llms-txt` and integrated into the docs build CI.

Starting with AgentChat as the first section, following maintainer guidance. The script is designed to be easily extended to cover additional documentation sections (Core, Extensions, AutoGen Studio).

## Related issue number

Closes #6271

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

### Changes

- **`python/scripts/generate_llms_txt.py`**: Script to generate llms.txt files from docs source
- **`python/docs/src/conf.py`**: Added `html_extra_path` to include llms.txt files in built docs
- **`python/pyproject.toml`**: Added `generate-llms-txt` poe task
- **`python/docs/src/llms.txt`**: Generated index (25 AgentChat pages)
- **`python/docs/src/llms-full.txt`**: Generated full text (~284KB)
