### PR TITLE
docs: add asqav audit trail cookbook using InterventionHandler

### DIFF
--- a/python/docs/src/user-guide/core-user-guide/cookbook/asqav-audit-trail-with-intervention.ipynb
+++ b/python/docs/src/user-guide/core-user-guide/cookbook/asqav-audit-trail-with-intervention.ipynb
@@ -1,0 +1,258 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tamper-Evident Audit Trail using Intervention Handler and asqav\n",
+    "\n",
+    "This cookbook shows how to use an intervention handler to log all agent messages\n",
+    "and tool calls to a tamper-evident audit trail using [asqav](https://github.com/jagmarques/asqav-sdk).\n",
+    "\n",
+    "asqav provides cryptographically signed audit trails for AI agents using\n",
+    "ML-DSA (FIPS 204). Each action is signed server-side and chained to form\n",
+    "a verifiable record of agent behavior.\n",
+    "\n",
+    "```{note}\n",
+    "This recipe uses {py:class}`~autogen_core.SingleThreadedAgentRuntime`,\n",
+    "which supports intervention handlers.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the required packages:\n",
+    "\n",
+    "```bash\n",
+    "pip install asqav autogen-core\n",
+    "```\n",
+    "\n",
+    "You will need an asqav API key from [asqav.com](https://asqav.com)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from dataclasses import dataclass\n",
+    "from typing import Any\n",
+    "\n",
+    "import asqav\n",
+    "from autogen_core import (\n",
+    "    AgentId,\n",
+    "    DefaultInterventionHandler,\n",
+    "    DefaultTopicId,\n",
+    "    FunctionCall,\n",
+    "    MessageContext,\n",
+    "    RoutedAgent,\n",
+    "    SingleThreadedAgentRuntime,\n",
+    "    default_subscription,\n",
+    "    message_handler,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define message types\n",
+    "\n",
+    "We define a simple message type for this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dataclass\n",
+    "class Message:\n",
+    "    content: str"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the AsqavInterventionHandler\n",
+    "\n",
+    "The handler subclasses {py:class}`~autogen_core.DefaultInterventionHandler` and\n",
+    "signs each message and response to asqav's audit trail. It intercepts three\n",
+    "lifecycle hooks:\n",
+    "\n",
+    "- `on_send` - direct messages between agents\n",
+    "- `on_publish` - broadcast messages to topics\n",
+    "- `on_response` - responses returned from agent message handlers\n",
+    "\n",
+    "If a message contains a {py:class}`~autogen_core.FunctionCall`, the handler\n",
+    "logs the tool name and arguments separately for fine-grained auditing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class AsqavInterventionHandler(DefaultInterventionHandler):\n",
+    "    \"\"\"Intervention handler that logs all agent messages and tool calls\n",
+    "    to a tamper-evident audit trail using asqav.\"\"\"\n",
+    "\n",
+    "    def __init__(self, asqav_agent: asqav.Agent) -> None:\n",
+    "        self._agent = asqav_agent\n",
+    "\n",
+    "    async def on_send(\n",
+    "        self, message: Any, *, message_context: MessageContext, recipient: AgentId\n",
+    "    ) -> Any:\n",
+    "        action_data = {\n",
+    "            \"recipient\": str(recipient),\n",
+    "            \"message_type\": type(message).__name__,\n",
+    "        }\n",
+    "        # Log tool calls with additional detail.\n",
+    "        if isinstance(message, FunctionCall):\n",
+    "            action_data[\"tool_name\"] = message.name\n",
+    "            action_data[\"tool_arguments\"] = message.arguments\n",
+    "            self._agent.sign(\"agent:tool_call\", action_data)\n",
+    "        else:\n",
+    "            self._agent.sign(\"agent:send\", action_data)\n",
+    "        return message\n",
+    "\n",
+    "    async def on_publish(\n",
+    "        self, message: Any, *, message_context: MessageContext\n",
+    "    ) -> Any:\n",
+    "        action_data = {\n",
+    "            \"message_type\": type(message).__name__,\n",
+    "        }\n",
+    "        self._agent.sign(\"agent:publish\", action_data)\n",
+    "        return message\n",
+    "\n",
+    "    async def on_response(\n",
+    "        self, message: Any, *, sender: AgentId, recipient: AgentId | None\n",
+    "    ) -> Any:\n",
+    "        action_data = {\n",
+    "            \"sender\": str(sender),\n",
+    "            \"recipient\": str(recipient) if recipient else None,\n",
+    "            \"message_type\": type(message).__name__,\n",
+    "        }\n",
+    "        self._agent.sign(\"agent:response\", action_data)\n",
+    "        return message"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a sample agent\n",
+    "\n",
+    "A minimal agent that echoes messages back, so we can demonstrate the audit trail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@default_subscription\n",
+    "class EchoAgent(RoutedAgent):\n",
+    "    def __init__(self) -> None:\n",
+    "        super().__init__(\"EchoAgent\")\n",
+    "\n",
+    "    @message_handler\n",
+    "    async def on_message(self, message: Message, ctx: MessageContext) -> None:\n",
+    "        print(f\"EchoAgent received: {message.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wire up the runtime\n",
+    "\n",
+    "Initialize asqav, create the intervention handler, and register it with the runtime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize asqav with your API key.\n",
+    "asqav.init(api_key=\"sk_...\")\n",
+    "audit_agent = asqav.Agent.create(\"autogen-auditor\")\n",
+    "\n",
+    "# Create the runtime with the asqav intervention handler.\n",
+    "handler = AsqavInterventionHandler(asqav_agent=audit_agent)\n",
+    "runtime = SingleThreadedAgentRuntime(intervention_handlers=[handler])\n",
+    "\n",
+    "# Register the agent.\n",
+    "await EchoAgent.register(runtime, \"echo_agent\", EchoAgent)\n",
+    "\n",
+    "runtime.start()\n",
+    "\n",
+    "# Publish messages - each one is signed to the audit trail.\n",
+    "await runtime.publish_message(Message(\"Hello from user\"), DefaultTopicId())\n",
+    "await runtime.publish_message(Message(\"Another message\"), DefaultTopicId())\n",
+    "\n",
+    "await runtime.stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Every message that passes through the runtime is now signed with ML-DSA and\n",
+    "recorded in asqav's tamper-evident log. You can view the full audit trail\n",
+    "and verify individual signatures at [asqav.com/dashboard](https://asqav.com/dashboard).\n",
+    "\n",
+    "## What gets logged\n",
+    "\n",
+    "| Hook | Action type | Details |\n",
+    "|---|---|---|\n",
+    "| `on_send` | `agent:send` | Recipient, message type |\n",
+    "| `on_send` (tool call) | `agent:tool_call` | Tool name, arguments, recipient |\n",
+    "| `on_publish` | `agent:publish` | Message type |\n",
+    "| `on_response` | `agent:response` | Sender, recipient, message type |\n",
+    "\n",
+    "Each signed action returns a `signature_id`, `chain_hash`, and `verify_url`\n",
+    "that can be used for compliance reporting and independent verification.\n",
+    "\n",
+    "## Further reading\n",
+    "\n",
+    "- [asqav documentation](https://asqav.com/docs)\n",
+    "- [asqav SDK on PyPI](https://pypi.org/project/asqav/)\n",
+    "- [InterventionHandler API reference](https://microsoft.github.io/autogen/dev/reference/python/autogen_core.html#autogen_core.DefaultInterventionHandler)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/docs/src/user-guide/core-user-guide/cookbook/index.md
+++ b/python/docs/src/user-guide/core-user-guide/cookbook/index.md
@@ -19,4 +19,5 @@ instrumenting
 topic-subscription-scenarios
 structured-output-agent
 llm-usage-logger
+asqav-audit-trail-with-intervention
 ```


### PR DESCRIPTION
## Summary

- Adds a cookbook recipe showing how to use [asqav](https://github.com/jagmarques/asqav-sdk) with `DefaultInterventionHandler` to create a tamper-evident audit trail for agent messages and tool calls.
- The recipe subclasses `DefaultInterventionHandler` to intercept `on_send`, `on_publish`, and `on_response` hooks, signing each action to asqav's ML-DSA (FIPS 204) audit log.
- Adds the new recipe to the cookbook index.

## Details

asqav is an open-source Python SDK (`pip install asqav`) that provides cryptographically signed audit trails for AI agents. The integration is lightweight - a single `AsqavInterventionHandler` class that plugs into `SingleThreadedAgentRuntime`.

The cookbook covers:
- Creating an `AsqavInterventionHandler` that logs sends, publishes, responses, and tool calls
- Wiring it into the runtime via `intervention_handlers`
- What gets logged at each lifecycle hook

## Test plan

- [ ] Verify notebook renders correctly in the docs build
- [ ] Confirm cookbook index includes the new entry