### PR TITLE
feat(code_executors): add opt-in sandbox flag to LocalCommandLineCodeExecutor (#7462)

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import os
+import re
 import sys
 import tempfile
 import warnings
@@ -11,7 +12,7 @@ from hashlib import sha256
 from pathlib import Path
 from string import Template
 from types import SimpleNamespace
-from typing import Any, Callable, ClassVar, List, Optional, Sequence, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
 from autogen_core import CancellationToken, Component
 from autogen_core.code_executor import CodeBlock, CodeExecutor, FunctionWithRequirements, FunctionWithRequirementsStr
@@ -32,6 +33,71 @@ __all__ = ("LocalCommandLineCodeExecutor",)
 
 A = ParamSpec("A")
 
+logger = logging.getLogger(__name__)
+
+# Default hard memory cap applied via RLIMIT_AS when sandbox=True (POSIX only).
+# 512 MiB is enough for most small Python scripts while still bounding runaway
+# LLM-generated code. Callers that need more can override via the
+# ``sandbox_memory_bytes`` constructor argument.
+_DEFAULT_SANDBOX_MEMORY_BYTES: int = 512 * 1024 * 1024
+
+# Env-var name patterns scrubbed when sandbox=True. Matched case-insensitively
+# against variable *names* (not values). Best-effort only: this is not a
+# substitute for a real sandbox, and secrets stored under non-matching names
+# will still leak to the subprocess.
+_CREDENTIAL_ENV_PATTERNS: Tuple[re.Pattern[str], ...] = (
+    re.compile(r".*_API_KEY$", re.IGNORECASE),
+    re.compile(r".*_TOKEN$", re.IGNORECASE),
+    re.compile(r".*_SECRET$", re.IGNORECASE),
+    re.compile(r".*PASSWORD.*", re.IGNORECASE),
+    re.compile(r"^AWS_.*", re.IGNORECASE),
+    re.compile(r"^AZURE_.*", re.IGNORECASE),
+    re.compile(r"^GCP_.*", re.IGNORECASE),
+    re.compile(r"^GOOGLE_.*", re.IGNORECASE),
+    re.compile(r"^OPENAI_.*", re.IGNORECASE),
+    re.compile(r"^ANTHROPIC_.*", re.IGNORECASE),
+    re.compile(r"^HF_.*", re.IGNORECASE),
+    re.compile(r"^HUGGINGFACE_.*", re.IGNORECASE),
+    re.compile(r"^GITHUB_TOKEN$", re.IGNORECASE),
+    re.compile(r"^GH_TOKEN$", re.IGNORECASE),
+    re.compile(r"^NPM_TOKEN$", re.IGNORECASE),
+    re.compile(r"^PYPI_.*", re.IGNORECASE),
+)
+
+
+def _scrub_credentials_from_env(env: Dict[str, str]) -> Dict[str, str]:
+    """Return a copy of ``env`` with credential-shaped variable names removed."""
+    scrubbed: Dict[str, str] = {}
+    for key, value in env.items():
+        if any(pattern.match(key) for pattern in _CREDENTIAL_ENV_PATTERNS):
+            continue
+        scrubbed[key] = value
+    return scrubbed
+
+
+def _make_sandbox_preexec_fn(cpu_seconds: int, memory_bytes: int) -> Optional[Callable[[], None]]:
+    """Build a ``preexec_fn`` that applies POSIX resource limits before ``exec``.
+
+    Returns ``None`` on platforms where the ``resource`` module is unavailable
+    (notably Windows). The returned closure is intended to be passed as
+    ``preexec_fn`` to :func:`asyncio.create_subprocess_exec`.
+    """
+    try:
+        import resource  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+
+    def _apply_limits() -> None:  # pragma: no cover - runs in child process
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+        try:
+            resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+        except (ValueError, OSError):
+            # Some platforms (e.g. macOS) refuse RLIMIT_AS; continue so
+            # sandbox=True still provides env-scrub + CPU capping.
+            pass
+
+    return _apply_limits
+
 
 class LocalCommandLineCodeExecutorConfig(BaseModel):
     """Configuration for LocalCommandLineCodeExecutor"""
@@ -40,6 +106,8 @@ class LocalCommandLineCodeExecutorConfig(BaseModel):
     work_dir: Optional[str] = None
     functions_module: str = "functions"
     cleanup_temp_files: bool = True
+    sandbox: Optional[bool] = None
+    sandbox_memory_bytes: int = _DEFAULT_SANDBOX_MEMORY_BYTES
 
 
 class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeExecutorConfig]):
@@ -81,6 +149,25 @@ class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeE
         functions_module (str, optional): The name of the module that will be created to store the functions. Defaults to "functions".
         cleanup_temp_files (bool, optional): Whether to automatically clean up temporary files after execution. Defaults to True.
         virtual_env_context (Optional[SimpleNamespace], optional): The virtual environment context. Defaults to None.
+        sandbox (Optional[bool], optional): Opt-in best-effort hardening for LLM-generated code.
+            This is **NOT** a substitute for :class:`~autogen_ext.code_executors.docker.DockerCommandLineCodeExecutor`
+            and provides no strong isolation guarantees; it is only a defense-in-depth layer for
+            users who cannot run Docker.
+
+            * ``None`` (default): backward-compatible behavior. Emits a :class:`DeprecationWarning`
+              noting that a future release will make this parameter required, and executes code
+              without any added hardening.
+            * ``False``: explicit acknowledgement that no sandboxing should be applied. No
+              warning is emitted.
+            * ``True``: applies POSIX ``RLIMIT_CPU`` (= ``timeout + 5`` seconds) and
+              ``RLIMIT_AS`` (default 512 MiB, see ``sandbox_memory_bytes``) via ``preexec_fn``
+              on code-execution and pip-install subprocesses, and scrubs credential-shaped
+              environment variables (``*_API_KEY``, ``*_TOKEN``, ``*_SECRET``, ``AWS_*``,
+              ``OPENAI_*``, etc.) from the subprocess environment. On Windows, resource limits
+              are unavailable and a warning is logged; env scrub still applies.
+        sandbox_memory_bytes (int, optional): Address-space cap (``RLIMIT_AS``) applied when
+            ``sandbox=True`` on POSIX. Defaults to 512 MiB. Ignored when ``sandbox`` is ``None``
+            or ``False``, and on platforms without the ``resource`` module.
 
     .. note::
         Using the current directory (".") as working directory is deprecated. Using it will raise a deprecation warning.
