### PR TITLE
fix: include ImportError details in provider validation

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/validation/validation_service.py
+++ b/python/packages/autogen-studio/autogenstudio/validation/validation_service.py
@@ -43,11 +43,11 @@ class ValidationService:
                     suggestion="Ensure the class inherits from Component and implements required methods",
                 )
             return None
-        except ImportError:
+        except ImportError as e:
             return ValidationError(
                 field="provider",
-                error=f"Could not import provider {provider}",
-                suggestion="Check that the provider module is installed and the path is correct",
+                error=f"Could not import provider {provider}: {str(e)}",
+                suggestion="Check that the provider module and any optional/transitive dependencies are installed and the path is correct",
             )
         except Exception as e:
             return ValidationError(


### PR DESCRIPTION
When optional dependency imports fail, users currently see only a generic 'Could not import provider X' message without the original exception details (e.g., 'No module named vertexai').

This change:
- Captures the original ImportError exception
- Includes it in the error message for better debugging
- Updates suggestion to mention optional/transitive dependencies

Fixes #7404