### PR TITLE
Pass tools through reflection model calls

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -1425,6 +1425,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         """
         all_messages = system_messages + await model_context.get_messages()
         llm_messages = cls._get_compatible_context(model_client=model_client, messages=all_messages)
+        tools = [tool for wb in workbench for tool in await wb.list_tools()] + handoff_tools
 
         reflection_result: Optional[CreateResult] = None
 
@@ -1434,6 +1435,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         if model_client_stream:
             async for chunk in model_client.create_stream(
                 llm_messages,
+                tools=tools,
                 json_output=output_content_type,
                 cancellation_token=cancellation_token,
                 tool_choice="none",  # Do not use tools in reflection flow.
@@ -1449,6 +1451,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         else:
             reflection_result = await model_client.create(
                 llm_messages,
+                tools=tools,
                 json_output=output_content_type,
                 cancellation_token=cancellation_token,
                 tool_choice="none",  # Do not use tools in reflection flow.

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -2916,10 +2916,12 @@ class TestAssistantAgentStreamingEdgeCases:
         model_client.model_info = {"function_calling": True, "vision": False, "family": ModelFamily.GPT_4O}
 
         call_count = 0
+        create_stream_calls: List[dict[str, Any]] = []
 
         async def mock_create_stream(*args: Any, **kwargs: Any) -> Any:
             nonlocal call_count
             call_count += 1
+            create_stream_calls.append(kwargs)
 
             if call_count == 1:
                 # First call: tool call
@@ -2968,6 +2970,12 @@ class TestAssistantAgentStreamingEdgeCases:
         assert chunk_events[0].content == "Reflection "
         assert chunk_events[1].content == "response "
         assert chunk_events[2].content == "complete"
+        assert len(create_stream_calls) == 2
+        assert len(create_stream_calls[0]["tools"]) == 1
+        assert create_stream_calls[0]["tools"][0]["name"] == "mock_tool_function"
+        assert len(create_stream_calls[1]["tools"]) == 1
+        assert create_stream_calls[1]["tools"][0]["name"] == "mock_tool_function"
+        assert create_stream_calls[1]["tool_choice"] == "none"
 
     @pytest.mark.asyncio
     async def test_streaming_with_large_chunks(self) -> None:


### PR DESCRIPTION
## Summary
- keep the same tool schemas available during the reflection pass when `reflect_on_tool_use=True`
- continue disabling tool execution in the reflection call via `tool_choice="none"`
- add a regression test covering the streaming reflection flow

## Testing
- `uv run --group dev pytest packages/autogen-agentchat/tests/test_assistant_agent.py -q -k "streaming_with_tool_calls_and_reflection or model_client_stream_with_tool_calls"`
- `uv run --group dev python -m ruff check packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py packages/autogen-agentchat/tests/test_assistant_agent.py`

Closes #6328