### PR TITLE
fix: Include original error message in ImportError for LLM client dependencies

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/azure/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/azure/__init__.py
@@ -2,7 +2,7 @@ try:
     from ._azure_ai_agent import AzureAIAgent
 except ImportError as e:
     raise ImportError(
-        "Dependencies for AzureAIAgent not found. "
+        f"Dependencies for AzureAIAgent not found. Original error: {e}\n"
         'Please install autogen-ext with the "azure" extra: '
         'pip install "autogen-ext[azure]"'
     ) from e

--- a/python/packages/autogen-ext/src/autogen_ext/agents/magentic_one/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/magentic_one/__init__.py
@@ -2,7 +2,7 @@ try:
     from ._magentic_one_coder_agent import MagenticOneCoderAgent
 except ImportError as e:
     raise ImportError(
-        "Dependencies for MagenticOneCoderAgent not found. "
+        f"Dependencies for MagenticOneCoderAgent not found. Original error: {e}\n"
         'Please install autogen-ext with the "magentic-one" extra: '
         'pip install "autogen-ext[magentic-one]"'
     ) from e

--- a/python/packages/autogen-ext/src/autogen_ext/memory/chromadb/_chromadb.py
+++ b/python/packages/autogen-ext/src/autogen_ext/memory/chromadb/_chromadb.py
@@ -28,7 +28,8 @@ try:
     from chromadb.api import ClientAPI
 except ImportError as e:
     raise ImportError(
-        "To use the ChromaDBVectorMemory the chromadb extra must be installed. Run `pip install autogen-ext[chromadb]`"
+        f"To use the ChromaDBVectorMemory the chromadb extra must be installed. Original error: {e}\n"
+        "Run `pip install autogen-ext[chromadb]`"
     ) from e
 
 

--- a/python/packages/autogen-ext/src/autogen_ext/memory/redis/_redis_memory.py
+++ b/python/packages/autogen-ext/src/autogen_ext/memory/redis/_redis_memory.py
@@ -15,7 +15,10 @@ try:
     from redisvl.utils.utils import deserialize, serialize
     from redisvl.utils.vectorize import HFTextVectorizer
 except ImportError as e:
-    raise ImportError("To use Redis Memory RedisVL must be installed. Run `pip install autogen-ext[redisvl]`") from e
+    raise ImportError(
+        f"To use Redis Memory RedisVL must be installed. Original error: {e}\n"
+        "Run `pip install autogen-ext[redisvl]`"
+    ) from e
 
 
 class RedisMemoryConfig(BaseModel):

--- a/python/packages/autogen-ext/src/autogen_ext/models/llama_cpp/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/llama_cpp/__init__.py
@@ -2,7 +2,7 @@ try:
     from ._llama_cpp_completion_client import LlamaCppChatCompletionClient
 except ImportError as e:
     raise ImportError(
-        "Dependencies for Llama Cpp not found. "
+        f"Dependencies for Llama Cpp not found. Original error: {e}\n"
         "Please install llama-cpp-python: "
         "pip install autogen-ext[llama-cpp]"
     ) from e

