### PR TITLE
fix(agentchat): respect allow_repeated_speaker=False in selector fallback

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -299,6 +299,15 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                     trace_logger.debug(f"Model selected a valid name: {agent_name} (attempt {num_attempts})")
                     return agent_name
 
+        if self._previous_speaker is not None and not self._allow_repeated_speaker:
+            # Repeated speaker is not allowed; pick randomly from the already-filtered
+            # participants list (which already excludes the previous speaker).
+            trace_logger.warning(
+                f"Model failed to select a speaker after {max_attempts}, "
+                f"falling back to a random participant (excluding previous speaker '{self._previous_speaker}')."
+            )
+            import random
+            return random.choice(participants)
         if self._previous_speaker is not None:
             trace_logger.warning(f"Model failed to select a speaker after {max_attempts}, using the previous speaker.")
             return self._previous_speaker


### PR DESCRIPTION
Fixes #7471

## Problem

When `allow_repeated_speaker=False` and the model exhausts `max_selector_attempts` without picking a valid (non-previous) speaker, the fallback in `_select_speaker` returns `self._previous_speaker`:

```python
if self._previous_speaker is not None:
    trace_logger.warning(...)
    return self._previous_speaker  # ← returns the excluded speaker
```

This creates a livelock: agent A speaks → selector tries to pick someone else → exhausts attempts → falls back to A → A speaks again → repeat.

## Root Cause

The `_select_speaker` method receives a `participants` list that already has the previous speaker filtered out (done by the caller when `allow_repeated_speaker=False`). The fallback logic ignores this filtered list and reads directly from `self._previous_speaker`.

## Fix

Add an early-exit branch before the existing fallback: when `allow_repeated_speaker=False` and there is a previous speaker, use `random.choice(participants)` (the already-filtered list) instead of returning the excluded speaker.

```python
if self._previous_speaker is not None and not self._allow_repeated_speaker:
    # participants already excludes the previous speaker
    return random.choice(participants)
```

The existing fallback for `allow_repeated_speaker=True` (return previous speaker) is unchanged.