### PR TITLE
fix: move temp_dir cleanup after container stop in DockerCommandLineCodeExecutor.stop()

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
@@ -439,10 +439,6 @@ $functions"""
         if not self._running:
             return
 
-        if self._temp_dir is not None:
-            self._temp_dir.cleanup()
-            self._temp_dir = None
-
         client = docker.from_env()
         try:
             try:
@@ -489,6 +485,9 @@ $functions"""
         except Exception as e:
             logging.exception(f"Unexpected error during stop operation for container {self.container_name}: {e}")
         finally:
+            if self._temp_dir is not None:
+                self._temp_dir.cleanup()
+                self._temp_dir = None
             self._running = False
             self._cancellation_futures.clear()
 


### PR DESCRIPTION
DockerCommandLineCodeExecutor.stop() cleans up the temporary directory before stopping the Docker container. Since the temp dir is bind-mounted as /workspace, removing it while the container is still running can cause in-flight code executions to fail with I/O errors. Move temp_dir cleanup into the finally block that runs after the container has been stopped. Fixes #7225