### PR TITLE
Improve import error messages for all optional model clients and agents

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/__init__.py
@@ -1,3 +1,10 @@
-from ._file_surfer import FileSurfer
+try:
+    from ._file_surfer import FileSurfer
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for FileSurfer agent not found: {e}\n"
+        'Please install autogen-ext with the "file-surfer" extra: '
+        'pip install "autogen-ext[file-surfer]"'
+    ) from e
 
 __all__ = ["FileSurfer"]

--- a/python/packages/autogen-ext/src/autogen_ext/agents/openai/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/openai/__init__.py
@@ -1,5 +1,12 @@
-from ._openai_agent import OpenAIAgent
-from ._openai_assistant_agent import OpenAIAssistantAgent
+try:
+    from ._openai_agent import OpenAIAgent
+    from ._openai_assistant_agent import OpenAIAssistantAgent
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for OpenAI agents not found: {e}\n"
+        'Please install autogen-ext with the "openai" extra: '
+        'pip install "autogen-ext[openai]"'
+    ) from e
 
 __all__ = [
     "OpenAIAgent",

--- a/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/__init__.py
@@ -1,3 +1,10 @@
-from ._video_surfer import VideoSurfer
+try:
+    from ._video_surfer import VideoSurfer
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for VideoSurfer agent not found: {e}\n"
+        'Please install autogen-ext with the "video-surfer" extra: '
+        'pip install "autogen-ext[video-surfer]"'
+    ) from e
 
 __all__ = ["VideoSurfer"]

--- a/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/web_surfer/__init__.py
@@ -1,4 +1,11 @@
-from ._multimodal_web_surfer import MultimodalWebSurfer
-from .playwright_controller import PlaywrightController
+try:
+    from ._multimodal_web_surfer import MultimodalWebSurfer
+    from .playwright_controller import PlaywrightController
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for MultimodalWebSurfer agent not found: {e}\n"
+        'Please install autogen-ext with the "web-surfer" extra: '
+        'pip install "autogen-ext[web-surfer]"'
+    ) from e
 
 __all__ = ["MultimodalWebSurfer", "PlaywrightController"]

--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/__init__.py
@@ -1,8 +1,16 @@
-from ._anthropic_client import (
-    AnthropicBedrockChatCompletionClient,
-    AnthropicChatCompletionClient,
-    BaseAnthropicChatCompletionClient,
-)
+try:
+    from ._anthropic_client import (
+        AnthropicBedrockChatCompletionClient,
+        AnthropicChatCompletionClient,
+        BaseAnthropicChatCompletionClient,
+    )
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for Anthropic model client not found: {e}\n"
+        'Please install autogen-ext with the "anthropic" extra: '
+        'pip install "autogen-ext[anthropic]"'
+    ) from e
+
 from .config import (
     AnthropicBedrockClientConfiguration,
     AnthropicBedrockClientConfigurationConfigModel,

--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/__init__.py
@@ -1,4 +1,12 @@
-from ._azure_ai_client import AzureAIChatCompletionClient
+try:
+    from ._azure_ai_client import AzureAIChatCompletionClient
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for Azure AI model client not found: {e}\n"
+        'Please install autogen-ext with the "azure" extra: '
+        'pip install "autogen-ext[azure]"'
+    ) from e
+
 from .config import AzureAIChatCompletionClientConfig
 
 __all__ = ["AzureAIChatCompletionClient", "AzureAIChatCompletionClientConfig"]

--- a/python/packages/autogen-ext/src/autogen_ext/models/llama_cpp/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/llama_cpp/__init__.py
@@ -2,9 +2,9 @@ try:
     from ._llama_cpp_completion_client import LlamaCppChatCompletionClient
 except ImportError as e:
     raise ImportError(
-        "Dependencies for Llama Cpp not found. "
-        "Please install llama-cpp-python: "
-        "pip install autogen-ext[llama-cpp]"
+        f"Dependencies for Llama.cpp model client not found: {e}\n"
+        'Please install autogen-ext with the "llama-cpp" extra: '
+        'pip install "autogen-ext[llama-cpp]"'
     ) from e
 
 __all__ = ["LlamaCppChatCompletionClient"]

--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/__init__.py
@@ -1,4 +1,12 @@
-from ._ollama_client import OllamaChatCompletionClient
+try:
+    from ._ollama_client import OllamaChatCompletionClient
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for Ollama model client not found: {e}\n"
+        'Please install autogen-ext with the "ollama" extra: '
+        'pip install "autogen-ext[ollama]"'
+    ) from e
+
 from .config import (
     BaseOllamaClientConfigurationConfigModel,
     CreateArgumentsConfigModel,

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/__init__.py
@@ -1,10 +1,19 @@
 from . import _message_transform
-from ._openai_client import (
-    AZURE_OPENAI_USER_AGENT,
-    AzureOpenAIChatCompletionClient,
-    BaseOpenAIChatCompletionClient,
-    OpenAIChatCompletionClient,
-)
+
+try:
+    from ._openai_client import (
+        AZURE_OPENAI_USER_AGENT,
+        AzureOpenAIChatCompletionClient,
+        BaseOpenAIChatCompletionClient,
+        OpenAIChatCompletionClient,
+    )
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for OpenAI model client not found: {e}\n"
+        'Please install autogen-ext with the "openai" extra: '
+        'pip install "autogen-ext[openai]"'
+    ) from e
+
 from .config import (
     AzureOpenAIClientConfigurationConfigModel,
     BaseOpenAIClientConfigurationConfigModel,

--- a/python/packages/autogen-ext/src/autogen_ext/models/semantic_kernel/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/semantic_kernel/__init__.py
@@ -1,3 +1,10 @@
-from ._sk_chat_completion_adapter import SKChatCompletionAdapter
+try:
+    from ._sk_chat_completion_adapter import SKChatCompletionAdapter
+except ImportError as e:
+    raise ImportError(
+        f"Dependencies for Semantic Kernel model client not found: {e}\n"
+        'Please install autogen-ext with the "semantic-kernel-core" extra: '
+        'pip install "autogen-ext[semantic-kernel-core]"'
+    ) from e
 
 __all__ = ["SKChatCompletionAdapter"]


### PR DESCRIPTION
## Summary

Improve import error messages across all model clients and agent modules in `autogen-ext` that depend on optional packages. When a dependency is missing, users now see:
1. The **original error message** (preserving the actual root cause)
2. The **exact pip install command** to fix it

This covers model clients (OpenAI, Anthropic, Ollama, Azure AI, Semantic Kernel) and agents (FileSurfer, MultimodalWebSurfer, VideoSurfer, OpenAI agents). Also improves the existing Llama.cpp error message to include the original error.

**Before:**
```
ModuleNotFoundError: No module named 'openai'
```

**After:**
```
ImportError: Dependencies for OpenAI model client not found: No module named 'openai'
Please install autogen-ext with the "openai" extra: pip install "autogen-ext[openai]"
```

## Why are these changes needed?

When optional dependencies are missing, users get raw `ImportError`/`ModuleNotFoundError` exceptions with no guidance on how to fix the issue. This is especially confusing when the error comes from a transitive dependency (e.g., `vertexai` missing when trying to use Gemini). The improved messages chain the original exception (`from e`) so the full traceback is preserved, while the message itself tells the user exactly which package extra to install.

## Related issue number

Closes #4605

## Checks
- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.