### PR TITLE
Add deterministic CLI exit-code taxonomy for config/runtime failures

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/cli.py
+++ b/python/packages/autogen-studio/autogenstudio/cli.py
@@ -9,6 +9,10 @@ from typing_extensions import Annotated
 from .version import VERSION
 
 app = typer.Typer()
+EXIT_SUCCESS = 0
+EXIT_USAGE = 2
+EXIT_CONFIG = 3
+EXIT_RUNTIME = 4
 
 # Ignore deprecation warnings from websockets
 warnings.filterwarnings("ignore", message="websockets.legacy is deprecated*")
@@ -62,7 +66,7 @@ def ui(
     if auth_config:
         if not os.path.exists(auth_config):
             typer.echo(f"Error: Auth config file not found: {auth_config}", err=True)
-            raise typer.Exit(1)
+            raise typer.Exit(code=EXIT_CONFIG)
         env_vars["AUTOGENSTUDIO_AUTH_CONFIG"] = auth_config
     if upgrade_database:
         env_vars["AUTOGENSTUDIO_UPGRADE_DATABASE"] = "1"
@@ -73,15 +77,21 @@ def ui(
         for key, value in env_vars.items():
             temp_env.write(f"{key}={value}\n")
 
-    uvicorn.run(
-        "autogenstudio.web.app:app",
-        host=host,
-        port=port,
-        workers=workers,
-        reload=reload,
-        reload_excludes=["**/alembic/*", "**/alembic.ini", "**/versions/*"] if reload else None,
-        env_file=env_file_path,
-    )
+    try:
+        uvicorn.run(
+            "autogenstudio.web.app:app",
+            host=host,
+            port=port,
+            workers=workers,
+            reload=reload,
+            reload_excludes=["**/alembic/*", "**/alembic.ini", "**/versions/*"] if reload else None,
+            env_file=env_file_path,
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        typer.echo(f"Runtime error: {exc}", err=True)
+        raise typer.Exit(code=EXIT_RUNTIME) from exc
 
 
 @app.command()
@@ -111,15 +121,22 @@ def serve(
 
     # validate the team file
     if not os.path.exists(team):
-        raise ValueError(f"Team file not found: {team}")
+        typer.echo(f"Error: Team file not found: {team}", err=True)
+        raise typer.Exit(code=EXIT_CONFIG)
 
-    uvicorn.run(
-        "autogenstudio.web.serve:app",
-        host=host,
-        port=port,
-        workers=workers,
-        reload=reload,
-    )
+    try:
+        uvicorn.run(
+            "autogenstudio.web.serve:app",
+            host=host,
+            port=port,
+            workers=workers,
+            reload=reload,
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        typer.echo(f"Runtime error: {exc}", err=True)
+        raise typer.Exit(code=EXIT_RUNTIME) from exc
 
 
 @app.command()
@@ -158,6 +175,9 @@ def lite(
         studio.start()  # Blocking call for CLI
     except KeyboardInterrupt:
         studio.stop()
+    except Exception as exc:
+        typer.echo(f"Runtime error: {exc}", err=True)
+        raise typer.Exit(code=EXIT_RUNTIME) from exc
 
 
 def run():

--- a/python/packages/autogen-studio/tests/test_cli_exit_codes.py
+++ b/python/packages/autogen-studio/tests/test_cli_exit_codes.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+import typer
+
+from autogenstudio import cli
+
+
+def test_ui_missing_auth_config_uses_config_exit_code() -> None:
+    with pytest.raises(typer.Exit) as exc_info:
+        cli.ui(auth_config="/path/does/not/exist.yaml")
+    assert exc_info.value.exit_code == cli.EXIT_CONFIG
+
+
+def test_serve_missing_team_uses_config_exit_code() -> None:
+    with pytest.raises(typer.Exit) as exc_info:
+        cli.serve(team="/path/does/not/exist.json")
+    assert exc_info.value.exit_code == cli.EXIT_CONFIG
+
+
+def test_ui_uvicorn_error_uses_runtime_exit_code(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(cli, "get_env_file_path", lambda: str(tmp_path / "env.tmp"))
+
+    def _raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli.uvicorn, "run", _raise_runtime_error)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        cli.ui()
+    assert exc_info.value.exit_code == cli.EXIT_RUNTIME

--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -13,6 +13,11 @@ from autogen_ext.teams.magentic_one import MagenticOne
 from autogen_ext.ui import RichConsole
 
 DEFAULT_CONFIG_FILE = "config.yaml"
+EXIT_SUCCESS = 0
+EXIT_USAGE = 2
+EXIT_CONFIG = 3
+EXIT_RUNTIME = 4
+
 DEFAULT_CONFIG_CONTENTS = """# config.yaml
 #
 
@@ -85,25 +90,31 @@ def main() -> None:
 
     if args.sample_config:
         sys.stdout.write(DEFAULT_CONFIG_CONTENTS + "\n")
-        return
+        raise SystemExit(EXIT_SUCCESS)
 
     # We're not printing a sample, so we need a task
     if args.task is None:
-        parser.print_usage()
-        return
+        parser.error("task is required unless --sample-config is set")
 
     # Load the configuration
     config: Dict[str, Any] = {}
 
-    if args.config is None:
-        if os.path.isfile(DEFAULT_CONFIG_FILE):
-            with open(DEFAULT_CONFIG_FILE, "r") as f:
-                config = yaml.safe_load(f)
+    try:
+        if args.config is None:
+            if os.path.isfile(DEFAULT_CONFIG_FILE):
+                with open(DEFAULT_CONFIG_FILE, "r") as f:
+                    config = yaml.safe_load(f)
+            else:
+                config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)
         else:
-            config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)
-    else:
-        with open(args.config if isinstance(args.config, str) else args.config[0], "r") as f:
-            config = yaml.safe_load(f)
+            with open(args.config if isinstance(args.config, str) else args.config[0], "r") as f:
+                config = yaml.safe_load(f)
+
+        if not isinstance(config, dict) or "client" not in config:
+            raise ValueError("configuration must contain a top-level 'client' section")
+    except (FileNotFoundError, PermissionError, yaml.YAMLError, ValueError) as exc:
+        sys.stderr.write(f"Configuration error: {exc}\n")
+        raise SystemExit(EXIT_CONFIG) from exc
 
     # Run the task
     async def run_task(task: str, hil_mode: bool, use_rich_console: bool) -> None:
@@ -126,7 +137,13 @@ def main() -> None:
         await client.close()
 
     task = args.task if isinstance(args.task, str) else args.task[0]
-    asyncio.run(run_task(task, not args.no_hil, args.rich))
+    try:
+        asyncio.run(run_task(task, not args.no_hil, args.rich))
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        sys.stderr.write(f"Runtime error: {exc}\n")
+        raise SystemExit(EXIT_RUNTIME) from exc
 
 
 if __name__ == "__main__":

--- a/python/packages/magentic-one-cli/tests/test_m1_exit_codes.py
+++ b/python/packages/magentic-one-cli/tests/test_m1_exit_codes.py
@@ -1,0 +1,41 @@
+import asyncio
+import sys
+
+import pytest
+from magentic_one_cli import _m1
+
+
+def test_missing_task_exits_with_usage_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["m1"])
+    with pytest.raises(SystemExit) as exc_info:
+        _m1.main()
+    assert exc_info.value.code == _m1.EXIT_USAGE
+
+
+def test_missing_config_file_exits_with_config_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["m1", "--config", "/path/does/not/exist.yaml", "demo task"],
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _m1.main()
+    assert exc_info.value.code == _m1.EXIT_CONFIG
+
+
+def test_runtime_failure_exits_with_runtime_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["m1", "demo task"])
+
+    def _raise_runtime_error(coro, *_args, **_kwargs):
+        coro.close()
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(asyncio, "run", _raise_runtime_error)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _m1.main()
+    assert exc_info.value.code == _m1.EXIT_RUNTIME


### PR DESCRIPTION
## Problem
CLI failure modes returned inconsistent exit behavior across usage/config/runtime paths, making automation retries and classification unreliable.

## Why now
Deterministic exit-code contracts are needed for CI and operator workflows to distinguish actionable categories.

## What changed
- Added explicit exit code constants across Magentic-One CLI and AutoGen Studio CLI:
  - success: `0`
  - usage: `2`
  - config: `3`
  - runtime: `4`
- Updated Magentic-One CLI to:
  - route missing task to usage exit
  - route config/load/validation failures to config exit
  - route runtime failures to runtime exit.
- Updated AutoGen Studio CLI to:
  - route config validation failures to config exit
  - route runtime server failures to runtime exit.
- Added regression tests:
  - `python/packages/magentic-one-cli/tests/test_m1_exit_codes.py`
  - `python/packages/autogen-studio/tests/test_cli_exit_codes.py`

## Validation
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest -q tests/test_m1_exit_codes.py`
- `uv run ruff check autogenstudio tests`
- `uv run ruff format --check autogenstudio tests`
- `uv run pytest -q tests/test_cli_exit_codes.py`

Refs #7330
