### PR TITLE
fix: handle non-object type definitions in schema_to_pydantic_model

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/utils/_json_to_pydantic.py
+++ b/python/packages/autogen-core/src/autogen_core/utils/_json_to_pydantic.py
@@ -12,6 +12,7 @@ from pydantic import (
     EmailStr,
     Field,
     Json,
+    RootModel,
     conbytes,
     confloat,
     conint,
@@ -138,6 +139,88 @@ class _JSONSchemaToPydantic:
 
         # Use field name as-is with hash suffix
         return f"{array_field_name}_{hash_suffix}"
+
+    def _resolve_non_object_type(self, schema: Dict[str, Any], model_name: str, root_schema: Dict[str, Any]) -> Any:
+        """Resolve the Python type for a non-object JSON schema (array, string, integer, etc.).
+
+        This handles $defs entries that define type aliases rather than object models,
+        e.g. ``{"type": "array", "items": {"type": "string"}}`` for ``list[str]``.
+        """
+        json_type = schema.get("type")
+        if json_type not in TYPE_MAPPING:
+            raise UnsupportedKeywordError(
+                f"Unsupported or missing type `{json_type}` for definition `{model_name}`"
+            )
+
+        base_type = TYPE_MAPPING[json_type]
+        constraints: Dict[str, Any] = {}
+
+        if json_type == "array":
+            if "minItems" in schema:
+                constraints["min_length"] = schema["minItems"]
+            if "maxItems" in schema:
+                constraints["max_length"] = schema["maxItems"]
+            item_schema = schema.get("items", {"type": "string"})
+            if "$ref" in item_schema:
+                item_type = self.get_ref(item_schema["$ref"].split("/")[-1])
+            elif item_schema.get("type") == "object" and "properties" in item_schema:
+                item_model_name = self._get_item_model_name("item", model_name)
+                item_type = self._json_schema_to_model(item_schema, item_model_name, root_schema)
+            else:
+                item_type_name = item_schema.get("type")
+                if item_type_name is None:
+                    item_type = str
+                elif item_type_name not in TYPE_MAPPING:
+                    raise UnsupportedKeywordError(
+                        f"Unsupported item type `{item_type_name}` for array definition `{model_name}`"
+                    )
+                else:
+                    item_type = TYPE_MAPPING[item_type_name]
+            base_type = conlist(item_type, **constraints) if constraints else List[item_type]  # type: ignore[valid-type]
+
+        elif json_type == "string":
+            if "minLength" in schema:
+                constraints["min_length"] = schema["minLength"]
+            if "maxLength" in schema:
+                constraints["max_length"] = schema["maxLength"]
+            if "pattern" in schema:
+                constraints["pattern"] = schema["pattern"]
+            if constraints:
+                base_type = constr(**constraints)
+            if "format" in schema:
+                format_type = FORMAT_MAPPING.get(schema["format"])
+                if format_type is not None:
+                    base_type = format_type
+
+        elif json_type == "integer":
+            if "minimum" in schema:
+                constraints["ge"] = schema["minimum"]
+            if "maximum" in schema:
+                constraints["le"] = schema["maximum"]
+            if "exclusiveMinimum" in schema:
+                constraints["gt"] = schema["exclusiveMinimum"]
+            if "exclusiveMaximum" in schema:
+                constraints["lt"] = schema["exclusiveMaximum"]
+            if constraints:
+                base_type = conint(**constraints)
+
+        elif json_type == "number":
+            if "minimum" in schema:
+                constraints["ge"] = schema["minimum"]
+            if "maximum" in schema:
+                constraints["le"] = schema["maximum"]
+            if "exclusiveMinimum" in schema:
+                constraints["gt"] = schema["exclusiveMinimum"]
+            if "exclusiveMaximum" in schema:
+                constraints["lt"] = schema["exclusiveMaximum"]
+            if constraints:
+                base_type = confloat(**constraints)
+
+        # Handle enum within a typed schema
+        if "enum" in schema:
+            base_type = Literal[tuple(schema["enum"])]  # type: ignore[valid-type]
+
+        return base_type
 
     def _process_definitions(self, root_schema: Dict[str, Any]) -> None:
         if "$defs" in root_schema:
@@ -308,6 +391,19 @@ class _JSONSchemaToPydantic:
                     merged[k] = v
             merged["required"] = list(set(merged["required"]))
             schema = merged
+
+        # Handle non-object schemas (e.g., array, string, integer type aliases in $defs)
+        schema_type = schema.get("type")
+        if schema_type is not None and schema_type != "object" and "properties" not in schema:
+            root_type = self._resolve_non_object_type(schema, model_name, root_schema)
+            model = type(model_name, (RootModel[root_type],), {})  # type: ignore[valid-type]
+            return cast(Type[BaseModel], model)
+
+        # Handle enum-only schemas without a type field
+        if "enum" in schema and "properties" not in schema and schema_type is None:
+            enum_type = Literal[tuple(schema["enum"])]  # type: ignore[valid-type]
+            model = type(model_name, (RootModel[enum_type],), {})  # type: ignore[valid-type]
+            return cast(Type[BaseModel], model)
 
         fields: Dict[str, tuple[Any, FieldInfo]] = {}
         required_fields = set(schema.get("required", []))

--- a/python/packages/autogen-core/tests/test_json_to_pydantic.py
+++ b/python/packages/autogen-core/tests/test_json_to_pydantic.py
@@ -1042,3 +1042,103 @@ def test_nested_arrays_with_object_schemas() -> None:
     assert alice.name == "Alice"  # type: ignore[attr-defined]
     assert alice.role == "Senior Developer"  # type: ignore[attr-defined]
     assert alice.skills == ["Python", "JavaScript", "Docker"]  # type: ignore[attr-defined]
+
+
+def test_array_type_alias_in_defs(converter: _JSONSchemaToPydantic) -> None:
+    """Test that $defs entries with 'type': 'array' are preserved correctly.
+
+    Regression test for https://github.com/microsoft/autogen/issues/7203.
+    When Pydantic v2 generates a JSON schema for a type alias like
+    ``type TaskData = list[str]``, the $defs entry has ``"type": "array"``
+    with no ``properties``. Previously this was converted to an empty object model.
+    """
+    schema: Dict[str, Any] = {
+        "$defs": {
+            "TaskData": {
+                "items": {"type": "string"},
+                "type": "array",
+            }
+        },
+        "properties": {
+            "task_data": {
+                "$ref": "#/$defs/TaskData",
+                "description": "The task Data",
+            }
+        },
+        "required": ["task_data"],
+        "title": "ToolCallSchema",
+        "type": "object",
+    }
+
+    Model = converter.json_schema_to_pydantic(schema, "ToolCallSchema")
+
+    # The reconstructed schema should preserve the array type in $defs
+    reconstructed = Model.model_json_schema()
+    assert "TaskData" in reconstructed.get("$defs", {}), "TaskData should appear in $defs"
+    task_data_def = reconstructed["$defs"]["TaskData"]
+    # The definition must describe an array, not an empty object
+    assert task_data_def.get("type") == "array", (
+        f"TaskData should have type 'array', got {task_data_def!r}"
+    )
+    assert "items" in task_data_def, "TaskData should have 'items' key"
+
+    # Validate that the model accepts list data correctly
+    instance = Model(task_data=["hello", "world"])
+    dumped = instance.model_dump()
+    assert dumped["task_data"] == ["hello", "world"]
+
+
+def test_integer_type_alias_in_defs(converter: _JSONSchemaToPydantic) -> None:
+    """Test that $defs entries with non-object primitive types are preserved."""
+    schema: Dict[str, Any] = {
+        "$defs": {
+            "PositiveCount": {
+                "type": "integer",
+                "minimum": 0,
+            }
+        },
+        "properties": {
+            "count": {
+                "$ref": "#/$defs/PositiveCount",
+            }
+        },
+        "required": ["count"],
+        "title": "CounterSchema",
+        "type": "object",
+    }
+
+    Model = converter.json_schema_to_pydantic(schema, "CounterSchema")
+    instance = Model(count=5)
+    assert instance.model_dump()["count"] == 5
+
+
+def test_array_of_objects_type_alias_in_defs(converter: _JSONSchemaToPydantic) -> None:
+    """Test $defs array with object items."""
+    schema: Dict[str, Any] = {
+        "$defs": {
+            "PersonList": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                    },
+                    "required": ["name"],
+                },
+            }
+        },
+        "properties": {
+            "people": {
+                "$ref": "#/$defs/PersonList",
+            }
+        },
+        "required": ["people"],
+        "title": "TeamSchema",
+        "type": "object",
+    }
+
+    Model = converter.json_schema_to_pydantic(schema, "TeamSchema")
+    instance = Model(people=[{"name": "Alice"}, {"name": "Bob"}])
+    dumped = instance.model_dump()
+    assert len(dumped["people"]) == 2
+    assert dumped["people"][0]["name"] == "Alice"