@@ -158,15 +245,38 @@ $functions"""
         functions_module: str = "functions",
         cleanup_temp_files: bool = True,
         virtual_env_context: Optional[SimpleNamespace] = None,
+        sandbox: Optional[bool] = None,
+        sandbox_memory_bytes: int = _DEFAULT_SANDBOX_MEMORY_BYTES,
     ):
-        # Issue warning about using LocalCommandLineCodeExecutor
-        warnings.warn(
-            "Using LocalCommandLineCodeExecutor may execute code on the local machine which can be unsafe. "
-            "For security, it is recommended to use DockerCommandLineCodeExecutor instead. "
-            "To install Docker, visit: https://docs.docker.com/get-docker/",
-            UserWarning,
-            stacklevel=2,
-        )
+        # Warn based on the caller's choice of ``sandbox``. When ``sandbox`` is
+        # left at its default (``None``), we emit a ``DeprecationWarning`` so
+        # callers are nudged toward making an explicit decision before a future
+        # release makes the parameter required. An explicit ``False`` opts out
+        # of the warning (but preserves the insecure behavior), while ``True``
+        # enables best-effort hardening. See issue #7462.
+        if sandbox is None:
+            deprecation_msg = (
+                "LocalCommandLineCodeExecutor was constructed without an explicit "
+                "`sandbox` argument. A future release will require this parameter. "
+                "Pass `sandbox=True` for best-effort in-process hardening (POSIX "
+                "resource limits + credential env-var scrub), or `sandbox=False` to "
+                "explicitly acknowledge unsandboxed execution. For real isolation, "
+                "prefer DockerCommandLineCodeExecutor. See "
+                "https://github.com/microsoft/autogen/issues/7462."
+            )
+            warnings.warn(deprecation_msg, DeprecationWarning, stacklevel=2)
+            logger.warning(deprecation_msg)
+
+        self._sandbox: Optional[bool] = sandbox
+        self._sandbox_memory_bytes: int = sandbox_memory_bytes
+        if sandbox is True and sys.platform == "win32":
+            logger.warning(
+                "LocalCommandLineCodeExecutor(sandbox=True) on Windows: POSIX "
+                "resource limits (RLIMIT_CPU, RLIMIT_AS) are not available on "
+                "this platform. Credential env-var scrubbing still applies, but "
+                "no CPU/memory caps will be enforced. Use "
+                "DockerCommandLineCodeExecutor for real isolation."
+            )
 
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
@@ -270,6 +380,33 @@ $functions"""
         """(Experimental) Whether to automatically clean up temporary files after execution."""
         return self._cleanup_temp_files
 
+    @property
+    def sandbox(self) -> Optional[bool]:
+        """(Experimental) Whether sandbox hardening is enabled. See ``__init__`` docs."""
+        return self._sandbox
+
+    def _prepare_sandbox_subprocess_kwargs(self, env: Dict[str, str]) -> Tuple[Dict[str, str], Dict[str, Any]]:
+        """Apply sandbox policy to a subprocess env + kwargs pair.
+
+        Returns ``(env, extra_kwargs)``. When ``sandbox`` is not ``True``, the
+        env is returned unchanged and extra_kwargs is empty. When ``sandbox`` is
+        ``True``, credential-shaped env vars are stripped and (on POSIX) a
+        ``preexec_fn`` applying RLIMIT_CPU and RLIMIT_AS is attached.
+        """
+        if self._sandbox is not True:
+            return env, {}
+
+        scrubbed = _scrub_credentials_from_env(env)
+        extra_kwargs: Dict[str, Any] = {}
+        if sys.platform != "win32":
+            preexec = _make_sandbox_preexec_fn(
+                cpu_seconds=self._timeout + 5,
+                memory_bytes=self._sandbox_memory_bytes,
+            )
+            if preexec is not None:
+                extra_kwargs["preexec_fn"] = preexec
+        return scrubbed, extra_kwargs
+
     async def _setup_functions(self, cancellation_token: CancellationToken) -> None:
         func_file_content = build_python_functions_file(self._functions)
         func_file = self.work_dir / f"{self._functions_module}.py"
@@ -290,6 +427,8 @@ $functions"""
             else:
                 py_executable = sys.executable
 
+            pip_env, pip_extra_kwargs = self._prepare_sandbox_subprocess_kwargs(os.environ.copy())
+
             task = asyncio.create_task(
                 asyncio.create_subprocess_exec(
                     py_executable,
@@ -297,6 +436,8 @@ $functions"""
                     cwd=self.work_dir,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    env=pip_env,
+                    **pip_extra_kwargs,
                 )
             )
             cancellation_token.link_future(task)
@@ -422,6 +563,9 @@ $functions"""
                     # Shell commands (bash, sh, etc.)
                     extra_args = [str(written_file.absolute())]
 
+            # Apply sandbox policy (env scrub + POSIX rlimits) if enabled.
+            env, sandbox_kwargs = self._prepare_sandbox_subprocess_kwargs(env)
+
             # Create a subprocess and run
             task = asyncio.create_task(
                 asyncio.create_subprocess_exec(
@@ -431,6 +575,7 @@ $functions"""
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     env=env,
+                    **sandbox_kwargs,
                 )
             )
             cancellation_token.link_future(task)
@@ -514,6 +659,8 @@ $functions"""
             work_dir=str(self.work_dir),
             functions_module=self._functions_module,
             cleanup_temp_files=self._cleanup_temp_files,
+            sandbox=self._sandbox,
+            sandbox_memory_bytes=self._sandbox_memory_bytes,
         )
 
     @classmethod
@@ -523,4 +670,6 @@ $functions"""
             work_dir=Path(config.work_dir) if config.work_dir is not None else None,
             functions_module=config.functions_module,
             cleanup_temp_files=config.cleanup_temp_files,