--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/__init__.py
@@ -6,7 +6,8 @@ try:
     import grpc  # type: ignore
 except ImportError as e:
     raise ImportError(
-        "To use the GRPC runtime the grpc extra must be installed. Run `pip install autogen-ext[grpc]`"
+        f"To use the GRPC runtime the grpc extra must be installed. Original error: {e}\n"
+        "Run `pip install autogen-ext[grpc]`"
     ) from e
 
 __all__ = [

--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py
@@ -66,7 +66,7 @@ from .protos import agent_worker_pb2, agent_worker_pb2_grpc, cloudevent_pb2
 try:
     import grpc.aio
 except ImportError as e:
-    raise ImportError(GRPC_IMPORT_ERROR_STR) from e
+    raise ImportError(f"{GRPC_IMPORT_ERROR_STR} Original error: {e}") from e
 
 if TYPE_CHECKING:
     from .protos.agent_worker_pb2_grpc import AgentRpcAsyncStub

--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host.py
@@ -10,7 +10,7 @@ from ._worker_runtime_host_servicer import GrpcWorkerAgentRuntimeHostServicer
 try:
     import grpc
 except ImportError as e:
-    raise ImportError(GRPC_IMPORT_ERROR_STR) from e
+    raise ImportError(f"{GRPC_IMPORT_ERROR_STR} Original error: {e}") from e
 from .protos import agent_worker_pb2_grpc
 
 logger = logging.getLogger("autogen_core")

--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host_servicer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host_servicer.py
@@ -16,7 +16,7 @@ from ._utils import subscription_from_proto, subscription_to_proto
 try:
     import grpc
 except ImportError as e:
-    raise ImportError(GRPC_IMPORT_ERROR_STR) from e
+    raise ImportError(f"{GRPC_IMPORT_ERROR_STR} Original error: {e}") from e
 
 from .protos import agent_worker_pb2, agent_worker_pb2_grpc, cloudevent_pb2
 

--- a/python/packages/autogen-ext/src/autogen_ext/tools/azure/_ai_search.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/azure/_ai_search.py
@@ -154,11 +154,11 @@ class EmbeddingProviderMixin:
                 from openai import AsyncAzureOpenAI
 
                 from azure.identity import DefaultAzureCredential
-            except ImportError:
+            except ImportError as e:
                 raise ImportError(
-                    "Azure OpenAI SDK is required for client-side embedding generation. "
+                    f"Azure OpenAI SDK is required for client-side embedding generation. Original error: {e}\n"
                     "Please install it with: uv add openai azure-identity"
-                ) from None
+                ) from e
 
             api_key = getattr(search_config, "openai_api_key", None)
             api_version = getattr(search_config, "openai_api_version", "2023-11-01")
@@ -193,11 +193,11 @@ class EmbeddingProviderMixin:
         elif embedding_provider.lower() == "openai":
             try:
                 from openai import AsyncOpenAI
-            except ImportError:
+            except ImportError as e:
                 raise ImportError(
-                    "OpenAI SDK is required for client-side embedding generation. "
+                    f"OpenAI SDK is required for client-side embedding generation. Original error: {e}\n"
                     "Please install it with: uv add openai"
-                ) from None
+                ) from e
 
             api_key = getattr(search_config, "openai_api_key", None)
             openai_client = AsyncOpenAI(api_key=api_key)


### PR DESCRIPTION
## Summary

Improved import error handling across `autogen-ext` to include the original error message in re-raised `ImportError` exceptions. This makes it significantly easier for users to diagnose dependency issues.

## Problem

When an import error occurs while initializing LLM clients or other extension components, the code raises a generic `ImportError` with a hardcoded message suggesting to install specific packages. However, the actual import error might be caused by other issues (like missing transitive dependencies or version conflicts).

**Before:**
```
ImportError: Dependencies for Llama Cpp not found. Please install llama-cpp-python: pip install autogen-ext[llama-cpp]
```

**After:**
```
ImportError: Dependencies for Llama Cpp not found. Original error: No module named 'llama_cpp'
Please install llama-cpp-python: pip install autogen-ext[llama-cpp]
```

## Changes

Updated 10 files across `autogen-ext` to include the original exception message:

- `models/llama_cpp/__init__.py`
- `agents/azure/__init__.py`
- `agents/magentic_one/__init__.py`
- `runtimes/grpc/__init__.py` and 3 worker runtime files
- `memory/chromadb/_chromadb.py`
- `memory/redis/_redis_memory.py`
- `tools/azure/_ai_search.py`

## Testing

The change is minimal and only affects error message formatting. The `from e` chain is preserved in all cases, and the original exception object is still accessible via `__cause__`.

Closes #4605
