### PR TITLE
fix(mcp): preserve $defs in McpWorkbench.list_tools() for $ref resolution

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
@@ -1,7 +1,7 @@
 import asyncio
 import builtins
 import warnings
-from typing import Any, Dict, List, Literal, Mapping, Optional
+from typing import Any, Dict, List, Literal, Mapping, Optional, cast
 
 from autogen_core import CancellationToken, Component, ComponentModel, Image, trace_tool_span
 from autogen_core.tools import (
@@ -297,12 +297,17 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
                 if override.description is not None:
                     description = override.description
 
-            parameters = ParametersSchema(
-                type="object",
-                properties=tool.inputSchema.get("properties", {}),
-                required=tool.inputSchema.get("required", []),
-                additionalProperties=tool.inputSchema.get("additionalProperties", False),
-            )
+            # Build the parameters schema, preserving $defs so that $ref entries
+            # in properties remain resolvable by the model client.
+            schema_dict: Dict[str, Any] = {
+                "type": "object",
+                "properties": tool.inputSchema.get("properties", {}),
+                "required": tool.inputSchema.get("required", []),
+                "additionalProperties": tool.inputSchema.get("additionalProperties", False),
+            }
+            if "$defs" in tool.inputSchema:
+                schema_dict["$defs"] = tool.inputSchema["$defs"]
+            parameters = cast(ParametersSchema, schema_dict)
             tool_schema = ToolSchema(
                 name=name,
                 description=description,

--- a/python/packages/autogen-ext/tests/tools/test_mcp_workbench_overrides.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_workbench_overrides.py
@@ -296,3 +296,93 @@ def test_mcp_workbench_conflict_detection() -> None:
     }
     with pytest.raises(ValueError):
         McpWorkbench(server_params=server_params, tool_overrides=overrides_duplicate)
+
+
+@pytest.mark.asyncio
+async def test_mcp_workbench_list_tools_preserves_defs(
+    mock_mcp_actor: AsyncMock, sample_server_params: StdioServerParams
+) -> None:
+    """Test that list_tools preserves $defs from inputSchema for $ref resolution."""
+    tools_with_defs = [
+        Tool(
+            name="create_customer",
+            description="Creates a customer record",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "first_name": {"$ref": "#/$defs/Name"},
+                    "last_name": {"$ref": "#/$defs/Name"},
+                    "status": {"$ref": "#/$defs/Status"},
+                },
+                "required": ["first_name", "last_name"],
+                "$defs": {
+                    "Name": {"type": "string", "minLength": 1},
+                    "Status": {"type": "string", "enum": ["active", "inactive"]},
+                },
+            },
+        )
+    ]
+
+    workbench = McpWorkbench(server_params=sample_server_params)
+    workbench._actor = mock_mcp_actor  # type: ignore[reportPrivateUsage]
+
+    list_tools_result = ListToolsResult(tools=tools_with_defs)
+    future_result: asyncio.Future[ListToolsResult] = asyncio.Future()
+    future_result.set_result(list_tools_result)
+    mock_mcp_actor.call.return_value = future_result
+
+    try:
+        tools = await workbench.list_tools()
+        assert len(tools) == 1
+
+        params = tools[0].get("parameters", {})
+        assert params.get("type") == "object"
+
+        # $defs must be forwarded so model clients can resolve $ref entries in properties
+        assert "$defs" in params, "ParametersSchema should include $defs when present in inputSchema"
+        assert "Name" in params["$defs"]
+        assert "Status" in params["$defs"]
+
+        # Properties should still reference $defs via $ref
+        assert params["properties"]["first_name"] == {"$ref": "#/$defs/Name"}
+        assert params["properties"]["status"] == {"$ref": "#/$defs/Status"}
+    finally:
+        workbench._actor = None  # type: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_mcp_workbench_list_tools_without_defs(
+    mock_mcp_actor: AsyncMock, sample_server_params: StdioServerParams
+) -> None:
+    """Test that list_tools works correctly when inputSchema has no $defs (unchanged behavior)."""
+    tools_without_defs = [
+        Tool(
+            name="simple_tool",
+            description="A simple tool",
+            inputSchema={
+                "type": "object",
+                "properties": {"value": {"type": "integer"}},
+                "required": ["value"],
+            },
+        )
+    ]
+
+    workbench = McpWorkbench(server_params=sample_server_params)
+    workbench._actor = mock_mcp_actor  # type: ignore[reportPrivateUsage]
+
+    list_tools_result = ListToolsResult(tools=tools_without_defs)
+    future_result: asyncio.Future[ListToolsResult] = asyncio.Future()
+    future_result.set_result(list_tools_result)
+    mock_mcp_actor.call.return_value = future_result
+
+    try:
+        tools = await workbench.list_tools()
+        assert len(tools) == 1
+
+        params = tools[0].get("parameters", {})
+        assert params.get("type") == "object"
+        assert "$defs" not in params
+        assert params["properties"] == {"value": {"type": "integer"}}
+    finally:
+        workbench._actor = None  # type: ignore[reportPrivateUsage]
+


### PR DESCRIPTION
Fixes #6663

## Problem

When an MCP tool's `inputSchema` contains `$defs` for reusable type definitions,
`McpWorkbench.list_tools()` only extracted `properties`, `required`, and
`additionalProperties` into the `ParametersSchema`, silently dropping `$defs`.

This means any properties that reference types via `$ref: "#/$defs/SomeName"` are
forwarded to the model client with unresolvable references — the LLM sees e.g.
`{"$ref": "#/$defs/Name"}` but without the `$defs` dict it cannot know the actual
type. This is particularly common with MCP servers whose tools share enums or
sub-schemas across parameters.

## Solution

Include `$defs` from `inputSchema` in the outgoing `ParametersSchema` dict when
present. OpenAI's `FunctionParameters` type is `Dict[str, object]`, so it accepts
`$defs` and will forward them to the API where they can be used to resolve `$ref`
entries in the properties. Schemas without `$defs` are unaffected.

The change is a two-line addition in `_workbench.py` plus a matching test.

## Changes

- `python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py`: preserve
  `$defs` when building `ParametersSchema` in `list_tools()`
- `python/packages/autogen-ext/tests/tools/test_mcp_workbench_overrides.py`: add
  tests for schemas with and without `$defs`

## Testing

- Added `test_mcp_workbench_list_tools_preserves_defs`: verifies `$defs` is
  forwarded and `$ref` entries in properties are intact
- Added `test_mcp_workbench_list_tools_without_defs`: verifies unchanged behavior
  for schemas that don't use `$defs`