### PR TITLE
feat(agentchat): add get_thread() to retrieve group chat message history

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -27,11 +27,13 @@ from ...messages import (
 from ...state import TeamState
 from ._chat_agent_container import ChatAgentContainer
 from ._events import (
+    GroupChatGetThread,
     GroupChatPause,
     GroupChatReset,
     GroupChatResume,
     GroupChatStart,
     GroupChatTermination,
+    GroupChatThreadResponse,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -744,6 +746,76 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
             GroupChatResume(),
             recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
         )
+
+    async def get_thread(self) -> List[BaseAgentEvent | BaseChatMessage]:
+        """Get the current message thread from the group chat.
+
+        This method allows external code to retrieve the messages exchanged
+        so far in the group chat without waiting for the team to terminate.
+
+        Returns:
+            A list of messages in the order they were added to the thread.
+
+        Raises:
+            RuntimeError: If the team has not been initialized.
+
+        Example using the :class:`~autogen_agentchat.teams.RoundRobinGroupChat` team:
+
+        .. code-block:: python
+
+            import asyncio
+            from autogen_agentchat.agents import AssistantAgent
+            from autogen_agentchat.conditions import MaxMessageTermination
+            from autogen_agentchat.teams import RoundRobinGroupChat
+            from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+
+            async def main() -> None:
+                model_client = OpenAIChatCompletionClient(model="gpt-4o")
+
+                agent1 = AssistantAgent("Assistant1", model_client=model_client)
+                agent2 = AssistantAgent("Assistant2", model_client=model_client)
+                termination = MaxMessageTermination(3)
+                team = RoundRobinGroupChat([agent1, agent2], termination_condition=termination)
+
+                # Run the team in the background
+                run_task = asyncio.create_task(team.run(task="Count from 1 to 3, respond one at a time."))
+
+                # Wait a bit for some messages to be exchanged
+                await asyncio.sleep(1)
+
+                # Get the current thread while the team is still running
+                thread = await team.get_thread()
+                for msg in thread:
+                    print(f"{msg.source}: {msg.content}")
+
+                await run_task
+
+
+            asyncio.run(main())
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "The group chat has not been initialized. It must be run before the thread can be retrieved."
+            )
+
+        if self._embedded_runtime:
+            # Start the runtime for embedded mode.
+            assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+            self._runtime.start()
+
+        try:
+            response: GroupChatThreadResponse = await self._runtime.send_message(
+                GroupChatGetThread(),
+                recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
+            )
+        finally:
+            if self._embedded_runtime:
+                # Stop the runtime.
+                assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+                await self._runtime.stop_when_idle()
+
+        return list(response.messages)
 
     async def save_state(self) -> Mapping[str, Any]:
         """Save the state of the group chat team.

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -9,6 +9,7 @@ from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory, SelectS
 from ._events import (
     GroupChatAgentResponse,
     GroupChatError,
+    GroupChatGetThread,
     GroupChatMessage,
     GroupChatPause,
     GroupChatRequestPublish,
@@ -17,6 +18,7 @@ from ._events import (
     GroupChatStart,
     GroupChatTeamResponse,
     GroupChatTermination,
+    GroupChatThreadResponse,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -56,6 +58,7 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
                 GroupChatTeamResponse,
                 GroupChatMessage,
                 GroupChatReset,
+                GroupChatGetThread,
             ],
         )
         if max_turns is not None and max_turns <= 0:
@@ -284,6 +287,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
     async def handle_resume(self, message: GroupChatResume, ctx: MessageContext) -> None:
         """Resume the group chat manager. This is a no-op in the base class."""
         pass
+
+    @rpc
+    async def handle_get_thread(self, message: GroupChatGetThread, ctx: MessageContext) -> GroupChatThreadResponse:
+        """Handle a request to get the current message thread."""
+        return GroupChatThreadResponse(messages=list(self._message_thread))
 
     @abstractmethod
     async def validate_group_state(self, messages: List[BaseChatMessage] | None) -> None:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
@@ -111,3 +111,16 @@ class GroupChatError(BaseModel):
 
     error: SerializableException
     """The error that occurred."""
+
+
+class GroupChatGetThread(BaseModel):
+    """A request to get the current message thread from the group chat."""
+
+    ...
+
+
+class GroupChatThreadResponse(BaseModel):
+    """The response containing the current message thread from the group chat."""
+
+    messages: List[SerializeAsAny[BaseAgentEvent | BaseChatMessage]]
+    """The list of messages in the current thread."""

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -1944,3 +1944,63 @@ async def test_selector_group_chat_streaming(runtime: AgentRuntime | None) -> No
 
     # Content-based verification instead of index-based
     # Note: The streaming test verifies the streaming behavior, not the final result content
+
+
+@pytest.mark.asyncio
+async def test_round_robin_group_chat_get_thread(runtime: AgentRuntime | None) -> None:
+    """Test that get_thread() returns the current message thread from the group chat."""
+    agent1 = _EchoAgent("agent1", description="echo agent 1")
+    agent2 = _EchoAgent("agent2", description="echo agent 2")
+    termination = MaxMessageTermination(3)
+    team = RoundRobinGroupChat([agent1, agent2], termination_condition=termination, runtime=runtime)
+
+    # get_thread should fail before initialization
+    with pytest.raises(RuntimeError, match="not been initialized"):
+        await team.get_thread()
+
+    # Run the team
+    result = await team.run(task="hello")
+
+    # get_thread should work after the team has run
+    thread = await team.get_thread()
+    assert len(thread) > 0
+    assert isinstance(thread[0], TextMessage)
+    assert thread[0].content == "hello"
+    assert thread[0].source == "user"
+
+    # Verify the thread matches the result messages
+    assert len(thread) == len(result.messages)
+    for t, r in zip(thread, result.messages, strict=False):
+        assert isinstance(t, TextMessage)
+        assert isinstance(r, TextMessage)
+        assert t.content == r.content
+        assert t.source == r.source
+
+
+@pytest.mark.asyncio
+async def test_round_robin_group_chat_get_thread_while_running(runtime: AgentRuntime | None) -> None:
+    """Test that get_thread() works while the team is still running."""
+    agent1 = _EchoAgent("agent1", description="echo agent 1")
+    agent2 = _EchoAgent("agent2", description="echo agent 2")
+
+    # Use a high max_turns so the team keeps running
+    termination = MaxMessageTermination(100)
+    team = RoundRobinGroupChat([agent1, agent2], termination_condition=termination, runtime=runtime, max_turns=50)
+
+    # Run the team in the background
+    run_task = asyncio.create_task(team.run(task="start"))
+
+    # Wait for some messages to be exchanged
+    await asyncio.sleep(0.5)
+
+    # Get the thread while the team is running
+    thread = await team.get_thread()
+    assert len(thread) > 0
+    first_message = thread[0]
+    assert isinstance(first_message, TextMessage)
+    assert first_message.content == "start"
+    assert first_message.source == "user"
+
+    # Clean up - reset to stop the team
+    await team.reset()
+    await run_task


### PR DESCRIPTION
## Description

This PR implements the `get_thread()` method on `BaseGroupChat` to allow external code to retrieve the current message thread from a group chat without waiting for the team to terminate.

### Changes
- **`_events.py`**: Added `GroupChatGetThread` request and `GroupChatThreadResponse` models following the existing RPC event pattern.
- **`_base_group_chat_manager.py`**: Implemented `handle_get_thread()` RPC handler and registered it in `sequential_message_types` to prevent race conditions.
- **`_base_group_chat.py`**: Added public `get_thread()` async method with full docstring and usage example.
- **`test_group_chat.py`**: Added comprehensive unit tests covering pre-initialization error, post-run retrieval, and concurrent access during execution.

### Motivation

As requested in #6085, this feature enables:
- Monitoring ongoing conversations in real-time
- Retrieving message history without blocking on team termination
- External systems querying the chat state for logging, debugging, or UI updates

### Testing

- All 91 existing tests pass
- 2 new tests added (4 test cases with single_threaded + embedded modes)
- `pyright` type checking: 0 errors
- `ruff` lint and format: passed