### PR TITLE
Add llms.txt and llms-full.txt generation to AutoGen documentation

### DIFF
--- a/python/docs/src/_extension/llms_txt.py
+++ b/python/docs/src/_extension/llms_txt.py
@@ -1,0 +1,246 @@
+"""Sphinx extension to generate llms.txt for AutoGen documentation.
+
+The llms.txt file follows the llms.txt standard (https://llmstxt.org/) which provides
+a structured index of documentation content for Large Language Models (LLMs).
+
+A companion llms-full.txt file is also generated, containing the same index followed
+by the full plain-text body of every indexed page.
+"""
+
+import re
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from sphinx.application import Sphinx
+from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+# Default documentation sections (display title → docname prefix), in display order.
+# Override via ``llms_txt_sections`` in conf.py.
+_DEFAULT_SECTIONS: Dict[str, str] = {
+    "AutoGen Studio": "user-guide/autogenstudio-user-guide",
+    "AgentChat": "user-guide/agentchat-user-guide",
+    "Core": "user-guide/core-user-guide",
+    "Extensions": "user-guide/extensions-user-guide",
+}
+
+
+class _BodyTextExtractor(HTMLParser):
+    """Extract readable text from the main content area of a Sphinx HTML page.
+
+    Only text inside ``<article>`` or ``<main>`` tags is captured; ``<script>``,
+    ``<style>``, ``<nav>``, ``<header>``, and ``<footer>`` content is skipped.
+    """
+
+    _SKIP_TAGS = frozenset({"script", "style", "nav", "header", "footer"})
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._in_main = 0
+        self._in_skip = 0
+        self._chunks: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: Any) -> None:
+        if tag in ("article", "main"):
+            self._in_main += 1
+        if tag in self._SKIP_TAGS:
+            self._in_skip += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("article", "main"):
+            self._in_main = max(0, self._in_main - 1)
+        if tag in self._SKIP_TAGS:
+            self._in_skip = max(0, self._in_skip - 1)
+
+    def handle_data(self, data: str) -> None:
+        if self._in_main and not self._in_skip:
+            self._chunks.append(data)
+
+    def get_text(self) -> str:
+        text = "".join(self._chunks)
+        # Collapse runs of more than two blank lines
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()
+
+
+def _get_sections(app: Sphinx) -> Dict[str, str]:
+    """Return the sections mapping, preferring ``llms_txt_sections`` from conf.py."""
+    return app.config.llms_txt_sections or _DEFAULT_SECTIONS
+
+
+def _page_url(app: Sphinx, docname: str) -> str:
+    """Return the full URL for a documentation page.
+
+    Uses ``llms_txt_base_url`` from conf.py when set; otherwise falls back to
+    ``html_baseurl``.  Emits a warning when the resolved base URL is
+    root-relative rather than absolute, because llms.txt consumers expect
+    fully-qualified links.
+    """
+    base_url = (app.config.llms_txt_base_url or app.config.html_baseurl or "").rstrip("/")
+    if base_url and not base_url.startswith(("http://", "https://")):
+        logger.warning(
+            "llms_txt: base URL %r is not absolute. "
+            "Set 'llms_txt_base_url' in conf.py to a fully-qualified URL "
+            "so that llms.txt contains absolute links.",
+            base_url,
+        )
+    target_uri = app.builder.get_target_uri(docname)  # type: ignore[attr-defined]
+    return f"{base_url}/{target_uri}"
+
+
+def _page_title(app: Sphinx, docname: str) -> Optional[str]:
+    """Return the plain-text title for a documentation page, or *None*."""
+    title_node = app.env.titles.get(docname)
+    if title_node is not None:
+        return title_node.astext()
+    return None
+
+
+def _page_description(app: Sphinx, docname: str) -> Optional[str]:
+    """Return a one-line description for a documentation page, or *None*.
+
+    The description is taken from the MyST ``html_meta`` frontmatter field
+    ``"description lang=en"`` when present.
+    """
+    metadata = app.env.metadata.get(docname, {})
+    myst_config = metadata.get("myst", {})
+    if not isinstance(myst_config, dict):
+        return None
+    html_meta = myst_config.get("html_meta", {})
+    if not isinstance(html_meta, dict):
+        return None
+    for key, value in html_meta.items():
+        if "description" in str(key).lower():
+            # Collapse any embedded newlines or extra whitespace
+            return " ".join(str(value).split())
+    return None
+
+
+def _page_content(app: Sphinx, docname: str) -> Optional[str]:
+    """Return the plain-text body of a built HTML page, or *None*.
+
+    Reads the HTML file that Sphinx wrote to ``app.outdir`` and extracts the
+    text inside the ``<article>`` / ``<main>`` element, stripping navigation,
+    scripts, and other chrome.  Returns *None* if the file does not exist or
+    yields no extractable text.
+    """
+    target_uri = app.builder.get_target_uri(docname)  # type: ignore[attr-defined]
+    html_path = Path(app.outdir) / target_uri
+    if not html_path.exists():
+        return None
+    html_text = html_path.read_text(encoding="utf-8")
+    extractor = _BodyTextExtractor()
+    extractor.feed(html_text)
+    text = extractor.get_text()
+    return text if text else None
+
+
+def _build_llms_txt(app: Sphinx) -> str:
+    """Assemble and return the llms.txt index content as a string."""
+    all_docs = sorted(app.env.found_docs)
+    sections = _get_sections(app)
+
+    project_title = app.config.html_title or app.config.project
+    description = app.config.llms_txt_description or app.config.project
+
+    lines = [
+        f"# {project_title}",
+        "",
+        f"> {description}",
+        "",
+    ]
+
+    for section_title, prefix in sections.items():
+        section_docs = [doc for doc in all_docs if doc.startswith(prefix)]
+        if not section_docs:
+            continue
+
+        lines.append(f"## {section_title}")
+        lines.append("")
+
+        for docname in section_docs:
+            title = _page_title(app, docname)
+            if not title:
+                continue
+
+            url = _page_url(app, docname)
+            doc_description = _page_description(app, docname)
+
+            if doc_description:
+                lines.append(f"- [{title}]({url}): {doc_description}")
+            else:
+                lines.append(f"- [{title}]({url})")
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _build_llms_full_txt(app: Sphinx) -> str:
+    """Assemble and return llms-full.txt: the index followed by each page's content.
+
+    Pages whose HTML file cannot be read (e.g. notebooks or pages without a
+    rendered ``<article>`` element) are listed in the index but their content
+    block is omitted from this file.
+    """
+    all_docs = sorted(app.env.found_docs)
+    sections = _get_sections(app)
+
+    parts = [_build_llms_txt(app), ""]
+
+    for _section_title, prefix in sections.items():
+        section_docs = [doc for doc in all_docs if doc.startswith(prefix)]
+        for docname in section_docs:
+            title = _page_title(app, docname)
+            if not title:
+                continue
+
+            url = _page_url(app, docname)
+            content = _page_content(app, docname)
+            if content:
+                parts.append(f"## {title}")
+                parts.append(f"URL: {url}")
+                parts.append("")
+                parts.append(content)
+                parts.append("")
+
+    return "\n".join(parts)
+
+
+def generate_llms_txt(app: Sphinx, exception: Optional[Exception]) -> None:
+    """Generate ``llms.txt`` and ``llms-full.txt`` after the HTML build finishes.
+
+    This function is wired to Sphinx's ``build-finished`` event.  It is a
+    no-op when an exception occurred during the build or when a non-HTML
+    builder is in use.
+    """
+    if exception:
+        return
+    if not isinstance(app.builder, StandaloneHTMLBuilder):
+        return
+
+    content = _build_llms_txt(app)
+    output_path = Path(app.outdir) / "llms.txt"
+    output_path.write_text(content, encoding="utf-8")
+    logger.info(f"llms.txt generated at {output_path}")
+
+    full_content = _build_llms_full_txt(app)
+    full_output_path = Path(app.outdir) / "llms-full.txt"
+    full_output_path.write_text(full_content, encoding="utf-8")
+    logger.info(f"llms-full.txt generated at {full_output_path}")
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    """Register the extension with the Sphinx application."""
+    app.add_config_value("llms_txt_base_url", default=None, rebuild="html")
+    app.add_config_value("llms_txt_sections", default=None, rebuild="html")
+    app.add_config_value("llms_txt_description", default=None, rebuild="html")
+    app.connect("build-finished", generate_llms_txt)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/python/docs/src/conf.py
+++ b/python/docs/src/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "_extension.gallery_directive",
+    "_extension.llms_txt",
     "myst_nb",
     "sphinxcontrib.autodoc_pydantic",
     "_extension.code_lint",
