### PR TITLE
fix: add explicit type validation for participants in BaseGroupChat (#7580)

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -78,6 +78,16 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
     ):
         self._name = name
         self._description = description
+        if not isinstance(participants, (list, tuple)) or isinstance(participants, str):
+            raise TypeError(
+                f"participants must be a list of ChatAgent or Team instances, got {type(participants).__name__}."
+            )
+        for i, participant in enumerate(participants):
+            if not isinstance(participant, (ChatAgent, Team)):
+                raise TypeError(
+                    f"All participants must be ChatAgent or Team instances, "
+                    f"but participants[{i}] is {type(participant).__name__}."
+                )
         if len(participants) == 0:
             raise ValueError("At least one participant is required.")
         if len(participants) != len(set(participant.name for participant in participants)):

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -222,6 +222,30 @@ async def runtime(request: pytest.FixtureRequest) -> AsyncGenerator[AgentRuntime
         yield None
 
 
+def test_round_robin_group_chat_invalid_participants() -> None:
+    agent = _EchoAgent("agent1", description="echo agent")
+
+    # participants must be a list/tuple, not None
+    with pytest.raises(TypeError, match="participants must be a list"):
+        RoundRobinGroupChat(None)  # type: ignore
+
+    # participants must be a list/tuple, not a plain string
+    with pytest.raises(TypeError, match="participants must be a list"):
+        RoundRobinGroupChat("not_a_list")  # type: ignore
+
+    # participants must be a list/tuple, not an integer
+    with pytest.raises(TypeError, match="participants must be a list"):
+        RoundRobinGroupChat(42)  # type: ignore
+
+    # each element must be a ChatAgent or Team, not a string
+    with pytest.raises(TypeError, match=r"participants\[1\] is str"):
+        RoundRobinGroupChat([agent, "not_an_agent"])  # type: ignore
+
+    # each element must be a ChatAgent or Team, not an integer
+    with pytest.raises(TypeError, match=r"participants\[0\] is int"):
+        RoundRobinGroupChat([123])  # type: ignore
+
+
 @pytest.mark.asyncio
 async def test_round_robin_group_chat(runtime: AgentRuntime | None) -> None:
     model_client = ReplayChatCompletionClient(


### PR DESCRIPTION
Fixes #7580.

Passing `None`, a string, an integer, or a list containing non-agent objects to any group chat constructor previously raised cryptic internal errors (e.g. `TypeError: object of type 'NoneType' has no len()`). This adds two `isinstance` guards in `BaseGroupChat.__init__` before any existing checks, raising a clear `TypeError` that identifies the offending type or index. Applies to all subclasses (`RoundRobinGroupChat`, `SelectorGroupChat`, etc.) because they all delegate to the base class.