### PR TITLE
Add MiniMax model support: M3 (default) + M2.7 via OpenAI-compatible API

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
@@ -483,12 +483,12 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## MiniMax (experimental)\n\n[MiniMax](https://www.minimax.io/) offers an [OpenAI-compatible API](https://platform.minimaxi.com/document/Fast%20access?key=66701332a427f0c8a5701643).\nSo you can use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with the MiniMax API.\n\nAvailable models:\n* `MiniMax-M2.5` — 204K context window, supports vision, function calling, and structured output.\n* `MiniMax-M2.5-highspeed` — Same capabilities as M2.5 with optimized inference speed.\n\n```{note}\nMiniMax requires `temperature` to be in (0.0, 1.0] — a value of 0 is not accepted.\n```",
+   "source": "## MiniMax (experimental)\n\n[MiniMax](https://www.minimax.io/) offers an [OpenAI-compatible API](https://platform.minimaxi.com/document/Fast%20access?key=66701332a427f0c8a5701643).\nSo you can use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with the MiniMax API.\n\nAvailable models:\n* `MiniMax-M2.7` — Latest flagship model, 204K context window, supports vision, function calling, and structured output.\n* `MiniMax-M2.7-highspeed` — Same capabilities as M2.7 with optimized inference speed.\n* `MiniMax-M2.5` — Previous generation, 204K context window.\n* `MiniMax-M2.5-highspeed` — Same capabilities as M2.5 with optimized inference speed.\n\n```{note}\nMiniMax requires `temperature` to be in (0.0, 1.0] — a value of 0 is not accepted.\n```",
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "source": "from autogen_core.models import UserMessage\nfrom autogen_ext.models.openai import OpenAIChatCompletionClient\n\nmodel_client = OpenAIChatCompletionClient(\n    model=\"MiniMax-M2.5\",\n    # api_key=\"MINIMAX_API_KEY\",\n)\n\nresponse = await model_client.create([UserMessage(content=\"What is the capital of France?\", source=\"user\")])\nprint(response)\nawait model_client.close()",
+   "source": "from autogen_core.models import UserMessage\nfrom autogen_ext.models.openai import OpenAIChatCompletionClient\n\nmodel_client = OpenAIChatCompletionClient(\n    model=\"MiniMax-M2.7\",\n    # api_key=\"MINIMAX_API_KEY\",\n)\n\nresponse = await model_client.create([UserMessage(content=\"What is the capital of France?\", source=\"user\")])\nprint(response)\nawait model_client.close()",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
@@ -483,6 +483,18 @@
   },
   {
    "cell_type": "markdown",
+   "source": "## MiniMax (experimental)\n\n[MiniMax](https://www.minimax.io/) offers an [OpenAI-compatible API](https://platform.minimaxi.com/document/Fast%20access?key=66701332a427f0c8a5701643).\nSo you can use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with the MiniMax API.\n\nAvailable models:\n* `MiniMax-M2.5` — 204K context window, supports vision, function calling, and structured output.\n* `MiniMax-M2.5-highspeed` — Same capabilities as M2.5 with optimized inference speed.\n\n```{note}\nMiniMax requires `temperature` to be in (0.0, 1.0] — a value of 0 is not accepted.\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from autogen_core.models import UserMessage\nfrom autogen_ext.models.openai import OpenAIChatCompletionClient\n\nmodel_client = OpenAIChatCompletionClient(\n    model=\"MiniMax-M2.5\",\n    # api_key=\"MINIMAX_API_KEY\",\n)\n\nresponse = await model_client.create([UserMessage(content=\"What is the capital of France?\", source=\"user\")])\nprint(response)\nawait model_client.close()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Semantic Kernel Adapter\n",

--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
@@ -483,12 +483,12 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## MiniMax (experimental)\n\n[MiniMax](https://www.minimax.io/) offers an [OpenAI-compatible API](https://platform.minimaxi.com/document/Fast%20access?key=66701332a427f0c8a5701643).\nSo you can use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with the MiniMax API.\n\nAvailable models:\n* `MiniMax-M2.7` — Latest flagship model, 204K context window, supports vision, function calling, and structured output.\n* `MiniMax-M2.7-highspeed` — Same capabilities as M2.7 with optimized inference speed.\n* `MiniMax-M2.5` — Previous generation, 204K context window.\n* `MiniMax-M2.5-highspeed` — Same capabilities as M2.5 with optimized inference speed.\n\n```{note}\nMiniMax requires `temperature` to be in (0.0, 1.0] — a value of 0 is not accepted.\n```",
+   "source": "## MiniMax (experimental)\n\n[MiniMax](https://www.minimax.io/) offers an [OpenAI-compatible API](https://platform.minimaxi.com/document/Fast%20access?key=66701332a427f0c8a5701643).\nSo you can use the {py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with the MiniMax API.\n\nAvailable models:\n* `MiniMax-M3` — Latest flagship model (default), 512K context window, up to 128K output, supports vision, function calling, and structured output.\n* `MiniMax-M2.7` — Previous generation, 204K context window.\n* `MiniMax-M2.7-highspeed` — Same capabilities as M2.7 with optimized inference speed.\n\n```{note}\nMiniMax requires `temperature` to be in (0.0, 1.0] — a value of 0 is not accepted.\n```",
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "source": "from autogen_core.models import UserMessage\nfrom autogen_ext.models.openai import OpenAIChatCompletionClient\n\nmodel_client = OpenAIChatCompletionClient(\n    model=\"MiniMax-M2.7\",\n    # api_key=\"MINIMAX_API_KEY\",\n)\n\nresponse = await model_client.create([UserMessage(content=\"What is the capital of France?\", source=\"user\")])\nprint(response)\nawait model_client.close()",
+   "source": "from autogen_core.models import UserMessage\nfrom autogen_ext.models.openai import OpenAIChatCompletionClient\n\nmodel_client = OpenAIChatCompletionClient(\n    model=\"MiniMax-M3\",\n    # api_key=\"MINIMAX_API_KEY\",\n)\n\nresponse = await model_client.create([UserMessage(content=\"What is the capital of France?\", source=\"user\")])\nprint(response)\nawait model_client.close()",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/python/packages/autogen-core/src/autogen_core/models/_model_client.py
+++ b/python/packages/autogen-core/src/autogen_core/models/_model_client.py
@@ -45,6 +45,7 @@ class ModelFamily:
     LLAMA_3_3_70B = "llama-3.3-70b"
     LLAMA_4_SCOUT = "llama-4-scout"
     LLAMA_4_MAVERICK = "llama-4-maverick"
+    MINIMAX_M2_5 = "minimax-m2.5"
     CODESRAL = "codestral"
     OPEN_CODESRAL_MAMBA = "open-codestral-mamba"
     MISTRAL = "mistral"
@@ -84,6 +85,8 @@ class ModelFamily:
         "llama-3.3-70b",
         "llama-4-scout",
         "llama-4-maverick",
+        # minimax_models
+        "minimax-m2.5",
         # mistral_models
         "codestral",
         "open-codestral-mamba",
@@ -142,6 +145,10 @@ class ModelFamily:
             ModelFamily.LLAMA_4_SCOUT,
             ModelFamily.LLAMA_4_MAVERICK,
         )
