### PR TITLE
fix(azure): single-chunk text stream misclassified as tool-call response

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
@@ -559,17 +559,22 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
 
         content: Union[str, List[FunctionCall]]
 
-        if len(content_deltas) > 1:
-            content = "".join(content_deltas)
+        if full_tool_calls:
+            # This is a tool call response.
+            content = list(full_tool_calls.values())
+            if content_deltas:
+                # Store any text alongside tool calls as thoughts.
+                thought = "".join(content_deltas)
+        else:
+            # This is a text response.
+            if content_deltas:
+                content = "".join(content_deltas)
+            else:
+                content = ""
             if chunk and chunk.usage:
                 completion_tokens = chunk.usage.completion_tokens
             else:
                 completion_tokens = 0
-        else:
-            content = list(full_tool_calls.values())
-
-            if len(content_deltas) > 0:
-                thought = "".join(content_deltas)
 
         usage = RequestUsage(
             completion_tokens=completion_tokens,

--- a/python/packages/autogen-ext/tests/models/test_azure_ai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_azure_ai_model_client.py
@@ -626,6 +626,66 @@ async def test_thought_field_with_tool_calls_streaming(
     assert final_result.thought == "Let me think about what function to call."
 
 
+@pytest.mark.asyncio
+async def test_azure_ai_chat_completion_client_create_stream_single_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test: a text response that arrives in a single streaming chunk
+    must be returned as string content, not misclassified as a tool-call response."""
+
+    async def _mock_single_chunk_stream(
+        *args: Any, **kwargs: Any
+    ) -> AsyncGenerator[StreamingChatCompletionsUpdate, None]:
+        yield StreamingChatCompletionsUpdate(
+            id="id",
+            choices=[
+                StreamingChatChoiceUpdate(
+                    index=0,
+                    finish_reason="stop",
+                    delta=StreamingChatResponseMessageUpdate(role="assistant", content="Short answer"),
+                )
+            ],
+            created=datetime.now(),
+            model="model",
+            usage=CompletionsUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+        )
+
+    async def _mock_create(
+        *args: Any, **kwargs: Any
+    ) -> ChatCompletions | AsyncGenerator[StreamingChatCompletionsUpdate, None]:
+        stream = kwargs.get("stream", False)
+        if stream:
+            return _mock_single_chunk_stream(*args, **kwargs)
+        raise NotImplementedError
+
+    monkeypatch.setattr(ChatCompletionsClient, "complete", _mock_create)
+    client = AzureAIChatCompletionClient(
+        endpoint="endpoint",
+        credential=AzureKeyCredential("api_key"),
+        model_info={
+            "json_output": False,
+            "function_calling": False,
+            "vision": False,
+            "family": "unknown",
+            "structured_output": False,
+        },
+        model="model",
+    )
+
+    chunks: List[str | CreateResult] = []
+    async for chunk in client.create_stream(messages=[UserMessage(content="Hi", source="user")]):
+        chunks.append(chunk)
+
+    # The streamed text delta should appear as a string chunk.
+    assert chunks[0] == "Short answer"
+
+    # The final CreateResult must contain the text as string content.
+    final = chunks[-1]
+    assert isinstance(final, CreateResult)
+    assert isinstance(final.content, str)
+    assert final.content == "Short answer"
+
+
 def _pass_function(input: str) -> str:
     """Simple passthrough function."""
     return f"Processed: {input}"


### PR DESCRIPTION
## Summary

- **Bug**: `AzureAIChatCompletionClient.create_stream()` uses `len(content_deltas) > 1` to distinguish text responses from tool-call responses. When a model returns a short answer in a single streaming chunk, `content_deltas` has exactly 1 element, the `> 1` check fails, and the code falls through to return an empty tool-call list `[]` as content — silently discarding the actual text (or misassigning it to `thought`).
- **Fix**: Rewrite the content/tool-call branching to match the OpenAI client's correct logic: check `if full_tool_calls:` first, else treat as text content.
- **Test**: Add regression test that streams a single-chunk text response and asserts it is returned as string content in the `CreateResult`.

## Root cause

```python
# BEFORE (wrong) — line 562 of _azure_ai_client.py
if len(content_deltas) > 1:        # <-- fails when exactly 1 chunk
    content = "".join(content_deltas)
else:
    content = list(full_tool_calls.values())  # <-- returns [] for text responses
```

```python
# AFTER (correct) — matches OpenAI client pattern
if full_tool_calls:
    content = list(full_tool_calls.values())
else:
    content = "".join(content_deltas) if content_deltas else ""
```

## Test plan

- [x] New test `test_azure_ai_chat_completion_client_create_stream_single_chunk` — mocks a single-chunk text stream, asserts `CreateResult.content` is a string (not an empty list)
- [ ] Existing Azure AI model client tests continue to pass
- [ ] Manual verification with a real Azure endpoint returning short responses