### PR TITLE
fix: standardize open() calls with explicit encoding='utf-8' across codebase

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:

--- a/python/docs/src/generate_api_reference.py
+++ b/python/docs/src/generate_api_reference.py
@@ -190,7 +190,7 @@ def generate_rst_files(package_roots: List[Path], reference_dir: Path) -> Set[st
 """
                 
                 # Write the .rst file
-                with open(rst_path, 'w') as f:
+                with open(rst_path, 'w', encoding="utf-8") as f:
                     f.write(rst_content)
                 
                 generated_files.add(module_name)
@@ -288,7 +288,7 @@ def main():
     print("✍️  Writing index.md...")
     content = generate_index_content(toctree_sections)
     
-    with open(index_file, 'w') as f:
+    with open(index_file, 'w', encoding="utf-8") as f:
         f.write(content)
     
     print(f"✅ Generated API documentation index at {index_file}")

--- a/python/fixup_generated_files.py
+++ b/python/fixup_generated_files.py
@@ -24,12 +24,12 @@ substitutions: Dict[str, str] = {
 
 def main():
     for file in files:
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8") as f:
             content = f.read()
 
         print("Fixing imports in file:", file)
         for old, new in substitutions.items():
             content = content.replace(old, new)
 
-        with open(file, "w") as f:
+        with open(file, "w", encoding="utf-8") as f:
             f.write(content)

--- a/python/packages/agbench/benchmarks/GAIA/Scripts/custom_tabulate.py
+++ b/python/packages/agbench/benchmarks/GAIA/Scripts/custom_tabulate.py
@@ -131,7 +131,7 @@ def scorer(instance_dir):
         return None
 
     expected_answer = None
-    with open(expected_answer_file, "rt") as fh:
+    with open(expected_answer_file, "rt", encoding="utf-8") as fh:
         expected_answer = fh.read().strip()
 
     # Read the console
@@ -140,7 +140,7 @@ def scorer(instance_dir):
         return None
 
     console_log = ""
-    with open(console_log_file, "rt") as fh:
+    with open(console_log_file, "rt", encoding="utf-8") as fh:
         console_log = fh.read()
 
         final_answer = None 

--- a/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
@@ -20,7 +20,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])
@@ -30,7 +30,7 @@ async def main() -> None:
     
     # Read the prompt
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt", encoding="utf-8") as fh:
         prompt = fh.read().strip()
     filename = "__FILE_NAME__".strip()
 

--- a/python/packages/agbench/benchmarks/GAIA/Templates/ParallelAgents/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/ParallelAgents/scenario.py
@@ -267,7 +267,7 @@ async def aggregate_final_answer(task: str, client: ChatCompletionClient, team_r
 async def main(num_teams: int, num_answers: int) -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])
@@ -277,7 +277,7 @@ async def main(num_teams: int, num_answers: int) -> None:
 
     # Read the prompt
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt", encoding="utf-8") as fh:
         prompt = fh.read().strip()
     filename = "__FILE_NAME__".strip()
 
@@ -338,7 +338,7 @@ If you are asked for a comma separated list, apply the above rules depending on 
         teams.append(team)
         cancellation_token = CancellationToken()
         tokens.append(cancellation_token)
-        logfile = open(f"console_log_{team_idx}.txt", "w")
+        logfile = open(f"console_log_{team_idx}.txt", "w", encoding="utf-8")
         team_agentchat_logger = logging.getLogger(f"{AGENTCHAT_EVENT_LOGGER_NAME}.team{team_idx}")
         team_core_logger = logging.getLogger(f"{CORE_EVENT_LOGGER_NAME}.team{team_idx}")
         team_log_handler = LogHandler(f"log_{team_idx}.jsonl", print_message=False)

--- a/python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py
@@ -25,7 +25,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])
@@ -35,7 +35,7 @@ async def main() -> None:
     
     # Read the prompt
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt", encoding="utf-8") as fh:
         prompt = fh.read().strip()
     filename = "__FILE_NAME__".strip()
 

--- a/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/custom_code_executor.py
+++ b/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/custom_code_executor.py
@@ -17,7 +17,7 @@ class CustomCodeExecutorAgent(CodeExecutorAgent):
     ) -> None:
         super().__init__(name=name, description=description, code_executor=code_executor, sources=sources)
         self._test_code = ""
-        with open("test.txt", "rt") as fh:
+        with open("test.txt", "rt", encoding="utf-8") as fh:
             self._test_code = fh.read()
 
 

--- a/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py
+++ b/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py
@@ -15,7 +15,7 @@ from autogen_core.models import ChatCompletionClient
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(config["model_config"])
 
@@ -48,7 +48,7 @@ async def main() -> None:
     agent_team = RoundRobinGroupChat([coder_agent, executor], max_turns=12, termination_condition=termination)
 
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt", encoding="utf-8") as fh:
         prompt = fh.read()
 
     task = f"""Complete the following python function. Format your output as Markdown python code block containing the entire function definition:

--- a/python/packages/agbench/benchmarks/process_logs.py
+++ b/python/packages/agbench/benchmarks/process_logs.py
@@ -96,7 +96,7 @@ def scorer(instance_dir, benchmark_name):
         if not os.path.isfile(expected_answer_file):
             return None
 
-        with open(expected_answer_file, "rt") as fh:
+        with open(expected_answer_file, "rt", encoding="utf-8") as fh:
             expected_answer = fh.read().strip()
 
         # Read the console log
@@ -104,7 +104,7 @@ def scorer(instance_dir, benchmark_name):
         if not os.path.isfile(console_log_file):
             return None
 
-        with open(console_log_file, "rt") as fh:
+        with open(console_log_file, "rt", encoding="utf-8") as fh:
             console_log = fh.read()
             final_answer = None
             m = re.search(r"FINAL ANSWER:(.*?)\n", console_log, re.DOTALL)
@@ -125,7 +125,7 @@ def scorer(instance_dir, benchmark_name):
         if not os.path.isfile(console_log_file):
             return None
 
-        with open(console_log_file, "rt") as fh:
+        with open(console_log_file, "rt", encoding="utf-8") as fh:
             console_log = fh.read()
             final_score = None
             m = re.search(r"FINAL SCORE:(.*?)\n", console_log, re.DOTALL)
@@ -145,7 +145,7 @@ def get_number_of_chat_messages(chat_messages_dir):
     # Count the number of chat messages in the chat_messages_dir
     result = 0
     for file in glob.glob(f"{chat_messages_dir}/*_messages.json"):
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8") as f:
             content = json.load(f)
             for agent, messages in content.items():
                 result += len(messages)
@@ -158,7 +158,7 @@ def did_agent_stall(instance_dir):
     if not os.path.isfile(log_file_path):
         return None
     # Stalled.... Replanning...
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r", encoding="utf-8") as f:
         for line in f:
             if "Stalled.... Replanning..." in line:
                 return True
@@ -172,7 +172,7 @@ def get_message_logs(instance_dir):
         return None
     messages = []
     # for each line, convert to dict, check if it has a message and source key, and append to messages
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r", encoding="utf-8") as f:
         for line in f:
             line_dict = json.loads(line)
             if "message" in line_dict and "source" in line_dict:
@@ -186,13 +186,13 @@ def get_task_information(instance_dir, benchmark_name):
         prompt_file = os.path.join(instance_dir, "prompt.txt")
         if not os.path.isfile(prompt_file):
             return None
-        with open(prompt_file, "r") as f:
+        with open(prompt_file, "r", encoding="utf-8") as f:
             return f.read().strip()
     elif benchmark_name == "webarena":
         task_prompt_file = os.path.join(instance_dir, "task_prompt.json")
         if not os.path.isfile(task_prompt_file):
             return None
-        with open(task_prompt_file, "r") as f:
+        with open(task_prompt_file, "r", encoding="utf-8") as f:
             return json.load(f)["intent"]
     else:
         raise ValueError(f"Unsupported benchmark_name: {benchmark_name}")
@@ -204,7 +204,7 @@ def is_progress_not_being_made(instance_dir):
     log_file_path = os.path.join(instance_dir, "log.jsonl")
     if not os.path.isfile(log_file_path):
         return None
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r", encoding="utf-8") as f:
         for line in f:
             line_dict = json.loads(line)
             if (

--- a/python/packages/agbench/src/agbench/linter/cli.py
+++ b/python/packages/agbench/src/agbench/linter/cli.py
@@ -19,7 +19,7 @@ def prepend_line_numbers(lines: List[str]) -> List[str]:
 
 
 def load_log_file(path: str, prepend_numbers: bool = False) -> Document:
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         lines = f.readlines()
     if prepend_numbers:
         lines = prepend_line_numbers(lines)

--- a/python/packages/agbench/src/agbench/linter/coders/oai_coder.py
+++ b/python/packages/agbench/src/agbench/linter/coders/oai_coder.py
@@ -41,7 +41,7 @@ class OAIQualitativeCoder(BaseQualitativeCoder):
             if not os.path.exists(self.cache_dir):
                 os.makedirs(self.cache_dir)
             if cache_file and os.path.exists(cache_file):
-                with open(cache_file, "r") as f:
+                with open(cache_file, "r", encoding="utf-8") as f:
                     cached_coded_doc_json = f.read()
                     return CodedDocument.from_json(cached_coded_doc_json)
 
@@ -203,6 +203,6 @@ the context of the example.
             raise ValueError("Error in coding document with OpenAI")
 
         if self.cache_enabled and cache_file:
-            with open(cache_file, "w") as f:
+            with open(cache_file, "w", encoding="utf-8") as f:
                 f.write(coded_document.model_dump_json(indent=4))
         return coded_document

--- a/python/packages/agbench/src/agbench/remove_missing_cmd.py
+++ b/python/packages/agbench/src/agbench/remove_missing_cmd.py
@@ -11,7 +11,7 @@ def default_scorer(instance_dir: str) -> bool:
     """
     console_log = os.path.join(instance_dir, "console_log.txt")
     if os.path.isfile(console_log):
-        with open(console_log, "rt") as fh:
+        with open(console_log, "rt", encoding="utf-8") as fh:
             content = fh.read()
             # Use a regular expression to match the expected ending pattern
             has_final_answer = "FINAL ANSWER:" in content

--- a/python/packages/agbench/src/agbench/run_cmd.py
+++ b/python/packages/agbench/src/agbench/run_cmd.py
@@ -113,7 +113,7 @@ def run_scenarios(
             scenario_name_parts.pop()
             scenario_name = ".".join(scenario_name_parts)
             scenario_dir = os.path.dirname(os.path.realpath(scenario_file))
-            file_handle = open(scenario_file, "rt")
+            file_handle = open(scenario_file, "rt", encoding="utf-8")
 
         # Read all the lines, then subsample if needed
         lines = [line for line in file_handle]
@@ -295,10 +295,10 @@ def get_scenario_env(token_provider: Optional[Callable[[], str]] = None, env_fil
     if env_file is None:
         # Env file was not specified, so read the default, or warn if the default file is missing.
         if os.path.isfile(DEFAULT_ENV_FILE_YAML):
-            with open(DEFAULT_ENV_FILE_YAML, "r") as fh:
+            with open(DEFAULT_ENV_FILE_YAML, "r", encoding="utf-8") as fh:
                 env_file_contents = yaml.safe_load(fh)
         elif os.path.isfile(DEFAULT_ENV_FILE_JSON):
-            with open(DEFAULT_ENV_FILE_JSON, "rt") as fh:
+            with open(DEFAULT_ENV_FILE_JSON, "rt", encoding="utf-8") as fh:
                 env_file_contents = json.loads(fh.read())
             logging.warning(f"JSON environment files are deprecated. Migrate to '{DEFAULT_ENV_FILE_YAML}'")
         else:
@@ -307,7 +307,7 @@ def get_scenario_env(token_provider: Optional[Callable[[], str]] = None, env_fil
             )
     else:
         # Env file was specified. Throw an error if the file can't be read.
-        with open(env_file, "rt") as fh:
+        with open(env_file, "rt", encoding="utf-8") as fh:
             if env_file.endswith(".json"):
                 logging.warning("JSON environment files are deprecated. Migrate to YAML")
                 env_file_contents = json.loads(fh.read())
@@ -396,7 +396,7 @@ def run_scenario_natively(work_dir: str, env: Dict[str, str], timeout: int = TAS
     print("\n\n" + os.getcwd() + "\n===================================================================")
 
     # Prepare the run script
-    with open(os.path.join("run.sh"), "wt") as f:
+    with open(os.path.join("run.sh"), "wt", encoding="utf-8") as f:
         f.write(
             f"""#
 echo RUN.SH STARTING !#!#
@@ -737,7 +737,7 @@ def split_jsonl(file_path: str, num_parts: int) -> List[List[Dict[str, Any]]]:
     """
     Split a JSONL file into num_parts approximately equal parts.
     """
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         data = [json.loads(line) for line in f]
 
     random.shuffle(data)  # Shuffle the data for better distribution
@@ -942,7 +942,7 @@ def run_cli(args: Sequence[str]) -> None:
 
     if parsed_args.config is not None:
         # Make sure the config file is readable, so that we fail early
-        with open(parsed_args.config, "r"):
+        with open(parsed_args.config, "r", encoding="utf-8"):
             pass
 
     # don't support parallel and subsample together

--- a/python/packages/agbench/src/agbench/tabulate_cmd.py
+++ b/python/packages/agbench/src/agbench/tabulate_cmd.py
@@ -68,7 +68,7 @@ def find_tabulate_module(search_dir: str, stop_dir: Optional[str] = None) -> Opt
 def default_scorer(instance_dir: str, success_strings: List[str] = SUCCESS_STRINGS) -> Optional[bool]:
     console_log = os.path.join(instance_dir, "console_log.txt")
     if os.path.isfile(console_log):
-        with open(console_log, "rt") as fh:
+        with open(console_log, "rt", encoding="utf-8") as fh:
             content = fh.read()
 
             # It succeeded
@@ -90,7 +90,7 @@ def default_scorer(instance_dir: str, success_strings: List[str] = SUCCESS_STRIN
 def default_timer(instance_dir: str, timer_regex: str = TIMER_REGEX) -> Optional[float]:
     console_log = os.path.join(instance_dir, "console_log.txt")
     if os.path.isfile(console_log):
-        with open(console_log, "rt") as fh:
+        with open(console_log, "rt", encoding="utf-8") as fh:
             content = fh.read()
 
             # It succeeded

--- a/python/packages/autogen-ext/examples/mcp_session_host_example.py
+++ b/python/packages/autogen-ext/examples/mcp_session_host_example.py
@@ -63,10 +63,10 @@ def load_model_client_from_config(config_path: str) -> ChatCompletionClient:
 
     # Load config based on file extension
     if config_file.suffix.lower() == ".json":
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             config_data = json.load(f)
     elif config_file.suffix.lower() in [".yml", ".yaml"]:
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8") as f:
             config_data = yaml.safe_load(f)
     else:
         raise ValueError(f"Unsupported config file type: {config_file.suffix}. Use .json, .yml, or .yaml")

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
@@ -275,7 +275,7 @@ class DockerJupyterCodeExecutor(CodeExecutor, Component[DockerJupyterCodeExecuto
         """Save html data to a file."""
         filename = f"{uuid.uuid4().hex}.html"
         path = os.path.join(str(self._output_dir), filename)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(html_data)
         return os.path.abspath(path)
 

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
@@ -73,7 +73,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
             # Load the previously recorded messages and responses from disk.
             self.logger.info("Replay mode enabled.\nRetrieving session from: " + self.session_file_path)
             try:
-                with open(self.session_file_path, "r") as f:
+                with open(self.session_file_path, "r", encoding="utf-8") as f:
                     self.records = json.load(f)
             except Exception as e:
                 error_str = f"\nFailed to load recorded session: '{self.session_file_path}': {e}"
@@ -211,7 +211,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
                 # Create the directory if it doesn't exist.
                 os.makedirs(os.path.dirname(self.session_file_path), exist_ok=True)
                 # Write the records to disk.
-                with open(self.session_file_path, "w") as f:
+                with open(self.session_file_path, "w", encoding="utf-8") as f:
                     json.dump(self.records, f, indent=2)
                     self.logger.info("\nRecorded session was saved to: " + self.session_file_path)
             except Exception as e:

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py
@@ -117,7 +117,7 @@ class PageLogger:
         # Write the hash and other details to a file.
         hash_str, num_files, num_subdirs = hash_directory(self.log_dir)
         hash_path = os.path.join(self.log_dir, "hash.txt")
-        with open(hash_path, "w") as f:
+        with open(hash_path, "w", encoding="utf-8") as f:
             f.write(hash_str)
             f.write("\n")
             f.write("{} files\n".format(num_files))
@@ -386,7 +386,7 @@ class PageLogger:
             return
         # Create a call tree of the log.
         call_tree_path = os.path.join(self.log_dir, self.name + ".html")
-        with open(call_tree_path, "w") as f:
+        with open(call_tree_path, "w", encoding="utf-8") as f:
             f.write(_html_opening("0 Call Tree", finished=finished))
             f.write(f"<h3>{self.name}</h3>")
             f.write("\n")
@@ -498,7 +498,7 @@ class Page:
         Writes the HTML page to disk.
         """
         page_path = os.path.join(self.page_logger.log_dir, self.index_str + ".html")
-        with open(page_path, "w") as f:
+        with open(page_path, "w", encoding="utf-8") as f:
             f.write(_html_opening(self.file_title, finished=self.finished))
             f.write(f"<h3>{self.file_title}</h3>\n")
             for line in self.lines:

--- a/python/packages/autogen-ext/tests/code_executors/test_aca_dynamic_sessions.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_aca_dynamic_sessions.py
@@ -242,9 +242,9 @@ async def test_download_files() -> None:
         code_blocks = [
             CodeBlock(
                 code=f"""
-with open("{test_file_1}", "w") as f:
+with open("{test_file_1}", "w", encoding="utf-8") as f:
     f.write("{test_file_1_contents}")
-with open("{test_file_2}", "w") as f:
+with open("{test_file_2}", "w", encoding="utf-8") as f:
     f.write("{test_file_2_contents}")
 """,
                 language="python",

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -187,7 +187,7 @@ async def test_commandline_code_executor_cancellation() -> None:
         # to a file.
         code = """import time
 time.sleep(10)
-with open("hello.txt", "w") as f:
+with open("hello.txt", "w", encoding="utf-8") as f:
     f.write("hello world!")
 """
         code_blocks = [CodeBlock(code=code, language="python")]

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
@@ -133,7 +133,7 @@ async def test_commandline_code_executor_cancellation(
     # to a file.
     code = """import time
 time.sleep(10)
-with open("hello.txt", "w") as f:
+with open("hello.txt", "w", encoding="utf-8") as f:
     f.write("hello world!")
 """
     code_blocks = [CodeBlock(code=code, language="python")]
@@ -289,7 +289,7 @@ async def test_error_wrong_path(executor_and_temp_dir: ExecutorFixture, cleanup_
     cancellation_token = CancellationToken()
     code_blocks = [
         CodeBlock(
-            code="""with open("/nonexistent_dir/test.txt", "w") as f:
+            code="""with open("/nonexistent_dir/test.txt", "w", encoding="utf-8") as f:
             f.write("hello world!")""",
             language="python",
         )

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_jupyter_code_executor.py
@@ -115,7 +115,7 @@ async def test_canncellation(executor_and_temp_dir: ExecutorFixture) -> None:
     # to a file.
     code = """import time, os
 time.sleep(10)
-with open("hello.txt", "w") as f:
+with open("hello.txt", "w", encoding="utf-8") as f:
     f.write("hello world!")
     """
     code_blocks = [CodeBlock(code=code, language="python")]

--- a/python/packages/autogen-ext/tests/code_executors/test_user_defined_functions.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_user_defined_functions.py
@@ -261,7 +261,7 @@ async def test_error_wrong_path() -> None:
 
         code_blocks = [
             CodeBlock(
-                code="""with open("/nonexistent_dir/test.txt", "w") as f:
+                code="""with open("/nonexistent_dir/test.txt", "w", encoding="utf-8") as f:
                 f.write("hello word")""",
                 language="python",
             )

--- a/python/packages/autogen-ext/tests/task_centric_memory/utils.py
+++ b/python/packages/autogen-ext/tests/task_centric_memory/utils.py
@@ -27,5 +27,5 @@ def load_yaml_file(file_path: str) -> Any:
     """
     Opens a file and returns its contents.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)

--- a/python/packages/autogen-ext/tests/test_filesurfer_agent.py
+++ b/python/packages/autogen-ext/tests/test_filesurfer_agent.py
@@ -62,7 +62,7 @@ logger.addHandler(FileLogHandler("test_filesurfer_agent.log"))
 async def test_run_filesurfer(monkeypatch: pytest.MonkeyPatch) -> None:
     # Create a test file
     test_file = os.path.abspath("test_filesurfer_agent.html")
-    async with aiofiles.open(test_file, "wt") as file:
+    async with aiofiles.open(test_file, "wt", encoding="utf-8") as file:
         await file.write("""<html>
   <head>
     <title>FileSurfer test file</title>

--- a/python/packages/autogen-studio/autogenstudio/cli.py
+++ b/python/packages/autogen-studio/autogenstudio/cli.py
@@ -69,7 +69,7 @@ def ui(
 
     # Create temporary env file to share configuration with uvicorn workers
     env_file_path = get_env_file_path()
-    with open(env_file_path, "w") as temp_env:
+    with open(env_file_path, "w", encoding="utf-8") as temp_env:
         for key, value in env_vars.items():
             temp_env.write(f"{key}={value}\n")
 

--- a/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
+++ b/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
@@ -75,7 +75,7 @@ class SchemaManager:
 
         # Update alembic.ini
         config_content = self._generate_alembic_ini_content()
-        with open(self.alembic_ini_path, "w") as f:
+        with open(self.alembic_ini_path, "w", encoding="utf-8") as f:
             f.write(config_content)
 
         # Update env.py
@@ -115,7 +115,7 @@ class SchemaManager:
 
             # Create initial config file for alembic init
             config_content = self._generate_alembic_ini_content()
-            with open(self.alembic_ini_path, "w") as f:
+            with open(self.alembic_ini_path, "w", encoding="utf-8") as f:
                 f.write(config_content)
 
             # Use the config we just created
@@ -187,7 +187,7 @@ if context.is_offline_mode():
 else:
     run_migrations_online()"""
 
-        with open(env_path, "w") as f:
+        with open(env_path, "w", encoding="utf-8") as f:
             f.write(content)
 
     def _generate_alembic_ini_content(self) -> str:
@@ -239,7 +239,7 @@ datefmt = %H:%M:%S
         """Update the Alembic script template to include SQLModel."""
         template_path = self.alembic_dir / "script.py.mako"
         try:
-            with open(template_path, "r") as f:
+            with open(template_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
             # Add sqlmodel import to imports section
@@ -248,7 +248,7 @@ datefmt = %H:%M:%S
 
             content = content.replace(import_section, new_imports)
 
-            with open(template_path, "w") as f:
+            with open(template_path, "w", encoding="utf-8") as f:
                 f.write(content)
 
             return True
@@ -265,7 +265,7 @@ datefmt = %H:%M:%S
             self._create_minimal_env_py(env_path)
             return
         try:
-            with open(env_path, "r") as f:
+            with open(env_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
             # Add SQLModel import if not present
@@ -303,7 +303,7 @@ datefmt = %H:%M:%S
             )""",
             )
 
-            with open(env_path, "w") as f:
+            with open(env_path, "w", encoding="utf-8") as f:
                 f.write(content)
         except Exception as e:
             logger.error(f"Failed to update env.py: {e}")

--- a/python/packages/autogen-studio/autogenstudio/gallery/builder.py
+++ b/python/packages/autogen-studio/autogenstudio/gallery/builder.py
@@ -630,5 +630,5 @@ if __name__ == "__main__":
     gallery = create_default_gallery()
 
     # Save to file
-    with open("gallery_default.json", "w") as f:
+    with open("gallery_default.json", "w", encoding="utf-8") as f:
         f.write(gallery.model_dump_json(indent=2))

--- a/python/packages/autogen-studio/autogenstudio/lite/studio.py
+++ b/python/packages/autogen-studio/autogenstudio/lite/studio.py
@@ -151,7 +151,7 @@ class LiteStudio:
         }
 
         env_file_path = self._get_env_file_path()
-        with open(env_file_path, "w") as temp_env:
+        with open(env_file_path, "w", encoding="utf-8") as temp_env:
             for key, value in env_vars.items():
                 temp_env.write(f"{key}={value}\n")
 

--- a/python/packages/autogen-studio/autogenstudio/web/auth/manager.py
+++ b/python/packages/autogen-studio/autogenstudio/web/auth/manager.py
@@ -117,7 +117,7 @@ class AuthManager:
     def from_yaml(cls, yaml_path: str) -> Self:
         """Create AuthManager from YAML config file."""
         try:
-            with open(yaml_path, "r") as f:
+            with open(yaml_path, "r", encoding="utf-8") as f:
                 config_data = yaml.safe_load(f)
             config = AuthConfig(**config_data)
             return cls(config)

--- a/python/packages/autogen-studio/tests/test_lite_studio.py
+++ b/python/packages/autogen-studio/tests/test_lite_studio.py
@@ -18,7 +18,7 @@ def sample_team_file(tmp_path: Path) -> str:
         "agents": []
     }
     team_file = tmp_path / "test_team.json"
-    with open(team_file, 'w') as f:
+    with open(team_file, 'w', encoding="utf-8") as f:
         json.dump(team_data, f)
     return str(team_file)
 
@@ -35,7 +35,7 @@ def sample_team_object() -> Dict[str, Union[str, List[Any]]]:
 
 def load_team_from_file(file_path: str) -> Dict[str, Any]:
     """Helper function to load team data from file"""
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -101,7 +101,7 @@ def test_setup_environment(sample_team_file: str) -> None:
     
     # Read the environment file to verify contents
     env_vars = {}
-    with open(env_file_path, 'r') as f:
+    with open(env_file_path, 'r', encoding="utf-8") as f:
         for line in f:
             if '=' in line:
                 key, value = line.strip().split('=', 1)
@@ -272,7 +272,7 @@ def test_init_with_path_object(tmp_path: Path) -> None:
         "agents": []
     }
     team_file = tmp_path / "path_team.json"
-    with open(team_file, 'w') as f:
+    with open(team_file, 'w', encoding="utf-8") as f:
         json.dump(team_data, f)
     
     # Use Path object instead of string

--- a/python/packages/autogen-studio/tests/test_team_manager.py
+++ b/python/packages/autogen-studio/tests/test_team_manager.py
@@ -39,7 +39,7 @@ def sample_config():
 def config_file(sample_config, tmp_path):
     """Create a temporary config file"""
     config_path = tmp_path / "test_config.json"
-    with open(config_path, "w") as f:
+    with open(config_path, "w", encoding="utf-8") as f:
         json.dump(sample_config, f)
     return config_path
 
@@ -49,7 +49,7 @@ def config_dir(sample_config, tmp_path):
     """Create a temporary directory with multiple config files"""
     # Create JSON config
     json_path = tmp_path / "team1.json"
-    with open(json_path, "w") as f:
+    with open(json_path, "w", encoding="utf-8") as f:
         json.dump(sample_config, f)
     
     # Create YAML config from the same dict
@@ -58,7 +58,7 @@ def config_dir(sample_config, tmp_path):
     # Create a modified copy to verify we can distinguish between them
     yaml_config = sample_config.copy()
     yaml_config["label"] = "YamlTeam"  # Change a field to identify this as the YAML version
-    with open(yaml_path, "w") as f:
+    with open(yaml_path, "w", encoding="utf-8") as f:
         yaml.dump(yaml_config, f)
     
     return tmp_path

--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -97,7 +97,7 @@ def main() -> None:
 
     if args.config is None:
         if os.path.isfile(DEFAULT_CONFIG_FILE):
-            with open(DEFAULT_CONFIG_FILE, "r") as f:
+            with open(DEFAULT_CONFIG_FILE, "r", encoding="utf-8") as f:
                 config = yaml.safe_load(f)
         else:
             config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)

--- a/python/samples/agentchat_chainlit/app_agent.py
+++ b/python/samples/agentchat_chainlit/app_agent.py
@@ -31,7 +31,7 @@ async def get_weather(city: str) -> str:
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chainlit/app_team.py
+++ b/python/samples/agentchat_chainlit/app_team.py
@@ -14,7 +14,7 @@ from autogen_core.models import ChatCompletionClient
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chainlit/app_team_user_proxy.py
+++ b/python/samples/agentchat_chainlit/app_team_user_proxy.py
@@ -47,7 +47,7 @@ async def user_action_func(prompt: str, cancellation_token: CancellationToken | 
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chess_game/main.py
+++ b/python/samples/agentchat_chess_game/main.py
@@ -101,7 +101,7 @@ async def get_ai_move(board: chess.Board, player: AssistantAgent, max_tries: int
 async def main(human_player: bool, max_tries: int) -> None:
     board = chess.Board()
     # Load the model client from config.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
     player = create_ai_player(model_client)

--- a/python/samples/agentchat_fastapi/app_agent.py
+++ b/python/samples/agentchat_fastapi/app_agent.py
@@ -40,7 +40,7 @@ history_path = "agent_history.json"
 async def get_agent() -> AssistantAgent:
     """Get the assistant agent, load state from file."""
     # Get model client from config.
-    async with aiofiles.open(model_config_path, "r") as file:
+    async with aiofiles.open(model_config_path, "r", encoding="utf-8") as file:
         model_config = yaml.safe_load(await file.read())
     model_client = ChatCompletionClient.load_component(model_config)
     # Create the assistant agent.
@@ -52,7 +52,7 @@ async def get_agent() -> AssistantAgent:
     # Load state from file.
     if not os.path.exists(state_path):
         return agent  # Return agent without loading state.
-    async with aiofiles.open(state_path, "r") as file:
+    async with aiofiles.open(state_path, "r", encoding="utf-8") as file:
         state = json.loads(await file.read())
     await agent.load_state(state)
     return agent
@@ -62,7 +62,7 @@ async def get_history() -> list[dict[str, Any]]:
     """Get chat history from file."""
     if not os.path.exists(history_path):
         return []
-    async with aiofiles.open(history_path, "r") as file:
+    async with aiofiles.open(history_path, "r", encoding="utf-8") as file:
         return json.loads(await file.read())
 
 
@@ -83,14 +83,14 @@ async def chat(request: TextMessage) -> TextMessage:
 
         # Save agent state to file.
         state = await agent.save_state()
-        async with aiofiles.open(state_path, "w") as file:
+        async with aiofiles.open(state_path, "w", encoding="utf-8") as file:
             await file.write(json.dumps(state))
 
         # Save chat history to file.
         history = await get_history()
         history.append(request.model_dump())
         history.append(response.chat_message.model_dump())
-        async with aiofiles.open(history_path, "w") as file:
+        async with aiofiles.open(history_path, "w", encoding="utf-8") as file:
             await file.write(json.dumps(history))
 
         assert isinstance(response.chat_message, TextMessage)

--- a/python/samples/agentchat_fastapi/app_team.py
+++ b/python/samples/agentchat_fastapi/app_team.py
@@ -46,7 +46,7 @@ async def get_team(
     user_input_func: Callable[[str, Optional[CancellationToken]], Awaitable[str]],
 ) -> RoundRobinGroupChat:
     # Get model client from config.
-    async with aiofiles.open(model_config_path, "r") as file:
+    async with aiofiles.open(model_config_path, "r", encoding="utf-8") as file:
         model_config = yaml.safe_load(await file.read())
     model_client = ChatCompletionClient.load_component(model_config)
     # Create the team.
@@ -70,7 +70,7 @@ async def get_team(
     # Load state from file.
     if not os.path.exists(state_path):
         return team
-    async with aiofiles.open(state_path, "r") as file:
+    async with aiofiles.open(state_path, "r", encoding="utf-8") as file:
         state = json.loads(await file.read())
     await team.load_state(state)
     return team
@@ -80,7 +80,7 @@ async def get_history() -> list[dict[str, Any]]:
     """Get chat history from file."""
     if not os.path.exists(history_path):
         return []
-    async with aiofiles.open(history_path, "r") as file:
+    async with aiofiles.open(history_path, "r", encoding="utf-8") as file:
         return json.loads(await file.read())
 
 
@@ -127,12 +127,12 @@ async def chat(websocket: WebSocket):
                         history.append(message.model_dump())
 
                 # Save team state to file.
-                async with aiofiles.open(state_path, "w") as file:
+                async with aiofiles.open(state_path, "w", encoding="utf-8") as file:
                     state = await team.save_state()
                     await file.write(json.dumps(state))
 
                 # Save chat history to file.
-                async with aiofiles.open(history_path, "w") as file:
+                async with aiofiles.open(history_path, "w", encoding="utf-8") as file:
                     await file.write(json.dumps(history))
                     
             except WebSocketDisconnect:

--- a/python/samples/agentchat_streamlit/agent.py
+++ b/python/samples/agentchat_streamlit/agent.py
@@ -8,7 +8,7 @@ from autogen_core.models import ChatCompletionClient
 class Agent:
     def __init__(self) -> None:
         # Load the model client from config.
-        with open("model_config.yml", "r") as f:
+        with open("model_config.yml", "r", encoding="utf-8") as f:
             model_config = yaml.safe_load(f)
         model_client = ChatCompletionClient.load_component(model_config)
         self.agent = AssistantAgent(

--- a/python/samples/core_chainlit/app_agent.py
+++ b/python/samples/core_chainlit/app_agent.py
@@ -55,7 +55,7 @@ async def get_weather(city: str) -> str:
 async def start_chat() -> None:
 
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
     #context = BufferedChatCompletionContext(buffer_size=10)

--- a/python/samples/core_chainlit/app_team.py
+++ b/python/samples/core_chainlit/app_team.py
@@ -83,7 +83,7 @@ async def output_result(_agent: ClosureContext, message: StreamResult, ctx: Mess
 async def start_chat() -> None:
 
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/core_chess_game/main.py
+++ b/python/samples/core_chess_game/main.py
@@ -275,6 +275,6 @@ if __name__ == "__main__":
         handler = logging.FileHandler("chess_game.log")
         logging.getLogger("autogen_core").addHandler(handler)
 
-    with open(args.model_config, "r") as f:
+    with open(args.model_config, "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     asyncio.run(main(model_config))

--- a/python/samples/core_distributed-group-chat/_utils.py
+++ b/python/samples/core_distributed-group-chat/_utils.py
@@ -11,7 +11,7 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 def load_config(file_path: str = os.path.join(os.path.dirname(__file__), "config.yaml")) -> AppConfig:
     model_client = {}
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         config_data = yaml.safe_load(file)
         model_client = config_data["client_config"]
         del config_data["client_config"]

--- a/python/samples/core_streaming_handoffs_fastapi/agent_user.py
+++ b/python/samples/core_streaming_handoffs_fastapi/agent_user.py
@@ -36,7 +36,7 @@ class UserAgent(RoutedAgent):
         if ctx.topic_id is None:
             raise ValueError("MessageContext.topic_id is None, cannot save chat history")
         file_path = os.path.join(chat_history_dir, f"history-{ctx.topic_id.source}.json")
-        with open(file_path, 'w') as f:
+        with open(file_path, 'w', encoding="utf-8") as f:
             json.dump(save_context, f, indent=4)
         
         #End stream

--- a/python/samples/core_streaming_handoffs_fastapi/app.py
+++ b/python/samples/core_streaming_handoffs_fastapi/app.py
@@ -66,7 +66,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         os.makedirs(chat_history_dir)
 
     # Get model client from config.
-    async with aiofiles.open("model_config.yaml", "r") as file:
+    async with aiofiles.open("model_config.yaml", "r", encoding="utf-8") as file:
         model_config = yaml.safe_load(await file.read())
     model_client = ChatCompletionClient.load_component(model_config)
 
@@ -224,7 +224,7 @@ async def chat_completions_stream(request: Request):
     if os.path.exists(chat_history_file):
         context = BufferedChatCompletionContext(buffer_size=15)
         try:
-            async with aiofiles.open(chat_history_file, "r") as f:
+            async with aiofiles.open(chat_history_file, "r", encoding="utf-8") as f:
                 content = await f.read()
                 if content: # Check if file is not empty
                     chat_history = json.loads(content)

--- a/python/samples/core_streaming_response_fastapi/app.py
+++ b/python/samples/core_streaming_response_fastapi/app.py
@@ -84,7 +84,7 @@ class MyAgent(RoutedAgent):
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Get model client from config.
-    async with aiofiles.open("model_config.yaml", "r") as file:
+    async with aiofiles.open("model_config.yaml", "r", encoding="utf-8") as file:
         model_config = yaml.safe_load(await file.read())
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/gitty/src/gitty/__main__.py
+++ b/python/samples/gitty/src/gitty/__main__.py
@@ -32,7 +32,7 @@ def check_gh_cli() -> bool:
 
 def edit_config_file(file_path: str) -> None:
     if not os.path.exists(file_path):
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write("# Instructions for gitty agents\n")
             f.write("# Add your configuration below\n")
     editor = os.getenv("EDITOR", "vi")

--- a/python/samples/gitty/src/gitty/_gitty.py
+++ b/python/samples/gitty/src/gitty/_gitty.py
@@ -66,7 +66,7 @@ async def run_gitty(owner: str, repo: str, command: str, number: int) -> None:
     try:
         global_config_path = os.path.expanduser("~/.gitty/config")
         if os.path.exists(global_config_path):
-            with open(global_config_path, "r") as f:
+            with open(global_config_path, "r", encoding="utf-8") as f:
                 global_instructions = f.read().strip()
     except Exception as e:
         print("Warning: Could not load global config:", e)
@@ -77,7 +77,7 @@ async def run_gitty(owner: str, repo: str, command: str, number: int) -> None:
         local_config_path = os.path.join(gitty_dir, "config")
         print(f"Local config path: {local_config_path}")
         if os.path.exists(local_config_path):
-            with open(local_config_path, "r") as f:
+            with open(local_config_path, "r", encoding="utf-8") as f:
                 local_instructions = f.read().strip()
     except Exception as e:
         print("Warning: Could not load local config:", e)

--- a/python/samples/task_centric_memory/utils.py
+++ b/python/samples/task_centric_memory/utils.py
@@ -27,6 +27,6 @@ def load_yaml_file(file_path: str) -> Any:
     """
     Opens a file and returns its contents.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)
 


### PR DESCRIPTION
Related to issue #5566. Calling `open()` without explicitly passing `encoding='utf-8'` causes fatal `UnicodeDecodeError`s on Windows machines operating in non-English environments (such as cp1252 or cp950). 

While the root issue reported in #5566 was fixed for one file, this PR acts as a comprehensive repository-wide cleanup, adding explicit utf-8 encodings to over 60 Python files where text paths were opened without it.