### PR TITLE
fix: preserve database password in Alembic migration config

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
+++ b/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
@@ -194,7 +194,7 @@ else:
         """
         Generates content for alembic.ini file.
         """
-        engine_url = str(self.engine.url).replace("%", "%%")
+        engine_url = self.engine.url.render_as_string(hide_password=False).replace("%", "%%")
         return f"""
 [alembic]
 script_location = {self.alembic_dir}


### PR DESCRIPTION
## Summary

Fixes #7341

When Autogen Studio starts with a PostgreSQL database, `schema_manager.generate_revision` fails with "password authentication failed" even though the database credentials are correct and the main application connects successfully.

**Root cause:** In `SchemaManager._generate_alembic_ini_content()`, the database URL is serialized using `str(self.engine.url)`. In SQLAlchemy 2.x, `str()` on a URL object obfuscates the password as `***`, so the URL written to `alembic.ini` becomes:

```
postgresql+psycopg://autogen:***@postgres:5432/autogen
```

When Alembic reads this config to run `generate_revision`, it tries to authenticate with the literal string `***` as the password, which naturally fails.

**Fix:** Replace `str(self.engine.url)` with `self.engine.url.render_as_string(hide_password=False)` to write the actual password into `alembic.ini`.

## Test Plan

- Verified with `sqlalchemy.make_url` that the old code produces `***` for the password while the new code preserves it
- Confirmed the fix also handles special characters in passwords (URL-encoded `%` chars are properly escaped for ConfigParser with `%%`)
- All existing `test_db_manager.py` tests pass (6/6)