### PR TITLE
Fix cleanup of JupyterCodeExecutor temp output dir

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -145,11 +145,15 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
 
-        self._output_dir: Path = Path(tempfile.mkdtemp()) if output_dir is None else Path(output_dir)
-        self._output_dir.mkdir(exist_ok=True, parents=True)
+        self._should_cleanup_output_dir = output_dir is None
+        if self._should_cleanup_output_dir:
+            self._temp_dir: Optional[tempfile.TemporaryDirectory[str]] = tempfile.TemporaryDirectory()
+            self._output_dir = Path(self._temp_dir.name)
+        else:
+            self._temp_dir = None
+            self._output_dir = Path(output_dir)
 
-        self._temp_dir: Optional[tempfile.TemporaryDirectory[str]] = None
-        self._temp_dir_path: Optional[Path] = None
+        self._output_dir.mkdir(exist_ok=True, parents=True)
 
         self._started = False
 
@@ -280,6 +284,12 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
         if self._started:
             return
 
+        if self._should_cleanup_output_dir and self._temp_dir is None:
+            self._temp_dir = tempfile.TemporaryDirectory()
+            self._output_dir = Path(self._temp_dir.name)
+
+        self._output_dir.mkdir(exist_ok=True, parents=True)
+
         notebook: NotebookNode = nbformat.new_notebook()  # type: ignore
 
         self._client = NotebookClient(
@@ -307,6 +317,12 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
 
         self._client = None
         self._started = False
+
+        if self._should_cleanup_output_dir:
+            temp_dir = self._temp_dir
+            self._temp_dir = None
+            if temp_dir is not None:
+                temp_dir.cleanup()
 
     def _to_config(self) -> JupyterCodeExecutorConfig:
         """Convert current instance to config object"""

--- a/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
@@ -213,6 +213,25 @@ def test_invalid_timeout() -> None:
 
 
 @pytest.mark.asyncio
+async def test_default_output_dir_cleanup() -> None:
+    executor = JupyterCodeExecutor()
+    try:
+        await executor.start()
+        temp_dir = executor.output_dir
+        assert temp_dir.exists()
+
+        await executor.stop()
+        assert not temp_dir.exists()
+
+        await executor.start()
+        new_temp_dir = executor.output_dir
+        assert new_temp_dir.exists()
+        assert new_temp_dir != temp_dir
+    finally:
+        await executor.stop()
+
+
+@pytest.mark.asyncio
 async def test_deprecation_output_dir() -> None:
     with pytest.warns(DeprecationWarning, match="Using the current directory as output_dir is deprecated"):
         async with JupyterCodeExecutor(output_dir=".") as executor:


### PR DESCRIPTION
## Summary
- ensure the Jupyter code executor recreates and removes its managed temporary output directory when stopping
- cover the default path cleanup with a regression test

## Testing
- .venv/bin/python -m pytest python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py -k output_dir

Fixes #7217