### PR TITLE
fix(agentchat): prevent livelock in SelectorGroupChat fallback when allow_repeated_speaker=False

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import random
 import re
 from inspect import iscoroutinefunction
 from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Sequence, Union, cast
@@ -300,6 +301,17 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                     return agent_name
 
         if self._previous_speaker is not None:
+            if not self._allow_repeated_speaker:
+                # When repeated speaker is not allowed, pick a random non-previous participant
+                # to avoid a livelock where the same speaker is selected indefinitely.
+                candidates = [p for p in participants if p != self._previous_speaker]
+                if candidates:
+                    fallback = random.choice(candidates)
+                    trace_logger.warning(
+                        f"Model failed to select a speaker after {max_attempts}, "
+                        f"using a random non-previous participant: {fallback}."
+                    )
+                    return fallback
             trace_logger.warning(f"Model failed to select a speaker after {max_attempts}, using the previous speaker.")
             return self._previous_speaker
         trace_logger.warning(

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -1146,6 +1146,7 @@ async def test_selector_group_chat_fall_back_to_previous_after_3_attempts(runtim
     team = SelectorGroupChat(
         participants=[agent1, agent2, agent3],
         model_client=model_client,
+        allow_repeated_speaker=True,
         max_turns=2,
         runtime=runtime,
     )
@@ -1155,6 +1156,39 @@ async def test_selector_group_chat_fall_back_to_previous_after_3_attempts(runtim
     assert result.messages[0].content == "Write a program that prints 'Hello, world!'"
     assert result.messages[1].source == "agent2"
     assert result.messages[2].source == "agent2"
+
+
+@pytest.mark.asyncio
+async def test_selector_group_chat_no_livelock_on_fallback_when_repeated_speaker_disallowed(
+    runtime: AgentRuntime | None,
+) -> None:
+    """When allow_repeated_speaker=False and the LLM keeps selecting the previous
+    speaker until max_selector_attempts is exhausted, the fallback must pick a
+    different participant instead of returning the previous speaker (which would
+    cause a livelock)."""
+    # The LLM always selects agent1 (the previous speaker after the first turn).
+    # First response selects agent1 for turn 1, then 3 more for the retry loop in turn 2.
+    model_client = ReplayChatCompletionClient(
+        ["agent1", "agent1", "agent1", "agent1"],
+    )
+    agent1 = _EchoAgent("agent1", description="echo agent 1")
+    agent2 = _EchoAgent("agent2", description="echo agent 2")
+    agent3 = _EchoAgent("agent3", description="echo agent 3")
+    team = SelectorGroupChat(
+        participants=[agent1, agent2, agent3],
+        model_client=model_client,
+        allow_repeated_speaker=False,
+        max_selector_attempts=3,
+        max_turns=2,
+        runtime=runtime,
+    )
+    result = await team.run(task="task")
+    assert len(result.messages) == 3
+    # First turn: agent1 is selected (no previous speaker yet).
+    assert result.messages[1].source == "agent1"
+    # Second turn: LLM keeps picking agent1, but fallback must NOT return agent1.
+    assert result.messages[2].source != "agent1"
+    assert result.messages[2].source in ("agent2", "agent3")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fix a livelock bug in `SelectorGroupChat` where the fallback after exhausting `max_selector_attempts` returns `self._previous_speaker` even when `allow_repeated_speaker=False`, causing an infinite loop (A speaks -> selector fails to pick non-A -> falls back to A -> repeat)
- When `allow_repeated_speaker=False` and selector attempts are exhausted, the fallback now picks a random participant that is NOT the previous speaker
- Updated existing test to explicitly set `allow_repeated_speaker=True` for the case that tests fallback-to-previous behavior
- Added new test `test_selector_group_chat_no_livelock_on_fallback_when_repeated_speaker_disallowed` to verify the fix

Fixes #7471

## Test plan

- [ ] Existing test `test_selector_group_chat_fall_back_to_previous_after_3_attempts` continues to pass (now explicitly uses `allow_repeated_speaker=True`)
- [ ] New test verifies that when `allow_repeated_speaker=False` and the LLM exhausts all attempts by picking the previous speaker, the fallback selects a different participant
- [ ] Edge case: if only one participant exists, fallback still returns the previous speaker (no alternative available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)