### PR TITLE
fix: add explicit encoding='utf-8' to text file operations

### DIFF
--- a/python/packages/agbench/src/agbench/linter/cli.py
+++ b/python/packages/agbench/src/agbench/linter/cli.py
@@ -19,7 +19,7 @@ def prepend_line_numbers(lines: List[str]) -> List[str]:
 
 
 def load_log_file(path: str, prepend_numbers: bool = False) -> Document:
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         lines = f.readlines()
     if prepend_numbers:
         lines = prepend_line_numbers(lines)

--- a/python/packages/agbench/src/agbench/linter/coders/oai_coder.py
+++ b/python/packages/agbench/src/agbench/linter/coders/oai_coder.py
@@ -41,7 +41,7 @@ class OAIQualitativeCoder(BaseQualitativeCoder):
             if not os.path.exists(self.cache_dir):
                 os.makedirs(self.cache_dir)
             if cache_file and os.path.exists(cache_file):
-                with open(cache_file, "r") as f:
+                with open(cache_file, "r", encoding="utf-8") as f:
                     cached_coded_doc_json = f.read()
                     return CodedDocument.from_json(cached_coded_doc_json)
 
@@ -203,6 +203,6 @@ the context of the example.
             raise ValueError("Error in coding document with OpenAI")
 
         if self.cache_enabled and cache_file:
-            with open(cache_file, "w") as f:
+            with open(cache_file, "w", encoding="utf-8") as f:
                 f.write(coded_document.model_dump_json(indent=4))
         return coded_document

--- a/python/packages/agbench/src/agbench/remove_missing_cmd.py
+++ b/python/packages/agbench/src/agbench/remove_missing_cmd.py
@@ -11,7 +11,7 @@ def default_scorer(instance_dir: str) -> bool:
     """
     console_log = os.path.join(instance_dir, "console_log.txt")
     if os.path.isfile(console_log):
-        with open(console_log, "rt") as fh:
+        with open(console_log, "rt", encoding="utf-8") as fh:
             content = fh.read()
             # Use a regular expression to match the expected ending pattern
             has_final_answer = "FINAL ANSWER:" in content

--- a/python/packages/agbench/src/agbench/run_cmd.py
+++ b/python/packages/agbench/src/agbench/run_cmd.py
@@ -113,7 +113,7 @@ def run_scenarios(
             scenario_name_parts.pop()
             scenario_name = ".".join(scenario_name_parts)
             scenario_dir = os.path.dirname(os.path.realpath(scenario_file))
-            file_handle = open(scenario_file, "rt")
+            file_handle = open(scenario_file, "rt", encoding="utf-8")
 
         # Read all the lines, then subsample if needed
         lines = [line for line in file_handle]
@@ -241,13 +241,13 @@ def expand_scenario(
     for templated_file in substitutions.keys():  # Keys are relative file paths
         # Read the templated file into memory
         template_contents: List[str] = list()
-        with open(os.path.join(output_dir, templated_file), "rt") as fh:
+        with open(os.path.join(output_dir, templated_file), "rt", encoding="utf-8") as fh:
             for line in fh:
                 template_contents.append(line)
 
         # Rewrite the templated file with substitutions
         values = substitutions[templated_file]
-        with open(os.path.join(output_dir, templated_file), "wt") as fh:
+        with open(os.path.join(output_dir, templated_file), "wt", encoding="utf-8") as fh:
             for line in template_contents:
                 for k, v in values.items():
                     line = line.replace(k, v)
@@ -295,10 +295,10 @@ def get_scenario_env(token_provider: Optional[Callable[[], str]] = None, env_fil
     if env_file is None:
         # Env file was not specified, so read the default, or warn if the default file is missing.
         if os.path.isfile(DEFAULT_ENV_FILE_YAML):
-            with open(DEFAULT_ENV_FILE_YAML, "r") as fh:
+            with open(DEFAULT_ENV_FILE_YAML, "r", encoding="utf-8") as fh:
                 env_file_contents = yaml.safe_load(fh)
         elif os.path.isfile(DEFAULT_ENV_FILE_JSON):
-            with open(DEFAULT_ENV_FILE_JSON, "rt") as fh:
+            with open(DEFAULT_ENV_FILE_JSON, "rt", encoding="utf-8") as fh:
                 env_file_contents = json.loads(fh.read())
             logging.warning(f"JSON environment files are deprecated. Migrate to '{DEFAULT_ENV_FILE_YAML}'")
         else:
@@ -307,7 +307,7 @@ def get_scenario_env(token_provider: Optional[Callable[[], str]] = None, env_fil
             )
     else:
         # Env file was specified. Throw an error if the file can't be read.
-        with open(env_file, "rt") as fh:
+        with open(env_file, "rt", encoding="utf-8") as fh:
             if env_file.endswith(".json"):
                 logging.warning("JSON environment files are deprecated. Migrate to YAML")
                 env_file_contents = json.loads(fh.read())
@@ -396,7 +396,7 @@ def run_scenario_natively(work_dir: str, env: Dict[str, str], timeout: int = TAS
     print("\n\n" + os.getcwd() + "\n===================================================================")
 
     # Prepare the run script
-    with open(os.path.join("run.sh"), "wt") as f:
+    with open(os.path.join("run.sh"), "wt", encoding="utf-8") as f:
         f.write(
             f"""#
 echo RUN.SH STARTING !#!#
