### PR TITLE
fix: separate Docker tests into dedicated CI job for autogen-ext

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -162,6 +162,37 @@ jobs:
           name: coverage-${{ env.PKG_NAME }}
           path: ./python/coverage_${{ env.PKG_NAME }}.xml
 
+  test-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run uv sync
+        run: |
+          uv sync --locked --all-extras
+        working-directory: ./python
+      - name: Run task
+        run: |
+          source ${{ github.workspace }}/python/.venv/bin/activate
+          poe --directory ./packages/autogen-ext test-docker
+        working-directory: ./python
+
+      - name: Move coverage file
+        run: |
+          mv ./packages/autogen-ext/coverage.xml coverage_autogen-ext-docker.xml
+        working-directory: ./python
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-autogen-ext-docker
+          path: ./python/coverage_autogen-ext-docker.xml
+
   test-grpc:
     runs-on: ubuntu-latest
     steps:
@@ -232,7 +263,7 @@ jobs:
 
   codecov:
     runs-on: ubuntu-latest
-    needs: [test, test-grpc]
+    needs: [test, test-grpc, test-docker]
     strategy:
       matrix:
         package:
@@ -241,6 +272,7 @@ jobs:
             "./packages/autogen-ext",
             "./packages/autogen-agentchat",
             "autogen-ext-grpc",
+            "autogen-ext-docker",
           ]
     steps:
       - uses: actions/checkout@v4

--- a/python/packages/autogen-ext/conftest.py
+++ b/python/packages/autogen-ext/conftest.py
@@ -4,14 +4,25 @@ def pytest_addoption(parser):
     parser.addoption(
         "--grpc", action="store_true", default=False, help="run grpc tests"
     )
+    parser.addoption(
+        "--docker", action="store_true", default=False, help="run docker tests"
+    )
 
 def pytest_collection_modifyitems(config, items):
     grpc_option_passed = config.getoption("--grpc")
+    docker_option_passed = config.getoption("--docker")
     skip_grpc = pytest.mark.skip(reason="Need --grpc option to run")
     skip_non_grpc = pytest.mark.skip(reason="Skipped since --grpc passed")
+    skip_docker = pytest.mark.skip(reason="Need --docker option to run")
+    skip_non_docker = pytest.mark.skip(reason="Skipped since --docker passed")
 
     for item in items:
         if "grpc" in item.keywords and not grpc_option_passed:
             item.add_marker(skip_grpc)
         elif "grpc" not in item.keywords and grpc_option_passed:
             item.add_marker(skip_non_grpc)
+
+        if "docker" in item.keywords and not docker_option_passed:
+            item.add_marker(skip_docker)
+        elif "docker" not in item.keywords and docker_option_passed:
+            item.add_marker(skip_non_docker)

--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -184,6 +184,7 @@ minversion = "6.0"
 testpaths = ["tests"]
 markers = [
     "grpc",
+    "docker",
 ]
 
 [tool.poe]
@@ -196,6 +197,7 @@ test.sequence = [
 ]
 test.default_item_type = "cmd"
 test-grpc = "pytest -n 1 --cov=src --cov-report=term-missing --cov-report=xml --grpc"
+test-docker = "pytest -n 1 --cov=src --cov-report=term-missing --cov-report=xml --docker"
 test-windows = "pytest -n 1 --cov=src --cov-report=term-missing --cov-report=xml -m 'windows'"
 mypy = "mypy --config-file ../../pyproject.toml --exclude src/autogen_ext/runtimes/grpc/protos --exclude tests/protos --ignore-missing-imports src tests"
 

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
@@ -14,6 +14,8 @@ from autogen_core import CancellationToken
 from autogen_core.code_executor import CodeBlock
 from autogen_ext.code_executors.docker import DockerCommandLineCodeExecutor
 
+pytestmark = pytest.mark.docker
+
 
 def docker_tests_enabled() -> bool:
     if os.environ.get("SKIP_DOCKER", "unset").lower() == "true":

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_jupyter_code_executor.py
@@ -13,6 +13,8 @@ from autogen_ext.code_executors.docker_jupyter import (
     DockerJupyterServer,
 )
 
+pytestmark = pytest.mark.docker
+
 
 def docker_tests_enabled() -> bool:
     if os.environ.get("SKIP_DOCKER", "unset").lower() == "true":


### PR DESCRIPTION
## Why are these changes needed?

Docker code executor tests (`DockerCommandLineCodeExecutor` and `DockerJupyterCodeExecutor`) add ~160s to the `autogen-ext` test suite because each test creates a new Docker container (~10s build time per container). This PR separates them into a dedicated CI job, following the existing `test-grpc` pattern, so they no longer block the main test suite.

Fixes #6376

## Changes

- Add `docker` pytest marker to both Docker test files via `pytestmark = pytest.mark.docker`
- Add `--docker` CLI option to `conftest.py` for marker-based test filtering (same pattern as `--grpc`)
- Add `test-docker` poe task in `pyproject.toml`
- Add `test-docker` CI job in `.github/workflows/checks.yml` with coverage upload
- Add Docker coverage to `codecov` job dependencies
- Regular `poe test` now skips Docker-marked tests automatically

## Related issue number

Fixes #6376

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.