### PR TITLE
docs: add autogen-ext-agentwallet to community extensions

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -48,6 +48,8 @@ Find community samples and examples of how to use AutoGen
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
 
 
+| [autogen-ext-agentwallet](https://github.com/agentwallet-sdk/autogen-ext-agentwallet) | [PyPI](https://pypi.org/project/autogen-ext-agentwallet/) | Non-custodial wallet for agents — EVM + Solana, x402 payments, 17-chain CCTP bridge, on-chain spend limits |
+
 <!-- Example -->
 <!-- | [My Model Client](https://github.com/example)  | [PyPi](https://pypi.org/project/example) | Model client for my custom model service | -->
 <!-- - Name should link to the project page or repo


### PR DESCRIPTION
## Summary

Adds `autogen-ext-agentwallet` to the community extensions discovery page.

### What is autogen-ext-agentwallet?

A non-custodial wallet extension for AutoGen agents with:
- **EVM + Solana** balance checks and token transfers (via web3.py)
- **x402 payments** — automatic HTTP 402 Payment Required handling
- **17-chain CCTP bridge** — USDC bridging via Circle Cross-Chain Transfer Protocol
- **On-chain spend limits** — query AgentAccountV2 contract before spending

```python
from autogen_ext_agentwallet import AgentWalletToolkit

toolkit = AgentWalletToolkit(
    wallet_address="0x...",
    private_key="0x...",
    chain_id=8453,
    rpc_url="https://mainnet.base.org",
)
tools = toolkit.get_tools()
```

### Ecosystem adoption

This payment pattern was recently [merged into NVIDIA's NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) as an official example, demonstrating industry demand for agent payment infrastructure.

### Links

- PyPI: https://pypi.org/project/autogen-ext-agentwallet/
- GitHub: https://github.com/agentwallet-sdk/autogen-ext-agentwallet
- License: MIT