+            sandbox=config.sandbox,
+            sandbox_memory_bytes=config.sandbox_memory_bytes,
         )

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -11,7 +11,7 @@ from hashlib import sha256
 from pathlib import Path
 from string import Template
 from types import SimpleNamespace
-from typing import Any, Callable, ClassVar, List, Optional, Sequence, Union
+from typing import Any, Callable, ClassVar, List, Mapping, Optional, Sequence, Union
 
 from autogen_core import CancellationToken, Component
 from autogen_core.code_executor import CodeBlock, CodeExecutor, FunctionWithRequirements, FunctionWithRequirementsStr
@@ -32,6 +32,80 @@ __all__ = ("LocalCommandLineCodeExecutor",)
 
 A = ParamSpec("A")
 
+logger = logging.getLogger(__name__)
+
+# Environment variable name patterns considered sensitive enough to strip when
+# the executor is instantiated with sandbox=True. Matching is case-insensitive
+# and uses substring containment, not prefix, to catch variants like
+# "HF_TOKEN" / "GH_TOKEN" / "MY_API_KEY" without enumerating every provider.
+_SENSITIVE_ENV_SUBSTRINGS: tuple[str, ...] = (
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "PASSWD",
+    "API_KEY",
+    "APIKEY",
+    "PRIVATE_KEY",
+    "CREDENTIAL",
+    "SESSION",
+    "COOKIE",
+    "AUTH",
+)
+
+
+def _scrub_sensitive_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Return a copy of *env* with entries whose name matches a sensitive
+    pattern removed. Case-insensitive substring match."""
+    scrubbed: dict[str, str] = {}
+    for key, value in env.items():
+        upper = key.upper()
+        if any(marker in upper for marker in _SENSITIVE_ENV_SUBSTRINGS):
+            continue
+        scrubbed[key] = value
+    return scrubbed
+
+
+# Default per-process resource ceilings when sandbox=True on POSIX. These are
+# best-effort safety rails, not a security boundary — an adversarial payload
+# can still read files, make outbound connections, and write to work_dir.
+_SANDBOX_MAX_ADDRESS_SPACE_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+_SANDBOX_MAX_OPEN_FILES = 256
+_SANDBOX_MAX_PROCESSES = 64
+
+
+def _build_preexec_rlimits(timeout_seconds: int) -> Callable[[], None]:
+    """Return a ``preexec_fn`` callable that applies POSIX rlimits in the
+    forked child before ``exec``. Isolated in its own factory so we can patch
+    it in tests and to keep the ``resource`` import POSIX-scoped."""
+    import resource  # POSIX-only; import at call time for Windows safety
+
+    cpu_seconds = max(1, int(timeout_seconds))
+
+    def _apply() -> None:
+        # CPU time — gives a hard second-level ceiling that complements the
+        # asyncio-level timeout (which can be suppressed by blocking syscalls).
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+        # Address space — blocks naive memory-bomb payloads.
+        resource.setrlimit(
+            resource.RLIMIT_AS,
+            (_SANDBOX_MAX_ADDRESS_SPACE_BYTES, _SANDBOX_MAX_ADDRESS_SPACE_BYTES),
+        )
+        # File descriptors.
+        resource.setrlimit(
+            resource.RLIMIT_NOFILE,
+            (_SANDBOX_MAX_OPEN_FILES, _SANDBOX_MAX_OPEN_FILES),
+        )
+        # Fork bomb guard; RLIMIT_NPROC is advisory on some platforms.
+        try:
+            resource.setrlimit(
+                resource.RLIMIT_NPROC,
+                (_SANDBOX_MAX_PROCESSES, _SANDBOX_MAX_PROCESSES),
+            )
+        except (ValueError, OSError):
+            pass
+
+    return _apply
+
 
 class LocalCommandLineCodeExecutorConfig(BaseModel):
     """Configuration for LocalCommandLineCodeExecutor"""
@@ -40,6 +114,7 @@ class LocalCommandLineCodeExecutorConfig(BaseModel):
     work_dir: Optional[str] = None
     functions_module: str = "functions"
     cleanup_temp_files: bool = True
+    sandbox: Optional[bool] = None
 
 
 class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeExecutorConfig]):
@@ -81,6 +156,14 @@ class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeE
         functions_module (str, optional): The name of the module that will be created to store the functions. Defaults to "functions".
         cleanup_temp_files (bool, optional): Whether to automatically clean up temporary files after execution. Defaults to True.
         virtual_env_context (Optional[SimpleNamespace], optional): The virtual environment context. Defaults to None.
+        sandbox (Optional[bool], optional): Explicit sandbox posture. When ``None`` (default, legacy) the executor runs unsandboxed
+            and emits a ``DeprecationWarning``; in a future release this parameter will become required. When ``False`` the caller
+            explicitly acknowledges unsandboxed execution and no warning is emitted. When ``True`` the executor applies best-effort
+            in-process hardening: environment entries whose name contains common credential patterns (``TOKEN``, ``SECRET``,
+            ``API_KEY``, ``PASSWORD``, ``PRIVATE_KEY`` etc.) are stripped from the child process, and on POSIX platforms per-child
+            rlimits (``RLIMIT_CPU``, ``RLIMIT_AS``, ``RLIMIT_NOFILE``, ``RLIMIT_NPROC``) are applied via ``preexec_fn``. This is
+            **not** a substitute for :class:`DockerCommandLineCodeExecutor`; it does not provide filesystem, network, or user
+            isolation. Use the Docker executor for untrusted-code deployments.
 
     .. note::
         Using the current directory (".") as working directory is deprecated. Using it will raise a deprecation warning.
@@ -158,15 +241,45 @@ $functions"""
         functions_module: str = "functions",
         cleanup_temp_files: bool = True,
         virtual_env_context: Optional[SimpleNamespace] = None,
