### PR TITLE
fix: return consistent List[str] from SwarmGroupChatManager.select_speaker

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_swarm_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_swarm_group_chat.py
@@ -95,7 +95,7 @@ class SwarmGroupChatManager(BaseGroupChatManager):
                 # The latest handoff message should always target a valid participant.
                 assert self._current_speaker in self._participant_names
                 return [self._current_speaker]
-        return self._current_speaker
+        return [self._current_speaker]
 
     async def save_state(self) -> Mapping[str, Any]:
         state = SwarmManagerState(


### PR DESCRIPTION
## Why Are These Changes Needed?

`SwarmGroupChatManager.select_speaker()` has inconsistent return types:
- Lines 91, 97: return `[self._current_speaker]` (List[str])
- Line 98: return `self._current_speaker` (str)

The return type annotation is `List[str] | str`, but the docstring says "This method always returns a single speaker." Callers that process the result uniformly as a list will get a TypeError when the fallback path returns a bare string.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed
- [x] I've added tests (if applicable) corresponding to the changes introduced in this PR
- [x] I've made sure all auto checks have passed