+
+    @staticmethod
+    def is_minimax(family: str) -> bool:
+        return family in (ModelFamily.MINIMAX_M2_5,)
 
     @staticmethod
     def is_mistral(family: str) -> bool:

--- a/python/packages/autogen-core/src/autogen_core/models/_model_client.py
+++ b/python/packages/autogen-core/src/autogen_core/models/_model_client.py
@@ -46,6 +46,7 @@ class ModelFamily:
     LLAMA_4_SCOUT = "llama-4-scout"
     LLAMA_4_MAVERICK = "llama-4-maverick"
     MINIMAX_M2_5 = "minimax-m2.5"
+    MINIMAX_M2_7 = "minimax-m2.7"
     CODESRAL = "codestral"
     OPEN_CODESRAL_MAMBA = "open-codestral-mamba"
     MISTRAL = "mistral"
@@ -87,6 +88,7 @@ class ModelFamily:
         "llama-4-maverick",
         # minimax_models
         "minimax-m2.5",
+        "minimax-m2.7",
         # mistral_models
         "codestral",
         "open-codestral-mamba",
@@ -148,7 +150,7 @@ class ModelFamily:
 
     @staticmethod
     def is_minimax(family: str) -> bool:
-        return family in (ModelFamily.MINIMAX_M2_5,)
+        return family in (ModelFamily.MINIMAX_M2_5, ModelFamily.MINIMAX_M2_7)
 
     @staticmethod
     def is_mistral(family: str) -> bool:

--- a/python/packages/autogen-core/src/autogen_core/models/_model_client.py
+++ b/python/packages/autogen-core/src/autogen_core/models/_model_client.py
@@ -45,7 +45,7 @@ class ModelFamily:
     LLAMA_3_3_70B = "llama-3.3-70b"
     LLAMA_4_SCOUT = "llama-4-scout"
     LLAMA_4_MAVERICK = "llama-4-maverick"
