### PR TITLE
docs: Add EU AI Act compliance guide for AutoGen deployers

### DIFF
--- a/docs/EU_AI_ACT_COMPLIANCE_GUIDE.md
+++ b/docs/EU_AI_ACT_COMPLIANCE_GUIDE.md
@@ -84,7 +84,7 @@ agent = AssistantAgent(
 )
 ```
 
-A system message alone is insufficient. The disclosure must appear in your application's UI before or at the start of interaction, not just in the agent's prompt.
+A system message alone may be insufficient for embedded AI features. The disclosure should appear in your application's UI before or at the start of interaction. For dedicated AI platforms where the context makes AI interaction obvious, the platform's nature may satisfy Article 50(1) without additional per-interaction disclosure.
 
 ---
 

--- a/docs/EU_AI_ACT_COMPLIANCE_GUIDE.md
+++ b/docs/EU_AI_ACT_COMPLIANCE_GUIDE.md
@@ -86,29 +86,6 @@ agent = AssistantAgent(
 
 A system message alone is insufficient. The disclosure must appear in your application's UI before or at the start of interaction, not just in the agent's prompt.
 
-## 6. Tooling: Automated Compliance Checking
-
-Manual compliance tracking across multi-agent systems does not scale. `ai-trace-auditor` audits trace files against EU AI Act requirements:
-
-```bash
-pip install ai-trace-auditor
-aitrace audit autogen_traces.jsonl --framework eu-ai-act
-```
-
-This checks Article 12 completeness, flags logging gaps, and generates evidence packs for audit review. Supports AutoGen traces, OpenTelemetry, Langfuse, and raw JSONL.
-
-For CI integration:
-
-```yaml
-# .github/workflows/compliance.yml
-- name: EU AI Act audit
-  run: |
-    pip install ai-trace-auditor
-    aitrace audit traces/ --framework eu-ai-act --exit-code
-```
-
-A failing audit blocks the merge. Compliance evidence generates automatically, not after the fact.
-
 ---
 
 **Further reading:** [EU AI Act full text](https://artificialintelligenceact.eu/) | [Annex III high-risk categories](https://artificialintelligenceact.eu/annex/3/) | [AutoGen tracing documentation](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tracing.html)

--- a/docs/EU_AI_ACT_COMPLIANCE_GUIDE.md
+++ b/docs/EU_AI_ACT_COMPLIANCE_GUIDE.md
@@ -1,0 +1,114 @@
+# EU AI Act Compliance Guide for AutoGen Deployers
+
+AutoGen is an open-source multi-agent orchestration framework. Under Article 25(4) of the EU AI Act, open-source tools released under a free license carry no compliance obligations themselves. AutoGen is Apache 2.0. It is exempt.
+
+You are not. If you build a high-risk AI system using AutoGen and deploy it in the EU, the obligations land on you. This guide maps those obligations to AutoGen's architecture so you know exactly what to implement.
+
+Enforcement begins **August 2, 2026**.
+
+## 1. Scope: Is Your System High-Risk?
+
+Before implementing anything, determine whether your AutoGen application falls under Annex III of the EU AI Act. Annex III lists eight categories of high-risk AI systems:
+
+1. **Biometrics** (remote identification, emotion recognition)
+2. **Critical infrastructure** (energy, transport, water, digital)
+3. **Education** (admissions scoring, exam proctoring, learning assessment)
+4. **Employment** (CV screening, interview evaluation, task allocation, performance monitoring)
+5. **Essential services** (credit scoring, insurance risk, emergency dispatch)
+6. **Law enforcement** (risk assessment, polygraph alternatives, evidence analysis)
+7. **Migration and border control** (visa processing, risk indicators)
+8. **Administration of justice** (sentencing assistance, case outcome prediction)
+
+If your AutoGen system does not fall into these categories, your only obligation is Article 50 (user disclosure). Skip to Section 5.
+
+If it does, keep reading.
+
+## 2. Article 12: Record-Keeping
+
+Article 12 requires automatic logging of events relevant to risk identification. Logs must be retained for at least six months. In AutoGen terms, capture:
+
+- **Agent messages.** Every `TextMessage`, `MultiModalMessage`, `StopMessage`, and `HandoffMessage` between agents. This is the decision trail.
+- **Tool calls.** Every `ToolCallRequestEvent` and `ToolCallExecutionEvent`, including external API calls and code execution results.
+- **Model responses.** Raw LLM completions, token counts, and model identifiers.
+- **Termination events.** Which `TerminationCondition` fired, and any exceptions raised.
+
+AutoGen 0.4 supports OpenTelemetry tracing natively:
+
+```python
+from autogen_agentchat import TRACE_LOGGER_NAME
+import logging
+
+trace_logger = logging.getLogger(TRACE_LOGGER_NAME)
+trace_logger.setLevel(logging.DEBUG)
+trace_logger.addHandler(logging.FileHandler("autogen_traces.jsonl"))
+```
+
+For production, route traces to an OpenTelemetry backend (Jaeger, Grafana Tempo) with a retention policy meeting the six-month minimum.
+
+## 3. Article 13: Transparency Documentation
+
+Article 13 requires high-risk systems to be interpretable by deployers. You must document:
+
+- **System architecture.** Agent roster, roles, backing models, interaction patterns. For `RoundRobinGroupChat`, document turn order. For `SocietyOfMindAgent`, document the inner team structure.
+- **Decision boundaries.** Registered tools, permissions, and `TerminationCondition` configurations.
+- **Intended purpose and limitations.** What the system does, what it should not be used for, known failure modes.
+- **Human oversight.** How operators intervene or override. If using `HandoffMessage` for human-in-the-loop, document the escalation flow.
+
+This goes to downstream deployers and, on request, to national competent authorities.
+
+## 4. Article 25: Value Chain Accountability
+
+Article 25 says every party contributing to a high-risk AI system bears obligations proportional to their role. This is where multi-agent systems get interesting.
+
+A typical AutoGen deployment might chain: an `AssistantAgent` backed by GPT-4o making a recommendation, a second `AssistantAgent` backed by a different model validating it, a `SocietyOfMindAgent` resolving disagreements via an inner team, and tool calls to external services. Each link is a potential liability point.
+
+**In practice:**
+
+- **Model providers.** If you use LLM APIs from OpenAI, Anthropic, or others, verify their EU AI Act compliance documentation and terms of service.
+- **Third-party tools.** External services your agents call (e.g., a credit scoring API) carry their own Article 25 obligations. Verify contractually.
+- **Internal delegation.** Agent-to-agent delegation within your system does not split liability. A `SocietyOfMindAgent` wrapping a `RoundRobinGroupChat` is one system. You own the full chain.
+
+## 5. Article 50: User Disclosure
+
+If your AutoGen system interacts with humans, they must be informed it is AI. This applies to all AI systems, not just high-risk ones.
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+
+agent = AssistantAgent(
+    name="support_agent",
+    system_message=(
+        "You are an AI assistant. Always inform the user "
+        "they are communicating with an AI system, not a human."
+    ),
+)
+```
+
+A system message alone is insufficient. The disclosure must appear in your application's UI before or at the start of interaction, not just in the agent's prompt.
+
+## 6. Tooling: Automated Compliance Checking
+
+Manual compliance tracking across multi-agent systems does not scale. `ai-trace-auditor` audits trace files against EU AI Act requirements:
+
+```bash
+pip install ai-trace-auditor
+aitrace audit autogen_traces.jsonl --framework eu-ai-act
+```
+
+This checks Article 12 completeness, flags logging gaps, and generates evidence packs for audit review. Supports AutoGen traces, OpenTelemetry, Langfuse, and raw JSONL.
+
+For CI integration:
+
+```yaml
+# .github/workflows/compliance.yml
+- name: EU AI Act audit
+  run: |
+    pip install ai-trace-auditor
+    aitrace audit traces/ --framework eu-ai-act --exit-code
+```
+
+A failing audit blocks the merge. Compliance evidence generates automatically, not after the fact.
+
+---
+
+**Further reading:** [EU AI Act full text](https://artificialintelligenceact.eu/) | [Annex III high-risk categories](https://artificialintelligenceact.eu/annex/3/) | [AutoGen tracing documentation](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tracing.html)


### PR DESCRIPTION
AutoGen itself has no EU AI Act obligations (open-source exemption, Article 25(4)). But teams building high-risk applications with AutoGen do, and the August 2, 2026 enforcement deadline is approaching.

This guide helps AutoGen deployers understand which obligations apply to their multi-agent systems under the EU AI Act: scope classification (Annex III), record-keeping (Article 12), transparency (Article 13), value chain accountability (Article 25), and user disclosure (Article 50).

It covers AutoGen-specific implementation details: what to log from agent conversations, how team patterns like `RoundRobinGroupChat` and `SocietyOfMindAgent` map to liability chains, and how to use OpenTelemetry tracing for compliance evidence.

Making compliance accessible for deployers strengthens AutoGen's position as the production-ready multi-agent framework.