### PR TITLE
fix: fix build_python_functions_file generating malformed source

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/code_executor/_func_with_reqs.py
+++ b/python/packages/autogen-core/src/autogen_core/code_executor/_func_with_reqs.py
@@ -236,12 +236,12 @@ def build_python_functions_file(
         if isinstance(func, (FunctionWithRequirements, FunctionWithRequirementsStr)):
             global_imports.update(func.global_imports)
 
-    content = "\n".join(map(_import_to_str, global_imports)) + "\n\n"
+    parts: list[str] = []
+    if global_imports:
+        parts.append("\n".join(sorted(map(_import_to_str, global_imports))))
+    parts.extend(_to_code(func) for func in funcs)
 
-    for func in funcs:
-        content += _to_code(func) + "\n\n"
-
-    return content
+    return "\n\n".join(parts) + "\n"
 
 
 def to_stub(func: Union[Callable[..., Any], FunctionWithRequirementsStr]) -> str:


### PR DESCRIPTION
When global_imports is empty, the function produced a leading blank line followed by an extra trailing newline per function. This resulted in source code that fails linting tools and confuses downstream parsing. Rewrite the assembly logic to only emit the import block when there are actual imports, sort imports for deterministic output, use a single join with double newlines for clean separation, and end with exactly one trailing newline (PEP 8). Fixes #7209