+        sandbox: Optional[bool] = None,
     ):
-        # Issue warning about using LocalCommandLineCodeExecutor
-        warnings.warn(
-            "Using LocalCommandLineCodeExecutor may execute code on the local machine which can be unsafe. "
-            "For security, it is recommended to use DockerCommandLineCodeExecutor instead. "
-            "To install Docker, visit: https://docs.docker.com/get-docker/",
-            UserWarning,
-            stacklevel=2,
-        )
+        # ── Sandbox posture notification ────────────────────────────────────
+        # The legacy UserWarning at construction was easily suppressed by
+        # production configurations (`python -W ignore`, warning filters in
+        # logging pipelines). Callers now choose one of three postures:
+        #   • sandbox=None  (default, legacy)  → DeprecationWarning + logger
+        #   • sandbox=False                    → explicit opt-out, silent
+        #   • sandbox=True                     → best-effort in-process
+        #                                         hardening (env scrub +
+        #                                         POSIX rlimits). NOT a
+        #                                         substitute for the Docker
+        #                                         executor.
+        if sandbox is None:
+            warnings.warn(
+                "LocalCommandLineCodeExecutor is running WITHOUT sandboxing. "
+                "Pass sandbox=False to acknowledge this explicitly, or "
+                "sandbox=True for best-effort POSIX hardening. "
+                "For strong isolation use DockerCommandLineCodeExecutor "
+                "(https://docs.docker.com/get-docker/). "
+                "In a future release the `sandbox` parameter will become "
+                "required.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            logger.warning(
+                "LocalCommandLineCodeExecutor instantiated without explicit "
+                "sandbox posture; defaulting to unsandboxed execution."
+            )
+        elif sandbox is True and sys.platform == "win32":
+            warnings.warn(
+                "sandbox=True requested but POSIX rlimits / preexec hooks "
+                "are not available on Windows; falling back to env scrub "
+                "only. Use DockerCommandLineCodeExecutor for strong "
+                "isolation on Windows.",
+                UserWarning,
+                stacklevel=2,
+            )
+        self._sandbox: Optional[bool] = sandbox
 
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")
@@ -399,6 +512,14 @@ $functions"""
                 virtual_env_bin_abs_path = os.path.abspath(self._virtual_env_context.bin_path)
                 env["PATH"] = f"{virtual_env_bin_abs_path}{os.pathsep}{env['PATH']}"
 
+            # Sandbox hardening: strip env entries that look like credentials.
+            # This is a shallow defence — LLM-generated code can still read
+            # files, call out to the network, or touch the filesystem — but it
+            # prevents the most common leak pattern where provider API keys
+            # sit in the parent process environment.
+            if self._sandbox is True:
+                env = _scrub_sensitive_env(env)
+
             # Decide how to invoke the script
             if lang == "python":
                 program = (
@@ -422,6 +543,14 @@ $functions"""
                     # Shell commands (bash, sh, etc.)
                     extra_args = [str(written_file.absolute())]
 
