### PR TITLE
fix: make McpWorkbench.stop() idempotent instead of raising RuntimeError

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
@@ -478,8 +478,6 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
             # Close the actor
             await self._actor.close()
             self._actor = None
-        else:
-            raise RuntimeError("McpWorkbench is not started. Call start() first.")
 
     async def reset(self) -> None:
         pass


### PR DESCRIPTION
McpWorkbench.stop() raises RuntimeError when the actor has not been initialized. This is problematic because __del__ calls stop() via asyncio.create_task - if the workbench was never started (or start() failed), the RuntimeError propagates as an unhandled exception in the background task. Make stop() idempotent by silently returning when there is nothing to stop, consistent with DockerCommandLineCodeExecutor.stop(). Fixes #7226