### PR TITLE
fix(ext): ignore None chunks in OpenAI streaming

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -890,7 +890,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             )
 
         # Prepare data to process streaming chunks.
-        chunk: ChatCompletionChunk | None = None
+        last_valid_chunk: ChatCompletionChunk | None = None
         stop_reason = None
         maybe_model = None
         content_deltas: List[str] = []
@@ -906,6 +906,11 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         # Process the stream of chunks.
         async for chunk in chunks:
+            if chunk is None:
+                continue
+
+            last_valid_chunk = chunk
+
             if first_chunk:
                 first_chunk = False
                 # Emit the start event.
@@ -1013,9 +1018,9 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         model = model.replace("gpt-35", "gpt-3.5")  # hack for Azure API
 
         # Because the usage chunk is not guaranteed to be the last chunk, we need to check if it is available.
-        if chunk and chunk.usage:
-            prompt_tokens = chunk.usage.prompt_tokens
-            completion_tokens = chunk.usage.completion_tokens
+        if last_valid_chunk and last_valid_chunk.usage:
+            prompt_tokens = last_valid_chunk.usage.prompt_tokens
+            completion_tokens = last_valid_chunk.usage.completion_tokens
         else:
             prompt_tokens = 0
             completion_tokens = 0

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -345,6 +345,87 @@ async def test_openai_chat_completion_client_create_stream_no_usage_default(monk
 
 
 @pytest.mark.asyncio
+async def test_openai_chat_completion_client_create_stream_skips_none_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _mock_create_stream_chunks(
+        self: BaseOpenAIChatCompletionClient, *args: Any, **kwargs: Any
+    ) -> AsyncGenerator[ChatCompletionChunk | None, None]:
+        yield None
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[
+                ChunkChoice(
+                    finish_reason=None,
+                    index=0,
+                    delta=ChoiceDelta(
+                        content="Hello",
+                        role="assistant",
+                    ),
+                )
+            ],
+            created=0,
+            model="gpt-4o",
+            object="chat.completion.chunk",
+            usage=None,
+        )
+        yield None
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[
+                ChunkChoice(
+                    finish_reason="stop",
+                    index=0,
+                    delta=ChoiceDelta(
+                        content=None,
+                        role="assistant",
+                    ),
+                )
+            ],
+            created=0,
+            model="gpt-4o",
+            object="chat.completion.chunk",
+            usage=None,
+        )
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[],
+            created=0,
+            model="gpt-4o",
+            object="chat.completion.chunk",
+            usage=CompletionUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+        )
+        yield None
+
+    monkeypatch.setattr(
+        BaseOpenAIChatCompletionClient,
+        "_create_stream_chunks",
+        _mock_create_stream_chunks,
+    )
+
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="api_key")
+    chunks: List[str | CreateResult] = []
+
+    async for chunk in client.create_stream(
+        messages=[UserMessage(content="Hello", source="user")],
+        include_usage=True,
+    ):
+        chunks.append(chunk)
+
+    assert chunks == [
+        "Hello",
+        CreateResult(
+            finish_reason="stop",
+            content="Hello",
+            usage=RequestUsage(prompt_tokens=3, completion_tokens=2),
+            cached=False,
+            logprobs=None,
+            thought=None,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_openai_chat_completion_client_create_stream_no_usage_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(AsyncCompletions, "create", _mock_create)
     client = OpenAIChatCompletionClient(model="gpt-4o", api_key="api_key")


### PR DESCRIPTION
## Summary
- skip `None` chunks before the streaming loop touches chunk attributes
- preserve the last valid chunk so trailing `None` events do not drop usage accounting
- add a regression test covering `None` chunks before, between, and after valid streaming chunks

Fixes #7130

## Testing
- `.venv/bin/ruff check packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py packages/autogen-ext/tests/models/test_openai_model_client.py`
- `.venv/bin/ruff format --check packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py packages/autogen-ext/tests/models/test_openai_model_client.py`
- `.venv/bin/python -m pytest packages/autogen-ext/tests/models/test_openai_model_client.py -k "create_stream_with_usage or create_stream_no_usage_default or create_stream_no_usage_explicit or skips_none_chunks"`