### PR TITLE
Add Mistral model support to OpenAIChatCompletionClient

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -46,6 +46,16 @@ _MODEL_POINTERS = {
     "llama-3.3-70b": "Llama-3.3-70B-Instruct",
     "llama-4-scout": "Llama-4-Scout-17B-16E-Instruct-FP8",
     "llama-4-maverick": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+    # Mistral models
+    "mistral-large-latest": "mistral-large-2411",
+    "mistral-small-latest": "mistral-small-2503",
+    "codestral-latest": "codestral-2501",
+    "mistral-embed": "mistral-embed",
+    "pixtral-large-latest": "pixtral-large-2411",
+    "pixtral-12b-2409": "pixtral-12b-2409",
+    "open-mistral-nemo": "open-mistral-nemo-2407",
+    "ministral-8b-latest": "ministral-8b-2410",
+    "open-codestral-mamba": "open-codestral-mamba",
 }
 
 _MODEL_INFO: Dict[str, ModelInfo] = {
@@ -441,6 +451,79 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
         "structured_output": True,
         "multiple_system_messages": True,
     },
+    # Mistral models
+    "mistral-large-2411": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "mistral-small-2503": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "codestral-2501": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.CODESRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "mistral-embed": {
+        "vision": False,
+        "function_calling": False,
+        "json_output": False,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
+    "pixtral-large-2411": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.PIXTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "pixtral-12b-2409": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.PIXTRAL,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
+    "open-mistral-nemo-2407": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
+    "ministral-8b-2410": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MINISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
+    "open-codestral-mamba": {
+        "vision": False,
+        "function_calling": False,
+        "json_output": True,
+        "family": ModelFamily.OPEN_CODESRAL_MAMBA,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
 }
 
 _MODEL_TOKEN_LIMITS: Dict[str, int] = {
@@ -491,11 +574,29 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
     "Llama-3.3-70B-Instruct": 128000,
     "Llama-4-Scout-17B-16E-Instruct-FP8": 128000,
     "Llama-4-Maverick-17B-128E-Instruct-FP8": 128000,
+    # Mistral models
+    "mistral-large-2411": 128000,
+    "mistral-small-2503": 32000,
+    "codestral-2501": 256000,
+    "mistral-embed": 8192,
+    "pixtral-large-2411": 128000,
+    "pixtral-12b-2409": 128000,
+    "open-mistral-nemo-2407": 128000,
+    "ministral-8b-2410": 128000,
+    "open-codestral-mamba": 256000,
 }
 
 GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 ANTHROPIC_OPENAI_BASE_URL = "https://api.anthropic.com/v1/"
 LLAMA_API_BASE_URL = "https://api.llama.com/compat/v1/"
+MISTRAL_API_BASE_URL = "https://api.mistral.ai/v1/"
+
+_MISTRAL_MODEL_PREFIXES = ("mistral-", "codestral-", "pixtral-", "ministral-", "open-mistral-", "open-codestral-")
+
+
+def is_mistral_model(model: str) -> bool:
+    """Check if a model name corresponds to a Mistral AI model."""
+    return model.startswith(_MISTRAL_MODEL_PREFIXES)
 
 
 def resolve_model(model: str) -> str:

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1480,6 +1480,11 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
                 copied_args["base_url"] = _model_info.LLAMA_API_BASE_URL
             if "api_key" not in copied_args and "LLAMA_API_KEY" in os.environ:
                 copied_args["api_key"] = os.environ["LLAMA_API_KEY"]
+        if _model_info.is_mistral_model(copied_args["model"]):
+            if "base_url" not in copied_args:
+                copied_args["base_url"] = _model_info.MISTRAL_API_BASE_URL
+            if "api_key" not in copied_args and "MISTRAL_API_KEY" in os.environ:
+                copied_args["api_key"] = os.environ["MISTRAL_API_KEY"]
 
         client = _openai_client_from_config(copied_args)
         create_args = _create_args_from_config(copied_args)


### PR DESCRIPTION
## Summary
- Add Mistral AI model entries to `_model_info.py`: model pointers (aliases), model info (capabilities), and token limits for `mistral-large-2411`, `mistral-small-2503`, `codestral-2501`, `pixtral-large-2411`, `pixtral-12b-2409`, `open-mistral-nemo-2407`, `ministral-8b-2410`, `open-codestral-mamba`, and `mistral-embed`
- Auto-detect `base_url` (`https://api.mistral.ai/v1/`) and `MISTRAL_API_KEY` environment variable in `OpenAIChatCompletionClient`, following the existing pattern for Gemini, Anthropic, and Llama models
- Add `is_mistral_model()` helper using prefix-based matching for all Mistral model name prefixes

## Motivation
Currently, using Mistral models requires manually specifying `base_url` and `api_key`. This PR adds the same level of auto-detection already available for Gemini, Anthropic, and Llama models, allowing users to simply write:

```python
client = OpenAIChatCompletionClient(model="mistral-large-latest")
```

## Test plan
- [ ] Verify `mistral-large-latest` resolves to `mistral-large-2411` via model pointers
- [ ] Verify `OpenAIChatCompletionClient(model="mistral-large-latest")` auto-sets `base_url` and reads `MISTRAL_API_KEY`
- [ ] Verify existing Gemini/Claude/Llama auto-detection is unaffected

Closes #6151

🤖 Generated with [Claude Code](https://claude.com/claude-code)