+            # Build sandbox-specific subprocess kwargs.
+            # On POSIX with sandbox=True we set per-child rlimits via a
+            # preexec_fn so runaway memory or fork bombs are capped. Windows
+            # does not support preexec_fn or RLIMIT_AS → env scrub only.
+            exec_kwargs: dict[str, Any] = {}
+            if self._sandbox is True and sys.platform != "win32":
+                exec_kwargs["preexec_fn"] = _build_preexec_rlimits(self._timeout)
+
             # Create a subprocess and run
             task = asyncio.create_task(
                 asyncio.create_subprocess_exec(
@@ -431,6 +560,7 @@ $functions"""
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     env=env,
+                    **exec_kwargs,
                 )
             )
             cancellation_token.link_future(task)
@@ -514,6 +644,7 @@ $functions"""
             work_dir=str(self.work_dir),
             functions_module=self._functions_module,
             cleanup_temp_files=self._cleanup_temp_files,
+            sandbox=self._sandbox,
         )
 
     @classmethod
@@ -523,4 +654,5 @@ $functions"""
             work_dir=Path(config.work_dir) if config.work_dir is not None else None,
             functions_module=config.functions_module,
             cleanup_temp_files=config.cleanup_temp_files,
+            sandbox=config.sandbox,
         )

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -28,7 +28,27 @@ from .._common import (
     to_stub,
 )
 
-__all__ = ("LocalCommandLineCodeExecutor",)
+__all__ = ("LocalCommandLineCodeExecutor", "PlatformExecutionScopeError")
+
+
+class PlatformExecutionScopeError(RuntimeError):
+    """Raised when ``sandbox=True`` was requested but the current platform
+    cannot honor the in-process isolation contract.
+
+    The :class:`LocalCommandLineCodeExecutor` ``sandbox=True`` posture is a
+    *contract*, not a hint: it promises a specific set of guarantees
+    (POSIX rlimits + credential-pattern environment scrub). When the running
+    platform cannot deliver one or more of those guarantees — for example,
+    Windows has no ``preexec_fn`` and no ``RLIMIT_AS`` — the executor refuses
+    to construct rather than silently degrade to a weaker posture.
+
+    The error message names *which* guarantee is unavailable so procurement
+    and threat-model reviewers can audit the failure surface without
+    inferring from "falls back to" prose. Callers that need cross-platform
+    untrusted-code execution should use
+    :class:`~autogen_ext.code_executors.docker.DockerCommandLineCodeExecutor`,
+    which provides container-based isolation independent of the host OS.
+    """
 
 A = ParamSpec("A")
 
@@ -156,14 +176,36 @@ class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeE
         functions_module (str, optional): The name of the module that will be created to store the functions. Defaults to "functions".
         cleanup_temp_files (bool, optional): Whether to automatically clean up temporary files after execution. Defaults to True.
         virtual_env_context (Optional[SimpleNamespace], optional): The virtual environment context. Defaults to None.
-        sandbox (Optional[bool], optional): Explicit sandbox posture. When ``None`` (default, legacy) the executor runs unsandboxed
-            and emits a ``DeprecationWarning``; in a future release this parameter will become required. When ``False`` the caller
-            explicitly acknowledges unsandboxed execution and no warning is emitted. When ``True`` the executor applies best-effort
-            in-process hardening: environment entries whose name contains common credential patterns (``TOKEN``, ``SECRET``,
-            ``API_KEY``, ``PASSWORD``, ``PRIVATE_KEY`` etc.) are stripped from the child process, and on POSIX platforms per-child
-            rlimits (``RLIMIT_CPU``, ``RLIMIT_AS``, ``RLIMIT_NOFILE``, ``RLIMIT_NPROC``) are applied via ``preexec_fn``. This is
-            **not** a substitute for :class:`DockerCommandLineCodeExecutor`; it does not provide filesystem, network, or user
-            isolation. Use the Docker executor for untrusted-code deployments.
+        sandbox (Optional[bool], optional): Explicit sandbox posture. This parameter is a **contract**, not a hint — see the
+            per-platform behavior below. The executor refuses to construct rather than silently degrade to a weaker posture.
+
+            **When** ``sandbox`` **is** ``None`` (default, legacy):
+                The executor runs unsandboxed and emits a ``DeprecationWarning``. In a future release this parameter will become
+                required.
+
+            **When** ``sandbox`` **is** ``False``:
+                The caller explicitly acknowledges unsandboxed execution. No warning is emitted; no isolation is applied.
+
+            **When** ``sandbox`` **is** ``True`` **on POSIX (Linux, macOS):**
+                The executor applies the following in-process hardening contract on every child process:
+
+                * Environment scrub — entries whose name matches any of the credential substrings ``TOKEN``, ``SECRET``,
+                  ``PASSWORD``, ``PASSWD``, ``API_KEY``, ``APIKEY``, ``PRIVATE_KEY``, ``CREDENTIAL``, ``SESSION``, ``COOKIE``,
+                  ``AUTH`` (case-insensitive) are stripped from the child environment.
+                * ``RLIMIT_CPU`` set to the per-block ``timeout`` value — caps wall-clock-equivalent CPU consumption.
+                * ``RLIMIT_AS`` set to 2 GiB — caps the child process address space (memory-bomb guard).
+                * ``RLIMIT_NOFILE`` set to 256 — caps simultaneously open file descriptors.
+                * ``RLIMIT_NPROC`` set to 64 (best-effort; advisory on some platforms) — fork-bomb guard.
+
+                These rlimits are applied via ``preexec_fn`` in the forked child before ``exec``. This is **not** a substitute
+                for :class:`~autogen_ext.code_executors.docker.DockerCommandLineCodeExecutor`; it does not provide filesystem,
+                network, user, or namespace isolation.
+
+            **When** ``sandbox`` **is** ``True`` **on Windows:**
+                Raises :class:`PlatformExecutionScopeError` at construction. ``preexec_fn`` and the ``resource``-module rlimits
+                used to enforce the POSIX hardening contract are not available on Windows, so the in-process isolation
+                guarantees cannot be honored. Use :class:`~autogen_ext.code_executors.docker.DockerCommandLineCodeExecutor`
+                for untrusted-code execution on Windows hosts.
 
     .. note::
         Using the current directory (".") as working directory is deprecated. Using it will raise a deprecation warning.
@@ -271,13 +313,20 @@ $functions"""
                 "sandbox posture; defaulting to unsandboxed execution."
             )
         elif sandbox is True and sys.platform == "win32":
-            warnings.warn(
-                "sandbox=True requested but POSIX rlimits / preexec hooks "
-                "are not available on Windows; falling back to env scrub "
-                "only. Use DockerCommandLineCodeExecutor for strong "
-                "isolation on Windows.",
-                UserWarning,
-                stacklevel=2,
+            # Contract framing per #7611 reviewer feedback: name the failure
+            # mode explicitly. Silent fallback to env-scrub-only would let a
+            # caller believe they obtained the POSIX hardening contract when
+            # the rlimit guarantees (RLIMIT_AS / RLIMIT_CPU / RLIMIT_NOFILE /
+            # RLIMIT_NPROC) and the preexec_fn hook required to install them
+            # are platform-unavailable.
+            raise PlatformExecutionScopeError(
+                "sandbox=True requires the POSIX in-process hardening contract "
+                "(preexec_fn + RLIMIT_CPU / RLIMIT_AS / RLIMIT_NOFILE / "
+                "RLIMIT_NPROC), which is not available on Windows: "
+                "the `resource` module and `preexec_fn` are POSIX-only, so the "
+                "memory-cap, FD-cap, and fork-bomb guarantees cannot be "
+                "enforced. Use DockerCommandLineCodeExecutor for untrusted "
+                "code on Windows hosts."
             )
         self._sandbox: Optional[bool] = sandbox
 
@@ -545,10 +594,19 @@ $functions"""
 
             # Build sandbox-specific subprocess kwargs.
             # On POSIX with sandbox=True we set per-child rlimits via a
-            # preexec_fn so runaway memory or fork bombs are capped. Windows
-            # does not support preexec_fn or RLIMIT_AS → env scrub only.
+            # preexec_fn so runaway memory or fork bombs are capped. The
+            # Windows path is unreachable here because __init__ raises
+            # PlatformExecutionScopeError when sandbox=True on win32; this
+            # second guard is defense-in-depth so a future refactor cannot
+            # silently exec without the rlimit contract.
             exec_kwargs: dict[str, Any] = {}
-            if self._sandbox is True and sys.platform != "win32":
+            if self._sandbox is True:
+                if sys.platform == "win32":
+                    raise PlatformExecutionScopeError(
+                        "sandbox=True cannot be honored on Windows: "
+                        "preexec_fn + RLIMIT_* are POSIX-only. Use "
+                        "DockerCommandLineCodeExecutor instead."
+                    )
                 exec_kwargs["preexec_fn"] = _build_preexec_rlimits(self._timeout)
 
             # Create a subprocess and run

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -180,7 +180,7 @@ class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeE
             per-platform behavior below. The executor refuses to construct rather than silently degrade to a weaker posture.
 
             **When** ``sandbox`` **is** ``None`` (default, legacy):
-                The executor runs unsandboxed and emits a ``DeprecationWarning``. In a future release this parameter will become
+                The executor runs unsandboxed and emits a ``UserWarning`` plus a logger warning. In a future release this parameter will become
                 required.
 
             **When** ``sandbox`` **is** ``False``:
@@ -286,10 +286,12 @@ $functions"""
         sandbox: Optional[bool] = None,
     ):
         # ── Sandbox posture notification ────────────────────────────────────
