### PR TITLE
docs: add autogen-haldir to community projects list

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -46,6 +46,7 @@ Find community samples and examples of how to use AutoGen
 | [autogen-oaiapi](https://github.com/SongChiYoung/autogen-oaiapi)  | [PyPi](https://pypi.org/project/autogen-oaiapi/) | an OpenAI-style API server built on top of AutoGen |
 | [autogen-contextplus](https://github.com/SongChiYoung/autogen-contextplus)  | [PyPi](https://pypi.org/project/autogen-contextplus/) | Enhanced model_context implementations, with features such as automatic summarization and truncation of model context. |
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
+| [autogen-haldir](https://github.com/ExposureGuard/haldir/tree/main/integrations/autogen-haldir) | [PyPi](https://pypi.org/project/autogen-haldir/) | Governance layer for AutoGen tools — scoped sessions with spend caps, AES-256-GCM encrypted secrets, hash-chained tamper-evident audit trail, and instant session revocation. |
 
 
 <!-- Example -->


### PR DESCRIPTION
Adds [autogen-haldir](https://github.com/ExposureGuard/haldir/tree/main/integrations/autogen-haldir) to the community-projects table in \`docs/src/user-guide/extensions-user-guide/discover.md\`.

## What it is

[\`autogen-haldir\`](https://pypi.org/project/autogen-haldir/) is a governance layer for AutoGen agents:

- **Scoped sessions** with per-session spend caps and TTL
- **AES-256-GCM encrypted secrets** that never enter the model context (pydantic \`SecretStr\` masking in logs)
- **SHA-256 hash-chained tamper-evident audit trail** for every tool call
- **Instant mid-run revocation** — the kill switch works from any process

The \`govern_tool()\` helper wraps any \`BaseTool\`/\`FunctionTool\` with ~10 lines of code, preserving \`name\`/\`description\`/\`schema\` so AutoGen treats it as a native tool. Hooks both \`run\` and \`run_json\` entry points.

## Changes

- Adds one row to the community-projects table, alphabetically after \`autogen-ext-yepcode\`. Follows the existing format exactly (name → repo, package → PyPI, one-sentence description).

## Links

- Package: https://pypi.org/project/autogen-haldir/
- Source: https://github.com/ExposureGuard/haldir/tree/main/integrations/autogen-haldir
- Haldir: https://haldir.xyz · MIT licensed