### PR TITLE
docs: add Aegis governance runtime to community projects

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -46,6 +46,7 @@ Find community samples and examples of how to use AutoGen
 | [autogen-oaiapi](https://github.com/SongChiYoung/autogen-oaiapi)  | [PyPi](https://pypi.org/project/autogen-oaiapi/) | an OpenAI-style API server built on top of AutoGen |
 | [autogen-contextplus](https://github.com/SongChiYoung/autogen-contextplus)  | [PyPi](https://pypi.org/project/autogen-contextplus/) | Enhanced model_context implementations, with features such as automatic summarization and truncation of model context. |
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
+| [aegis](https://github.com/Acacian/aegis)  | [PyPi](https://pypi.org/project/agent-aegis/) | Governance runtime that auto-instruments AutoGen with prompt injection detection, PII masking, policy-as-code, and audit trail via `aegis.auto_instrument()`. |
 
 
 <!-- Example -->


### PR DESCRIPTION
## Summary

Add [Aegis](https://github.com/Acacian/aegis) to the community projects table in the Extensions documentation.

Aegis is an open-source governance runtime that auto-instruments AutoGen with:
- Prompt injection detection (107 patterns across 13 categories)
- PII masking (automatic redaction of sensitive data)
- Policy-as-code enforcement via YAML policies
- Complete audit trail of all LLM interactions

Zero code changes required — just `aegis.auto_instrument()` before creating agents.

- **PyPI**: https://pypi.org/project/agent-aegis/
- **Docs**: https://acacian.github.io/aegis/

## Changes

- Added one row to the community projects table in `python/docs/src/user-guide/extensions-user-guide/discover.md`

## Testing

Documentation-only change. No code modifications.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>