### PR TITLE
feat: add Mistral AI model support to OpenAIChatCompletionClient

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -46,6 +46,11 @@ _MODEL_POINTERS = {
     "llama-3.3-70b": "Llama-3.3-70B-Instruct",
     "llama-4-scout": "Llama-4-Scout-17B-16E-Instruct-FP8",
     "llama-4-maverick": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+    # Mistral models
+    "mistral-large-latest": "mistral-large-2411",
+    "mistral-small-latest": "mistral-small-2501",
+    "codestral-latest": "codestral-2501",
+    "mistral-nemo": "open-mistral-nemo-2407",
 }
 
 _MODEL_INFO: Dict[str, ModelInfo] = {
@@ -441,6 +446,39 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
         "structured_output": True,
         "multiple_system_messages": True,
     },
+    # Mistral models
+    "mistral-large-2411": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": True,
+    },
+    "mistral-small-2501": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": True,
+    },
+    "codestral-2501": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": True,
+    },
+    "open-mistral-nemo-2407": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": True,
+    },
 }
 
 _MODEL_TOKEN_LIMITS: Dict[str, int] = {
@@ -491,11 +529,16 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
     "Llama-3.3-70B-Instruct": 128000,
     "Llama-4-Scout-17B-16E-Instruct-FP8": 128000,
     "Llama-4-Maverick-17B-128E-Instruct-FP8": 128000,
+    "mistral-large-2411": 131072,
+    "mistral-small-2501": 32768,
+    "codestral-2501": 256000,
+    "open-mistral-nemo-2407": 131072,
 }
 
 GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 ANTHROPIC_OPENAI_BASE_URL = "https://api.anthropic.com/v1/"
 LLAMA_API_BASE_URL = "https://api.llama.com/compat/v1/"
+MISTRAL_API_BASE_URL = "https://api.mistral.ai/v1/"
 
 
 def resolve_model(model: str) -> str:
@@ -528,3 +571,4 @@ def get_info(model: str) -> ModelInfo:
 def get_token_limit(model: str) -> int:
     resolved_model = resolve_model(model)
     return _MODEL_TOKEN_LIMITS[resolved_model]
+

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1480,6 +1480,11 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
                 copied_args["base_url"] = _model_info.LLAMA_API_BASE_URL
             if "api_key" not in copied_args and "LLAMA_API_KEY" in os.environ:
                 copied_args["api_key"] = os.environ["LLAMA_API_KEY"]
+        if copied_args["model"].startswith("mistral-") or copied_args["model"].startswith("codestral-") or copied_args["model"].startswith("open-mistral-"):
+            if "base_url" not in copied_args:
+                copied_args["base_url"] = _model_info.MISTRAL_API_BASE_URL
+            if "api_key" not in copied_args and "MISTRAL_API_KEY" in os.environ:
+                copied_args["api_key"] = os.environ["MISTRAL_API_KEY"]
 
         client = _openai_client_from_config(copied_args)
         create_args = _create_args_from_config(copied_args)
@@ -1748,3 +1753,4 @@ class AzureOpenAIChatCompletionClient(
             )
 
         return cls(**copied_config)
+


### PR DESCRIPTION
Adds Mistral AI model support following the same pattern as Gemini, Claude, and Llama.

Changes:
- Add Mistral model entries to `_MODEL_POINTERS`, `_MODEL_INFO`, and `_MODEL_TOKEN_LIMITS` in `_model_info.py`
- Add `MISTRAL_API_BASE_URL` constant (`https://api.mistral.ai/v1/`)
- Auto-detect Mistral models by prefix (`mistral-`, `codestral-`, `open-mistral-`) and set base URL + API key from `MISTRAL_API_KEY` env var

Models added: `mistral-large-latest`, `mistral-small-latest`, `codestral-latest`, `mistral-nemo`

Closes #6151
Closes #6147