@@ -520,7 +520,7 @@ def run_scenario_in_docker(
                 print(f"Failed to pull image '{docker_image}'")
 
     # Prepare the run script
-    with open(os.path.join(work_dir, "run.sh"), "wt", newline="\n") as f:
+    with open(os.path.join(work_dir, "run.sh"), "wt", newline="\n", encoding="utf-8") as f:
         f.write(
             f"""#
 echo RUN.SH STARTING !#!#
@@ -737,7 +737,7 @@ def split_jsonl(file_path: str, num_parts: int) -> List[List[Dict[str, Any]]]:
     """
     Split a JSONL file into num_parts approximately equal parts.
     """
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         data = [json.loads(line) for line in f]
 
     random.shuffle(data)  # Shuffle the data for better distribution
@@ -942,7 +942,7 @@ def run_cli(args: Sequence[str]) -> None:
 
     if parsed_args.config is not None:
         # Make sure the config file is readable, so that we fail early
-        with open(parsed_args.config, "r"):
+        with open(parsed_args.config, "r", encoding="utf-8"):
             pass
 
     # don't support parallel and subsample together

--- a/python/packages/agbench/src/agbench/tabulate_cmd.py
+++ b/python/packages/agbench/src/agbench/tabulate_cmd.py
@@ -68,7 +68,7 @@ def find_tabulate_module(search_dir: str, stop_dir: Optional[str] = None) -> Opt
 def default_scorer(instance_dir: str, success_strings: List[str] = SUCCESS_STRINGS) -> Optional[bool]:
     console_log = os.path.join(instance_dir, "console_log.txt")
     if os.path.isfile(console_log):
-        with open(console_log, "rt") as fh:
+        with open(console_log, "rt", encoding="utf-8") as fh:
             content = fh.read()
 
             # It succeeded
@@ -90,7 +90,7 @@ def default_scorer(instance_dir: str, success_strings: List[str] = SUCCESS_STRIN
 def default_timer(instance_dir: str, timer_regex: str = TIMER_REGEX) -> Optional[float]:
     console_log = os.path.join(instance_dir, "console_log.txt")
     if os.path.isfile(console_log):
-        with open(console_log, "rt") as fh:
+        with open(console_log, "rt", encoding="utf-8") as fh:
             content = fh.read()
 
             # It succeeded

--- a/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
+++ b/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
@@ -75,7 +75,7 @@ class SchemaManager:
 
         # Update alembic.ini
         config_content = self._generate_alembic_ini_content()
-        with open(self.alembic_ini_path, "w") as f:
+        with open(self.alembic_ini_path, "w", encoding="utf-8") as f:
             f.write(config_content)
 
         # Update env.py
@@ -115,7 +115,7 @@ class SchemaManager:
 
             # Create initial config file for alembic init
             config_content = self._generate_alembic_ini_content()
-            with open(self.alembic_ini_path, "w") as f:
+            with open(self.alembic_ini_path, "w", encoding="utf-8") as f:
                 f.write(config_content)
 
             # Use the config we just created
@@ -187,7 +187,7 @@ if context.is_offline_mode():
 else:
     run_migrations_online()"""
 
-        with open(env_path, "w") as f:
+        with open(env_path, "w", encoding="utf-8") as f:
             f.write(content)
 
     def _generate_alembic_ini_content(self) -> str:
@@ -239,7 +239,7 @@ datefmt = %H:%M:%S
         """Update the Alembic script template to include SQLModel."""
         template_path = self.alembic_dir / "script.py.mako"
         try:
-            with open(template_path, "r") as f:
+            with open(template_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
             # Add sqlmodel import to imports section
@@ -248,7 +248,7 @@ datefmt = %H:%M:%S
 
             content = content.replace(import_section, new_imports)
 
-            with open(template_path, "w") as f:
+            with open(template_path, "w", encoding="utf-8") as f:
                 f.write(content)
 
             return True
@@ -303,7 +303,7 @@ datefmt = %H:%M:%S
             )""",
             )
 
-            with open(env_path, "w") as f:
+            with open(env_path, "w", encoding="utf-8") as f:
                 f.write(content)
         except Exception as e:
             logger.error(f"Failed to update env.py: {e}")

--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -97,12 +97,12 @@ def main() -> None:
 
     if args.config is None:
         if os.path.isfile(DEFAULT_CONFIG_FILE):
-            with open(DEFAULT_CONFIG_FILE, "r") as f:
+            with open(DEFAULT_CONFIG_FILE, "r", encoding="utf-8") as f:
                 config = yaml.safe_load(f)
         else:
             config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)
     else:
-        with open(args.config if isinstance(args.config, str) else args.config[0], "r") as f:
+        with open(args.config if isinstance(args.config, str) else args.config[0], "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
     # Run the task


### PR DESCRIPTION
## Summary
- Adds `encoding="utf-8"` to all `open()` calls for text files across `magentic-one-cli`, `autogen-studio`, and `agbench` packages
- Prevents `UnicodeDecodeError` on non-English Windows systems where Python defaults to the system locale encoding (e.g., cp1252, gbk)
- 7 files updated, 24 `open()` calls fixed

## Files Changed
- `magentic-one-cli/src/magentic_one_cli/_m1.py` — config file reads
- `autogen-studio/autogenstudio/database/schema_manager.py` — Alembic config/template reads and writes
- `agbench/src/agbench/run_cmd.py` — scenario files, env configs, run scripts
- `agbench/src/agbench/tabulate_cmd.py` — console log reads
- `agbench/src/agbench/remove_missing_cmd.py` — console log reads
- `agbench/src/agbench/linter/cli.py` — log file reads
- `agbench/src/agbench/linter/coders/oai_coder.py` — cache file reads/writes

## Test Plan
- [x] All changes are mechanical: adding `encoding="utf-8"` parameter only
- [x] No behavioral change on systems where UTF-8 is already the default
- [x] Fixes crashes on Windows with non-English locale (e.g., Chinese, Japanese, Korean)

Fixes #5566