-        # The legacy UserWarning at construction was easily suppressed by
-        # production configurations (`python -W ignore`, warning filters in
-        # logging pipelines). Callers now choose one of three postures:
-        #   • sandbox=None  (default, legacy)  → DeprecationWarning + logger
+        # The default notice intentionally uses UserWarning rather than
+        # DeprecationWarning so library-level construction remains visible
+        # under Python's stock warning filters. logger.warning stays as a
+        # second channel for applications that route warnings into logging.
+        # Callers choose one of three postures:
+        #   • sandbox=None  (default, legacy)  → UserWarning + logger
         #   • sandbox=False                    → explicit opt-out, silent
         #   • sandbox=True                     → best-effort in-process
         #                                         hardening (env scrub +
@@ -305,7 +307,7 @@ $functions"""
                 "(https://docs.docker.com/get-docker/). "
                 "In a future release the `sandbox` parameter will become "
                 "required.",
-                DeprecationWarning,
+                UserWarning,
                 stacklevel=2,
             )
             logger.warning(

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import types
 import venv
+import warnings
 from pathlib import Path
 from typing import AsyncGenerator, TypeAlias
 from unittest.mock import patch
@@ -445,3 +446,80 @@ async def test_cleanup_temp_files_oserror(caplog: pytest.LogCaptureFixture) -> N
                 # The code file should have been attempted to be deleted and failed
                 assert any("Failed to delete temporary file" in record.message for record in caplog.records)
                 assert any("Mocked OSError" in record.message for record in caplog.records)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sandbox posture tests (issue #7462)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sandbox_default_emits_deprecation_warning() -> None:
+    """Instantiating without an explicit sandbox posture should emit a
+    DeprecationWarning (not the legacy UserWarning) so warning-filter
+    pipelines that silence UserWarning still surface the security notice."""
+    with pytest.warns(DeprecationWarning, match=r"sandbox=False.*sandbox=True"):
+        LocalCommandLineCodeExecutor()
+
+
+@pytest.mark.asyncio
+async def test_sandbox_false_is_silent_opt_out() -> None:
+    """sandbox=False is the explicit "I accept the risk" acknowledgement and
+    must not emit the DeprecationWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        # Must not raise: the DeprecationWarning-as-error filter would trip
+        # if we regressed and emitted the warning in the explicit path.
+        LocalCommandLineCodeExecutor(sandbox=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only rlimit path")
+async def test_sandbox_true_strips_credential_env(tmp_path: Path) -> None:
+    """sandbox=True should remove environment variables whose names look
+    like credentials before invoking the child process."""
+    executor = LocalCommandLineCodeExecutor(work_dir=tmp_path, sandbox=True)
+    await executor.start()
+    try:
+        code = (
+            "import os\n"
+            "for k in ['MY_API_KEY', 'SOME_TOKEN', 'HARMLESS_VAR']:\n"
+            "    print(k, os.environ.get(k, '<missing>'))\n"
+        )
+        with patch.dict(
+            os.environ,
+            {
+                "MY_API_KEY": "sekret-1",
+                "SOME_TOKEN": "sekret-2",
+                "HARMLESS_VAR": "benign",
+            },
+            clear=False,
+        ):
+            result = await executor.execute_code_blocks(
+                [CodeBlock(code=code, language="python")],
+                cancellation_token=CancellationToken(),
+            )
+    finally:
+        await executor.stop()
+
+    assert result.exit_code == 0, result.output
+    assert "MY_API_KEY <missing>" in result.output
+    assert "SOME_TOKEN <missing>" in result.output
+    assert "HARMLESS_VAR benign" in result.output
+
+
+@pytest.mark.asyncio
+async def test_sandbox_roundtrips_through_config(tmp_path: Path) -> None:
+    """The sandbox posture must survive serialize → deserialize so declarative
+    deployments cannot silently downgrade to the default warning path."""
+    executor = LocalCommandLineCodeExecutor(work_dir=tmp_path, sandbox=True)
+    config = executor.dump_component()
+    # dump_component should preserve the explicit posture.
+    assert config.config["sandbox"] is True
+
+    # The load side must not emit the default DeprecationWarning — it would
+    # fire if sandbox weren't threaded through.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        restored = LocalCommandLineCodeExecutor.load_component(config)
+    assert restored._sandbox is True  # type: ignore[attr-defined]

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -20,7 +20,7 @@ import pytest_asyncio
 from aiofiles import open
 from autogen_core import CancellationToken
 from autogen_core.code_executor import CodeBlock
-from autogen_ext.code_executors.local import LocalCommandLineCodeExecutor
+from autogen_ext.code_executors.local import LocalCommandLineCodeExecutor, PlatformExecutionScopeError
 
 HAS_POWERSHELL: bool = platform.system() == "Windows" and (
     shutil.which("powershell") is not None or shutil.which("pwsh") is not None
@@ -506,6 +506,36 @@ async def test_sandbox_true_strips_credential_env(tmp_path: Path) -> None:
     assert "MY_API_KEY <missing>" in result.output
     assert "SOME_TOKEN <missing>" in result.output
     assert "HARMLESS_VAR benign" in result.output
+
+
+@pytest.mark.asyncio
+async def test_sandbox_true_on_windows_raises_platform_scope_error() -> None:
+    """sandbox=True must raise PlatformExecutionScopeError on Windows rather
+    than silently degrading to env-scrub-only. The contract is named in the
+    error message so threat-model and procurement reviewers can see exactly
+    which guarantees were unavailable."""
+    with patch("autogen_ext.code_executors.local.sys") as mock_sys:
+        mock_sys.platform = "win32"
+        # Preserve the real `sys.executable` since the executor reads it
+        # only after the platform branch; the ValueError-on-timeout etc.
+        # paths don't run during construction.
+        mock_sys.executable = sys.executable
+        with pytest.raises(PlatformExecutionScopeError) as excinfo:
+            LocalCommandLineCodeExecutor(sandbox=True)
+    msg = str(excinfo.value)
+    # The contract names the missing guarantees explicitly.
+    assert "RLIMIT_AS" in msg
+    assert "preexec_fn" in msg
+    # And points the caller at the right escape hatch.
+    assert "Docker" in msg
+
+
+@pytest.mark.asyncio
+async def test_platform_execution_scope_error_is_runtime_error() -> None:
+    """PlatformExecutionScopeError must subclass RuntimeError so existing
+    `except RuntimeError:` handlers in caller code still catch it without a
+    breaking change to the public exception hierarchy."""
+    assert issubclass(PlatformExecutionScopeError, RuntimeError)
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -2,6 +2,7 @@
 # Credit to original authors
 
 import asyncio
+import logging
 import os
 import platform
 import shutil
@@ -454,21 +455,34 @@ async def test_cleanup_temp_files_oserror(caplog: pytest.LogCaptureFixture) -> N
 
 
 @pytest.mark.asyncio
-async def test_sandbox_default_emits_deprecation_warning() -> None:
+async def test_sandbox_default_emits_user_warning() -> None:
     """Instantiating without an explicit sandbox posture should emit a
-    DeprecationWarning (not the legacy UserWarning) so warning-filter
-    pipelines that silence UserWarning still surface the security notice."""
-    with pytest.warns(DeprecationWarning, match=r"sandbox=False.*sandbox=True"):
+    UserWarning so library-level construction is visible under Python's
+    stock warning filters."""
+    with pytest.warns(UserWarning, match=r"sandbox=False.*sandbox=True"):
         LocalCommandLineCodeExecutor()
+
+
+@pytest.mark.asyncio
+async def test_sandbox_default_logs_when_warnings_are_ignored(caplog: pytest.LogCaptureFixture) -> None:
+    """The logging lane should still emit when an application suppresses
+    Python warnings globally."""
+    caplog.set_level(logging.WARNING, logger="autogen_ext.code_executors.local")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        LocalCommandLineCodeExecutor()
+
+    assert any("without explicit sandbox posture" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_sandbox_false_is_silent_opt_out() -> None:
     """sandbox=False is the explicit "I accept the risk" acknowledgement and
-    must not emit the DeprecationWarning."""
+    must not emit the UserWarning."""
     with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        # Must not raise: the DeprecationWarning-as-error filter would trip
+        warnings.simplefilter("error", UserWarning)
+        # Must not raise: the UserWarning-as-error filter would trip
         # if we regressed and emitted the warning in the explicit path.
         LocalCommandLineCodeExecutor(sandbox=False)
 
@@ -547,9 +561,9 @@ async def test_sandbox_roundtrips_through_config(tmp_path: Path) -> None:
     # dump_component should preserve the explicit posture.
     assert config.config["sandbox"] is True
 
-    # The load side must not emit the default DeprecationWarning — it would
+    # The load side must not emit the default UserWarning — it would
     # fire if sandbox weren't threaded through.
     with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
+        warnings.simplefilter("error", UserWarning)
         restored = LocalCommandLineCodeExecutor.load_component(config)
     assert restored._sandbox is True  # type: ignore[attr-defined]

--- a/python/packages/autogen-ext/tests/code_executors/test_local_sandbox.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_local_sandbox.py
@@ -1,0 +1,123 @@
+# Tests for the opt-in ``sandbox`` parameter on LocalCommandLineCodeExecutor.
+# See https://github.com/microsoft/autogen/issues/7462 for context.
+
+import os
+import sys
+import warnings
+
+import pytest
+from autogen_core import CancellationToken
+from autogen_core.code_executor import CodeBlock
+from autogen_ext.code_executors.local import LocalCommandLineCodeExecutor
+from autogen_ext.code_executors.local import (
+    LocalCommandLineCodeExecutorConfig,
+)
+
+
+def test_sandbox_none_emits_deprecation_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        LocalCommandLineCodeExecutor()
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    user_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning) and "DockerCommandLineCodeExecutor" in str(w.message)
+    ]
+    assert deprecations, "sandbox=None must emit a DeprecationWarning"
+    assert not user_warnings, "legacy UserWarning should be replaced by DeprecationWarning when sandbox=None"
+
+
+def test_sandbox_false_emits_no_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        LocalCommandLineCodeExecutor(sandbox=False)
+
+    sandbox_related = [
+        w
+        for w in caught
+        if "sandbox" in str(w.message).lower() or issubclass(w.category, DeprecationWarning)
+    ]
+    assert not sandbox_related, f"sandbox=False should not emit warnings, got: {[str(w.message) for w in caught]}"
+
+
+def test_sandbox_true_no_deprecation_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        LocalCommandLineCodeExecutor(sandbox=True)
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert not deprecations, "sandbox=True should not emit DeprecationWarning"
+
+
+def test_config_round_trip_preserves_sandbox() -> None:
+    for sandbox_value in (None, True, False):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            executor = LocalCommandLineCodeExecutor(sandbox=sandbox_value, sandbox_memory_bytes=123456789)
+        config = executor._to_config()
+        assert config.sandbox == sandbox_value
+        assert config.sandbox_memory_bytes == 123456789
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            rebuilt = LocalCommandLineCodeExecutor._from_config(config)
+        assert rebuilt.sandbox == sandbox_value
+        assert rebuilt._sandbox_memory_bytes == 123456789
+
+
+def test_config_model_defaults() -> None:
+    cfg = LocalCommandLineCodeExecutorConfig()
+    assert cfg.sandbox is None
+    assert cfg.sandbox_memory_bytes == 512 * 1024 * 1024
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only: env scrub + rlimits")
+@pytest.mark.asyncio
+async def test_sandbox_true_scrubs_credential_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("FAKE_API_KEY", "xyz-should-not-leak")
+    monkeypatch.setenv("HARMLESS_VAR", "keep-me")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        executor = LocalCommandLineCodeExecutor(work_dir=tmp_path, sandbox=True)
+
+    result = await executor.execute_code_blocks(
+        code_blocks=[
+            CodeBlock(
+                language="bash",
+                code='echo "API=${FAKE_API_KEY:-MISSING}"; echo "OK=${HARMLESS_VAR:-MISSING}"',
+            )
+        ],
+        cancellation_token=CancellationToken(),
+    )
+    assert result.exit_code == 0, result.output
+    assert "API=MISSING" in result.output, f"FAKE_API_KEY was not scrubbed. Output: {result.output!r}"
+    assert "OK=keep-me" in result.output, f"HARMLESS_VAR should have been preserved. Output: {result.output!r}"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only")
+@pytest.mark.asyncio
+async def test_sandbox_false_preserves_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("FAKE_API_KEY", "xyz-should-be-visible")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        executor = LocalCommandLineCodeExecutor(work_dir=tmp_path, sandbox=False)
+
+    result = await executor.execute_code_blocks(
+        code_blocks=[CodeBlock(language="bash", code='echo "API=${FAKE_API_KEY:-MISSING}"')],
+        cancellation_token=CancellationToken(),
+    )
+    assert result.exit_code == 0, result.output
+    assert "API=xyz-should-be-visible" in result.output
+
+
+def test_sandbox_true_imports_cleanly_on_windows() -> None:
+    # Smoke test: on any platform, constructing with sandbox=True must not raise.
+    # On Windows the Windows degrade path only logs a warning.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        executor = LocalCommandLineCodeExecutor(sandbox=True)
+    assert executor.sandbox is True