-    MINIMAX_M2_5 = "minimax-m2.5"
+    MINIMAX_M3 = "minimax-m3"
     MINIMAX_M2_7 = "minimax-m2.7"
     CODESRAL = "codestral"
     OPEN_CODESRAL_MAMBA = "open-codestral-mamba"
@@ -87,7 +87,7 @@ class ModelFamily:
         "llama-4-scout",
         "llama-4-maverick",
         # minimax_models
-        "minimax-m2.5",
+        "minimax-m3",
         "minimax-m2.7",
         # mistral_models
         "codestral",
@@ -150,7 +150,7 @@ class ModelFamily:
 
     @staticmethod
     def is_minimax(family: str) -> bool:
-        return family in (ModelFamily.MINIMAX_M2_5, ModelFamily.MINIMAX_M2_7)
+        return family in (ModelFamily.MINIMAX_M3, ModelFamily.MINIMAX_M2_7)
 
     @staticmethod
     def is_mistral(family: str) -> bool:

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -44,6 +44,8 @@ _MODEL_POINTERS = {
     # MiniMax models
     "minimax-m2.5": "MiniMax-M2.5",
     "minimax-m2.5-highspeed": "MiniMax-M2.5-highspeed",
+    "minimax-m2.7": "MiniMax-M2.7",
+    "minimax-m2.7-highspeed": "MiniMax-M2.7-highspeed",
     # Llama models
     "llama-3.3-8b": "Llama-3.3-8B-Instruct",
     "llama-3.3-70b": "Llama-3.3-70B-Instruct",
@@ -428,6 +430,22 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
         "structured_output": True,
         "multiple_system_messages": True,
     },
