### PR TITLE
Add explicit UTF-8 encoding to file operations in autogen-ext

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
@@ -275,7 +275,7 @@ class DockerJupyterCodeExecutor(CodeExecutor, Component[DockerJupyterCodeExecuto
         """Save html data to a file."""
         filename = f"{uuid.uuid4().hex}.html"
         path = os.path.join(str(self._output_dir), filename)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(html_data)
         return os.path.abspath(path)
 

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
@@ -73,7 +73,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
             # Load the previously recorded messages and responses from disk.
             self.logger.info("Replay mode enabled.\nRetrieving session from: " + self.session_file_path)
             try:
-                with open(self.session_file_path, "r") as f:
+                with open(self.session_file_path, "r", encoding="utf-8") as f:
                     self.records = json.load(f)
             except Exception as e:
                 error_str = f"\nFailed to load recorded session: '{self.session_file_path}': {e}"
@@ -211,7 +211,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
                 # Create the directory if it doesn't exist.
                 os.makedirs(os.path.dirname(self.session_file_path), exist_ok=True)
                 # Write the records to disk.
-                with open(self.session_file_path, "w") as f:
+                with open(self.session_file_path, "w", encoding="utf-8") as f:
                     json.dump(self.records, f, indent=2)
                     self.logger.info("\nRecorded session was saved to: " + self.session_file_path)
             except Exception as e:

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py
@@ -117,7 +117,7 @@ class PageLogger:
         # Write the hash and other details to a file.
         hash_str, num_files, num_subdirs = hash_directory(self.log_dir)
         hash_path = os.path.join(self.log_dir, "hash.txt")
-        with open(hash_path, "w") as f:
+        with open(hash_path, "w", encoding="utf-8") as f:
             f.write(hash_str)
             f.write("\n")
             f.write("{} files\n".format(num_files))
@@ -386,7 +386,7 @@ class PageLogger:
             return
         # Create a call tree of the log.
         call_tree_path = os.path.join(self.log_dir, self.name + ".html")
-        with open(call_tree_path, "w") as f:
+        with open(call_tree_path, "w", encoding="utf-8") as f:
             f.write(_html_opening("0 Call Tree", finished=finished))
             f.write(f"<h3>{self.name}</h3>")
             f.write("\n")
@@ -498,7 +498,7 @@ class Page:
         Writes the HTML page to disk.
         """
         page_path = os.path.join(self.page_logger.log_dir, self.index_str + ".html")
-        with open(page_path, "w") as f:
+        with open(page_path, "w", encoding="utf-8") as f:
             f.write(_html_opening(self.file_title, finished=self.finished))
             f.write(f"<h3>{self.file_title}</h3>\n")
             for line in self.lines:


### PR DESCRIPTION
## Summary

Fixes #5566 by adding `encoding='utf-8'` parameter to text-mode file operations that were missing it in the autogen-ext package. This prevents `UnicodeDecodeError` on Windows systems with non-English system locales.

## Problem

The codebase had multiple `open()` calls without explicit UTF-8 encoding, causing crashes on Windows with non-English locales (Chinese, Japanese, etc.). While one instance was previously fixed in `playwright_controller.py`, several others remained throughout the codebase.

## Changes

Added `encoding="utf-8"` to 6 file operations across 3 files:

### 1. `code_executors/docker_jupyter/_docker_jupyter.py`
- **Line 278**: HTML file writing in `_save_html` method

### 2. `experimental/task_centric_memory/utils/page_logger.py`
- **Line 120**: Hash file writing
- **Line 389**: Call tree HTML writing
- **Line 501**: Page HTML writing

### 3. `experimental/task_centric_memory/utils/chat_completion_client_recorder.py`
- **Line 76**: JSON session file reading
- **Line 214**: JSON session file writing

## Testing

- ✅ All changes are mechanical additions of the encoding parameter
- ✅ No functional changes to code logic
- ✅ Follows Python 3 best practices (PEP 597)
- ✅ Syntax validated

## Impact

**High** - Prevents crashes for international users on Windows systems with non-English locales, improving cross-platform compatibility.

## Diff Summary

```
 3 files changed, 6 insertions(+), 6 deletions(-)
```

All changes follow the same pattern:
```python
# Before
with open(path, "w") as f:

# After  
with open(path, "w", encoding="utf-8") as f:
```

Closes #5566