### PR TITLE
  Fix MagenticOne handoff resume context reset and document expected HITL behavior (#7036)

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/human-in-the-loop.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/human-in-the-loop.ipynb
@@ -442,6 +442,9 @@
     "{py:class}`~autogen_agentchat.conditions.HandoffTermination` targeting user,\n",
     "to resume the team, you need to set the `task` to a {py:class}`~autogen_agentchat.messages.HandoffMessage`\n",
     "with the `target` set to the next agent you want to run.\n",
+    "\n",
+    "For {py:class}`~autogen_agentchat.teams.MagenticOneGroupChat`, resuming after a handoff\n",
+    "with `run()` or `run_stream()` and a new user `task` continues from the preserved context.\n",
     "See [Swarm](../swarm.ipynb) for more details.\n",
     "```"
    ]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_magentic_one/_magentic_one_orchestrator.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_magentic_one/_magentic_one_orchestrator.py
@@ -142,52 +142,60 @@ class MagenticOneOrchestrator(BaseGroupChatManager):
             await self._signal_termination(early_stop_message)
             # Stop the group chat.
             return
-        assert message is not None and message.messages is not None
-
-        # Validate the group state given all the messages.
+        # Validate the group state given all start messages.
         await self.validate_group_state(message.messages)
 
-        # Log the message to the output topic.
-        await self.publish_message(message, topic_id=DefaultTopicId(type=self._output_topic_type))
-        # Log the message to the output queue.
-        for msg in message.messages:
-            await self._output_message_queue.put(msg)
+        if message.messages is not None:
+            # Log the start message to the output topic.
+            await self.publish_message(message, topic_id=DefaultTopicId(type=self._output_topic_type))
+            # Log the user-provided task/feedback messages to the output queue.
+            if message.output_task_messages:
+                for msg in message.messages:
+                    await self._output_message_queue.put(msg)
 
-        # Outer Loop for first time
-        # Create the initial task ledger
-        #################################
-        # Combine all message contents for task
-        self._task = " ".join([msg.to_model_text() for msg in message.messages])
-        planning_conversation: List[LLMMessage] = []
+            # If this is not the first run, preserve the task and append feedback to the existing thread.
+            if self._task != "":
+                await self.update_message_thread(message.messages)
 
-        # 1. GATHER FACTS
-        # create a closed book task and generate a response and update the chat history
-        planning_conversation.append(
-            UserMessage(content=self._get_task_ledger_facts_prompt(self._task), source=self._name)
-        )
-        response = await self._model_client.create(
-            self._get_compatible_context(planning_conversation), cancellation_token=ctx.cancellation_token
-        )
+        # First run requires a task to initialize the task ledger.
+        if self._task == "":
+            if message.messages is None:
+                raise ValueError("MagenticOneGroupChat requires a task message when starting a new conversation.")
 
-        assert isinstance(response.content, str)
-        self._facts = response.content
-        planning_conversation.append(AssistantMessage(content=self._facts, source=self._name))
+            # Outer loop for first run: create the initial task ledger.
+            self._task = " ".join([msg.to_model_text() for msg in message.messages])
+            planning_conversation: List[LLMMessage] = []
 
-        # 2. CREATE A PLAN
-        ## plan based on available information
-        planning_conversation.append(
-            UserMessage(content=self._get_task_ledger_plan_prompt(self._team_description), source=self._name)
-        )
-        response = await self._model_client.create(
-            self._get_compatible_context(planning_conversation), cancellation_token=ctx.cancellation_token
-        )
+            # 1. Gather facts.
+            planning_conversation.append(
+                UserMessage(content=self._get_task_ledger_facts_prompt(self._task), source=self._name)
+            )
+            response = await self._model_client.create(
+                self._get_compatible_context(planning_conversation), cancellation_token=ctx.cancellation_token
+            )
 
-        assert isinstance(response.content, str)
-        self._plan = response.content
+            assert isinstance(response.content, str)
+            self._facts = response.content
+            planning_conversation.append(AssistantMessage(content=self._facts, source=self._name))
 
