### PR TITLE
fix(agentchat): persist sources filter in TextMentionTerminationConfig

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -106,15 +106,19 @@ class MaxMessageTermination(TerminationCondition, Component[MaxMessageTerminatio
 
 class TextMentionTerminationConfig(BaseModel):
     text: str
+    sources: List[str] | None = None
 
 
 class TextMentionTermination(TerminationCondition, Component[TextMentionTerminationConfig]):
     """Terminate the conversation if a specific text is mentioned.
 
-
     Args:
         text: The text to look for in the messages.
-        sources: Check only messages of the specified agents for the text to look for.
+        sources: Check only messages from these sources for the termination text.
+            If ``None`` (the default), all messages are checked including the initial
+            user task message.  Pass the names of the agents whose responses should
+            trigger termination (e.g. ``sources=["assistant"]``) to avoid the
+            termination phrase in the task prompt causing an early exit.
     """
 
     component_config_schema = TextMentionTerminationConfig
@@ -148,11 +152,14 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
         self._terminated = False
 
     def _to_config(self) -> TextMentionTerminationConfig:
-        return TextMentionTerminationConfig(text=self._termination_text)
+        return TextMentionTerminationConfig(
+            text=self._termination_text,
+            sources=list(self._sources) if self._sources is not None else None,
+        )
 
     @classmethod
     def _from_config(cls, config: TextMentionTerminationConfig) -> Self:
-        return cls(text=config.text)
+        return cls(text=config.text, sources=config.sources)
 
 
 class FunctionalTermination(TerminationCondition):

--- a/python/packages/autogen-agentchat/tests/test_declarative_components.py
+++ b/python/packages/autogen-agentchat/tests/test_declarative_components.py
@@ -1,4 +1,13 @@
 import pytest
+from autogen_core import ComponentLoader, ComponentModel
+from autogen_core.model_context import (
+    BufferedChatCompletionContext,
+    HeadAndTailChatCompletionContext,
+    TokenLimitedChatCompletionContext,
+    UnboundedChatCompletionContext,
+)
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
 from autogen_agentchat.base import AndTerminationCondition
 from autogen_agentchat.conditions import (
     ExternalTermination,
@@ -10,14 +19,6 @@ from autogen_agentchat.conditions import (
     TimeoutTermination,
     TokenUsageTermination,
 )
-from autogen_core import ComponentLoader, ComponentModel
-from autogen_core.model_context import (
-    BufferedChatCompletionContext,
-    HeadAndTailChatCompletionContext,
-    TokenLimitedChatCompletionContext,
-    UnboundedChatCompletionContext,
-)
-from autogen_ext.models.openai import OpenAIChatCompletionClient
 
 
 @pytest.mark.asyncio
@@ -43,6 +44,14 @@ async def test_termination_declarative() -> None:
     text_config = text_term.dump_component()
     assert text_config.provider == "autogen_agentchat.conditions.TextMentionTermination"
     assert text_config.config.get("text") == "stop"
+    assert text_config.config.get("sources") is None
+
+    # TextMentionTermination with sources — round-trip must preserve the filter
+    text_term_sources = TextMentionTermination("stop", sources=["agent1", "agent2"])
+    text_sources_config = text_term_sources.dump_component()
+    assert text_sources_config.config.get("sources") == ["agent1", "agent2"]
+    loaded_text_sources = ComponentLoader.load_component(text_sources_config, TextMentionTermination)
+    assert isinstance(loaded_text_sources, TextMentionTermination)
 
     token_config = token_term.dump_component()
     assert token_config.provider == "autogen_agentchat.conditions.TokenUsageTermination"


### PR DESCRIPTION
## Summary

`TextMentionTermination` has accepted a `sources` whitelist parameter since its introduction, allowing callers to restrict termination checks to specific agent names. However, `TextMentionTerminationConfig` — the Pydantic model used for component serialization — only stored the `text` field. Every serialize → deserialize round-trip (e.g. loading a team from YAML or JSON) silently dropped the `sources` filter, restoring the "check all messages" behaviour. This meant a component configuration that worked correctly in memory would produce different, broken behaviour after persistence.

One observable consequence (reported in #6826) is that the termination phrase placed in the initial user task prompt triggers immediate termination: the user passes `sources=["assistant"]` to avoid checking their own prompt, but after loading from config `sources` is gone and the user message fires the condition instead.

The fix adds `sources: List[str] | None = None` to `TextMentionTerminationConfig`, updates `_to_config` to serialize the value, updates `_from_config` to pass it back to `__init__`, and improves the docstring with a concrete guidance note. A round-trip assertion is added to `test_declarative_components.py`.

## Issue

Refs #6826

## Local verification

```
$ cd python/packages/autogen-agentchat
$ python -m pytest tests/test_termination_condition.py tests/test_declarative_components.py::test_termination_declarative -v

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
asyncio: mode=Mode.STRICT
collected 14 items

tests/test_termination_condition.py::test_handoff_termination PASSED
tests/test_termination_condition.py::test_stop_message_termination PASSED
tests/test_termination_condition.py::test_text_message_termination PASSED
tests/test_termination_condition.py::test_max_message_termination PASSED
tests/test_termination_condition.py::test_mention_termination PASSED
tests/test_termination_condition.py::test_token_usage_termination PASSED
tests/test_termination_condition.py::test_and_termination PASSED
tests/test_termination_condition.py::test_or_termination PASSED
tests/test_termination_condition.py::test_timeout_termination PASSED
tests/test_termination_condition.py::test_external_termination PASSED
tests/test_termination_condition.py::test_source_match_termination PASSED
tests/test_termination_condition.py::test_function_call_termination PASSED
tests/test_termination_condition.py::test_functional_termination PASSED
tests/test_declarative_components.py::test_termination_declarative PASSED

14 passed in 1.17s
=== LOCAL_TEST_PASSED ===
```

Also ran ruff on the changed files — 1 import-ordering fix applied automatically, 0 remaining errors.

## Risk

The only change to the runtime `__call__` path is in `_to_config` / `_from_config`; in-memory behaviour of existing code that never round-trips through the config is unaffected. Callers who rely on the old (broken) serialisation omitting `sources` would see the field appear in their config JSON with value `null`, which is schema-compatible. No breaking API change.
