### PR TITLE
fix: handle non-string enum values in token counting for structured outputs

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -408,7 +408,7 @@ def count_tokens_openai(
                             tool_tokens -= 3
                             for o in v["enum"]:  # pyright: ignore
                                 tool_tokens += 3
-                                tool_tokens += len(encoding.encode(o))  # pyright: ignore
+                                tool_tokens += len(encoding.encode(str(o)))  # pyright: ignore
                         else:
                             trace_logger.warning(f"Not supported field {field}")
                 tool_tokens += 11


### PR DESCRIPTION
The token counting logic for tool schemas assumes enum values are always strings and passes them directly to tiktoken.encode(). When a Pydantic model uses IntEnum or other non-string enum types, this raises a TypeError. Wrap enum values with str() before encoding, matching the pattern already used for other JSON Schema fields like 'type'. Fixes #7201