-        # Kick things off
-        self._n_stalls = 0
-        await self._reenter_outer_loop(ctx.cancellation_token)
+            # 2. Create a plan.
+            planning_conversation.append(
+                UserMessage(content=self._get_task_ledger_plan_prompt(self._team_description), source=self._name)
+            )
+            response = await self._model_client.create(
+                self._get_compatible_context(planning_conversation), cancellation_token=ctx.cancellation_token
+            )
+
+            assert isinstance(response.content, str)
+            self._plan = response.content
+
+            # Kick off the first inner-loop round from the initial task ledger.
+            self._n_stalls = 0
+            await self._reenter_outer_loop(ctx.cancellation_token)
+            return
+
+        # Resume orchestration with preserved context.
+        await self._orchestrate_step(ctx.cancellation_token)
 
     @event
     async def handle_agent_response(  # type: ignore

--- a/python/packages/autogen-agentchat/tests/test_magentic_one_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_magentic_one_group_chat.py
@@ -10,8 +10,10 @@ from autogen_agentchat.agents import (
     BaseChatAgent,
 )
 from autogen_agentchat.base import Response
+from autogen_agentchat.conditions import HandoffTermination
 from autogen_agentchat.messages import (
     BaseChatMessage,
+    HandoffMessage,
     TextMessage,
 )
 from autogen_agentchat.teams import (
@@ -54,6 +56,21 @@ class _EchoAgent(BaseChatAgent):
 
     async def on_reset(self, cancellation_token: CancellationToken) -> None:
         self._last_message = None
+
+
+class _UserHandoffAgent(BaseChatAgent):
+    def __init__(self, name: str, description: str) -> None:
+        super().__init__(name, description)
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (HandoffMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        return Response(chat_message=HandoffMessage(content="Transfer to user.", target="user", source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass
 
 
 @pytest_asyncio.fixture(params=["single_threaded", "embedded"])  # type: ignore
@@ -219,3 +236,58 @@ async def test_magentic_one_group_chat_with_stalls(runtime: AgentRuntime | None)
     assert isinstance(result.messages[4], TextMessage)
     assert result.messages[4].content.startswith("\nWe are working to address the following user request:")
     assert result.stop_reason is not None and result.stop_reason == "test"
+
+
+@pytest.mark.asyncio
+async def test_magentic_one_handoff_resume_preserves_context(runtime: AgentRuntime | None) -> None:
+    agent = _UserHandoffAgent("agent_1", description="handoff agent")
+    model_client = ReplayChatCompletionClient(
+        chat_completions=[
+            "No facts",
+            "No plan",
+            json.dumps(
+                {
+                    "is_request_satisfied": {"answer": False, "reason": "needs user input"},
+                    "is_progress_being_made": {"answer": True, "reason": "waiting for user"},
+                    "is_in_loop": {"answer": False, "reason": "not looping"},
+                    "instruction_or_question": {"answer": "Please provide the missing detail.", "reason": "ask user"},
+                    "next_speaker": {"answer": "agent_1", "reason": "single agent"},
+                }
+            ),
+            json.dumps(
+                {
+                    "is_request_satisfied": {"answer": False, "reason": "needs user input"},
+                    "is_progress_being_made": {"answer": True, "reason": "waiting for user"},
+                    "is_in_loop": {"answer": False, "reason": "not looping"},
+                    "instruction_or_question": {"answer": "Use the user's follow-up detail.", "reason": "continue"},
+                    "next_speaker": {"answer": "agent_1", "reason": "single agent"},
+                }
+            ),
+        ]
+    )
+    termination = HandoffTermination(target="user")
+    team = MagenticOneGroupChat(participants=[agent], model_client=model_client, termination_condition=termination, runtime=runtime)
+
+    result = await team.run(task="Pick a color for the logo.")
+    assert isinstance(result.messages[-1], HandoffMessage)
+    assert result.stop_reason is not None and "Handoff to user" in result.stop_reason
+
+    manager = await team._runtime.try_get_underlying_agent_instance(  # pyright: ignore
+        AgentId(f"{team._group_chat_manager_name}_{team._team_id}", team._team_id),  # pyright: ignore
+        MagenticOneOrchestrator,  # pyright: ignore
+    )  # pyright: ignore
+    assert manager._task == "Pick a color for the logo."  # pyright: ignore
+
+    result = await team.run(task="Green")
+    assert isinstance(result.messages[-1], HandoffMessage)
+    assert result.stop_reason is not None and "Handoff to user" in result.stop_reason
+
+    manager = await team._runtime.try_get_underlying_agent_instance(  # pyright: ignore
+        AgentId(f"{team._group_chat_manager_name}_{team._team_id}", team._team_id),  # pyright: ignore
+        MagenticOneOrchestrator,  # pyright: ignore
+    )  # pyright: ignore
+    assert manager._task == "Pick a color for the logo."  # pyright: ignore
+    assert any(
+        isinstance(msg, TextMessage) and msg.source == "user" and msg.content == "Green"
+        for msg in manager._message_thread  # pyright: ignore
+    )


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

  `MagenticOneGroupChat` was not preserving context across human-in-the-loop handoff resumes.
  After `HandoffTermination(target="user")`, a follow-up `run()/run_stream(task=...)` call was treated as a new task because
  `MagenticOneOrchestrator.handle_start` rebuilt task/ledger state each time.

  This PR fixes that behavior so resumes continue from preserved context (matching expected HITL semantics), adds a regression test,
  and updates docs to clarify expected behavior.

  ### What changed

  - Fix in `MagenticOneOrchestrator.handle_start`:
      - Initialize task/facts/plan only on first run.
      - On subsequent runs, append user follow-up messages to existing thread.
      - Continue orchestration from preserved state instead of restarting planning.
  - Added regression test:
      - `test_magentic_one_handoff_resume_preserves_context`
  - Updated Human-in-the-Loop docs note:
      - Clarifies that `MagenticOneGroupChat` preserves context across handoff resumes.
      - Keeps existing Swarm-specific resume caveat.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #7036

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.


 Local validation run:

  - `uv run --project python pytest -q packages/autogen-agentchat/tests/test_magentic_one_group_chat.py` (passed)
  - `uv run --project python ruff check` on modified src/test files (passed)