### PR TITLE
feat(autogen-ext): add VoidlyPay x402 tool

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/voidly_pay/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/voidly_pay/__init__.py
@@ -1,0 +1,3 @@
+from ._voidly_pay import VoidlyPayTool, VoidlyPayToolConfig
+
+__all__ = ["VoidlyPayTool", "VoidlyPayToolConfig"]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/voidly_pay/_voidly_pay.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/voidly_pay/_voidly_pay.py
@@ -1,0 +1,315 @@
+"""VoidlyPay extension for AutoGen.
+
+Lets an AutoGen agent call any HTTP endpoint that speaks the
+[x402 protocol](https://x402.org) and pay for it automatically when the
+server returns ``HTTP 402 Payment Required``. Settles in <200ms via a
+Sourcify-verified USDC vault on Base mainnet
+(``0xb592512932a7b354969bb48039c2dc7ad6ad1c12``).
+
+When the optional [`voidly-pay-autogen`](https://pypi.org/project/voidly-pay-autogen/)
+package is installed, the tool defers to its full toolkit
+(`voidly_pay_tools()`). Otherwise it implements a self-contained x402
+round-trip using the lower-level [`voidly-pay`](https://pypi.org/project/voidly-pay/)
+SDK.
+
+Sits next to ``autogen_ext.tools.http`` and ``autogen_ext.tools.mcp`` —
+same shape, ``BaseTool``-based, ``Component``-loadable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+from autogen_core import CancellationToken, Component
+from autogen_core.tools import BaseTool
+from pydantic import BaseModel, Field
+from typing_extensions import Self
+
+
+class VoidlyPayArgs(BaseModel):
+    """Args for VoidlyPayTool."""
+
+    url: str = Field(
+        description=(
+            "HTTP URL to fetch. If the server returns 402 with a Voidly "
+            "Pay x402 quote, the tool transfers the asking amount and retries."
+        ),
+    )
+    method: str = Field(
+        default="GET",
+        description="HTTP method. Defaults to GET.",
+    )
+    body: Optional[Any] = Field(
+        default=None,
+        description="JSON-serialisable body for POST/PUT.",
+    )
+    max_amount_credits: float = Field(
+        default=0.05,
+        description=(
+            "Cap (in Voidly credits, where 1 credit = $0.001 USDC) on a single auto-pay. Default 0.05 = $0.05."
+        ),
+    )
+
+
+class VoidlyPayResult(BaseModel):
+    """Result returned by VoidlyPayTool."""
+
+    settled: bool = Field(
+        default=False,
+        description="True if the tool transferred funds and re-fetched.",
+    )
+    transfer_id: Optional[str] = Field(
+        default=None,
+        description="Voidly Pay transfer id of the settlement (if any).",
+    )
+    amount_micro: Optional[int] = Field(
+        default=None,
+        description="Amount paid in micro-USDC (1_000_000 = $1).",
+    )
+    recipient: Optional[str] = Field(
+        default=None,
+        description="DID of the endpoint operator who received the payment.",
+    )
+    response_status: Optional[int] = Field(
+        default=None,
+        description="HTTP status of the resolved response.",
+    )
+    response: Any = Field(
+        default=None,
+        description="Resolved response body (parsed JSON or text).",
+    )
+    blocked_by_cap: bool = Field(
+        default=False,
+        description="True if the tool refused to settle (price > cap).",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message, if anything went wrong.",
+    )
+
+
+class VoidlyPayToolConfig(BaseModel):
+    """Component config for VoidlyPayTool."""
+
+    name: str = Field(
+        default="voidly_pay_fetch",
+        description="The tool name surfaced to the model.",
+    )
+    description: str = Field(
+        default=(
+            "Fetch any URL. If the server returns HTTP 402 with a Voidly "
+            "Pay x402 quote, auto-transfers credits and retries."
+        ),
+        description="The tool description shown to the model.",
+    )
+    api_base: str = Field(
+        default="https://api.voidly.ai",
+        description="Voidly Pay API base URL.",
+    )
+    did: Optional[str] = Field(
+        default=None,
+        description=("DID of a funded wallet. Falls back to ``VOIDLY_PAY_DID`` env var, then the SDK's local keypair."),
+    )
+    secret_base64: Optional[str] = Field(
+        default=None,
+        description=(
+            "base64-encoded Ed25519 secret. Falls back to ``VOIDLY_PAY_SECRET`` env var. Sensitive — never log."
+        ),
+    )
+
+
+class VoidlyPayTool(BaseTool[VoidlyPayArgs, VoidlyPayResult], Component[VoidlyPayToolConfig]):
+    """Pay-on-402 fetch via the Voidly Pay rail.
+
+    Args:
+        config (VoidlyPayToolConfig): wallet + endpoint configuration.
+
+    Example:
+
+        .. code-block:: python
+
+            from autogen_ext.tools.voidly_pay import VoidlyPayTool, VoidlyPayToolConfig
+            from autogen_agentchat.agents import AssistantAgent
+
+            tool = VoidlyPayTool(VoidlyPayToolConfig())
+            agent = AssistantAgent(
+                name="researcher",
+                model_client=...,
+                tools=[tool],
+            )
+
+    Mint a DID + claim the free 10-credit faucet at
+    https://voidly.ai/pay/claim, then export ``VOIDLY_PAY_DID`` +
+    ``VOIDLY_PAY_SECRET``.
+    """
+
+    component_type = "tool"
+    component_config_schema = VoidlyPayToolConfig
+    component_provider_override = "autogen_ext.tools.voidly_pay.VoidlyPayTool"
+
+    def __init__(self, config: Optional[VoidlyPayToolConfig] = None) -> None:
+        self._config = config or VoidlyPayToolConfig()
+        super().__init__(
+            args_type=VoidlyPayArgs,
+            return_type=VoidlyPayResult,
+            name=self._config.name,
+            description=self._config.description,
+        )
+
+    async def run(self, args: VoidlyPayArgs, cancellation_token: CancellationToken) -> VoidlyPayResult:
+        # Prefer the maintained autogen integration when available — it
+        # has a richer 402-handler with receipt verification.
+        try:
+            from voidly_pay_autogen import voidly_pay_tools  # type: ignore[import-not-found]
+
+            return await self._run_via_autogen_extension(args, voidly_pay_tools)
+        except ImportError:
+            pass
+
+        return await self._run_inline(args)
+
+    async def _run_via_autogen_extension(
+        self,
+        args: VoidlyPayArgs,
+        voidly_pay_tools_factory: Any,
+    ) -> VoidlyPayResult:
+        """Delegate to voidly-pay-autogen's `voidly_pay_fetch` FunctionTool."""
+        client = self._build_client()
+        tools = voidly_pay_tools_factory(pay=client)
+        fetch_tool = next((t for t in tools if t.name == "voidly_pay_fetch"), None)
+        if fetch_tool is None:
+            return await self._run_inline(args)
+        kwargs: dict = {
+            "url": args.url,
+            "method": args.method,
+            "max_amount_credits": args.max_amount_credits,
+        }
+        if args.body is not None:
+            kwargs["body"] = args.body
+        raw = await fetch_tool.run_json(kwargs, CancellationToken())
+        try:
+            payload = json.loads(raw) if isinstance(raw, str) else raw
+        except json.JSONDecodeError:
+            payload = {"response": raw}
+        return _to_result(payload)
+
+    async def _run_inline(self, args: VoidlyPayArgs) -> VoidlyPayResult:
+        """Self-contained x402 round-trip — independent of voidly-pay-autogen."""
+        try:
+            client = self._build_client()
+        except ImportError as e:
+            return VoidlyPayResult(error=str(e))
+
+        try:
+            import httpx
+        except ImportError:
+            return VoidlyPayResult(
+                error=(
+                    "VoidlyPayTool requires httpx. Install with: "
+                    "pip install 'autogen-ext[http-tool]' or pip install httpx"
+                ),
+            )
+
+        cap_micro = round(args.max_amount_credits * 1_000_000)
+        async with httpx.AsyncClient(timeout=30.0) as http:
+            initial = await http.request(
+                args.method,
+                args.url,
+                json=args.body if args.body is not None else None,
+            )
+            if initial.status_code != 402:
+                return VoidlyPayResult(
+                    response_status=initial.status_code,
+                    response=_safe_json(initial),
+                )
+            try:
+                envelope = initial.json()
+            except json.JSONDecodeError:
+                return VoidlyPayResult(
+                    response_status=initial.status_code,
+                    response=initial.text[:4000],
+                    error="402 envelope was not JSON",
+                )
+            accept = next(
+                (a for a in envelope.get("accepts", []) if a.get("scheme") == "voidly-credit"),
+                None,
+            )
+            if accept is None:
+                return VoidlyPayResult(error="no voidly-credit option in 402 envelope")
+            if accept["amount_micro"] > cap_micro:
+                return VoidlyPayResult(
+                    blocked_by_cap=True,
+                    amount_micro=accept["amount_micro"],
+                    recipient=accept["recipient_did"],
+                )
+            receipt = client.pay(
+                to=accept["recipient_did"],
+                amount_micro=accept["amount_micro"],
+                memo=f"x402:{accept['quote_id']}",
+            )
+            sep = "&" if "?" in args.url else "?"
+            final = await http.request(
+                args.method,
+                f"{args.url}{sep}quote_id={accept['quote_id']}",
+                json=args.body if args.body is not None else None,
+            )
+            return VoidlyPayResult(
+                settled=True,
+                transfer_id=receipt.get("transfer_id"),
+                amount_micro=accept["amount_micro"],
+                recipient=accept["recipient_did"],
+                response_status=final.status_code,
+                response=_safe_json(final),
+            )
+
+    def _build_client(self) -> Any:
+        try:
+            from voidly_pay import VoidlyPay  # type: ignore[import-not-found]
+        except ImportError as e:
+            raise ImportError(
+                "VoidlyPayTool requires the `voidly-pay` package. Install with: pip install voidly-pay"
+            ) from e
+
+        kwargs: dict = {"api_base": self._config.api_base}
+        did = self._config.did or os.environ.get("VOIDLY_PAY_DID")
+        secret = self._config.secret_base64 or os.environ.get("VOIDLY_PAY_SECRET")
+        if did and secret:
+            kwargs["did"] = did
+            kwargs["secret_base64"] = secret
+        return VoidlyPay(**kwargs)
+
+    def _to_config(self) -> VoidlyPayToolConfig:
+        return self._config
+
+    @classmethod
+    def _from_config(cls, config: VoidlyPayToolConfig) -> Self:
+        return cls(config)
+
+
+def _safe_json(response: Any) -> Any:
+    """Return parsed JSON when content-type says so, else trimmed text."""
+    ct = response.headers.get("content-type", "") if hasattr(response, "headers") else ""
+    if ct.startswith("application/json"):
+        try:
+            return response.json()
+        except (ValueError, TypeError):
+            return response.text[:4000]
+    return response.text[:4000]
+
+
+def _to_result(payload: Any) -> VoidlyPayResult:
+    """Coerce a dict payload from the `voidly-pay-autogen` fetch tool."""
+    if not isinstance(payload, dict):
+        return VoidlyPayResult(response=payload)
+    return VoidlyPayResult(
+        settled=bool(payload.get("settled")),
+        transfer_id=payload.get("transfer_id"),
+        amount_micro=payload.get("amount_micro"),
+        recipient=payload.get("recipient") or payload.get("recipient_did"),
+        response_status=payload.get("response_status") or payload.get("status"),
+        response=payload.get("response") or payload.get("body"),
+        blocked_by_cap=bool(payload.get("blocked_by_cap")),
+        error=payload.get("error"),
+    )

