### PR TITLE
fix(agbench): add encoding='utf-8' to open() calls in GAIA benchmark scripts

### DIFF
--- a/python/packages/agbench/benchmarks/GAIA/Scripts/custom_tabulate.py
+++ b/python/packages/agbench/benchmarks/GAIA/Scripts/custom_tabulate.py
@@ -131,7 +131,7 @@ def scorer(instance_dir):
         return None
 
     expected_answer = None
-    with open(expected_answer_file, "rt") as fh:
+    with open(expected_answer_file, "rt", encoding='utf-8') as fh:
         expected_answer = fh.read().strip()
 
     # Read the console
@@ -140,7 +140,7 @@ def scorer(instance_dir):
         return None
 
     console_log = ""
-    with open(console_log_file, "rt") as fh:
+    with open(console_log_file, "rt", encoding='utf-8') as fh:
         console_log = fh.read()
 
         final_answer = None 

--- a/python/packages/agbench/benchmarks/GAIA/Scripts/init_tasks.py
+++ b/python/packages/agbench/benchmarks/GAIA/Scripts/init_tasks.py
@@ -42,7 +42,7 @@ def create_jsonl(name, tasks, files_dir, template):
     if not os.path.isdir(TASKS_DIR):
         os.mkdir(TASKS_DIR)
 
-    with open(os.path.join(TASKS_DIR, name + ".jsonl"), "wt") as fh:
+    with open(os.path.join(TASKS_DIR, name + ".jsonl", encoding='utf-8'), "wt") as fh:
         for task in tasks:
             print(f"Converting: [{name}] {task['task_id']}")
 
@@ -85,13 +85,13 @@ def main():
 
     # Load the GAIA data
     gaia_validation_tasks = [[], [], []]
-    with open(os.path.join(gaia_validation_files, "metadata.jsonl")) as fh:
+    with open(os.path.join(gaia_validation_files, "metadata.jsonl", encoding='utf-8')) as fh:
         for line in fh:
             data = json.loads(line)
             gaia_validation_tasks[data["Level"] - 1].append(data)
 
     gaia_test_tasks = [[], [], []]
-    with open(os.path.join(gaia_test_files, "metadata.jsonl")) as fh:
+    with open(os.path.join(gaia_test_files, "metadata.jsonl", encoding='utf-8')) as fh:
         for line in fh:
             data = json.loads(line)
 

--- a/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
@@ -20,7 +20,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding='utf-8') as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])
@@ -30,7 +30,7 @@ async def main() -> None:
     
     # Read the prompt
     prompt = ""
-    with open("prompt.txt", "rt") as fh:
+    with open("prompt.txt", "rt", encoding='utf-8') as fh:
         prompt = fh.read().strip()
     filename = "__FILE_NAME__".strip()
 


### PR DESCRIPTION
Addresses #5566

## Problem

Several `open()` calls in the GAIA benchmark scripts omit an explicit `encoding` parameter. Python uses the system default locale encoding when none is specified, which is not UTF-8 on many Windows installations. This causes `UnicodeDecodeError` when reading files containing non-ASCII characters in non-English environments.

Affected files:
- `benchmarks/GAIA/Scripts/custom_tabulate.py`
- `benchmarks/GAIA/Scripts/init_tasks.py`
- `benchmarks/GAIA/Templates/MagenticOne/scenario.py`

## Fix

Add `encoding='utf-8'` to all `open()` calls in the above files. This is consistent with the fix in PR #7648 which addressed the same issue in `task_centric_memory` utilities.