### PR TITLE
fix: clean up temporary directory in JupyterCodeExecutor.stop()

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -145,11 +145,13 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
 
-        self._output_dir: Path = Path(tempfile.mkdtemp()) if output_dir is None else Path(output_dir)
-        self._output_dir.mkdir(exist_ok=True, parents=True)
-
         self._temp_dir: Optional[tempfile.TemporaryDirectory[str]] = None
-        self._temp_dir_path: Optional[Path] = None
+        if output_dir is None:
+            self._temp_dir = tempfile.TemporaryDirectory()
+            self._output_dir = Path(self._temp_dir.name)
+        else:
+            self._output_dir = Path(output_dir)
+        self._output_dir.mkdir(exist_ok=True, parents=True)
 
         self._started = False
 
@@ -307,6 +309,10 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
 
         self._client = None
         self._started = False
+
+        if self._temp_dir is not None:
+            self._temp_dir.cleanup()
+            self._temp_dir = None
 
     def _to_config(self) -> JupyterCodeExecutorConfig:
         """Convert current instance to config object"""


### PR DESCRIPTION
When output_dir is None, JupyterCodeExecutor creates a temp directory via tempfile.mkdtemp() but never cleans it up in stop(). This leaks a directory per executor lifetime. Switch from mkdtemp() to TemporaryDirectory() and call cleanup() in stop() so the temp dir is properly removed when the executor is stopped. Fixes #7217