### PR TITLE
fix(agentchat): validate participants type in BaseGroupChat with clear TypeError

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -78,6 +78,16 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
     ):
         self._name = name
         self._description = description
+        if not isinstance(participants, list):
+            raise TypeError(
+                f"participants must be a list of ChatAgent or Team instances, got {type(participants).__name__!r}."
+            )
+        for i, participant in enumerate(participants):
+            if not isinstance(participant, (ChatAgent, Team)):
+                raise TypeError(
+                    f"participants[{i}] must be a ChatAgent or Team instance, "
+                    f"got {type(participant).__name__!r}."
+                )
         if len(participants) == 0:
             raise ValueError("At least one participant is required.")
         if len(participants) != len(set(participant.name for participant in participants)):

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_round_robin_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_round_robin_group_chat.py
@@ -123,6 +123,7 @@ class RoundRobinGroupChat(BaseGroupChat, Component[RoundRobinGroupChatConfig]):
         emit_team_events (bool, optional): Whether to emit team events through :meth:`BaseGroupChat.run_stream`. Defaults to False.
 
     Raises:
+        TypeError: If participants is not a list or contains non-agent/non-team items.
         ValueError: If no participants are provided or if participant names are not unique.
 
     Examples:

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -488,6 +488,26 @@ async def test_round_robin_group_chat_unknown_task_message_type(runtime: AgentRu
         )
 
 
+def test_group_chat_invalid_participants() -> None:
+    """Test that BaseGroupChat raises clear TypeError for invalid participants."""
+    agent = _EchoAgent("agent", "An echo agent.")
+
+    with pytest.raises(TypeError, match="participants must be a list"):
+        RoundRobinGroupChat(participants=None)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="participants must be a list"):
+        RoundRobinGroupChat(participants="not a list")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="participants must be a list"):
+        RoundRobinGroupChat(participants=42)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match=r"participants\[1\] must be a ChatAgent or Team instance"):
+        RoundRobinGroupChat(participants=[agent, "bad"])  # type: ignore[list-item]
+
+    with pytest.raises(TypeError, match=r"participants\[0\] must be a ChatAgent or Team instance"):
+        RoundRobinGroupChat(participants=[42])  # type: ignore[list-item]
+
+
 @pytest.mark.asyncio
 async def test_round_robin_group_chat_unknown_agent_message_type() -> None:
     model_client = ReplayChatCompletionClient(["Hello"])


### PR DESCRIPTION
## Summary

Fixes #7580

When a user accidentally passes `None`, a non-list value (e.g. a string or integer), or a list containing non-agent/non-team objects as `participants` to `RoundRobinGroupChat` (or any `BaseGroupChat` subclass), the current code raises low-level internal errors that are hard to debug:

- `TypeError: object of type 'NoneType' has no len()` — for `participants=None`
- `AttributeError: 'str' object has no attribute 'name'` — for `participants="not a list"` or a list containing a string

## Changes

- **`_base_group_chat.py`**: Added explicit type validation at the top of `BaseGroupChat.__init__` — checks that `participants` is a `list` and that every element is a `ChatAgent` or `Team` instance, raising a descriptive `TypeError` before any internal logic runs.
- **`_round_robin_group_chat.py`**: Updated the `Raises` docstring to document the new `TypeError`.
- **`tests/test_group_chat.py`**: Added `test_group_chat_invalid_participants` — a synchronous test covering all four bad-input cases: `None`, a string, an integer, and a list containing a non-agent item.

## Before / After

```python
# Before (confusing internal error)
RoundRobinGroupChat(participants=None)
# TypeError: object of type 'NoneType' has no len()

# After (clear, actionable message)
RoundRobinGroupChat(participants=None)
# TypeError: participants must be a list of ChatAgent or Team instances, got 'NoneType'.

# Before
RoundRobinGroupChat(participants=[agent, "bad"])
# AttributeError: 'str' object has no attribute 'name'

# After
RoundRobinGroupChat(participants=[agent, "bad"])
# TypeError: participants[1] must be a ChatAgent or Team instance, got 'str'.
```

The fix is in `BaseGroupChat`, so it covers all subclasses (`RoundRobinGroupChat`, `SelectorGroupChat`, `Swarm`, `MagenticOneGroupChat`) automatically.