### PR TITLE
fix: clean up temp directory in JupyterCodeExecutor.stop()

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -145,11 +145,13 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
 
-        self._output_dir: Path = Path(tempfile.mkdtemp()) if output_dir is None else Path(output_dir)
-        self._output_dir.mkdir(exist_ok=True, parents=True)
-
         self._temp_dir: Optional[tempfile.TemporaryDirectory[str]] = None
-        self._temp_dir_path: Optional[Path] = None
+        if output_dir is None:
+            self._temp_dir = tempfile.TemporaryDirectory()
+            self._output_dir = Path(self._temp_dir.name)
+        else:
+            self._output_dir = Path(output_dir)
+        self._output_dir.mkdir(exist_ok=True, parents=True)
 
         self._started = False
 
@@ -307,6 +309,10 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
 
         self._client = None
         self._started = False
+
+        if self._temp_dir is not None:
+            self._temp_dir.cleanup()
+            self._temp_dir = None
 
     def _to_config(self) -> JupyterCodeExecutorConfig:
         """Convert current instance to config object"""

--- a/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
@@ -225,3 +225,29 @@ async def test_runtime_error_not_started() -> None:
     code_blocks = [CodeBlock(code="print('hello world!')", language="python")]
     with pytest.raises(RuntimeError, match="Executor must be started before executing cells"):
         await executor.execute_code_blocks(code_blocks, CancellationToken())
+
+
+@pytest.mark.asyncio
+async def test_temp_dir_cleanup_on_stop() -> None:
+    """Test that temp directory is cleaned up when output_dir is not specified."""
+    executor = JupyterCodeExecutor()
+    temp_dir_path = executor.output_dir
+    assert temp_dir_path.exists()
+
+    await executor.start()
+    code_blocks = [CodeBlock(code="print('hello world!')", language="python")]
+    await executor.execute_code_blocks(code_blocks, CancellationToken())
+    await executor.stop()
+
+    assert not temp_dir_path.exists(), "Temp directory should be cleaned up after stop()"
+
+
+@pytest.mark.asyncio
+async def test_explicit_output_dir_not_cleaned_up(tmp_path: Path) -> None:
+    """Test that explicitly provided output_dir is NOT cleaned up after stop()."""
+    async with JupyterCodeExecutor(output_dir=tmp_path) as executor:
+        await executor.start()
+        code_blocks = [CodeBlock(code="print('hello world!')", language="python")]
+        await executor.execute_code_blocks(code_blocks, CancellationToken())
+
+    assert tmp_path.exists(), "Explicit output_dir should NOT be cleaned up after stop()"


### PR DESCRIPTION
## Summary

Fixes #7217

`JupyterCodeExecutor` creates a temp directory via `tempfile.mkdtemp()` when no `output_dir` is provided, but never cleans it up in `stop()`. This is inconsistent with every other executor in the codebase (`LocalCommandLineCodeExecutor`, `DockerCommandLineCodeExecutor`, `AzureContainerCodeExecutor`) which all properly clean up their temp directories.

Over time, leaked directories and their contents (generated images, HTML files) accumulate on disk.

## Changes

- **Use `tempfile.TemporaryDirectory()`** instead of `tempfile.mkdtemp()` when `output_dir` is `None`. This provides automatic cleanup via context manager semantics.
- **Add cleanup in `stop()`** method: if `_temp_dir` exists, call `cleanup()` and set to `None`.
- **Add two tests**:
  - `test_temp_dir_cleanup_on_stop` — verifies temp dir is removed after `stop()` when no `output_dir` is provided
  - `test_explicit_output_dir_not_cleaned_up` — verifies explicitly provided `output_dir` is preserved

## Pattern consistency

This follows the exact pattern used by `LocalCommandLineCodeExecutor`:

```python
# LocalCommandLineCodeExecutor (working correctly)
self._temp_dir = tempfile.TemporaryDirectory()  # line 255
# ...
self._temp_dir.cleanup()  # line 501
```

## Testing

- Added tests verify both the cleanup case and the non-cleanup case
- All existing tests pass (they all use explicit `output_dir`, so behavior is unchanged)