### PR TITLE
chore: standardize Unicode encodings explicitly as utf-8 across packages

### DIFF
--- a/python/fixup_generated_files.py
+++ b/python/fixup_generated_files.py
@@ -24,12 +24,12 @@ substitutions: Dict[str, str] = {
 
 def main():
     for file in files:
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8") as f:
             content = f.read()
 
         print("Fixing imports in file:", file)
         for old, new in substitutions.items():
             content = content.replace(old, new)
 
-        with open(file, "w") as f:
+        with open(file, "w", encoding="utf-8") as f:
             f.write(content)

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/azure/_azure_container_code_executor.py
@@ -250,7 +250,7 @@ import pkg_resources\n[d.project_name for d in pkg_resources.working_set]
                     raise ValueError(f"Packages unavailable in environment: {missing_pkgs}")
 
         func_file = self.work_dir / f"{self._functions_module}.py"
-        func_file.write_text(self._func_code)
+        func_file.write_text(self._func_code, encoding="utf-8")
 
         # Attempt to load the function file to check for syntax errors, imports etc.
         exec_result = await self._execute_code_dont_check_setup(

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
@@ -254,7 +254,7 @@ $functions"""
     async def _setup_functions(self, cancellation_token: CancellationToken) -> None:
         func_file_content = build_python_functions_file(self._functions)
         func_file = self.work_dir / f"{self._functions_module}.py"
-        func_file.write_text(func_file_content)
+        func_file.write_text(func_file_content, encoding="utf-8")
 
         # Collect requirements
         lists_of_packages = [x.python_packages for x in self._functions if isinstance(x, FunctionWithRequirements)]

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
@@ -275,7 +275,7 @@ class DockerJupyterCodeExecutor(CodeExecutor, Component[DockerJupyterCodeExecuto
         """Save html data to a file."""
         filename = f"{uuid.uuid4().hex}.html"
         path = os.path.join(str(self._output_dir), filename)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(html_data)
         return os.path.abspath(path)
 

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -262,7 +262,7 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
     def _save_html(self, html_data: str) -> Path:
         """Save HTML data to a file."""
         path = self._output_dir / f"{uuid.uuid4().hex}.html"
-        path.write_text(html_data)
+        path.write_text(html_data, encoding="utf-8")
         return path.absolute()
 
     async def restart(self) -> None:

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -273,7 +273,7 @@ $functions"""
     async def _setup_functions(self, cancellation_token: CancellationToken) -> None:
         func_file_content = build_python_functions_file(self._functions)
         func_file = self.work_dir / f"{self._functions_module}.py"
-        func_file.write_text(func_file_content)
+        func_file.write_text(func_file_content, encoding="utf-8")
 
         # Collect requirements
         lists_of_packages = [x.python_packages for x in self._functions if isinstance(x, FunctionWithRequirements)]

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
@@ -73,7 +73,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
             # Load the previously recorded messages and responses from disk.
             self.logger.info("Replay mode enabled.\nRetrieving session from: " + self.session_file_path)
             try:
-                with open(self.session_file_path, "r") as f:
+                with open(self.session_file_path, "r", encoding="utf-8") as f:
                     self.records = json.load(f)
             except Exception as e:
                 error_str = f"\nFailed to load recorded session: '{self.session_file_path}': {e}"
@@ -211,7 +211,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
                 # Create the directory if it doesn't exist.
                 os.makedirs(os.path.dirname(self.session_file_path), exist_ok=True)
                 # Write the records to disk.
-                with open(self.session_file_path, "w") as f:
+                with open(self.session_file_path, "w", encoding="utf-8") as f:
                     json.dump(self.records, f, indent=2)
                     self.logger.info("\nRecorded session was saved to: " + self.session_file_path)
             except Exception as e:

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/page_logger.py
@@ -117,7 +117,7 @@ class PageLogger:
         # Write the hash and other details to a file.
         hash_str, num_files, num_subdirs = hash_directory(self.log_dir)
         hash_path = os.path.join(self.log_dir, "hash.txt")
-        with open(hash_path, "w") as f:
+        with open(hash_path, "w", encoding="utf-8") as f:
             f.write(hash_str)
             f.write("\n")
             f.write("{} files\n".format(num_files))
@@ -386,7 +386,7 @@ class PageLogger:
             return
         # Create a call tree of the log.
         call_tree_path = os.path.join(self.log_dir, self.name + ".html")
-        with open(call_tree_path, "w") as f:
+        with open(call_tree_path, "w", encoding="utf-8") as f:
             f.write(_html_opening("0 Call Tree", finished=finished))
             f.write(f"<h3>{self.name}</h3>")
             f.write("\n")
@@ -498,7 +498,7 @@ class Page:
         Writes the HTML page to disk.
         """
         page_path = os.path.join(self.page_logger.log_dir, self.index_str + ".html")
-        with open(page_path, "w") as f:
+        with open(page_path, "w", encoding="utf-8") as f:
             f.write(_html_opening(self.file_title, finished=self.finished))
             f.write(f"<h3>{self.file_title}</h3>\n")
             for line in self.lines:


### PR DESCRIPTION
Standardizing Unicode Encodings In AutoGen

This PR systematically addresses potential `UnicodeDecodeError` and `UnicodeEncodeError` issues by ensuring that all relevant file operations (using `open()`, `Path.write_text()`, and `Path.read_text()`) explicitly specify `encoding='utf-8'`. 

This is particularly important for cross-platform compatibility, especially on Windows where the default locale encoding can often lead to failures when handling LLM-generated code or multi-language inputs.

### Changes:
- Updated `python/fixup_generated_files.py` to use UTF-8 for reading and writing.
- Updated multiple code executors (`local`, `docker`, `azure`, `docker_jupyter`, `jupyter`) in `autogen-ext` to ensure functions and outputs are saved with UTF-8 encoding.
- Updated experimental memory utilities (`page_logger`, `chat_completion_client_recorder`) to use UTF-8 for logging and session recordings.

### Verification:
- Performed a repository-wide grep to identify missing encodings.
- Verified that the changes do not introduce regressions in standard file handling.
- Confirmed that the fix for `playwright_controller.py` (reported in similar contexts) was already in place or properly covered.

Fixes #5666 (Related issue where encoding was missing in a code executor context)