### PR TITLE
Improve provider validation ImportError messages with root cause details

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/validation/validation_service.py
+++ b/python/packages/autogen-studio/autogenstudio/validation/validation_service.py
@@ -43,11 +43,14 @@ class ValidationService:
                     suggestion="Ensure the class inherits from Component and implements required methods",
                 )
             return None
-        except ImportError:
+        except ImportError as e:
             return ValidationError(
                 field="provider",
-                error=f"Could not import provider {provider}",
-                suggestion="Check that the provider module is installed and the path is correct",
+                error=f"Could not import provider {provider}: {e}",
+                suggestion=(
+                    "Check that the provider module and its optional dependencies "
+                    "are installed, then verify the import path."
+                ),
             )
         except Exception as e:
             return ValidationError(

--- a/python/packages/autogen-studio/tests/test_validation_service.py
+++ b/python/packages/autogen-studio/tests/test_validation_service.py
@@ -1,0 +1,19 @@
+import importlib
+
+from autogenstudio.validation.validation_service import ValidationService
+
+
+def test_validate_provider_surfaces_original_import_error(monkeypatch):
+    """Validation errors should include the original import exception details."""
+
+    def _raise_import_error(_module_path: str):
+        raise ImportError("No module named 'vertexai'")
+
+    monkeypatch.setattr(importlib, "import_module", _raise_import_error)
+
+    result = ValidationService.validate_provider("OpenAIChatCompletionClient")
+
+    assert result is not None
+    assert result.field == "provider"
+    assert "Could not import provider autogen_ext.models.openai.OpenAIChatCompletionClient" in result.error
+    assert "No module named 'vertexai'" in result.error


### PR DESCRIPTION
## Summary
Improve `ValidationService.validate_provider()` so provider validation errors include the original `ImportError` details instead of only a generic message.

## Changes
- Keep the current provider context in the error message.
- Append the original import exception text (for example: `No module named 'vertexai'`).
- Update suggestion text to mention optional/transitive dependencies explicitly.
- Add a unit test for this behavior.

## Why
When optional dependency imports fail, users currently only see `Could not import provider ...` and lose the root cause. Including the original error makes troubleshooting much faster.

## Tests
- `uv run pytest -q tests/test_validation_service.py`
- `uv run ruff check autogenstudio/validation/validation_service.py tests/test_validation_service.py`

Fixes #4605