--- a/python/packages/autogen-ext/tests/tools/voidly_pay/test_voidly_pay.py
+++ b/python/packages/autogen-ext/tests/tools/voidly_pay/test_voidly_pay.py
@@ -1,0 +1,243 @@
+"""Tests for autogen_ext.tools.voidly_pay.VoidlyPayTool.
+
+Mocks the x402 round-trip so the tests run offline. We pin the wire
+format we care about: the tool reads the ``voidly-credit`` accept option
+from a 402 envelope, signs a transfer to ``recipient_did``, retries
+with ``?quote_id=<id>``, and returns the resolved response.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from autogen_core import CancellationToken, ComponentModel
+
+from autogen_ext.tools.voidly_pay import VoidlyPayTool, VoidlyPayToolConfig
+
+
+def _install_fake_voidly_pay(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Drop a fake `voidly_pay` module into sys.modules.
+
+    `_build_client()` calls `from voidly_pay import VoidlyPay` and then
+    `VoidlyPay(api_base=..., did=..., secret_base64=...)`. We return a
+    MagicMock client whose `.pay(...)` records the call.
+    """
+    pay_client = MagicMock()
+    pay_client.pay.return_value = {"transfer_id": "tx-deadbeef"}
+    pay_client.did = "did:voidly:test"
+
+    fake_module = types.ModuleType("voidly_pay")
+    fake_module.VoidlyPay = MagicMock(return_value=pay_client)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "voidly_pay", fake_module)
+
+    # Ensure the optional autogen extension isn't picked up so we exercise
+    # the inline path.
+    monkeypatch.setitem(sys.modules, "voidly_pay_autogen", None)
+
+    return pay_client
+
+
+class _FakeResponse:
+    """Minimal stand-in for httpx.Response."""
+
+    def __init__(
+        self,
+        status_code: int,
+        body: dict[str, Any] | str,
+        content_type: str = "application/json",
+    ) -> None:
+        self.status_code = status_code
+        self._body = body
+        self.headers = {"content-type": content_type}
+        self.text = body if isinstance(body, str) else json.dumps(body)
+
+    def json(self) -> Any:
+        if isinstance(self._body, str):
+            return json.loads(self._body)
+        return self._body
+
+
+def _install_fake_httpx(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[_FakeResponse],
+    record: list[tuple[str, str, Any]],
+) -> None:
+    """Provide a fake `httpx.AsyncClient` returning queued responses."""
+    queue = list(responses)
+
+    class _FakeClient:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_FakeClient":
+            return self
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            url: str,
+            json: Any = None,  # noqa: A002 - mirror httpx kw
+            **_kwargs: Any,
+        ) -> _FakeResponse:
+            record.append((method, url, json))
+            if not queue:
+                raise AssertionError(f"No more queued responses for {method} {url}")
+            return queue.pop(0)
+
+    fake_httpx = types.ModuleType("httpx")
+    fake_httpx.AsyncClient = _FakeClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+
+def test_tool_schema() -> None:
+    tool = VoidlyPayTool(VoidlyPayToolConfig())
+    schema = tool.schema
+    assert schema["name"] == "voidly_pay_fetch"
+    assert "description" in schema
+    parameters = schema["parameters"]
+    assert parameters["type"] == "object"
+    assert "url" in parameters["properties"]
+    assert "max_amount_credits" in parameters["properties"]
+
+
+def test_component_round_trip() -> None:
+    tool = VoidlyPayTool(VoidlyPayToolConfig(api_base="https://example.test"))
+    dumped = tool.dump_component()
+    assert dumped is not None
+    restored = VoidlyPayTool.load_component(dumped, VoidlyPayTool)
+    assert isinstance(restored, VoidlyPayTool)
+    assert restored._config.api_base == "https://example.test"
+
+
+@pytest.mark.asyncio
+async def test_x402_round_trip_settles(monkeypatch: pytest.MonkeyPatch) -> None:
+    pay_client = _install_fake_voidly_pay(monkeypatch)
+
+    record: list[tuple[str, str, Any]] = []
+    _install_fake_httpx(
+        monkeypatch,
+        [
+            _FakeResponse(
+                402,
+                {
+                    "schema": "voidly-pay-402/v1",
+                    "accepts": [
+                        {
+                            "scheme": "voidly-credit",
+                            "amount_micro": 1000,
+                            "recipient_did": "did:voidly:server",
+                            "quote_id": "quote-abc",
+                            "expires_at": "2099-01-01T00:00:00Z",
+                        }
+                    ],
+                },
+            ),
+            _FakeResponse(200, {"summary": "Anthropic builds Claude."}),
+        ],
+        record,
+    )
+
+    tool = VoidlyPayTool(
+        VoidlyPayToolConfig(
+            did="did:voidly:caller",
+            secret_base64="AAAA",
+            api_base="https://api.voidly.ai",
+        )
+    )
+    args = tool.args_type().model_validate(
+        {
+            "url": "https://api.voidly.ai/v1/pay/wiki",
+            "max_amount_credits": 0.01,
+        }
+    )
+    result = await tool.run(args, CancellationToken())
+
+    assert result.settled is True
+    assert result.transfer_id == "tx-deadbeef"
+    assert result.amount_micro == 1000
+    assert result.recipient == "did:voidly:server"
+    assert result.response_status == 200
+    assert result.response == {"summary": "Anthropic builds Claude."}
+
+    pay_client.pay.assert_called_once()
+    pay_kwargs = pay_client.pay.call_args.kwargs
+    assert pay_kwargs["to"] == "did:voidly:server"
+    assert pay_kwargs["amount_micro"] == 1000
+    assert pay_kwargs["memo"].endswith("quote-abc")
+
+    # First call hit the bare URL, second call appended quote_id.
+    assert len(record) == 2
+    assert record[0][1] == "https://api.voidly.ai/v1/pay/wiki"
+    assert "quote_id=quote-abc" in record[1][1]
+
+
+@pytest.mark.asyncio
+async def test_x402_blocks_when_over_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    pay_client = _install_fake_voidly_pay(monkeypatch)
+
+    record: list[tuple[str, str, Any]] = []
+    _install_fake_httpx(
+        monkeypatch,
+        [
+            _FakeResponse(
+                402,
+                {
+                    "accepts": [
+                        {
+                            "scheme": "voidly-credit",
+                            "amount_micro": 5_000_000,  # $5 — way above cap
+                            "recipient_did": "did:voidly:server",
+                            "quote_id": "quote-xyz",
+                            "expires_at": "2099-01-01T00:00:00Z",
+                        }
+                    ]
+                },
+            ),
+        ],
+        record,
+    )
+
+    tool = VoidlyPayTool(VoidlyPayToolConfig(did="did:voidly:caller", secret_base64="AAAA"))
+    args = tool.args_type().model_validate(
+        {
+            "url": "https://api.example.com/expensive",
+            "max_amount_credits": 0.01,
+        }
+    )
+    result = await tool.run(args, CancellationToken())
+
+    assert result.blocked_by_cap is True
+    assert result.settled is False
+    assert result.amount_micro == 5_000_000
+    pay_client.pay.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_402_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    pay_client = _install_fake_voidly_pay(monkeypatch)
+
+    record: list[tuple[str, str, Any]] = []
+    _install_fake_httpx(
+        monkeypatch,
+        [
+            _FakeResponse(200, {"hello": "world"}),
+        ],
+        record,
+    )
+
+    tool = VoidlyPayTool(VoidlyPayToolConfig(did="did:voidly:caller", secret_base64="AAAA"))
+    args = tool.args_type().model_validate({"url": "https://api.example.com/free"})
+    result = await tool.run(args, CancellationToken())
+
+    assert result.settled is False
+    assert result.response_status == 200
+    assert result.response == {"hello": "world"}
+    pay_client.pay.assert_not_called()


