### PR TITLE
fix: add explicit encoding=utf-8 to open() calls in fixup_generated_files.py

### DIFF
--- a/python/fixup_generated_files.py
+++ b/python/fixup_generated_files.py
@@ -24,12 +24,12 @@ substitutions: Dict[str, str] = {
 
 def main():
     for file in files:
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8") as f:
             content = f.read()
 
         print("Fixing imports in file:", file)
         for old, new in substitutions.items():
             content = content.replace(old, new)
 
-        with open(file, "w") as f:
+        with open(file, "w", encoding="utf-8") as f:
             f.write(content)


### PR DESCRIPTION
Addresses issue #5566 - prevents UnicodeDecodeError on Windows in non-English environments (cp1252, cp950, etc.)

This is part of the comprehensive repository-wide cleanup to add explicit utf-8 encodings.

PR opened from fork: https://github.com/Jah-yee/autogen/pull/1