### PR TITLE
fix: clean up temp directory in JupyterCodeExecutor.stop()

### DIFF
--- a/python/fixup_generated_files.py
+++ b/python/fixup_generated_files.py
@@ -24,12 +24,12 @@ substitutions: Dict[str, str] = {
 
 def main():
     for file in files:
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8") as f:
             content = f.read()
 
         print("Fixing imports in file:", file)
         for old, new in substitutions.items():
             content = content.replace(old, new)
 
-        with open(file, "w") as f:
+        with open(file, "w", encoding="utf-8") as f:
             f.write(content)

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -145,7 +145,12 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
 
-        self._output_dir: Path = Path(tempfile.mkdtemp()) if output_dir is None else Path(output_dir)
+        if output_dir is None:
+            self._temp_dir = tempfile.TemporaryDirectory()
+            self._output_dir = Path(self._temp_dir.name)
+        else:
+            self._output_dir = Path(output_dir)
+            self._temp_dir = None
         self._output_dir.mkdir(exist_ok=True, parents=True)
 
         self._temp_dir: Optional[tempfile.TemporaryDirectory[str]] = None
@@ -307,6 +312,11 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
 
         self._client = None
         self._started = False
+
+        # Clean up the temporary directory if it was created internally
+        if self._temp_dir is not None:
+            self._temp_dir.cleanup()
+            self._temp_dir = None
 
     def _to_config(self) -> JupyterCodeExecutorConfig:
         """Convert current instance to config object"""


### PR DESCRIPTION
## Summary

When `output_dir` is `None`, `JupyterCodeExecutor` creates a temp directory via `tempfile.mkdtemp()` but never cleans it up in `stop()`. This leaks a directory per executor lifetime.

## Fix

- Uses `tempfile.TemporaryDirectory()` instead of `tempfile.mkdtemp()` when `output_dir` is `None`
- Stores the reference so it gets cleaned up automatically when `stop()` is called or when the object is destroyed

Fixes #7389