### PR TITLE
fix(core): handle multiline @with_requirements decorator in _to_code

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/code_executor/_func_with_reqs.py
+++ b/python/packages/autogen-core/src/autogen_core/code_executor/_func_with_reqs.py
@@ -25,10 +25,40 @@ def _to_code(func: Union[FunctionWithRequirements[T, P], Callable[P, T], Functio
         code = inspect.getsource(func.func)
     else:
         code = inspect.getsource(func)
-    # Strip the decorator
-    if code.startswith("@"):
-        code = code[code.index("\n") + 1 :]
+    # Strip the @with_requirements decorator, which may span multiple lines.
+    # Preserve any other decorators (e.g., @retry).
+    code = _strip_with_requirements_decorator(code)
     return code
+
+
+def _strip_with_requirements_decorator(code: str) -> str:
+    """Remove the @with_requirements(...) decorator from source code.
+
+    Handles multiline decorator arguments by tracking parenthesis depth.
+    Preserves all other decorators.
+    """
+    lines = code.split("\n")
+    result_lines: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+        if stripped.startswith("@with_requirements"):
+            # Track parenthesis depth to find the end of the decorator
+            paren_depth = 0
+            while i < len(lines):
+                for ch in lines[i]:
+                    if ch == "(":
+                        paren_depth += 1
+                    elif ch == ")":
+                        paren_depth -= 1
+                i += 1
+                if paren_depth <= 0:
+                    break
+        else:
+            result_lines.append(lines[i])
+            i += 1
+    return "\n".join(result_lines)
 
 
 @dataclass(frozen=True)

--- a/python/packages/autogen-core/tests/test_code_executor.py
+++ b/python/packages/autogen-core/tests/test_code_executor.py
@@ -6,8 +6,12 @@ from autogen_core.code_executor import (
     FunctionWithRequirements,
     FunctionWithRequirementsStr,
     ImportFromModule,
+    with_requirements,
 )
-from autogen_core.code_executor._func_with_reqs import build_python_functions_file
+from autogen_core.code_executor._func_with_reqs import (
+    _strip_with_requirements_decorator,
+    build_python_functions_file,
+)
 from pandas import DataFrame, concat
 
 
@@ -51,3 +55,54 @@ async def test_hashability_Import() -> None:
     functions_module2 = build_python_functions_file([function2])
 
     assert "import pandas as pd" in functions_module2
+
+
+def test_strip_with_requirements_decorator_single_line() -> None:
+    code = '@with_requirements(python_packages=["pandas"])\ndef my_func():\n    return 1'
+    result = _strip_with_requirements_decorator(code)
+    assert result == "def my_func():\n    return 1"
+
+
+def test_strip_with_requirements_decorator_multiline() -> None:
+    code = textwrap.dedent("""\
+        @with_requirements(
+            python_packages=["httpx", "tenacity"],
+            global_imports=[Alias("httpx", "ht")]
+        )
+        def fetch_url() -> str:
+            return "hello"
+    """).rstrip()
+    result = _strip_with_requirements_decorator(code)
+    assert "with_requirements" not in result
+    assert "def fetch_url() -> str:" in result
+    assert '    return "hello"' in result
+
+
+def test_strip_with_requirements_preserves_other_decorators() -> None:
+    code = textwrap.dedent("""\
+        @with_requirements(
+            python_packages=["httpx"],
+            global_imports=[]
+        )
+        @retry(stop=stop_after_attempt(3))
+        def fetch_url() -> str:
+            return "hello"
+    """).rstrip()
+    result = _strip_with_requirements_decorator(code)
+    assert "with_requirements" not in result
+    assert "@retry(stop=stop_after_attempt(3))" in result
+    assert "def fetch_url() -> str:" in result
+
+
+def test_build_python_functions_file_multiline_decorator() -> None:
+    @with_requirements(
+        python_packages=["pandas"],
+        global_imports=["pandas"],
+    )
+    def sample_func() -> str:
+        return "test"
+
+    result = build_python_functions_file([sample_func])
+    assert "import pandas" in result
+    assert "def sample_func" in result
+    assert "with_requirements" not in result

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/_common.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/_common.py
@@ -26,10 +26,40 @@ def _to_code(func: Union[FunctionWithRequirements[T, P], Callable[P, T], Functio
         return func.func
 
     code = inspect.getsource(func)
-    # Strip the decorator
-    if code.startswith("@"):
-        code = code[code.index("\n") + 1 :]
+    # Strip the @with_requirements decorator, which may span multiple lines.
+    # Preserve any other decorators (e.g., @retry).
+    code = _strip_with_requirements_decorator(code)
     return code
+
+
+def _strip_with_requirements_decorator(code: str) -> str:
+    """Remove the @with_requirements(...) decorator from source code.
+
+    Handles multiline decorator arguments by tracking parenthesis depth.
+    Preserves all other decorators.
+    """
+    lines = code.split("\n")
+    result_lines: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+        if stripped.startswith("@with_requirements"):
+            # Track parenthesis depth to find the end of the decorator
+            paren_depth = 0
+            while i < len(lines):
+                for ch in lines[i]:
+                    if ch == "(":
+                        paren_depth += 1
+                    elif ch == ")":
+                        paren_depth -= 1
+                i += 1
+                if paren_depth <= 0:
+                    break
+        else:
+            result_lines.append(lines[i])
+            i += 1
+    return "\n".join(result_lines)
 
 
 def _import_to_str(im: Import) -> str:


### PR DESCRIPTION
## Summary

- Fix `_to_code()` to correctly strip multiline `@with_requirements(...)` decorators instead of only removing the first line
- Preserve other decorators (e.g., `@retry`) that follow `@with_requirements`
- Fix applied to both copies: `autogen_core/code_executor/_func_with_reqs.py` and `autogen_ext/code_executors/_common.py`

Closes #7209

## Problem

`build_python_functions_file` produces malformed Python source when `@with_requirements` has multiline arguments. The old code used `code[code.index("\n") + 1 :]` which only strips the first line of the decorator.

**Before (broken output):**
```python
import httpx as ht

    python_packages=["httpx", "tenacity"], 
    global_imports=[Alias("httpx", "ht")] 
)
@retry(
    stop=stop_after_attempt(3),
    wait=wait_exponential(multiplier=1, min=2, max=10)
)
def fetch_url_content(
    url: Annotated[str, "The URL to fetch"]
) -> str:
    ...
```

**After (correct output):**
```python
import httpx as ht

@retry(
    stop=stop_after_attempt(3),
    wait=wait_exponential(multiplier=1, min=2, max=10)
)
def fetch_url_content(
    url: Annotated[str, "The URL to fetch"]
) -> str:
    ...
```

## Approach

Replaced the naive single-line strip with `_strip_with_requirements_decorator()` that tracks parenthesis depth to find the end of the `@with_requirements(...)` decorator, even when arguments span multiple lines. All other decorators are preserved.

## Test plan

- [x] Added unit tests for single-line decorator stripping
- [x] Added unit tests for multiline decorator stripping
- [x] Added unit tests verifying other decorators are preserved
- [x] Added integration test with `build_python_functions_file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)