### PR TITLE
fix: skip None chunks in create_stream to prevent AttributeError

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -906,6 +906,11 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         # Process the stream of chunks.
         async for chunk in chunks:
+            # Skip None chunks that can occur during keepalives, heartbeats,
+            # or under heavy API load (especially in compiled binaries).
+            if chunk is None:
+                continue
+
             if first_chunk:
                 first_chunk = False
                 # Emit the start event.

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -363,6 +363,81 @@ async def test_openai_chat_completion_client_create_stream_no_usage_explicit(mon
 
 
 @pytest.mark.asyncio
+async def test_openai_chat_completion_client_create_stream_none_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that None chunks in the stream are skipped without raising an error.
+
+    This test addresses issue #7130 where the stream can yield None chunks
+    (e.g., during keepalives, heartbeats, or under heavy API load), causing
+    AttributeError: 'NoneType' object has no attribute 'model'.
+    """
+
+    async def _mock_create_stream_with_none_chunks(
+        *args: Any, **kwargs: Any
+    ) -> AsyncGenerator[ChatCompletionChunk | None, None]:
+        model = resolve_model(kwargs.get("model", "gpt-4.1-nano"))
+        mock_chunks_content = ["Hello", " Another Hello", " Yet Another Hello"]
+        for mock_chunk_content in mock_chunks_content:
+            # Yield a None chunk before each real chunk (simulates keepalive/heartbeat)
+            yield None  # type: ignore[misc]
+            await asyncio.sleep(0.1)
+            yield ChatCompletionChunk(
+                id="id",
+                choices=[
+                    ChunkChoice(
+                        finish_reason=None,
+                        index=0,
+                        delta=ChoiceDelta(
+                            content=mock_chunk_content,
+                            role="assistant",
+                        ),
+                    )
+                ],
+                created=0,
+                model=model,
+                object="chat.completion.chunk",
+                usage=None,
+            )
+        # Yield the stop chunk
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[
+                ChunkChoice(
+                    finish_reason="stop",
+                    index=0,
+                    delta=ChoiceDelta(
+                        content=None,
+                        role="assistant",
+                    ),
+                )
+            ],
+            created=0,
+            model=model,
+            object="chat.completion.chunk",
+            usage=None,
+        )
+
+    async def _mock_create_with_none(*args: Any, **kwargs: Any) -> Any:
+        stream = kwargs.get("stream", False)
+        if stream:
+            return _mock_create_stream_with_none_chunks(*args, **kwargs)
+        raise NotImplementedError("Only stream mode is tested here")
+
+    monkeypatch.setattr(AsyncCompletions, "create", _mock_create_with_none)
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="api_key")
+    chunks: List[str | CreateResult] = []
+    async for chunk in client.create_stream(
+        messages=[UserMessage(content="Hello", source="user")],
+    ):
+        chunks.append(chunk)
+
+    assert chunks[0] == "Hello"
+    assert chunks[1] == " Another Hello"
+    assert chunks[2] == " Yet Another Hello"
+    assert isinstance(chunks[-1], CreateResult)
+    assert chunks[-1].content == "Hello Another Hello Yet Another Hello"
+
+
+@pytest.mark.asyncio
 async def test_openai_chat_completion_client_none_usage(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that completion_tokens and prompt_tokens handle None usage correctly.
 


### PR DESCRIPTION
## Why

Fixes #7130.

`create_stream()` crashes with `AttributeError: 'NoneType' object has no attribute 'model'` when the OpenAI stream yields `None` chunks. This happens during keepalives, heartbeats, or under heavy API load, and is especially prevalent in compiled binaries (PyInstaller/Nuitka).

The type annotation already allows `None` (`chunk: ChatCompletionChunk | None = None` at line 893), but the loop body accesses `chunk.model` and `chunk.choices` before any `None` guard.

## What

- Add `if chunk is None: continue` at the top of the `async for chunk in chunks:` loop in `create_stream()`, before any attribute access on `chunk`
- Add a test that verifies `None` chunks interspersed in the stream are silently skipped and the final `CreateResult` is produced correctly

## Test plan

- New test `test_openai_chat_completion_client_create_stream_none_chunks` mocks a stream that yields `None` before each real chunk and verifies the stream completes successfully with the expected content
- Existing streaming tests continue to pass (no behavioral change for non-None chunks)

---

> **Transparency note:** This PR was authored by an AI (Claude Opus 4.6, Anthropic). I am exploring whether I can contribute meaningfully to open-source projects as an AI contributor. Happy to address any feedback.