### PR DESCRIPTION
## Summary

Draft PR addressing #7462 — adds an opt-in `sandbox` parameter to `LocalCommandLineCodeExecutor` so users who cannot run Docker still get best-effort in-process hardening. This **supersedes #7467** with broader scope (env-scrub + rlimits + Windows degrade path + config round-trip).

Opening as **draft** because I'd like maintainer input on the Windows strategy (see below) before investing further.

### Three modes for `sandbox: Optional[bool]`

| Value   | Behavior                                                                                                                                                                         |
| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `None`  | Default. Emits `DeprecationWarning` + `logger.warning` that a future release will make the parameter required. Execution unchanged — fully backward compatible. Replaces the existing `UserWarning`. |
| `False` | Explicit acknowledgement of unsandboxed execution. No warning.                                                                                                                    |
| `True`  | POSIX: `preexec_fn` applying `RLIMIT_CPU` (= `timeout + 5`s) and `RLIMIT_AS` (default 512 MiB, configurable via `sandbox_memory_bytes`) + credential env-var scrub on **both** the code-execution subprocess and the pip-install subprocess in `_setup_functions`. Windows: logs a warning that rlimits are unavailable; env-scrub still applies. |

### Env-var scrub patterns (case-insensitive)

`*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*PASSWORD*`, `AWS_*`, `AZURE_*`, `GCP_*`, `GOOGLE_*`, `OPENAI_*`, `ANTHROPIC_*`, `HF_*`, `HUGGINGFACE_*`, `GITHUB_TOKEN`, `GH_TOKEN`, `NPM_TOKEN`, `PYPI_*`.

