### PR TITLE
feat(samples): governance workbench for tool call authorization

### DIFF
--- a/python/samples/core_governance_workbench/README.md
+++ b/python/samples/core_governance_workbench/README.md
@@ -1,0 +1,69 @@
+# Governance Workbench
+
+A governance wrapper for AutoGen workbenches that enforces structural authority separation on tool calls.
+
+## The Problem
+
+In a GroupChat, agents propose and execute tool calls with no authorization boundary between intent and action. An agent tasked with "research competitors" can call any tool its workbench exposes — file writes, shell commands, network requests — without policy evaluation.
+
+## The Solution: PROPOSE / DECIDE / PROMOTE
+
+`GovernanceWorkbench` wraps any existing `Workbench` and interposes deterministic policy evaluation on every `call_tool` invocation:
+
+| Phase | What Happens | Who Decides |
+|-------|-------------|-------------|
+| **PROPOSE** | Convert tool call into structured intent with SHA-256 hash | Automatic |
+| **DECIDE** | Evaluate intent against policy rules (pure function, no LLM) | Policy |
+| **PROMOTE** | Forward approved calls; return error `ToolResult` for denied | Verdict |
+
+Denied calls return `ToolResult(is_error=True)` — no exception, no disruption to the GroupChat loop. The agent sees a denial message and adjusts.
+
+## Usage
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_ext.tools.langchain import LangChainToolAdapter
+from governance_workbench import GovernanceWorkbench
+
+# Your existing workbench
+inner_workbench = ...
+
+# Define policy: fail-closed, explicit approvals
+policy = {
+    "default": "deny",
+    "rules": [
+        {"tools": ["search", "read_file"], "verdict": "approve"},
+        {"tools": ["write_file"], "verdict": "deny"},
+        {
+            "tools": ["shell"],
+            "verdict": "approve",
+            "constraints": {"blocked_patterns": ["rm -rf", "sudo"]},
+        },
+    ],
+}
+
+# Wrap it
+governed = GovernanceWorkbench(
+    inner=inner_workbench,
+    policy=policy,
+    witness_path="./governance_witness.jsonl",
+)
+
+# Use with any agent
+agent = AssistantAgent(
+    name="researcher",
+    model_client=model_client,
+    workbench=governed,  # <-- governance applied here
+)
+```
+
+## Design Principles
+
+1. **Deterministic** — `_decide()` is a pure function. Same intent + policy = same verdict.
+2. **Fail-closed** — unknown tools default to `deny`.
+3. **Non-disruptive** — denied calls return error results, not exceptions. The GroupChat continues.
+4. **Auditable** — hash-chained witness log records every verdict.
+
+## Going Further
+
+For a standalone implementation with YAML policy files, multiple presets, and adversarial test coverage, see [Governance-Guard](https://github.com/MetaCortex-Dynamics/governance-guard).

--- a/python/samples/core_governance_workbench/governance_workbench.py
+++ b/python/samples/core_governance_workbench/governance_workbench.py
@@ -1,0 +1,212 @@
+"""Governance Workbench — PROPOSE / DECIDE / PROMOTE for AutoGen tool calls.
+
+A wrapper around any AutoGen Workbench that interposes deterministic policy
+evaluation between an agent's tool selection and tool execution. The wrapped
+workbench's tools are exposed unchanged, but every ``call_tool`` invocation
+is authorized against a user-defined policy before execution proceeds.
+
+Denied calls return a ``ToolResult`` with ``is_error=True`` — no exception,
+no disruption to the GroupChat loop. The agent sees a structured denial
+message and can adjust its plan.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, AsyncGenerator, List, Mapping, Optional
+
+from autogen_core import CancellationToken
+from autogen_core.tools import ToolResult, ToolSchema, TextResultContent, Workbench
+
+
+class GovernanceWorkbench(Workbench):
+    """Wraps an existing Workbench with deterministic governance policy enforcement.
+
+    Three-phase authorization pipeline:
+
+    - **PROPOSE**: Convert each ``call_tool`` invocation into a structured intent
+      with a SHA-256 content hash.
+    - **DECIDE**: Evaluate the intent against user-defined policy rules.
+      Pure function — no LLM, no interpretation ambiguity.
+    - **PROMOTE**: Forward approved calls to the inner workbench. Return a
+      structured error ``ToolResult`` for denied calls.
+
+    Args:
+        inner: The workbench to wrap. All tool listing and lifecycle methods
+            delegate to it.
+        policy: Governance policy dict. Structure::
+
+            {
+                "default": "approve" | "deny",
+                "rules": [
+                    {
+                        "tools": ["tool_name", ...],
+                        "verdict": "approve" | "deny",
+                        "constraints": {  # optional
+                            "blocked_patterns": ["rm -rf", ...],
+                        },
+                    },
+                ],
+            }
+
+        witness_path: Optional path for hash-chained audit log.
+    """
+
+    component_type = "workbench"
+
+    def __init__(
+        self,
+        inner: Workbench,
+        policy: dict[str, Any],
+        witness_path: str | Path | None = None,
+    ) -> None:
+        super().__init__()
+        self._inner = inner
+        self._policy = policy
+
+        self._witness_file: Path | None = None
+        if witness_path is not None:
+            self._witness_file = Path(witness_path)
+            self._witness_file.parent.mkdir(parents=True, exist_ok=True)
+
+        self._prev_hash = self._read_last_hash()
+
+    def _read_last_hash(self) -> str:
+        """Resume chain from existing log, or start from genesis."""
+        if self._witness_file is None or not self._witness_file.exists():
+            return "0" * 64
+        last_line = ""
+        with open(self._witness_file, encoding="utf-8") as f:
+            for last_line in f:
+                pass
+        if last_line.strip():
+            return json.loads(last_line)["hash"]
+        return "0" * 64
+
+    # --- PROPOSE ---
+
+    @staticmethod
+    def _propose(name: str, arguments: Mapping[str, Any] | None) -> dict[str, Any]:
+        """Convert a tool call into a structured, hashable intent."""
+        intent: dict[str, Any] = {
+            "tool": name,
+            "arguments": dict(arguments) if arguments else {},
+        }
+        payload = json.dumps(intent, sort_keys=True, default=str).encode()
+        intent["content_hash"] = hashlib.sha256(payload).hexdigest()
+        return intent
+
+    # --- DECIDE ---
+
+    @staticmethod
+    def _decide(intent: dict[str, Any], policy: dict[str, Any]) -> str:
+        """Pure function: ``(intent, policy) -> 'approve' | 'deny'``.
+
+        No LLM involvement. No interpretation ambiguity.
+        """
+        tool_name = intent["tool"]
+        args_str = json.dumps(intent.get("arguments", {}), default=str).lower()
+
+        for rule in policy.get("rules", []):
+            if tool_name not in rule.get("tools", []):
+                continue
+
+            constraints = rule.get("constraints", {})
+            if constraints:
+                for pattern in constraints.get("blocked_patterns", []):
+                    if pattern.lower() in args_str:
+                        return "deny"
+
+            return rule.get("verdict", policy.get("default", "deny"))
+
+        return policy.get("default", "deny")
+
+    # --- Witness ---
+
+    def _record(self, entry: dict[str, Any]) -> None:
+        if self._witness_file is None:
+            return
+        entry["prev_hash"] = self._prev_hash
+        entry["timestamp"] = time.time()
+        payload = json.dumps(entry, sort_keys=True, default=str)
+        entry_hash = hashlib.sha256(payload.encode()).hexdigest()
+        entry["hash"] = entry_hash
+        with open(self._witness_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        self._prev_hash = entry_hash
+
+    # --- Workbench interface ---
+
+    async def list_tools(self) -> List[ToolSchema]:
+        return await self._inner.list_tools()
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+        cancellation_token: CancellationToken | None = None,
+        call_id: str | None = None,
+    ) -> ToolResult:
+        # PROPOSE
+        intent = self._propose(name, arguments)
+
+        # DECIDE
+        verdict = self._decide(intent, self._policy)
+
+        # PROMOTE
+        self._record({
+            "phase": "promote",
+            "verdict": verdict,
+            "tool": name,
+            "content_hash": intent["content_hash"],
+            "call_id": call_id or "",
+        })
+
+        if verdict == "deny":
+            return ToolResult(
+                name=name,
+                result=[TextResultContent(
+                    content=f"GOVERNANCE DENIED: Tool '{name}' blocked by policy. "
+                    f"Adjust your approach or use an approved tool."
+                )],
+                is_error=True,
+            )
+
+        # Approved — delegate to inner workbench
+        result = await self._inner.call_tool(
+            name, arguments, cancellation_token, call_id
+        )
+
+        self._record({
+            "phase": "audit",
+            "tool": name,
+            "call_id": call_id or "",
+            "is_error": result.is_error,
+        })
+
+        return result
+
+    async def start(self) -> None:
+        await self._inner.start()
+
+    async def stop(self) -> None:
+        await self._inner.stop()
+
+    async def reset(self) -> None:
+        await self._inner.reset()
+
+    async def save_state(self) -> Mapping[str, Any]:
+        return await self._inner.save_state()
+
+    async def load_state(self, state: Mapping[str, Any]) -> None:
+        await self._inner.load_state(state)
+
+    def _to_config(self) -> Any:
+        raise NotImplementedError("GovernanceWorkbench is not serializable")
+
+    @classmethod
+    def _from_config(cls, config: Any) -> "GovernanceWorkbench":
+        raise NotImplementedError("GovernanceWorkbench is not serializable")


### PR DESCRIPTION
## Summary

Adds a sample `GovernanceWorkbench` that wraps any AutoGen `Workbench` with deterministic policy enforcement on every `call_tool` invocation.

### How it works

The wrapper interposes a three-phase authorization pipeline between the agent's tool selection and tool execution:

- **PROPOSE**: Converts each `call_tool(name, arguments)` into a structured intent with SHA-256 content hash
- **DECIDE**: Evaluates the intent against user-defined policy rules — pure function, no LLM, no interpretation ambiguity
- **PROMOTE**: Forwards approved calls to the inner workbench; returns `ToolResult(is_error=True)` with a structured denial message for denied calls

Denied calls don't raise exceptions — they return error results. The GroupChat loop continues uninterrupted and the agent sees a denial message it can reason about.

### Policy format

```python
policy = {
    "default": "deny",  # fail-closed
    "rules": [
        {"tools": ["search", "read_file"], "verdict": "approve"},
        {"tools": ["shell"], "verdict": "approve",
         "constraints": {"blocked_patterns": ["rm -rf", "sudo"]}},
    ],
}
governed = GovernanceWorkbench(inner=workbench, policy=policy)
```

### Why Workbench wrapper (not agent subclass)

The `Workbench` interface is the natural interposition point — it's where tool calls happen. Wrapping at this level means:
- Works with any agent type (AssistantAgent, custom agents)
- Works in any team topology (GroupChat, Swarm, RoundRobin)
- No agent code changes required
- Composable — can stack governance with other workbench wrappers

## Changes

- `python/samples/core_governance_workbench/governance_workbench.py` — implementation
- `python/samples/core_governance_workbench/README.md` — usage guide

For a standalone implementation with YAML policies and adversarial test coverage, see [Governance-Guard](https://github.com/MetaCortex-Dynamics/governance-guard).

> This PR was developed with AI assistance.