### PR TITLE
Add group chat thread retrieval API

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -27,6 +27,8 @@ from ...messages import (
 from ...state import TeamState
 from ._chat_agent_container import ChatAgentContainer
 from ._events import (
+    GroupChatGetThread,
+    GroupChatGetThreadResponse,
     GroupChatPause,
     GroupChatReset,
     GroupChatResume,
@@ -699,6 +701,38 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
             GroupChatPause(),
             recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
         )
+
+    async def get_thread(self) -> List[BaseAgentEvent | BaseChatMessage]:
+        """Get the current message thread recorded by the team.
+
+        Returns:
+            A copy of the messages recorded in the group chat thread so far.
+            Returns an empty list if the team has not started yet.
+        """
+        if not self._initialized:
+            return []
+
+        should_stop_runtime = False
+        if self._embedded_runtime and not self._is_running:
+            assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+            self._runtime.start()
+            should_stop_runtime = True
+
+        try:
+            response = await self._runtime.send_message(
+                GroupChatGetThread(),
+                recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
+            )
+            if not isinstance(response, GroupChatGetThreadResponse):
+                raise RuntimeError(
+                    "Expected GroupChatGetThreadResponse from group chat manager, "
+                    f"got {type(response).__name__}."
+                )
+            return list(response.messages)
+        finally:
+            if should_stop_runtime:
+                assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+                await self._runtime.stop_when_idle()
 
     async def resume(self) -> None:
         """Resume its participants when the team is running and paused by calling their

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -9,6 +9,8 @@ from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory, SelectS
 from ._events import (
     GroupChatAgentResponse,
     GroupChatError,
+    GroupChatGetThread,
+    GroupChatGetThreadResponse,
     GroupChatMessage,
     GroupChatPause,
     GroupChatRequestPublish,
@@ -284,6 +286,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
     async def handle_resume(self, message: GroupChatResume, ctx: MessageContext) -> None:
         """Resume the group chat manager. This is a no-op in the base class."""
         pass
+
+    @rpc
+    async def handle_get_thread(self, message: GroupChatGetThread, ctx: MessageContext) -> GroupChatGetThreadResponse:
+        """Return the current message thread."""
+        return GroupChatGetThreadResponse(messages=list(self._message_thread))
 
     @abstractmethod
     async def validate_group_state(self, messages: List[BaseChatMessage] | None) -> None:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
@@ -106,6 +106,19 @@ class GroupChatResume(BaseModel):
     ...
 
 
+class GroupChatGetThread(BaseModel):
+    """A request to retrieve the current group chat thread."""
+
+    ...
+
+
+class GroupChatGetThreadResponse(BaseModel):
+    """The current group chat thread."""
+
+    messages: List[SerializeAsAny[BaseAgentEvent | BaseChatMessage]]
+    """All messages recorded in the group chat thread so far."""
+
+
 class GroupChatError(BaseModel):
     """A message indicating that an error occurred in the group chat."""
 

--- a/python/packages/autogen-agentchat/tests/test_events.py
+++ b/python/packages/autogen-agentchat/tests/test_events.py
@@ -4,6 +4,7 @@ from autogen_agentchat.base import Response, TaskResult
 from autogen_agentchat.messages import TextMessage
 from autogen_agentchat.teams._group_chat._events import (
     GroupChatAgentResponse,
+    GroupChatGetThreadResponse,
     GroupChatMessage,
     GroupChatStart,
     GroupChatTeamResponse,
@@ -83,3 +84,19 @@ def test_group_chat_team_response_preserves_nested_data() -> None:
     # Verify deeply nested subclass data is preserved
     assert "content" in parsed["result"]["messages"][0]
     assert parsed["result"]["messages"][0]["content"] == "Nested message"
+
+
+def test_group_chat_get_thread_response_preserves_message_list_data() -> None:
+    """Test that GroupChatGetThreadResponse preserves subclass data in message lists."""
+    text_msg1 = TextMessage(content="First message", source="Agent1")
+    text_msg2 = TextMessage(content="Second message", source="Agent2")
+
+    response = GroupChatGetThreadResponse(messages=[text_msg1, text_msg2])
+
+    json_data = response.model_dump_json()
+    parsed = json.loads(json_data)
+
+    assert parsed["messages"][0]["content"] == "First message"
+    assert parsed["messages"][1]["content"] == "Second message"
+    assert parsed["messages"][0]["type"] == "TextMessage"
+    assert parsed["messages"][1]["type"] == "TextMessage"

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -338,7 +338,6 @@ async def test_round_robin_group_chat_output_task_messages_false(runtime: AgentR
             assert isinstance(produced_message, TextMessage)
             content = produced_message.content.replace("\r\n", "\n").rstrip("\n")
             assert content == expected_messages[i]
-
         assert result.stop_reason is not None and result.stop_reason == "Text 'TERMINATE' mentioned"
 
         # Test streaming with output_task_messages=False.
@@ -398,6 +397,26 @@ async def test_round_robin_group_chat_output_task_messages_false(runtime: AgentR
         assert len(streamed_messages_3) == len(final_stream_result_3.messages)
         for streamed_msg, expected_msg in zip(streamed_messages_3, final_stream_result_3.messages, strict=False):
             assert compare_messages(streamed_msg, expected_msg)
+
+
+@pytest.mark.asyncio
+async def test_round_robin_group_chat_get_thread(runtime: AgentRuntime | None) -> None:
+    agent1 = _EchoAgent("agent1", description="echo agent 1")
+    agent2 = _StopAgent("agent2", description="stop agent 2", stop_at=1)
+    termination = TextMentionTermination("TERMINATE")
+    team = RoundRobinGroupChat([agent1, agent2], termination_condition=termination, runtime=runtime)
+
+    assert await team.get_thread() == []
+
+    result = await team.run(task="task")
+    thread = await team.get_thread()
+
+    assert len(thread) == len(result.messages)
+    for message, expected_message in zip(thread, result.messages, strict=True):
+        assert compare_messages(message, expected_message)
+
+    await team.reset()
+    assert await team.get_thread() == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why are these changes needed?

This PR adds a public API to retrieve the current message thread from a group chat team.

It introduces `BaseGroupChat.get_thread()` so callers can inspect the current conversation history without reaching into internal manager state. The implementation uses a new RPC request/response pair between `BaseGroupChat` and the group chat manager.

## Related issue number

Closes #6085

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

## Testing

```bash
uv run --project python pytest \
  python/packages/autogen-agentchat/tests/test_group_chat.py \
  python/packages/autogen-agentchat/tests/test_events.py