### What is intentionally out of scope for this draft

- Windows resource limits (Job Objects / `SetInformationJobObject`). The Windows path here is degrade-only. I'd like maintainer direction on whether you want a proper Windows implementation in this PR, a follow-up, or left documented as-is.
- README changes. Docstring-only for now to keep scope tight.
- Network isolation, filesystem chroot, seccomp — all correctly belong in `DockerCommandLineCodeExecutor`; the docstring says so explicitly.

### Tests

New `tests/code_executors/test_local_sandbox.py`:
1. `sandbox=None` emits `DeprecationWarning` (not `UserWarning`)
2. `sandbox=False` emits no warning
3. `sandbox=True` emits no `DeprecationWarning`
4. Config round-trip preserves `sandbox` + `sandbox_memory_bytes` for all three values
5. Config model defaults
6. **POSIX behavioral**: `FAKE_API_KEY` in env is scrubbed, harmless var survives
7. **POSIX behavioral**: with `sandbox=False`, `FAKE_API_KEY` reaches the subprocess
8. `sandbox=True` constructs cleanly (Windows smoke test)

Locally: `uv run pytest tests/code_executors/test_local_sandbox.py` — 8 passed. The existing `test_commandline_code_executor.py` — 13 passed, 1 skipped (Windows-only). One unrelated pre-existing failure in `test_user_defined_functions.py::test_can_load_function_with_reqs` due to `pip` missing in my uv-created venv, not touched by this PR.

### Decisions worth a second look

- **Default `RLIMIT_AS` = 512 MiB.** Large enough for most small Python/shell, tight enough to catch runaway allocations. Configurable via `sandbox_memory_bytes`.
- **`RLIMIT_CPU` = `timeout + 5`.** 5s grace above the async wait-for timeout so we don't race it and mask the existing timeout behavior.
- **`RLIMIT_AS` refused on some platforms (e.g. macOS)** — swallowed silently, CPU cap + env-scrub still apply. Let me know if you'd rather hard-fail there.
- **`preexec_fn` runs in the child between fork and exec.** Standard pattern for `subprocess` rlimit enforcement; `asyncio.create_subprocess_exec` passes it through.

Links: issue #7462 · supersedes #7467

cc @msaleme @hanselhansel @polterguy from the issue collaboration trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)