### PR TITLE
feat(agentchat): add BaseGroupChat.get_thread() for message history

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -27,11 +27,13 @@ from ...messages import (
 from ...state import TeamState
 from ._chat_agent_container import ChatAgentContainer
 from ._events import (
+    GroupChatGetThread,
     GroupChatPause,
     GroupChatReset,
     GroupChatResume,
     GroupChatStart,
     GroupChatTermination,
+    GroupChatThreadResponse,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -576,6 +578,50 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
 
                 # Indicate that the team is no longer running.
                 self._is_running = False
+
+    async def get_thread(self) -> List[BaseAgentEvent | BaseChatMessage]:
+        """Return the group chat manager's message thread so far.
+
+        This uses an RPC to the group chat manager and includes the same messages
+        the manager uses for speaker selection (including inner agent messages when applicable).
+
+        .. versionadded:: v0.7.6
+
+        When using the default embedded runtime, the runtime is started temporarily
+        if it is not already running (for example after :meth:`run` has finished).
+
+        Returns:
+            A list of messages and events in conversation order.
+
+        Raises:
+            RuntimeError: If the embedded runtime fails to start for the RPC call.
+        """
+        if not self._initialized:
+            await self._init(self._runtime)
+
+        need_stop = False
+        if self._embedded_runtime:
+            assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+            try:
+                self._runtime.start()
+                need_stop = True
+            except RuntimeError as exc:
+                if "already started" not in str(exc).lower():
+                    raise
+
+        try:
+            response = await self._runtime.send_message(
+                GroupChatGetThread(),
+                recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
+            )
+        finally:
+            if need_stop:
+                assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+                await self._runtime.stop_when_idle()
+
+        if not isinstance(response, GroupChatThreadResponse):
+            raise TypeError(f"Expected GroupChatThreadResponse, got {type(response)}")
+        return list(response.messages)
 
     async def reset(self) -> None:
         """Reset the team and its participants to their initial state.

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -9,6 +9,7 @@ from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory, SelectS
 from ._events import (
     GroupChatAgentResponse,
     GroupChatError,
+    GroupChatGetThread,
     GroupChatMessage,
     GroupChatPause,
     GroupChatRequestPublish,
@@ -17,6 +18,7 @@ from ._events import (
     GroupChatStart,
     GroupChatTeamResponse,
     GroupChatTermination,
+    GroupChatThreadResponse,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -56,6 +58,7 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
                 GroupChatTeamResponse,
                 GroupChatMessage,
                 GroupChatReset,
+                GroupChatGetThread,
             ],
         )
         if max_turns is not None and max_turns <= 0:
@@ -284,6 +287,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
     async def handle_resume(self, message: GroupChatResume, ctx: MessageContext) -> None:
         """Resume the group chat manager. This is a no-op in the base class."""
         pass
+
+    @rpc
+    async def handle_get_thread(self, message: GroupChatGetThread, ctx: MessageContext) -> GroupChatThreadResponse:
+        """Return the messages accumulated in the manager thread (including agent inner messages)."""
+        return GroupChatThreadResponse(messages=list(self._message_thread))
 
     @abstractmethod
     async def validate_group_state(self, messages: List[BaseChatMessage] | None) -> None:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
@@ -106,6 +106,19 @@ class GroupChatResume(BaseModel):
     ...
 
 
+class GroupChatGetThread(BaseModel):
+    """RPC request to read the group chat manager's current message thread."""
+
+    ...
+
+
+class GroupChatThreadResponse(BaseModel):
+    """RPC response with a snapshot of the group chat message thread."""
+
+    messages: List[SerializeAsAny[BaseAgentEvent | BaseChatMessage]]
+    """Messages recorded by the manager so far, in order."""
+
+
 class GroupChatError(BaseModel):
     """A message indicating that an error occurred in the group chat."""
 

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -1944,3 +1944,48 @@ async def test_selector_group_chat_streaming(runtime: AgentRuntime | None) -> No
 
     # Content-based verification instead of index-based
     # Note: The streaming test verifies the streaming behavior, not the final result content
+
+
+@pytest.mark.asyncio
+async def test_base_group_chat_get_thread_before_run(runtime: AgentRuntime | None) -> None:
+    model_client = ReplayChatCompletionClient(["hello", "TERMINATE"])
+    agent1 = AssistantAgent("a1", model_client=model_client)
+    agent2 = AssistantAgent("a2", model_client=model_client)
+    termination = TextMentionTermination("TERMINATE")
+    team = RoundRobinGroupChat(
+        participants=[agent1, agent2],
+        termination_condition=termination,
+        runtime=runtime,
+    )
+    thread = await team.get_thread()
+    assert thread == []
+
+
+@pytest.mark.asyncio
+async def test_base_group_chat_get_thread_after_run(runtime: AgentRuntime | None) -> None:
+    model_client = ReplayChatCompletionClient(
+        [
+            'Here is the program\n ```python\nprint("Hello, world!")\n```',
+            "TERMINATE",
+        ],
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        code_executor_agent = CodeExecutorAgent(
+            "code_executor", code_executor=LocalCommandLineCodeExecutor(work_dir=temp_dir)
+        )
+        coding_assistant_agent = AssistantAgent(
+            "coding_assistant",
+            model_client=model_client,
+        )
+        termination = TextMentionTermination("TERMINATE")
+        team = RoundRobinGroupChat(
+            participants=[coding_assistant_agent, code_executor_agent],
+            termination_condition=termination,
+            runtime=runtime,
+        )
+        result = await team.run(
+            task="Write a program that prints 'Hello, world!'",
+        )
+        thread = await team.get_thread()
+        assert len(thread) >= len(result.messages)
+        assert any(isinstance(m, TextMessage) and "Write a program" in m.content for m in thread)


### PR DESCRIPTION
## Summary
Implements retrieval of the group chat manager message thread via RPC (**fixes / closes microsoft/autogen#6085**).

### Changes
- Add \GroupChatGetThread\ / \GroupChatThreadResponse\ and \handle_get_thread\ on \BaseGroupChatManager\ (FIFO-ordered with other manager messages).
- Add \BaseGroupChat.get_thread()\; with the embedded runtime, temporarily start/stop the runtime when needed so the call works after \un\ completes.
- Tests: empty thread before run; thread after run (embedded + external runtime fixtures).

### Testing
- \pytest\ on the new tests (4 parametrized cases) passed locally.

Made with [Cursor](https://cursor.com)