@@ -77,6 +78,27 @@ if (switcher_version := os.getenv("PY_SWITCHER_VERSION")) is None:
     switcher_version = "dev"
 
 html_baseurl = f"/autogen/{path}/"
+
+# -- llms_txt extension settings --------------------------------------------
+# Absolute base URL for llms.txt links (html_baseurl is root-relative).
+llms_txt_base_url = f"https://microsoft.github.io/autogen/{path}"
+
+# Documentation sections included in llms.txt, in display order.
+# Each key is a section heading; the value is the docname path prefix.
+llms_txt_sections = {
+    "AutoGen Studio": "user-guide/autogenstudio-user-guide",
+    "AgentChat": "user-guide/agentchat-user-guide",
+    "Core": "user-guide/core-user-guide",
+    "Extensions": "user-guide/extensions-user-guide",
+}
+
+# One-paragraph description written as the blockquote in llms.txt.
+# Falls back to the Sphinx ``project`` value when not set.
+llms_txt_description = (
+    "AutoGen is an open-source framework for building AI agents and multi-agent applications. "
+    "It offers packages for conversational agents (AgentChat), event-driven multi-agent systems (Core), "
+    "a no-code web UI for prototyping (AutoGen Studio), and community-contributed extensions."
+)
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/python/docs/tests/test_llms_txt.py
+++ b/python/docs/tests/test_llms_txt.py
@@ -1,0 +1,435 @@
+"""Tests for the llms_txt Sphinx extension.
+
+These tests verify that the extension correctly generates the llms.txt and
+llms-full.txt files from a minimal Sphinx environment.
+"""
+
+import importlib.util
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the extension module by file path (no sys.path modification needed).
+# ---------------------------------------------------------------------------
+
+_EXT_FILE = Path(__file__).parent.parent / "src" / "_extension" / "llms_txt.py"
+_spec = importlib.util.spec_from_file_location("_ext_llms_txt", _EXT_FILE)
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+_build_llms_txt = _mod._build_llms_txt
+_build_llms_full_txt = _mod._build_llms_full_txt
+_page_content = _mod._page_content
+_page_description = _mod._page_description
+_page_title = _mod._page_title
+_page_url = _mod._page_url
+generate_llms_txt = _mod.generate_llms_txt
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(
+    *,
+    html_baseurl: str = "https://example.com/autogen/dev",
+    llms_txt_base_url: Optional[str] = None,
+    llms_txt_sections: Optional[Dict[str, str]] = None,
+    llms_txt_description: Optional[str] = None,
+    project: str = "AutoGen",
+    html_title: Optional[str] = None,
+    found_docs: Any = None,
+    titles: Any = None,
+    metadata: Any = None,
+) -> MagicMock:
+    """Return a minimal mock Sphinx app with the given attributes."""
+    from sphinx.builders.html import StandaloneHTMLBuilder
+
+    if found_docs is None:
+        found_docs = set()
+    if titles is None:
+        titles = {}
+    if metadata is None:
+        metadata = {}
+
+    app = MagicMock()
+    app.config.html_baseurl = html_baseurl
+    # Explicitly set every config value so MagicMock doesn't return a truthy
+    # MagicMock instance when the value should be None/falsy.
+    app.config.llms_txt_base_url = llms_txt_base_url
+    app.config.llms_txt_sections = llms_txt_sections
+    app.config.llms_txt_description = llms_txt_description
+    app.config.project = project
+    app.config.html_title = html_title
+    app.outdir = "/tmp/test-docs-out"
+
+    # Builder must be an instance of StandaloneHTMLBuilder for the hook to fire
+    app.builder = MagicMock(spec=StandaloneHTMLBuilder)
+    app.builder.get_target_uri.side_effect = lambda docname: f"{docname}.html"
+
+    # Sphinx environment
+    app.env.found_docs = found_docs
+    app.env.titles = titles
+    app.env.metadata = metadata
+
+    return app
+
+
+def _title_node(text: str) -> Any:
+    """Return a minimal docutils title node with the given text."""
+    from docutils import nodes
+
+    node = nodes.title()
+    node += nodes.Text(text)
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_page_url_basic() -> None:
+    app = _make_app(html_baseurl="https://docs.example.com/dev")
+    url = _page_url(app, "user-guide/core-user-guide/index")
+    assert url == "https://docs.example.com/dev/user-guide/core-user-guide/index.html"
+
+
+def test_page_url_strips_trailing_slash() -> None:
+    app = _make_app(html_baseurl="https://docs.example.com/dev/")
+    url = _page_url(app, "user-guide/core-user-guide/installation")
+    assert url == "https://docs.example.com/dev/user-guide/core-user-guide/installation.html"
+
+
+def test_page_url_uses_llms_txt_base_url_over_html_baseurl() -> None:
+    """When llms_txt_base_url is set it takes priority over html_baseurl."""
+    app = _make_app(
+        html_baseurl="/autogen/dev/",
+        llms_txt_base_url="https://microsoft.github.io/autogen/dev",
+    )
+    url = _page_url(app, "user-guide/core-user-guide/index")
+    assert url.startswith("https://microsoft.github.io/autogen/dev/")
+
+
+def test_page_url_warns_when_root_relative(caplog: pytest.LogCaptureFixture) -> None:
+    """A warning must be logged when the resolved base URL is root-relative."""
+    app = _make_app(html_baseurl="/autogen/dev/", llms_txt_base_url=None)
+    with caplog.at_level(logging.WARNING):
+        url = _page_url(app, "user-guide/core-user-guide/index")
+    assert "not absolute" in caplog.text
+    assert url == "/autogen/dev/user-guide/core-user-guide/index.html"
+
+
+def test_page_url_no_warning_for_absolute_url(caplog: pytest.LogCaptureFixture) -> None:
+    """No warning should be emitted when the base URL is absolute."""
+    app = _make_app(html_baseurl="https://docs.example.com/dev")
+    with caplog.at_level(logging.WARNING):
+        _page_url(app, "user-guide/core-user-guide/index")
+    assert "not absolute" not in caplog.text
+
+
+def test_page_title_present() -> None:
+    docname = "user-guide/core-user-guide/index"
+    app = _make_app(titles={docname: _title_node("Core User Guide")})
+    assert _page_title(app, docname) == "Core User Guide"
+
+
+def test_page_title_missing() -> None:
+    app = _make_app(titles={})
+    assert _page_title(app, "nonexistent") is None
+
+
+def test_page_description_from_myst_html_meta() -> None:
+    docname = "user-guide/agentchat-user-guide/index"
+    metadata = {
+        docname: {
+            "myst": {
+                "html_meta": {
+                    "description lang=en": "AgentChat description here."
+                }
+            }
+        }
+    }
+    app = _make_app(metadata=metadata)
+    desc = _page_description(app, docname)
+    assert desc == "AgentChat description here."
+
+
+def test_page_description_missing() -> None:
+    app = _make_app(metadata={})
+    assert _page_description(app, "any-doc") is None
+
+
+def test_page_description_collapses_whitespace() -> None:
+    docname = "user-guide/core-user-guide/index"
+    metadata = {
+        docname: {
+            "myst": {
+                "html_meta": {
+                    "description lang=en": "  Line one\n  line two.  "
+                }
+            }
+        }
+    }
+    app = _make_app(metadata=metadata)
+    desc = _page_description(app, docname)
+    assert desc == "Line one line two."
+
+
+def test_page_content_extracts_text_from_html(tmp_path: Path) -> None:
+    """_page_content must return text inside <article>, excluding <nav>."""
+    docname = "user-guide/core-user-guide/index"
+    html = (
+        "<html><body>"
+        "<nav>Navigation</nav>"
+        "<article><h1>Core</h1><p>Core overview text.</p></article>"
+        "</body></html>"
+    )
+    html_file = tmp_path / "user-guide" / "core-user-guide" / "index.html"
+    html_file.parent.mkdir(parents=True, exist_ok=True)
+    html_file.write_text(html, encoding="utf-8")
+
+    app = _make_app(found_docs={docname}, titles={docname: _title_node("Core")})
+    app.outdir = str(tmp_path)
+
+    text = _page_content(app, docname)
+    assert text is not None
+    assert "Core overview text." in text
+    assert "Navigation" not in text
+
+
+def test_page_content_returns_none_for_missing_file() -> None:
+    """_page_content must return None when the HTML file does not exist."""
+    app = _make_app()
+    app.outdir = "/nonexistent/path"
+    assert _page_content(app, "user-guide/core-user-guide/index") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests for the full llms.txt content
+# ---------------------------------------------------------------------------
+
+
+def test_build_llms_txt_contains_required_sections() -> None:
+    """Generated llms.txt must start with an H1 heading and include H2 sections."""
+    found_docs = {
+        "user-guide/core-user-guide/index",
+        "user-guide/core-user-guide/installation",
+        "user-guide/agentchat-user-guide/index",
+        "user-guide/autogenstudio-user-guide/index",
+        "user-guide/extensions-user-guide/index",
+    }
+    titles = {docname: _title_node(docname.split("/")[-1].replace("-", " ").title()) for docname in found_docs}
+    app = _make_app(found_docs=found_docs, titles=titles)
+
+    content = _build_llms_txt(app)
+
+    assert content.startswith("# AutoGen"), "llms.txt must start with '# AutoGen'"
+    assert "## Core" in content
+    assert "## AgentChat" in content
+    assert "## AutoGen Studio" in content
+    assert "## Extensions" in content
+
+
+def test_build_llms_txt_uses_html_title() -> None:
+    """The H1 heading should use html_title when set."""
+    app = _make_app(html_title="My Project Docs", project="MyProject")
+    content = _build_llms_txt(app)
+    assert content.startswith("# My Project Docs")
+
+
+def test_build_llms_txt_falls_back_to_project_for_title() -> None:
+    """The H1 heading should fall back to project when html_title is not set."""
+    app = _make_app(html_title=None, project="FallbackProject")
+    content = _build_llms_txt(app)
+    assert content.startswith("# FallbackProject")
+
+
+def test_build_llms_txt_uses_llms_txt_description() -> None:
+    """When llms_txt_description is set, the blockquote must use it."""
+    app = _make_app(
+        llms_txt_description="Custom description for the project.",
+        found_docs=set(),
+        titles={},
+    )
+    content = _build_llms_txt(app)
+    assert "> Custom description for the project." in content
+
+
+def test_build_llms_txt_description_fallback_to_project() -> None:
+    """When llms_txt_description is not set, the project name is the blockquote."""
+    app = _make_app(project="MyProject", found_docs=set(), titles={})
+    content = _build_llms_txt(app)
+    assert "> MyProject" in content
+
+
+def test_build_llms_txt_uses_configured_sections() -> None:
+    """When llms_txt_sections is set, only those sections appear in the output."""
+    custom_sections = {"My Section": "custom/path"}
+    docname = "custom/path/page"
+    app = _make_app(
+        llms_txt_sections=custom_sections,
+        found_docs={docname},
+        titles={docname: _title_node("My Page")},
+    )
+    content = _build_llms_txt(app)
+    assert "## My Section" in content
+    assert "## Core" not in content
+    assert "## AgentChat" not in content
+
+
+def test_build_llms_txt_blockquote_format() -> None:
+    """Every blockquote line in the summary must start with '> '."""
+    app = _make_app(found_docs=set(), titles={})
+    content = _build_llms_txt(app)
+
+    blockquote_lines = [line for line in content.splitlines() if line.startswith(">")]
+    assert blockquote_lines, "No blockquote lines found in llms.txt"
+    for line in blockquote_lines:
+        assert line.startswith("> "), f"Blockquote line does not start with '> ': {line!r}"
+
+
+def test_build_llms_txt_links_use_base_url() -> None:
+    """Every link in llms.txt must use the configured html_baseurl."""
+    docname = "user-guide/core-user-guide/installation"
+    app = _make_app(
+        html_baseurl="https://microsoft.github.io/autogen/dev",
+        found_docs={docname},
+        titles={docname: _title_node("Installation")},
+    )
+
+    content = _build_llms_txt(app)
+    assert "https://microsoft.github.io/autogen/dev/" in content
+
+
+def test_build_llms_txt_links_use_llms_txt_base_url() -> None:
+    """When llms_txt_base_url is set, links must use that value."""
+    docname = "user-guide/core-user-guide/installation"
+    app = _make_app(
+        html_baseurl="/autogen/dev/",
+        llms_txt_base_url="https://microsoft.github.io/autogen/dev",
+        found_docs={docname},
+        titles={docname: _title_node("Installation")},
+    )
+
+    content = _build_llms_txt(app)
+    assert "https://microsoft.github.io/autogen/dev/" in content
+    assert content.count("/autogen/dev/") == content.count("https://microsoft.github.io/autogen/dev/"), (
+        "Root-relative prefix must not appear in llms.txt when llms_txt_base_url is set"
+    )
+
+
+def test_build_llms_txt_includes_description_when_available() -> None:
+    """Links with a description should use the ': description' format."""
+    docname = "user-guide/core-user-guide/index"
+    metadata = {
+        docname: {
+            "myst": {
+                "html_meta": {"description lang=en": "Core overview."}
+            }
+        }
+    }
+    app = _make_app(
+        found_docs={docname},
+        titles={docname: _title_node("Core")},
+        metadata=metadata,
+    )
+
+    content = _build_llms_txt(app)
+    assert "Core overview." in content
+
+
+def test_build_llms_txt_skips_docs_without_title() -> None:
+    """Pages without a Sphinx title node must be omitted from llms.txt."""
+    docname = "user-guide/core-user-guide/installation"
+    app = _make_app(found_docs={docname}, titles={})  # no title for this doc
+
+    content = _build_llms_txt(app)
+    # The document URL should not appear because the title is missing
+    assert "installation.html" not in content
+
+
+def test_build_llms_full_txt_contains_index(tmp_path: Path) -> None:
+    """llms-full.txt must begin with the same index as llms.txt."""
+    docname = "user-guide/core-user-guide/index"
+    app = _make_app(found_docs={docname}, titles={docname: _title_node("Core")})
+    app.outdir = str(tmp_path)
+
+    full_content = _build_llms_full_txt(app)
+    index_content = _build_llms_txt(app)
+    assert full_content.startswith(index_content)
+
+
+def test_build_llms_full_txt_appends_page_content(tmp_path: Path) -> None:
+    """llms-full.txt must include the body text of each page when available."""
+    docname = "user-guide/core-user-guide/index"
+    html = "<html><body><article><p>Core page body text.</p></article></body></html>"
+    html_file = tmp_path / "user-guide" / "core-user-guide" / "index.html"
+    html_file.parent.mkdir(parents=True, exist_ok=True)
+    html_file.write_text(html, encoding="utf-8")
+
+    app = _make_app(found_docs={docname}, titles={docname: _title_node("Core")})
+    app.outdir = str(tmp_path)
+
+    full_content = _build_llms_full_txt(app)
+    assert "Core page body text." in full_content
+
+
+def test_build_llms_full_txt_omits_content_when_file_missing(tmp_path: Path) -> None:
+    """llms-full.txt must not error when an HTML file is absent; just skip content."""
+    docname = "user-guide/core-user-guide/index"
+    app = _make_app(found_docs={docname}, titles={docname: _title_node("Core")})
+    app.outdir = str(tmp_path)  # no HTML files created
+
+    full_content = _build_llms_full_txt(app)
+    # Index must be present, but no per-page URL/body block should appear
+    assert "# AutoGen" in full_content
+    assert "URL:" not in full_content  # URL: lines only appear in content blocks
+
+
+def test_generate_llms_txt_writes_both_files(tmp_path: Path) -> None:
+    """generate_llms_txt must write both llms.txt and llms-full.txt to app.outdir."""
+    docname = "user-guide/agentchat-user-guide/index"
+    app = _make_app(
+        found_docs={docname},
+        titles={docname: _title_node("AgentChat")},
+    )
+    app.outdir = str(tmp_path)
+
+    generate_llms_txt(app, exception=None)
+
+    assert (tmp_path / "llms.txt").exists(), "llms.txt was not created"
+    assert (tmp_path / "llms-full.txt").exists(), "llms-full.txt was not created"
+    assert "# AutoGen" in (tmp_path / "llms.txt").read_text(encoding="utf-8")
+    assert "# AutoGen" in (tmp_path / "llms-full.txt").read_text(encoding="utf-8")
+
+
+def test_generate_llms_txt_skips_on_exception(tmp_path: Path) -> None:
+    """generate_llms_txt must be a no-op when an exception is passed."""
+    app = _make_app()
+    app.outdir = str(tmp_path)
+
+    generate_llms_txt(app, exception=RuntimeError("build failed"))
+
+    assert not (tmp_path / "llms.txt").exists()
+    assert not (tmp_path / "llms-full.txt").exists()
+
+
+def test_generate_llms_txt_skips_non_html_builder(tmp_path: Path) -> None:
+    """generate_llms_txt must be a no-op for non-HTML builders."""
+    from sphinx.builders import Builder
+
+    docname = "user-guide/core-user-guide/index"
+    app = _make_app(found_docs={docname}, titles={docname: _title_node("Core")})
+    app.outdir = str(tmp_path)
+    # Replace the HTML builder mock with a generic Builder mock
+    app.builder = MagicMock(spec=Builder)
+
+    generate_llms_txt(app, exception=None)
+
+    assert not (tmp_path / "llms.txt").exists()
+    assert not (tmp_path / "llms-full.txt").exists()


### PR DESCRIPTION
## Summary

Fixes microsoft/autogen#6271: Add llms.txt and llms-full.txt generation to AutoGen documentation

## Changes

This PR addresses the issue described above. Changes were developed on the `fix/6271-add-llms-txt-and-llms-full-txt-generation-to-autog` branch.

## Related Issue

- Closes #6271
