### PR TITLE
feat: Add CRW web scraping tools

### DIFF
--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -144,6 +144,10 @@ http-tool = [
     "json-schema-to-pydantic>=0.2.0"
 ]
 
+crw = [
+    "httpx>=0.27.0",
+]
+
 semantic-kernel-all = [
     "semantic-kernel[google,hugging_face,mistralai,ollama,onnx,anthropic,usearch,pandas,aws,dapr]>=1.17.1",
 ]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/crw/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/crw/__init__.py
@@ -1,0 +1,19 @@
+from ._crw_tools import (
+    CrwCrawlTool,
+    CrwMapTool,
+    CrwScrapeTool,
+    CrawlResult,
+    CrawlStatusResult,
+    MapResult,
+    ScrapeResult,
+)
+
+__all__ = [
+    "CrwCrawlTool",
+    "CrwMapTool",
+    "CrwScrapeTool",
+    "CrawlResult",
+    "CrawlStatusResult",
+    "MapResult",
+    "ScrapeResult",
+]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/crw/_crw_tools.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/crw/_crw_tools.py
@@ -11,7 +11,7 @@ See https://github.com/nicholasgasior/crw for more information.
 """
 
 import asyncio
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 import httpx
 from autogen_core import CancellationToken
@@ -117,7 +117,7 @@ class CrwScrapeTool(BaseTool[ScrapeArgs, ScrapeResult]):
             ScrapeArgs,
             ScrapeResult,
             "scrape_url",
-            "Scrape a URL and return its content as markdown. Powered by CRW web scraper.",
+            "Scrape a URL and return its content (markdown, HTML, plain text, and links). Powered by the CRW web scraper.",
         )
 
     def _headers(self) -> dict[str, str]:
@@ -270,6 +270,8 @@ class CrwCrawlTool(BaseTool[CrawlArgs, CrawlResult]):
             "formats": args.formats,
         }
 
+        max_polls = int(self._timeout / args.poll_interval) if args.poll_interval > 0 else 150
+
         try:
             async with httpx.AsyncClient(timeout=self._timeout) as client:
                 resp = await client.post(
@@ -280,14 +282,24 @@ class CrwCrawlTool(BaseTool[CrawlArgs, CrawlResult]):
                 resp.raise_for_status()
                 body = resp.json()
 
-            job_id = body.get("id")
-            if not args.poll:
-                return CrawlResult(success=True, job_id=job_id, status="scraping")
+                success_flag = body.get("success", True)
+                job_id = body.get("id")
+                if not success_flag or not job_id:
+                    return CrawlResult(
+                        success=False,
+                        job_id=job_id,
+                        status=body.get("status"),
+                        error=body.get("error") or "Failed to start crawl job.",
+                    )
 
-            # Poll until completion
-            while True:
-                await asyncio.sleep(args.poll_interval)
-                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                if not args.poll:
+                    return CrawlResult(success=True, job_id=job_id, status="scraping")
+
+                # Poll until completion
+                for _ in range(max_polls):
+                    cancellation_token.throw_if_cancellation_requested()
+                    await asyncio.sleep(args.poll_interval)
+
                     status_resp = await client.get(
                         f"{self._base_url}/v1/crawl/{job_id}",
                         headers=self._headers(),
@@ -295,26 +307,33 @@ class CrwCrawlTool(BaseTool[CrawlArgs, CrawlResult]):
                     status_resp.raise_for_status()
                     status_body = status_resp.json()
 
-                status = status_body.get("status", "")
-                if status in ("completed", "failed"):
-                    pages = [
-                        CrawlPageResult(
-                            markdown=p.get("markdown"),
-                            title=p.get("metadata", {}).get("title"),
-                            source_url=p.get("metadata", {}).get("sourceURL"),
-                            status_code=p.get("metadata", {}).get("statusCode"),
+                    status = status_body.get("status", "")
+                    if status in ("completed", "failed"):
+                        pages = [
+                            CrawlPageResult(
+                                markdown=p.get("markdown"),
+                                title=p.get("metadata", {}).get("title"),
+                                source_url=p.get("metadata", {}).get("sourceURL"),
+                                status_code=p.get("metadata", {}).get("statusCode"),
+                            )
+                            for p in status_body.get("data", [])
+                        ]
+                        return CrawlResult(
+                            success=status == "completed",
+                            job_id=job_id,
+                            status=status,
+                            total=status_body.get("total"),
+                            completed=status_body.get("completed"),
+                            pages=pages,
+                            error=status_body.get("error") if status == "failed" else None,
                         )
-                        for p in status_body.get("data", [])
-                    ]
-                    return CrawlResult(
-                        success=status == "completed",
-                        job_id=job_id,
-                        status=status,
-                        total=status_body.get("total"),
-                        completed=status_body.get("completed"),
-                        pages=pages,
-                        error=status_body.get("error") if status == "failed" else None,
-                    )
+
+                return CrawlResult(
+                    success=False,
+                    job_id=job_id,
+                    status="timeout",
+                    error=f"Crawl did not complete within {max_polls} polls.",
+                )
         except Exception as e:
             return CrawlResult(success=False, error=str(e))
 

--- a/python/packages/autogen-ext/src/autogen_ext/tools/crw/_crw_tools.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/crw/_crw_tools.py
@@ -1,0 +1,416 @@
+"""CRW web scraping tools for AutoGen agents.
+
+CRW is an open-source web scraper for AI agents. It provides a single Rust binary
+with a Firecrawl-compatible REST API. These tools wrap the CRW API endpoints:
+- POST /v1/scrape - Scrape a single URL
+- POST /v1/crawl - Start a multi-page crawl
+- GET /v1/crawl/{id} - Check crawl status and get results
+- POST /v1/map - Discover all links on a site
+
+See https://github.com/nicholasgasior/crw for more information.
+"""
+
+import asyncio
+from typing import Any, Literal, Optional
+
+import httpx
+from autogen_core import CancellationToken
+from autogen_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+# --- Scrape ---
+
+
+class ScrapeArgs(BaseModel):
+    url: str = Field(..., description="The URL to scrape (http/https only).")
+    formats: list[str] = Field(
+        default=["markdown"],
+        description='Output formats: "markdown", "html", "rawHtml", "plainText", "links".',
+    )
+    only_main_content: bool = Field(
+        default=True,
+        description="Strip navigation, footer, and sidebar elements.",
+    )
+    css_selector: Optional[str] = Field(
+        default=None,
+        description="Extract only elements matching this CSS selector.",
+    )
+    render_js: Optional[bool] = Field(
+        default=None,
+        description="null=auto, true=force JS rendering, false=HTTP only.",
+    )
+    wait_for: Optional[int] = Field(
+        default=None,
+        description="Milliseconds to wait after JS rendering.",
+    )
+
+
+class ScrapeResult(BaseModel):
+    success: bool
+    markdown: Optional[str] = None
+    html: Optional[str] = None
+    plain_text: Optional[str] = None
+    links: Optional[list[str]] = None
+    title: Optional[str] = None
+    source_url: Optional[str] = None
+    error: Optional[str] = None
+
+
+class CrwScrapeTool(BaseTool[ScrapeArgs, ScrapeResult]):
+    """Scrape a single URL and return its content as markdown, HTML, or plain text.
+
+    Uses the CRW web scraper's ``POST /v1/scrape`` endpoint. CRW is an open-source,
+    high-performance web scraper built in Rust with a Firecrawl-compatible REST API.
+
+    .. note::
+        This tool requires the :code:`crw` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[crw]"
+
+        You must have a CRW server running. Install and start it with:
+
+        .. code-block:: bash
+
+            # Install crw (see https://github.com/nicholasgasior/crw)
+            crw --port 3000
+
+    Example:
+        Basic usage::
+
+            import asyncio
+
+            from autogen_agentchat.agents import AssistantAgent
+            from autogen_agentchat.messages import TextMessage
+            from autogen_core import CancellationToken
+            from autogen_ext.models.openai import OpenAIChatCompletionClient
+            from autogen_ext.tools.crw import CrwScrapeTool
+
+            scrape_tool = CrwScrapeTool(base_url="http://localhost:3000")
+
+            async def main():
+                model = OpenAIChatCompletionClient(model="gpt-4o")
+                agent = AssistantAgent("web_agent", model_client=model, tools=[scrape_tool])
+                result = await agent.on_messages(
+                    [TextMessage(content="Scrape https://example.com and summarize it.", source="user")],
+                    CancellationToken(),
+                )
+                print(result.chat_message)
+
+            asyncio.run(main())
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:3000",
+        api_key: Optional[str] = None,
+        timeout: float = 120.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+        super().__init__(
+            ScrapeArgs,
+            ScrapeResult,
+            "scrape_url",
+            "Scrape a URL and return its content as markdown. Powered by CRW web scraper.",
+        )
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    async def run(self, args: ScrapeArgs, cancellation_token: CancellationToken) -> ScrapeResult:
+        payload: dict[str, Any] = {
+            "url": args.url,
+            "formats": args.formats,
+            "onlyMainContent": args.only_main_content,
+        }
+        if args.css_selector is not None:
+            payload["cssSelector"] = args.css_selector
+        if args.render_js is not None:
+            payload["renderJs"] = args.render_js
+        if args.wait_for is not None:
+            payload["waitFor"] = args.wait_for
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.post(
+                    f"{self._base_url}/v1/scrape",
+                    headers=self._headers(),
+                    json=payload,
+                )
+                resp.raise_for_status()
+                body = resp.json()
+
+            data = body.get("data", {})
+            metadata = data.get("metadata", {})
+            return ScrapeResult(
+                success=body.get("success", True),
+                markdown=data.get("markdown"),
+                html=data.get("html"),
+                plain_text=data.get("plainText"),
+                links=data.get("links"),
+                title=metadata.get("title"),
+                source_url=metadata.get("sourceURL"),
+            )
+        except Exception as e:
+            return ScrapeResult(success=False, error=str(e))
+
+
+# --- Crawl ---
+
+
+class CrawlArgs(BaseModel):
+    url: str = Field(..., description="The starting URL for the crawl.")
+    max_depth: int = Field(default=2, description="Maximum link-follow depth.")
+    max_pages: int = Field(default=100, description="Maximum number of pages to scrape.")
+    formats: list[str] = Field(default=["markdown"], description="Output formats for each page.")
+    poll: bool = Field(
+        default=True,
+        description="If true, poll until the crawl completes and return results. If false, return the job ID immediately.",
+    )
+    poll_interval: float = Field(default=2.0, description="Seconds between status polls when poll=True.")
+
+
+class CrawlPageResult(BaseModel):
+    markdown: Optional[str] = None
+    title: Optional[str] = None
+    source_url: Optional[str] = None
+    status_code: Optional[int] = None
+
+
+class CrawlResult(BaseModel):
+    success: bool
+    job_id: Optional[str] = None
+    status: Optional[str] = None
+    total: Optional[int] = None
+    completed: Optional[int] = None
+    pages: list[CrawlPageResult] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class CrawlStatusResult(BaseModel):
+    success: bool
+    status: Optional[str] = None
+    total: Optional[int] = None
+    completed: Optional[int] = None
+    pages: list[CrawlPageResult] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class CrwCrawlTool(BaseTool[CrawlArgs, CrawlResult]):
+    """Crawl a website starting from a URL, following links up to a configurable depth.
+
+    Uses the CRW web scraper's ``POST /v1/crawl`` and ``GET /v1/crawl/{id}`` endpoints.
+    By default, this tool polls until the crawl completes and returns all scraped pages.
+
+    .. note::
+        This tool requires the :code:`crw` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[crw]"
+
+    Example:
+        Basic usage::
+
+            import asyncio
+
+            from autogen_ext.tools.crw import CrwCrawlTool
+            from autogen_core import CancellationToken
+
+            crawl_tool = CrwCrawlTool(base_url="http://localhost:3000")
+
+            async def main():
+                result = await crawl_tool.run_json(
+                    {"url": "https://example.com", "max_depth": 1, "max_pages": 5},
+                    CancellationToken(),
+                )
+                print(result)
+
+            asyncio.run(main())
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:3000",
+        api_key: Optional[str] = None,
+        timeout: float = 300.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+        super().__init__(
+            CrawlArgs,
+            CrawlResult,
+            "crawl_website",
+            "Crawl a website starting from a URL, following links to discover and scrape multiple pages.",
+        )
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    async def run(self, args: CrawlArgs, cancellation_token: CancellationToken) -> CrawlResult:
+        payload: dict[str, Any] = {
+            "url": args.url,
+            "maxDepth": args.max_depth,
+            "maxPages": args.max_pages,
+            "formats": args.formats,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.post(
+                    f"{self._base_url}/v1/crawl",
+                    headers=self._headers(),
+                    json=payload,
+                )
+                resp.raise_for_status()
+                body = resp.json()
+
+            job_id = body.get("id")
+            if not args.poll:
+                return CrawlResult(success=True, job_id=job_id, status="scraping")
+
+            # Poll until completion
+            while True:
+                await asyncio.sleep(args.poll_interval)
+                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                    status_resp = await client.get(
+                        f"{self._base_url}/v1/crawl/{job_id}",
+                        headers=self._headers(),
+                    )
+                    status_resp.raise_for_status()
+                    status_body = status_resp.json()
+
+                status = status_body.get("status", "")
+                if status in ("completed", "failed"):
+                    pages = [
+                        CrawlPageResult(
+                            markdown=p.get("markdown"),
+                            title=p.get("metadata", {}).get("title"),
+                            source_url=p.get("metadata", {}).get("sourceURL"),
+                            status_code=p.get("metadata", {}).get("statusCode"),
+                        )
+                        for p in status_body.get("data", [])
+                    ]
+                    return CrawlResult(
+                        success=status == "completed",
+                        job_id=job_id,
+                        status=status,
+                        total=status_body.get("total"),
+                        completed=status_body.get("completed"),
+                        pages=pages,
+                        error=status_body.get("error") if status == "failed" else None,
+                    )
+        except Exception as e:
+            return CrawlResult(success=False, error=str(e))
+
+
+# --- Map ---
+
+
+class MapArgs(BaseModel):
+    url: str = Field(..., description="The URL to discover links from.")
+    max_depth: int = Field(default=2, description="Maximum discovery depth.")
+    use_sitemap: bool = Field(default=True, description="Also read sitemap.xml for link discovery.")
+
+
+class MapResult(BaseModel):
+    success: bool
+    links: list[str] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class CrwMapTool(BaseTool[MapArgs, MapResult]):
+    """Discover all links on a website by crawling and reading its sitemap.
+
+    Uses the CRW web scraper's ``POST /v1/map`` endpoint to return a flat list
+    of all discovered URLs on a site.
+
+    .. note::
+        This tool requires the :code:`crw` extra for the :code:`autogen-ext` package.
+
+        To install:
+
+        .. code-block:: bash
+
+            pip install -U "autogen-agentchat" "autogen-ext[crw]"
+
+    Example:
+        Basic usage::
+
+            import asyncio
+
+            from autogen_ext.tools.crw import CrwMapTool
+            from autogen_core import CancellationToken
+
+            map_tool = CrwMapTool(base_url="http://localhost:3000")
+
+            async def main():
+                result = await map_tool.run_json(
+                    {"url": "https://example.com"},
+                    CancellationToken(),
+                )
+                print(result)
+
+            asyncio.run(main())
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:3000",
+        api_key: Optional[str] = None,
+        timeout: float = 120.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+        super().__init__(
+            MapArgs,
+            MapResult,
+            "map_site",
+            "Discover all links on a website. Returns a list of URLs found by crawling and reading sitemaps.",
+        )
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    async def run(self, args: MapArgs, cancellation_token: CancellationToken) -> MapResult:
+        payload: dict[str, Any] = {
+            "url": args.url,
+            "maxDepth": args.max_depth,
+            "useSitemap": args.use_sitemap,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.post(
+                    f"{self._base_url}/v1/map",
+                    headers=self._headers(),
+                    json=payload,
+                )
+                resp.raise_for_status()
+                body = resp.json()
+
+            return MapResult(
+                success=body.get("success", True),
+                links=body.get("data", {}).get("links", []),
+            )
+        except Exception as e:
+            return MapResult(success=False, error=str(e))

--- a/python/packages/autogen-ext/tests/tools/crw/test_crw_tools.py
+++ b/python/packages/autogen-ext/tests/tools/crw/test_crw_tools.py
@@ -1,0 +1,223 @@
+"""Unit tests for CRW web scraping tools."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from autogen_core import CancellationToken
+from autogen_ext.tools.crw import CrwCrawlTool, CrwMapTool, CrwScrapeTool
+from autogen_ext.tools.crw._crw_tools import (
+    CrawlArgs,
+    MapArgs,
+    MapResult,
+    ScrapeArgs,
+    ScrapeResult,
+)
+
+
+# --- CrwScrapeTool ---
+
+
+class TestCrwScrapeTool:
+    def test_tool_properties(self) -> None:
+        tool = CrwScrapeTool(base_url="http://localhost:3000")
+        assert tool.name == "scrape_url"
+        assert "content" in tool.description
+        assert "CRW" in tool.description
+
+    def test_custom_base_url_strips_trailing_slash(self) -> None:
+        tool = CrwScrapeTool(base_url="http://example.com:8080/")
+        assert tool._base_url == "http://example.com:8080"
+
+    def test_headers_without_api_key(self) -> None:
+        tool = CrwScrapeTool()
+        headers = tool._headers()
+        assert headers == {"Content-Type": "application/json"}
+        assert "Authorization" not in headers
+
+    def test_headers_with_api_key(self) -> None:
+        tool = CrwScrapeTool(api_key="test-key")
+        headers = tool._headers()
+        assert headers["Authorization"] == "Bearer test-key"
+
+    @pytest.mark.asyncio
+    async def test_scrape_success(self) -> None:
+        tool = CrwScrapeTool(base_url="http://localhost:3000")
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "success": True,
+            "data": {
+                "markdown": "# Hello World",
+                "metadata": {"title": "Test Page", "sourceURL": "https://example.com"},
+            },
+        }
+        mock_response.raise_for_status = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("autogen_ext.tools.crw._crw_tools.httpx.AsyncClient", return_value=mock_client):
+            result = await tool.run(ScrapeArgs(url="https://example.com"), CancellationToken())
+
+        assert isinstance(result, ScrapeResult)
+        assert result.success is True
+        assert result.markdown == "# Hello World"
+        assert result.title == "Test Page"
+
+    @pytest.mark.asyncio
+    async def test_scrape_error(self) -> None:
+        tool = CrwScrapeTool(base_url="http://localhost:3000")
+
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = Exception("Connection refused")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("autogen_ext.tools.crw._crw_tools.httpx.AsyncClient", return_value=mock_client):
+            result = await tool.run(ScrapeArgs(url="https://example.com"), CancellationToken())
+
+        assert result.success is False
+        assert "Connection refused" in (result.error or "")
+
+
+# --- CrwCrawlTool ---
+
+
+class TestCrwCrawlTool:
+    def test_tool_properties(self) -> None:
+        tool = CrwCrawlTool(base_url="http://localhost:3000")
+        assert tool.name == "crawl_website"
+
+    @pytest.mark.asyncio
+    async def test_crawl_no_poll(self) -> None:
+        tool = CrwCrawlTool(base_url="http://localhost:3000")
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {"success": True, "id": "job-123"}
+        mock_response.raise_for_status = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("autogen_ext.tools.crw._crw_tools.httpx.AsyncClient", return_value=mock_client):
+            result = await tool.run(
+                CrawlArgs(url="https://example.com", poll=False),
+                CancellationToken(),
+            )
+
+        assert result.success is True
+        assert result.job_id == "job-123"
+        assert result.status == "scraping"
+
+    @pytest.mark.asyncio
+    async def test_crawl_initial_failure(self) -> None:
+        """POST /v1/crawl returns success=false or no job id."""
+        tool = CrwCrawlTool(base_url="http://localhost:3000")
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {"success": False, "error": "Invalid URL"}
+        mock_response.raise_for_status = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("autogen_ext.tools.crw._crw_tools.httpx.AsyncClient", return_value=mock_client):
+            result = await tool.run(
+                CrawlArgs(url="https://example.com"),
+                CancellationToken(),
+            )
+
+        assert result.success is False
+        assert result.error == "Invalid URL"
+
+    @pytest.mark.asyncio
+    async def test_crawl_poll_completed(self) -> None:
+        tool = CrwCrawlTool(base_url="http://localhost:3000")
+
+        post_response = AsyncMock()
+        post_response.json.return_value = {"success": True, "id": "job-456"}
+        post_response.raise_for_status = AsyncMock()
+
+        get_response = AsyncMock()
+        get_response.json.return_value = {
+            "status": "completed",
+            "total": 1,
+            "completed": 1,
+            "data": [
+                {
+                    "markdown": "# Page",
+                    "metadata": {"title": "Page Title", "sourceURL": "https://example.com", "statusCode": 200},
+                }
+            ],
+        }
+        get_response.raise_for_status = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = post_response
+        mock_client.get.return_value = get_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("autogen_ext.tools.crw._crw_tools.httpx.AsyncClient", return_value=mock_client),
+            patch("autogen_ext.tools.crw._crw_tools.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await tool.run(
+                CrawlArgs(url="https://example.com", poll_interval=0.01),
+                CancellationToken(),
+            )
+
+        assert result.success is True
+        assert result.job_id == "job-456"
+        assert len(result.pages) == 1
+        assert result.pages[0].title == "Page Title"
+
+
+# --- CrwMapTool ---
+
+
+class TestCrwMapTool:
+    def test_tool_properties(self) -> None:
+        tool = CrwMapTool(base_url="http://localhost:3000")
+        assert tool.name == "map_site"
+        assert "links" in tool.description
+
+    @pytest.mark.asyncio
+    async def test_map_success(self) -> None:
+        tool = CrwMapTool(base_url="http://localhost:3000")
+        mock_response = AsyncMock()
+        mock_response.json.return_value = {
+            "success": True,
+            "data": {"links": ["https://example.com/a", "https://example.com/b"]},
+        }
+        mock_response.raise_for_status = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("autogen_ext.tools.crw._crw_tools.httpx.AsyncClient", return_value=mock_client):
+            result = await tool.run(MapArgs(url="https://example.com"), CancellationToken())
+
+        assert isinstance(result, MapResult)
+        assert result.success is True
+        assert len(result.links) == 2
+
+    @pytest.mark.asyncio
+    async def test_map_error(self) -> None:
+        tool = CrwMapTool(base_url="http://localhost:3000")
+
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = Exception("Timeout")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("autogen_ext.tools.crw._crw_tools.httpx.AsyncClient", return_value=mock_client):
+            result = await tool.run(MapArgs(url="https://example.com"), CancellationToken())
+
+        assert result.success is False
+        assert "Timeout" in (result.error or "")

--- a/python/samples/agentchat_crw_web_scraping/README.md
+++ b/python/samples/agentchat_crw_web_scraping/README.md
@@ -1,0 +1,26 @@
+# CRW Web Scraping Tools for AutoGen
+
+This sample shows how to use [CRW](https://github.com/nicholasgasior/crw) web scraping tools with AutoGen agents.
+
+CRW is an open-source web scraper for AI agents — a single Rust binary with a Firecrawl-compatible REST API.
+
+## Tools
+
+| Tool | Function | CRW Endpoint |
+|------|----------|-------------|
+| `CrwScrapeTool` | Scrape a single URL | `POST /v1/scrape` |
+| `CrwCrawlTool` | Crawl a website (multi-page) | `POST /v1/crawl` + `GET /v1/crawl/{id}` |
+| `CrwMapTool` | Discover all links on a site | `POST /v1/map` |
+
+## Prerequisites
+
+1. Install CRW: see [CRW installation docs](https://github.com/nicholasgasior/crw)
+2. Start the server: `crw --port 3000`
+3. Install Python deps: `pip install "autogen-agentchat" "autogen-ext[crw,openai]"`
+4. Set `OPENAI_API_KEY` environment variable
+
+## Run
+
+```bash
+python app.py
+```

--- a/python/samples/agentchat_crw_web_scraping/README.md
+++ b/python/samples/agentchat_crw_web_scraping/README.md
@@ -7,7 +7,7 @@ CRW is an open-source web scraper for AI agents — a single Rust binary with a 
 ## Tools
 
 | Tool | Function | CRW Endpoint |
-|------|----------|-------------|
+|------|----------|--------------|
 | `CrwScrapeTool` | Scrape a single URL | `POST /v1/scrape` |
 | `CrwCrawlTool` | Crawl a website (multi-page) | `POST /v1/crawl` + `GET /v1/crawl/{id}` |
 | `CrwMapTool` | Discover all links on a site | `POST /v1/map` |

--- a/python/samples/agentchat_crw_web_scraping/app.py
+++ b/python/samples/agentchat_crw_web_scraping/app.py
@@ -1,0 +1,115 @@
+"""Example: Using CRW web scraping tools with AutoGen agents.
+
+Prerequisites:
+    1. Install dependencies:
+        pip install "autogen-agentchat" "autogen-ext[crw,openai]"
+
+    2. Start a CRW server (https://github.com/nicholasgasior/crw):
+        crw --port 3000
+
+    3. Set your OpenAI API key:
+        export OPENAI_API_KEY=sk-...
+
+Usage:
+    python app.py
+"""
+
+import asyncio
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.ui import Console
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.tools.crw import CrwCrawlTool, CrwMapTool, CrwScrapeTool
+
+CRW_BASE_URL = "http://localhost:3000"
+
+
+async def example_scrape() -> None:
+    """Scrape a single page and summarize it."""
+    print("\n=== Scrape Example ===\n")
+
+    scrape_tool = CrwScrapeTool(base_url=CRW_BASE_URL)
+    model = OpenAIChatCompletionClient(model="gpt-4o")
+    agent = AssistantAgent(
+        "web_scraper",
+        model_client=model,
+        tools=[scrape_tool],
+        system_message="You are a helpful assistant that can scrape web pages and summarize their content.",
+    )
+
+    result = await agent.on_messages(
+        [TextMessage(content="Scrape https://example.com and give me a brief summary.", source="user")],
+        CancellationToken(),
+    )
+    print(result.chat_message.content)
+
+
+async def example_map() -> None:
+    """Discover all links on a site."""
+    print("\n=== Map Example ===\n")
+
+    map_tool = CrwMapTool(base_url=CRW_BASE_URL)
+    cancel = CancellationToken()
+
+    result = await map_tool.run_json({"url": "https://example.com"}, cancel)
+    print(f"Discovered {len(result.links)} links:")
+    for link in result.links[:10]:
+        print(f"  - {link}")
+
+
+async def example_crawl() -> None:
+    """Crawl a site and summarize the pages found."""
+    print("\n=== Crawl Example ===\n")
+
+    crawl_tool = CrwCrawlTool(base_url=CRW_BASE_URL)
+    cancel = CancellationToken()
+
+    result = await crawl_tool.run_json(
+        {"url": "https://example.com", "max_depth": 1, "max_pages": 3},
+        cancel,
+    )
+    print(f"Crawled {result.completed}/{result.total} pages (status: {result.status})")
+    for page in result.pages:
+        print(f"  - {page.source_url}: {page.title}")
+
+
+async def example_agent_with_all_tools() -> None:
+    """Give an agent all three CRW tools for flexible web research."""
+    print("\n=== Multi-Tool Agent Example ===\n")
+
+    scrape_tool = CrwScrapeTool(base_url=CRW_BASE_URL)
+    crawl_tool = CrwCrawlTool(base_url=CRW_BASE_URL)
+    map_tool = CrwMapTool(base_url=CRW_BASE_URL)
+
+    model = OpenAIChatCompletionClient(model="gpt-4o")
+    agent = AssistantAgent(
+        "web_researcher",
+        model_client=model,
+        tools=[scrape_tool, crawl_tool, map_tool],
+        system_message=(
+            "You are a web research assistant. You have three tools:\n"
+            "- scrape_url: Scrape a single page and get its content\n"
+            "- crawl_website: Crawl multiple pages starting from a URL\n"
+            "- map_site: Discover all links on a website\n"
+            "Use the most appropriate tool for each request."
+        ),
+    )
+
+    result = await agent.on_messages(
+        [TextMessage(content="Find all the links on https://example.com", source="user")],
+        CancellationToken(),
+    )
+    print(result.chat_message.content)
+
+
+async def main() -> None:
+    await example_scrape()
+    await example_map()
+    await example_crawl()
+    await example_agent_with_all_tools()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/agentchat_crw_web_scraping/app.py
+++ b/python/samples/agentchat_crw_web_scraping/app.py
@@ -18,7 +18,6 @@ import asyncio
 
 from autogen_agentchat.agents import AssistantAgent
 from autogen_agentchat.messages import TextMessage
-from autogen_agentchat.ui import Console
 from autogen_core import CancellationToken
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from autogen_ext.tools.crw import CrwCrawlTool, CrwMapTool, CrwScrapeTool


### PR DESCRIPTION
## Summary

Adds [CRW](https://github.com/nicholasgasior/crw) web scraping tools to `autogen-ext`. CRW is an open-source web scraper for AI agents — a single Rust binary with a built-in MCP server and Firecrawl-compatible REST API.

**New tools:**
- `CrwScrapeTool` — scrape a single URL to markdown/HTML/plaintext (`POST /v1/scrape`)
- `CrwCrawlTool` — crawl a website across multiple pages with depth/page limits (`POST /v1/crawl`)
- `CrwMapTool` — discover all links on a site via crawling + sitemap (`POST /v1/map`)

All tools follow the existing `BaseTool` pattern, include type hints and docstrings, and are installable via `pip install "autogen-ext[crw]"`. Includes a sample script demonstrating usage with an AssistantAgent.

## Why CRW?

- Zero-dependency single binary (Rust), easy to self-host
- Drop-in Firecrawl-compatible API — agents that already work with Firecrawl can switch to CRW
- Built-in chunking with BM25/cosine ranking for RAG pipelines
- Open source (MIT)