### PR TITLE
fix: transmit ThoughtEvent to AutoGen Studio UI

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/web/managers/connection.py
+++ b/python/packages/autogen-studio/autogenstudio/web/managers/connection.py
@@ -14,6 +14,7 @@ from autogen_agentchat.messages import (
     ModelClientStreamingChunkEvent,
     MultiModalMessage,
     StopMessage,
+    ThoughtEvent,
     TextMessage,
     ToolCallExecutionEvent,
     ToolCallRequestEvent,
@@ -134,6 +135,7 @@ class WebSocketManager:
                                 TextMessage,
                                 MultiModalMessage,
                                 StopMessage,
+                                ThoughtEvent,
                                 HandoffMessage,
                                 ToolCallRequestEvent,
                                 ToolCallExecutionEvent,
@@ -384,6 +386,7 @@ class WebSocketManager:
                 (
                     TextMessage,
                     StopMessage,
+                    ThoughtEvent,
                     HandoffMessage,
                     ToolCallRequestEvent,
                     ToolCallExecutionEvent,


### PR DESCRIPTION
## Summary

Fixes #6959.

`ThoughtEvent` messages from agents were silently dropped in the AutoGen Studio WebSocket UI because `_format_message` in `connection.py` did not recognize the type — it returned `None` and the message was never sent to the client.

## Changes

Three lines added to `python/packages/autogen-studio/autogenstudio/web/managers/connection.py`:

1. **Import**: Added `ThoughtEvent` to the import from `autogen_agentchat.messages`
2. **`_format_message`**: Added `ThoughtEvent` to the `isinstance` tuple so it is serialized and sent over the WebSocket (same handling as `TextMessage`, `StopMessage`, etc.)
3. **`_save_message` dispatcher**: Added `ThoughtEvent` to the `isinstance` tuple so thought events are also persisted to the database

## Test plan

- [ ] Run an agent that emits `ThoughtEvent` messages (e.g., a reasoning model with `thought` content)
- [ ] Verify the thought events appear in the AutoGen Studio UI chat stream
- [ ] Verify thought events are saved in the database and visible on session reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)