+    "MiniMax-M2.7": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MINIMAX_M2_7,
+        "structured_output": True,
+        "multiple_system_messages": True,
+    },
+    "MiniMax-M2.7-highspeed": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MINIMAX_M2_7,
+        "structured_output": True,
+        "multiple_system_messages": True,
+    },
     "Llama-3.3-8B-Instruct": {
         "vision": False,
         "function_calling": True,
@@ -508,6 +526,8 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
     "claude-opus-4-20250514": 200000,
     "MiniMax-M2.5": 204800,
     "MiniMax-M2.5-highspeed": 204800,
+    "MiniMax-M2.7": 204800,
+    "MiniMax-M2.7-highspeed": 204800,
     "Llama-3.3-8B-Instruct": 128000,
     "Llama-3.3-70B-Instruct": 128000,
     "Llama-4-Scout-17B-16E-Instruct-FP8": 128000,

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -41,6 +41,9 @@ _MODEL_POINTERS = {
     "claude-3-7-sonnet": "claude-3-7-sonnet-20250219",
     "claude-4-sonnet": "claude-sonnet-4-20250514",
     "claude-4-opus": "claude-opus-4-20250514",
+    # MiniMax models
+    "minimax-m2.5": "MiniMax-M2.5",
+    "minimax-m2.5-highspeed": "MiniMax-M2.5-highspeed",
     # Llama models
     "llama-3.3-8b": "Llama-3.3-8B-Instruct",
     "llama-3.3-70b": "Llama-3.3-70B-Instruct",
@@ -409,6 +412,22 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
         "structured_output": False,
         "multiple_system_messages": True,
     },
+    "MiniMax-M2.5": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MINIMAX_M2_5,
+        "structured_output": True,
+        "multiple_system_messages": True,
+    },
+    "MiniMax-M2.5-highspeed": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MINIMAX_M2_5,
+        "structured_output": True,
+        "multiple_system_messages": True,
+    },
     "Llama-3.3-8B-Instruct": {
         "vision": False,
         "function_calling": True,
@@ -487,6 +506,8 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
     "claude-3-7-sonnet-20250219": 200000,
     "claude-sonnet-4-20250514": 200000,
     "claude-opus-4-20250514": 200000,
+    "MiniMax-M2.5": 204800,
+    "MiniMax-M2.5-highspeed": 204800,
     "Llama-3.3-8B-Instruct": 128000,
     "Llama-3.3-70B-Instruct": 128000,
     "Llama-4-Scout-17B-16E-Instruct-FP8": 128000,
@@ -496,6 +517,7 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
 GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 ANTHROPIC_OPENAI_BASE_URL = "https://api.anthropic.com/v1/"
 LLAMA_API_BASE_URL = "https://api.llama.com/compat/v1/"
+MINIMAX_API_BASE_URL = "https://api.minimax.io/v1"
 
 
 def resolve_model(model: str) -> str:

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -42,8 +42,7 @@ _MODEL_POINTERS = {
     "claude-4-sonnet": "claude-sonnet-4-20250514",
     "claude-4-opus": "claude-opus-4-20250514",
     # MiniMax models
-    "minimax-m2.5": "MiniMax-M2.5",
-    "minimax-m2.5-highspeed": "MiniMax-M2.5-highspeed",
+    "minimax-m3": "MiniMax-M3",
     "minimax-m2.7": "MiniMax-M2.7",
     "minimax-m2.7-highspeed": "MiniMax-M2.7-highspeed",
     # Llama models
@@ -414,19 +413,11 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
         "structured_output": False,
         "multiple_system_messages": True,
     },
-    "MiniMax-M2.5": {
+    "MiniMax-M3": {
         "vision": True,
         "function_calling": True,
         "json_output": True,
-        "family": ModelFamily.MINIMAX_M2_5,
-        "structured_output": True,
-        "multiple_system_messages": True,
-    },
-    "MiniMax-M2.5-highspeed": {
-        "vision": True,
-        "function_calling": True,
-        "json_output": True,
-        "family": ModelFamily.MINIMAX_M2_5,
+        "family": ModelFamily.MINIMAX_M3,
         "structured_output": True,
         "multiple_system_messages": True,
     },
@@ -524,8 +515,7 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
     "claude-3-7-sonnet-20250219": 200000,
     "claude-sonnet-4-20250514": 200000,
     "claude-opus-4-20250514": 200000,
-    "MiniMax-M2.5": 204800,
-    "MiniMax-M2.5-highspeed": 204800,
+    "MiniMax-M3": 524288,
     "MiniMax-M2.7": 204800,
     "MiniMax-M2.7-highspeed": 204800,
     "Llama-3.3-8B-Instruct": 128000,

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1480,6 +1480,11 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
                 copied_args["base_url"] = _model_info.LLAMA_API_BASE_URL
             if "api_key" not in copied_args and "LLAMA_API_KEY" in os.environ:
                 copied_args["api_key"] = os.environ["LLAMA_API_KEY"]
+        if copied_args["model"].startswith("MiniMax-"):
+            if "base_url" not in copied_args:
+                copied_args["base_url"] = _model_info.MINIMAX_API_BASE_URL
+            if "api_key" not in copied_args and "MINIMAX_API_KEY" in os.environ:
+                copied_args["api_key"] = os.environ["MINIMAX_API_KEY"]
 
         client = _openai_client_from_config(copied_args)
         create_args = _create_args_from_config(copied_args)


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to use M3 as the default model, following the same OpenAI-compatible client pattern used for Gemini, Anthropic, and Llama providers.

### Supported Models

| Model | Description |
|-------|-------------|
| `MiniMax-M3` | Latest flagship model (default), 512K context window, up to 128K output, supports vision, function calling, and structured output |
| `MiniMax-M2.7` | Previous generation, 204K context window |
| `MiniMax-M2.7-highspeed` | Same capabilities as M2.7 with optimized inference speed |

### Changes

- **autogen-core**: Add `MINIMAX_M3` to `ModelFamily`, remove `MINIMAX_M2_5`; `is_minimax()` accepts M3 and M2.7
- **autogen-ext (OpenAI provider)**:
  - Register `MiniMax-M3` in `_model_info.py` with capabilities (vision, function calling, structured output) and 512K (524288) token limit
  - Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` registrations
  - Remove `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries
  - `MINIMAX_API_BASE_URL = "https://api.minimax.io/v1"` remains as the auto-detected base URL
  - Auto-detect `MINIMAX_API_KEY` env var for `MiniMax-*` models
- **Docs**: Update MiniMax tutorial section in the models notebook (M3 default; M2.7 / M2.7-highspeed kept)

### Why

`MiniMax-M3` is the latest flagship model — 512K context window, up to 128K output, image input support — and should be the default choice. Older M2.5 models are deprecated and removed from the list.

### Test Plan

- [x] Syntax validation passes on all modified Python files
- [x] Notebook JSON is valid
- [x] `MODEL_POINTERS["minimax-m3"] == "MiniMax-M3"`
- [x] `_MODEL_INFO["MiniMax-M3"]` has correct capabilities and `MINIMAX_M3` family
- [x] `_MODEL_TOKEN_LIMITS["MiniMax-M3"] == 524288` (512K)
- [x] M3 listed first; M2.5 entries removed
- [x] `ModelFamily.is_minimax(MINIMAX_M3)` returns `True`