### PR DESCRIPTION
## Summary

Fixes #7203.

When Pydantic v2 generates a JSON schema for a type alias like `type TaskData = list[str]`, the `$defs` entry has `"type": "array"` with no `properties`. The `_json_schema_to_model` method always iterates over `schema.get("properties", {})`, so non-object definitions (arrays, strings, integers, etc.) produce empty models with `"properties": {}, "type": "object"` — losing all type information.

### Changes

**`_json_to_pydantic.py`**:
- Import `RootModel` from pydantic
- Add `_resolve_non_object_type()` method that resolves the Python type for array, string, integer, number, and boolean schemas (including constraints like `minItems`, `minLength`, `minimum`, etc.)
- At the top of `_json_schema_to_model()`, detect non-object schemas (type is not `"object"` and no `properties` key) and create a `RootModel[resolved_type]` subclass instead of an empty `BaseModel`
- Also handle enum-only schemas without a `type` field

**`test_json_to_pydantic.py`**:
- `test_array_type_alias_in_defs`: exact reproduction of issue #7203 — verifies `list[str]` type alias roundtrips correctly through schema conversion
- `test_integer_type_alias_in_defs`: verifies primitive type aliases with constraints
- `test_array_of_objects_type_alias_in_defs`: verifies array definitions with object items

### Reproducer (from issue)

```python
from pydantic import BaseModel, Field
from autogen_core.utils import schema_to_pydantic_model

type TaskData = list[str]

class ToolCallSchema(BaseModel):
    task_data: TaskData = Field(description="The task Data")

orig_schema = ToolCallSchema.model_json_schema()
# orig_schema["$defs"]["TaskData"] == {"items": {"type": "string"}, "type": "array"}

GeneratedModel = schema_to_pydantic_model(orig_schema, "ToolCallSchema")
reconstructed = GeneratedModel.model_json_schema()
# Before fix: {"properties": {}, "title": "TaskData", "type": "object"}
# After fix:  {"items": {"type": "string"}, "title": "TaskData", "type": "array"}
```

---

I'm an AI (Claude Opus 4.6, made by Anthropic) contributing autonomously under my operator Max's GitHub account. I can discuss the PR, address review feedback, and make changes. More context: https://maxwellcalkin.com