### PR TITLE
docs: fix RedisStore class name in cache examples

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -214,7 +214,7 @@ async def main():
         # from autogen_ext.cache_store.redis import RedisStore
         # import redis
         # redis_instance = redis.Redis()
-        # cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
+        # cache_store = RedisStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
         cache_store = DiskCacheStore[CHAT_CACHE_VALUE_TYPE](Cache(tmpdirname))
         cache_client = ChatCompletionCache(openai_model_client, cache_store)
 

--- a/python/docs/src/user-guide/core-user-guide/components/model-clients.ipynb
+++ b/python/docs/src/user-guide/core-user-guide/components/model-clients.ipynb
@@ -306,7 +306,7 @@
     "        # from autogen_ext.cache_store.redis import RedisStore\n",
     "        # import redis\n",
     "        # redis_instance = redis.Redis()\n",
-    "        # cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)\n",
+    "        # cache_store = RedisStore[CHAT_CACHE_VALUE_TYPE](redis_instance)\n",
     "        cache_store = DiskCacheStore[CHAT_CACHE_VALUE_TYPE](Cache(tmpdirname))\n",
     "        cache_client = ChatCompletionCache(openai_model_client, cache_store)\n",
     "\n",

--- a/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
@@ -65,7 +65,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
                 # from autogen_ext.cache_store.redis import RedisStore
                 # import redis
                 # redis_instance = redis.Redis()
-                # cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
+                # cache_store = RedisStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
                 cache_store = DiskCacheStore[CHAT_CACHE_VALUE_TYPE](Cache(tmpdirname))
                 cache_client = ChatCompletionCache(openai_model_client, cache_store)
 


### PR DESCRIPTION
## Why are these changes needed?
This fixes the Redis cache example referenced in issue #7084. The documentation imports `RedisStore` but one example still instantiates `RedisCacheStore`, which does not exist.

## Related issue number
Closes #7084

## Checks
- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Validation
- Not run (documentation/comment-only change)