### PR TITLE
fix(llm): add default 60s timeout to prevent hanging LLM API calls

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -141,6 +141,9 @@ def _create_args_from_config(config: Mapping[str, Any]) -> Dict[str, Any]:
         raise ValueError(f"Required create args are missing: {required_create_args - create_args_keys}")
     if disallowed_create_args.intersection(create_args_keys):
         raise ValueError(f"Disallowed create args are present: {disallowed_create_args.intersection(create_args_keys)}")
+    # Add default timeout of 60s to prevent indefinite hangs on network issues
+    if "timeout" not in create_args_keys:
+        create_args["timeout"] = 60.0
     return create_args
 
 


### PR DESCRIPTION
## Summary

Adds default 60-second timeout to OpenAI client API calls to prevent indefinite hangs on network issues.

## Problem

Currently, autogen creates OpenAI client API calls without a default timeout, which can cause:
- Multi-agent workflows stuck waiting forever on network issues
- No way to recover from transient network failures

## Solution

Add a default timeout of 60 seconds in `_create_args_from_config()` when no timeout is explicitly provided by the user.

## Changes

- Modified `_create_args_from_config()` in `python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py`
- Added 3 lines to check if timeout is not provided and set default to 60.0 seconds