### PR TITLE
samples: agentchat_hdp — cryptographic delegation provenance for multi-agent conversations

### DIFF
--- a/python/samples/agentchat_hdp/README.md
+++ b/python/samples/agentchat_hdp/README.md
@@ -1,0 +1,83 @@
+# AgentChat — HDP Delegation Provenance
+
+This sample shows how to attach a **cryptographic audit trail** to any AutoGen AgentChat
+conversation using [HDP (Human Delegation Provenance)](https://github.com/Helixar-AI/HDP).
+
+When a human authorises an agent to act — and that agent delegates to another agent —
+HDP creates a tamper-evident chain of Ed25519 signatures from the authorising human to
+every downstream action. The chain is verifiable fully **offline** with a single public key.
+
+## What it covers
+
+| Scenario | File |
+|---|---|
+| Single `AssistantAgent` with HDP scope enforcement | `single_agent.py` |
+| Multi-agent `RoundRobinGroupChat` with per-turn delegation tracking | `group_chat.py` |
+| Offline chain verification after a session | both files |
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install "autogen-agentchat" "autogen-ext[openai]" "hdp-autogen>=0.1.3" pyyaml
+```
+
+> **`hdp-autogen`** is the AutoGen middleware published by [Helixar](https://github.com/Helixar-AI/HDP).
+> It wraps any `ConversableAgent` or `GroupChatManager` with zero changes to your agent code.
+
+Create `model_config.yaml` in this directory (same format as other AgentChat samples):
+
+```yaml
+provider: autogen_ext.models.openai.OpenAIChatCompletionClient
+config:
+  model: gpt-4o
+  api_key: YOUR_API_KEY   # or set OPENAI_API_KEY in your environment
+```
+
+Generate an Ed25519 signing key once and store it in an environment variable:
+
+```python
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+import base64, os
+
+key = Ed25519PrivateKey.generate()
+raw = key.private_bytes_raw()
+print("HDP_SIGNING_KEY=" + base64.urlsafe_b64encode(raw).decode())
+# → export HDP_SIGNING_KEY=<value>
+```
+
+## Run
+
+```bash
+# Multi-agent group chat with delegation chain
+python group_chat.py
+
+# Single agent with scope enforcement
+python single_agent.py
+```
+
+## How it works
+
+HDP tokens are compact, self-contained JSON objects signed with Ed25519.
+Each delegation hop appends a new signed entry to the chain. `verify_chain()`
+validates every signature offline — no network call, no central registry.
+
+```
+Human (Alice)
+  └── Root token  [signed by Alice's key]
+        └── Hop 0: orchestrator-agent  [signed over root]
+              └── Hop 1: research-agent  [signed over hop 0]
+                    └── Hop 2: writer-agent  [signed over hop 1]
+```
+
+The chain records: *who authorised*, *what scope*, *which agents acted*, and *when*.
+Any modification of any hop is immediately detectable at verification time.
+
+## Further reading
+
+- [HDP protocol specification and docs](https://helixar.ai/about/labs/hdp/)
+- [`hdp-autogen` package on PyPI](https://pypi.org/project/hdp-autogen/)
+- [HDP GitHub repository](https://github.com/Helixar-AI/HDP)
+- [IETF draft: draft-helixar-hdp-agentic-delegation](https://datatracker.ietf.org/doc/draft-helixar-hdp-agentic-delegation/)
+- [Community discussion: accountability in multi-agent systems](https://github.com/microsoft/autogen/discussions/7485)

--- a/python/samples/agentchat_hdp/group_chat.py
+++ b/python/samples/agentchat_hdp/group_chat.py
@@ -1,0 +1,168 @@
+# Copyright (c) Microsoft. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# This sample requires:
+#   pip install "autogen-agentchat" "autogen-ext[openai]" "hdp-autogen>=0.1.3" pyyaml
+#
+# Before running, export your Ed25519 signing key:
+#   python -c "
+#   from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+#   import base64; k = Ed25519PrivateKey.generate()
+#   print('HDP_SIGNING_KEY=' + base64.urlsafe_b64encode(k.private_bytes_raw()).decode())
+#   "
+#   export HDP_SIGNING_KEY=<value>
+#
+# Create model_config.yaml in this directory — see README.md for format.
+
+"""
+HDP Delegation Provenance — Multi-Agent Group Chat
+
+Demonstrates how to attach a cryptographic audit trail to an AutoGen
+RoundRobinGroupChat. Every speaker turn is recorded as a delegation hop
+signed with Ed25519. The full chain is verifiable offline after the session.
+
+HDP answers the question: "Which human authorised this agent action,
+through what delegation chain, and with what scope?"
+
+Reference: https://helixar.ai/about/labs/hdp/
+Package:   https://pypi.org/project/hdp-autogen/
+"""
+
+import asyncio
+import base64
+import os
+import sys
+
+import yaml
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import MaxMessageTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_core.models import ChatCompletionClient
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+# HDP middleware — pip install hdp-autogen
+# Docs: https://github.com/Helixar-AI/HDP/tree/main/packages/hdp-autogen
+from hdp_autogen import HdpMiddleware, HdpPrincipal, ScopePolicy, verify_chain
+
+
+def _load_model_client() -> ChatCompletionClient:
+    """Load model client from model_config.yaml in this directory."""
+    config_path = os.path.join(os.path.dirname(__file__), "model_config.yaml")
+    if not os.path.exists(config_path):
+        print("ERROR: model_config.yaml not found. See README.md for setup.")
+        sys.exit(1)
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+    return ChatCompletionClient.load_component(config)
+
+
+def _load_signing_key() -> Ed25519PrivateKey:
+    """Load Ed25519 private key from HDP_SIGNING_KEY env var (base64url)."""
+    raw_b64 = os.getenv("HDP_SIGNING_KEY")
+    if not raw_b64:
+        print(
+            "ERROR: HDP_SIGNING_KEY environment variable not set.\n"
+            "Generate one with:\n"
+            "  python -c \"\n"
+            "  from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey\n"
+            "  import base64; k = Ed25519PrivateKey.generate()\n"
+            "  print('HDP_SIGNING_KEY=' + base64.urlsafe_b64encode(k.private_bytes_raw()).decode())\n"
+            "  \"\n"
+            "  export HDP_SIGNING_KEY=<value>"
+        )
+        sys.exit(1)
+    raw = base64.urlsafe_b64decode(raw_b64 + "==")
+    return Ed25519PrivateKey.from_private_bytes(raw)
+
+
+async def main() -> None:
+    private_key = _load_signing_key()
+    model_client = _load_model_client()
+
+    # ── 1. Define what the human is authorising ────────────────────────────
+    middleware = HdpMiddleware(
+        signing_key=private_key.private_bytes_raw(),
+        session_id="research-session-2026",
+        principal=HdpPrincipal(id="researcher@example.com", id_type="email"),
+        scope=ScopePolicy(
+            intent="Research recent LLM papers and write a concise summary",
+            authorized_tools=["web_search"],
+            max_hops=10,
+        ),
+    )
+
+    # ── 2. Build agents as normal ──────────────────────────────────────────
+    researcher = AssistantAgent(
+        name="researcher",
+        model_client=model_client,
+        system_message=(
+            "You are a research assistant. Find key themes in recent LLM papers "
+            "and present them as bullet points."
+        ),
+    )
+
+    writer = AssistantAgent(
+        name="writer",
+        model_client=model_client,
+        system_message=(
+            "You are a technical writer. Turn the researcher's bullet points into "
+            "a clear, concise two-paragraph summary."
+        ),
+    )
+
+    team = RoundRobinGroupChat(
+        participants=[researcher, writer],
+        termination_condition=MaxMessageTermination(max_messages=4),
+    )
+
+    # ── 3. Attach HDP — one call, zero changes to agents or team ──────────
+    middleware.configure(team)
+
+    # ── 4. Run the team ────────────────────────────────────────────────────
+    print("Running group chat with HDP delegation tracking...\n")
+    await Console(team.run_stream(task="Summarise key themes in LLM papers from early 2026."))
+
+    # ── 5. Verify the delegation chain offline ─────────────────────────────
+    token = middleware.export_token()
+    if token is None:
+        print("\n[HDP] No token issued — did the team produce any messages?")
+        return
+
+    result = verify_chain(token, private_key.public_key())
+
+    print("\n" + "=" * 60)
+    print("HDP Delegation Chain Verification")
+    print("=" * 60)
+    print(f"  Valid:      {result.valid}")
+    print(f"  Hops:       {result.hop_count}")
+    print(f"  Session:    {token['header']['session_id']}")
+    print(f"  Principal:  {token['principal']['display_name']}")
+    print(f"  Intent:     {token['scope']['intent']}")
+
+    if result.violations:
+        print(f"\n  Violations ({len(result.violations)}):")
+        for v in result.violations:
+            print(f"    - {v}")
+    else:
+        print("  Violations: none")
+
+    print("\n  Per-hop results:")
+    for hop in result.hop_results:
+        status = "✓" if hop.valid else "✗"
+        print(f"    {status} Hop {hop.seq}: {hop.agent_id}")
+
+    print("=" * 60)
+
+    if not result.valid:
+        print("\n[HDP] WARNING: chain verification failed — see violations above.")
+        sys.exit(1)
+
+    print(
+        "\n[HDP] Chain verified. Token is suitable for audit storage.\n"
+        "      See https://helixar.ai/about/labs/hdp/ for the full protocol spec."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/agentchat_hdp/single_agent.py
+++ b/python/samples/agentchat_hdp/single_agent.py
@@ -1,0 +1,142 @@
+# Copyright (c) Microsoft. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# This sample requires:
+#   pip install "autogen-agentchat" "autogen-ext[openai]" "hdp-autogen>=0.1.3" pyyaml
+#
+# See README.md for key generation and model_config.yaml setup.
+
+"""
+HDP Delegation Provenance — Single Agent with Scope Enforcement
+
+Demonstrates HDP attached to a single AssistantAgent. The middleware records
+every tool call as a delegation hop and optionally raises on scope violations.
+
+Reference: https://helixar.ai/about/labs/hdp/
+Package:   https://pypi.org/project/hdp-autogen/
+"""
+
+import asyncio
+import base64
+import os
+import sys
+
+import yaml
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_core.models import ChatCompletionClient
+from autogen_core.tools import FunctionTool
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from hdp_autogen import HdpMiddleware, HdpPrincipal, ScopePolicy, verify_chain
+
+
+def _load_model_client() -> ChatCompletionClient:
+    config_path = os.path.join(os.path.dirname(__file__), "model_config.yaml")
+    if not os.path.exists(config_path):
+        print("ERROR: model_config.yaml not found. See README.md for setup.")
+        sys.exit(1)
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+    return ChatCompletionClient.load_component(config)
+
+
+def _load_signing_key() -> Ed25519PrivateKey:
+    raw_b64 = os.getenv("HDP_SIGNING_KEY")
+    if not raw_b64:
+        print("ERROR: HDP_SIGNING_KEY not set. See README.md.")
+        sys.exit(1)
+    raw = base64.urlsafe_b64decode(raw_b64 + "==")
+    return Ed25519PrivateKey.from_private_bytes(raw)
+
+
+# ── Tools available to the agent ──────────────────────────────────────────
+
+
+def fetch_sales_data(region: str, quarter: str) -> str:
+    """Simulate fetching sales data for a region and quarter."""
+    return f"[MOCK] Sales data for {region} in {quarter}: revenue $2.4M, units 1,200."
+
+
+def write_report(title: str, content: str) -> str:
+    """Simulate writing a report to a file."""
+    return f"[MOCK] Report '{title}' written ({len(content)} chars)."
+
+
+async def main() -> None:
+    private_key = _load_signing_key()
+    model_client = _load_model_client()
+
+    # ── HDP: declare what the human is authorising ─────────────────────────
+    #
+    # authorized_tools lists the tool names this agent is permitted to use.
+    # In strict=True mode, any tool call outside this list raises immediately.
+    # In default mode, violations are logged and recorded in the token for audit.
+    middleware = HdpMiddleware(
+        signing_key=private_key.private_bytes_raw(),
+        session_id="sales-analysis-2026-q1",
+        principal=HdpPrincipal(id="analyst@corp.example.com", id_type="email"),
+        scope=ScopePolicy(
+            intent="Analyse Q1 EMEA sales and write a one-page summary",
+            authorized_tools=["fetch_sales_data", "write_report"],
+            data_classification="confidential",
+            network_egress=False,
+            persistence=True,
+            max_hops=5,
+        ),
+        strict=False,  # set True to raise HDPScopeViolationError on violations
+    )
+
+    agent = AssistantAgent(
+        name="sales_analyst",
+        model_client=model_client,
+        tools=[
+            FunctionTool(fetch_sales_data, description="Fetch sales data for a region and quarter."),
+            FunctionTool(write_report, description="Write a report to a file."),
+        ],
+        system_message=(
+            "You are a sales analyst. Use fetch_sales_data to retrieve data, "
+            "then use write_report to save a concise one-page summary."
+        ),
+    )
+
+    # ── Attach HDP — zero changes to agent ────────────────────────────────
+    middleware.configure(agent)
+
+    print("Running agent with HDP scope enforcement...\n")
+    await Console(
+        agent.run_stream(
+            task="Analyse Q1 EMEA sales and produce a one-page written summary."
+        )
+    )
+
+    # ── Offline verification ───────────────────────────────────────────────
+    token = middleware.export_token()
+    if token is None:
+        print("\n[HDP] No token issued.")
+        return
+
+    result = verify_chain(token, private_key.public_key())
+
+    print("\n" + "=" * 60)
+    print("HDP Delegation Chain Verification")
+    print("=" * 60)
+    print(f"  Valid:      {result.valid}")
+    print(f"  Hops:       {result.hop_count}")
+    print(f"  Intent:     {token['scope']['intent']}")
+    print(f"  Classification: {token['scope']['data_classification']}")
+
+    if result.violations:
+        print(f"\n  Violations ({len(result.violations)}):")
+        for v in result.violations:
+            print(f"    - {v}")
+
+    print("=" * 60)
+    print(
+        "\n[HDP] See https://helixar.ai/about/labs/hdp/ for the protocol spec\n"
+        "      and https://github.com/Helixar-AI/HDP for the full SDK."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/agentchat_hdp/single_agent.py
+++ b/python/samples/agentchat_hdp/single_agent.py
@@ -131,7 +131,31 @@ async def main() -> None:
         for v in result.violations:
             print(f"    - {v}")
 
+    if result.hop_results:
+        print(f"\n  Per-hop results:")
+        for hop in result.hop_results:
+            status = "OK" if hop.valid else f"INVALID — {hop.reason}"
+            print(f"    Hop {hop.seq} ({hop.agent_id}): {status}")
+
     print("=" * 60)
+
+    # ── Tamper-resistance check ────────────────────────────────────────────
+    # Mutating any hop signature causes verify_chain to return valid=False.
+    # Chain verification stops at the first invalid hop — each hop is signed
+    # over the cumulative chain, so subsequent results would be unreliable.
+    if result.hop_count > 0:
+        tampered = dict(token)
+        tampered["chain"] = [dict(h) for h in token["chain"]]
+        tampered["chain"][0]["hop_signature"] = "AAAA"  # simulate attacker modifying chain
+        tampered_result = verify_chain(tampered, private_key.public_key())
+        print("\n[HDP] Tamper-resistance check:")
+        print(f"  Tampered chain valid: {tampered_result.valid}")   # False
+        print(f"  Violations:           {tampered_result.violations}")
+
+    # ── max_hops exceeded ─────────────────────────────────────────────────
+    # ScopePolicy(max_hops=N) caps delegation depth.  verify_chain returns
+    # valid=False with "Chain depth N exceeds max_hops M" when len(chain) > N.
+
     print(
         "\n[HDP] See https://helixar.ai/about/labs/hdp/ for the protocol spec\n"
         "      and https://github.com/Helixar-AI/HDP for the full SDK."


### PR DESCRIPTION
## Summary

This PR adds `python/samples/agentchat_hdp/` — two runnable samples showing how to attach **HDP (Human Delegation Provenance)** to AutoGen AgentChat conversations.

HDP creates a tamper-evident Ed25519 chain from the authorising human to every downstream agent action. The chain is verifiable fully offline — no network call, no central registry. The [`hdp-autogen`](https://pypi.org/project/hdp-autogen/) PyPI package hooks into any `ConversableAgent` or `GroupChatManager` with a single `middleware.configure(target)` call.

### What's included

| File | What it demonstrates |
|---|---|
| `single_agent.py` | `AssistantAgent` with HDP scope enforcement — authorized tools list, strict vs. audit mode |
| `group_chat.py` | `RoundRobinGroupChat` with per-turn delegation tracking — every speaker turn = one signed hop |
| `README.md` | Setup, concept diagram, further reading |

### Why this matters

Multi-agent systems have no standard way to prove that a downstream action was authorised by a specific human. Conversation history alone is neither tamper-evident nor cryptographically bound to an identity. This gap was raised and validated by the AutoGen community in [discussion #7485](https://github.com/microsoft/autogen/discussions/7485), where researchers confirmed that agents across frameworks cannot distinguish legitimate orchestrator messages from injected ones.

HDP fills that gap: a compact, self-contained token signed with Ed25519 that any verifier — including a different process, service, or framework — can validate with just a public key.

### How it works

```
Human (Alice)  ──► Root token  [signed: intent, scope, principal]
                      └── Hop 0: orchestrator  [signed over root]
                            └── Hop 1: researcher  [signed over hop 0]
                                  └── Hop 2: writer  [signed over hop 1]
```

Any modification of any hop is immediately detectable at verification time.

### Relation to existing AutoGen observability

HDP **complements** OpenTelemetry tracing (which records *what* happened) — it records *who authorised it* with a cryptographic proof. Both can be active simultaneously.

## Test plan

- [ ] `pip install "autogen-agentchat" "autogen-ext[openai]" "hdp-autogen>=0.1.3" pyyaml`
- [ ] Export `HDP_SIGNING_KEY` (generation command in README)
- [ ] Add `model_config.yaml` pointing at a model of your choice
- [ ] `python group_chat.py` — verify chain printed at the end shows `Valid: True`
- [ ] `python single_agent.py` — same
- [ ] Tamper with a hop field in the exported token JSON → verify chain shows `Valid: False`

## References

- [HDP protocol specification and docs](https://helixar.ai/about/labs/hdp/)
- [`hdp-autogen` on PyPI](https://pypi.org/project/hdp-autogen/)
- [HDP GitHub repository](https://github.com/Helixar-AI/HDP)
- [IETF draft: draft-helixar-hdp-agentic-delegation](https://datatracker.ietf.org/doc/draft-helixar-hdp-agentic-delegation/)
- [Community discussion: accountability in multi-agent systems (#7485)](https://github.com/microsoft/autogen/discussions/7485)