### PR TITLE
docs: fix AutoGenBench README command typo

### DIFF
--- a/python/packages/agbench/README.md
+++ b/python/packages/agbench/README.md
@@ -14,7 +14,7 @@ AutoGenBench also requires Docker (Desktop or Engine). **It will not run in GitH
 
 If you are working in WSL, you can follow the instructions below to set up your environment:
 
-1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Ressources, WSL Integration, Enable integration with additional distros – Ubuntu
+1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Resources, WSL Integration, Enable integration with additional distros – Ubuntu
 2. Clone autogen and export `AUTOGEN_REPO_BASE`. This environment variable enables the Docker containers to use the correct version agents.
     ```bash
     git clone git@github.com:microsoft/autogen.git
@@ -111,7 +111,7 @@ agbench tabulate Results/human_eval_MagenticOne
 Where:
 
 - `agbench run Tasks/human_eval_MagenticOne.jsonl` runs the tasks defined in `Tasks/human_eval_MagenticOne.jsonl`
-- `agbench tablue results/human_eval_MagenticOne` tabulates the results of the run
+- `agbench tabulate Results/human_eval_MagenticOne` tabulates the results of the run
 
 Each of these commands has extensive in-line help via:
 


### PR DESCRIPTION
Fixes two small README issues in the AutoGenBench docs: a typo in Docker Desktop Settings > Resources and an incorrect `agbench tablue` command, updating it to the documented `agbench tabulate Results/...` form.