### PR TITLE
fix: validate round robin participants early

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -78,8 +78,16 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
     ):
         self._name = name
         self._description = description
+        if not isinstance(participants, Sequence) or isinstance(participants, (str, bytes)):
+            raise TypeError("participants must be a non-empty sequence of ChatAgent or Team instances.")
         if len(participants) == 0:
             raise ValueError("At least one participant is required.")
+        invalid_participant = next(
+            (participant for participant in participants if not isinstance(participant, (ChatAgent, Team))),
+            None,
+        )
+        if invalid_participant is not None:
+            raise TypeError("participants must contain only ChatAgent or Team instances.")
         if len(participants) != len(set(participant.name for participant in participants)):
             raise ValueError("The participant names must be unique.")
         self._participants = participants

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -142,6 +142,24 @@ class _FlakyTermination(TerminationCondition):
         pass
 
 
+def test_round_robin_group_chat_rejects_non_sequence_participants() -> None:
+    with pytest.raises(TypeError, match="participants must be a non-empty sequence"):
+        RoundRobinGroupChat(participants=None)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="participants must be a non-empty sequence"):
+        RoundRobinGroupChat(participants=1)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="participants must be a non-empty sequence"):
+        RoundRobinGroupChat(participants="not a list")  # type: ignore[arg-type]
+
+
+def test_round_robin_group_chat_rejects_non_agent_participants() -> None:
+    agent = _EchoAgent("agent", "An echo agent")
+
+    with pytest.raises(TypeError, match="participants must contain only ChatAgent or Team instances"):
+        RoundRobinGroupChat(participants=[agent, "bad"])  # type: ignore[list-item]
+
+
 class _UnknownMessageType(BaseChatMessage):
     content: str
 


### PR DESCRIPTION
Summary:
- validate participants before using len() or participant.name
- raise clearer TypeErrors for non-sequence inputs and non-agent items
- add regression tests for None, scalar, string, and mixed invalid participant inputs

Testing:
- attempted targeted pytest run, but local environment is missing pytest_asyncio during test collection

Closes #7580