### PR TITLE
docs: fix grammar in SingleThreadedAgentRuntime docstring

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -161,7 +161,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
             handlers that can intercept messages before they are sent or published. Defaults to None.
         tracer_provider (TracerProvider, optional): The tracer provider to use for tracing. Defaults to None.
             Additionally, you can set environment variable `AUTOGEN_DISABLE_RUNTIME_TRACING` to `true` to disable the agent runtime telemetry if you don't have access to the runtime constructor. For example, if you are using `ComponentConfig`.
-        ignore_unhandled_exceptions (bool, optional): Whether to ignore unhandled exceptions in that occur in agent event handlers. Any background exceptions will be raised on the next call to `process_next` or from an awaited `stop`, `stop_when_idle` or `stop_when`. Note, this does not apply to RPC handlers. Defaults to True.
+        ignore_unhandled_exceptions (bool, optional): Whether to ignore unhandled exceptions that occur in agent event handlers. Any background exceptions will be raised on the next call to `process_next` or from an awaited `stop`, `stop_when_idle` or `stop_when`. Note, this does not apply to RPC handlers. Defaults to True.
 
     Examples:
 


### PR DESCRIPTION
## Summary

Fix a small grammar slip in the docstring for `SingleThreadedAgentRuntime.__init__` (autogen-core). The `ignore_unhandled_exceptions` arg description read:

> Whether to ignore unhandled exceptions **in that occur** in agent event handlers.

Changed to:

> Whether to ignore unhandled exceptions **that occur** in agent event handlers.

### Why

This docstring is rendered into the public API reference under `autogen_core.SingleThreadedAgentRuntime`, so the stray "in" is visible to every user reading the runtime docs. One-word deletion, no behavior change, no tests affected.

## Scope

- Single file: `python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py`
- 1 line changed (1 insertion, 1 deletion)
- No new dependencies, no API surface change, no functional change

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/.
- [x] I've made sure all auto checks have passed.

---
_Part of open-source blockchain work from [kcolbchain.com](https://kcolbchain.com) — maintained by [Abhishek Krishna](https://abhishekkrishna.com). PR opened via [kcolbchain contrib-bot](https://github.com/kcolbchain/kcolbchain.github.io/blob/master/deploy/contrib-bot/README.md)._