### PR DESCRIPTION
Adds a `VoidlyPay` extension under `autogen-ext` that lets AutoGen agents
pay for HTTP 402 endpoints via the [x402 protocol](https://x402.org).
Sits next to `tools/http/` and `tools/mcp/` and follows the same
`BaseTool` + `Component`-loadable pattern.

Wraps the existing
[`voidly-pay-autogen`](https://pypi.org/project/voidly-pay-autogen/)
PyPI package when installed (full toolkit), with a self-contained x402
round-trip fallback using
[`voidly-pay`](https://pypi.org/project/voidly-pay/) so the tool works
out-of-the-box. Settles in <200ms via a Sourcify-verified USDC vault on
Base mainnet ([`0xb592...1c12`](https://repo.sourcify.dev/contracts/full_match/8453/0xb592512932a7b354969bb48039c2dc7ad6ad1c12/)).

### Files

- `python/packages/autogen-ext/src/autogen_ext/tools/voidly_pay/_voidly_pay.py` (new)
- `python/packages/autogen-ext/src/autogen_ext/tools/voidly_pay/__init__.py` (new)
- `python/packages/autogen-ext/tests/tools/voidly_pay/test_voidly_pay.py` (new — 5 unit tests)
- `python/packages/autogen-ext/tests/tools/voidly_pay/__init__.py` (new)

No changes to `pyproject.toml` — the tool imports `voidly_pay` and
`httpx` lazily and reports a clear `error` on the result model when
either is missing. (Happy to add a `voidly-pay` extra if maintainers
prefer.)

### Tests

5 unit tests, all passing locally. They mock `voidly_pay` and `httpx`
to exercise the inline x402 path without network:

- `test_tool_schema` — args schema correctness
- `test_component_round_trip` — `dump_component` / `load_component`
- `test_x402_round_trip_settles` — full 402 -> sign -> retry happy path
- `test_x402_blocks_when_over_cap` — refuses to spend over `max_amount_credits`
- `test_non_402_passthrough` — 200 responses bypass payment logic

```
$ pytest tests/tools/voidly_pay/
========================= 5 passed in 0.18s ==========================
```

`ruff check` + `ruff format` both clean against the project config.

### How an AutoGen agent uses it

```python
from autogen_agentchat.agents import AssistantAgent
from autogen_ext.tools.voidly_pay import VoidlyPayTool, VoidlyPayToolConfig

tool = VoidlyPayTool(VoidlyPayToolConfig())
agent = AssistantAgent(
    name="researcher",
    model_client=...,
    tools=[tool],
)
```

Mint a DID + claim a 10-credit faucet at <https://voidly.ai/pay/claim>
(no install), then export `VOIDLY_PAY_DID` + `VOIDLY_PAY_SECRET`.

### Honest scope

Voidly Pay is an open marketplace (anyone can list a paid endpoint at
[/pay/list-your-service](https://voidly.ai/pay/list-your-service)). Real
volume is small today (~$4 in the vault); the value here is the working
pattern for x402-aware tool design.

### CLA

Aware Microsoft requires a CLA. The cla-bot will comment and I'll sign
on the standard flow.