### PR TITLE
docs: fix minor doc comment typos

### DIFF
--- a/dotnet/samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs
+++ b/dotnet/samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs
@@ -38,7 +38,7 @@ public class Chat_With_LLaVA
         #region Send_MultiModal_Message
         // You can also use MultiModalMessage to put text and image together in one message
         // In this case, all the messages in the multi-modal message will be put into single piece of message
-        // where the text is the concatenation of all the text messages seperated by \n
+        // where the text is the concatenation of all the text messages separated by \n
         // and the images are all the images in the multi-modal message
         var multiModalMessage = new MultiModalMessage(Role.User, [textMessage, imageMessage]);
 

--- a/dotnet/test/Microsoft.AutoGen.Core.Tests/InProcessRuntimeTests.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Tests/InProcessRuntimeTests.cs
@@ -77,7 +77,7 @@ public class InProcessRuntimeTests()
 
         await runtime.RunUntilIdleAsync();
 
-        // Agent sucessfully published to self
+        // Agent successfully published to self
         agent.Text.Source.Should().Be("TestTopic");
         agent.Text.Content.Should().Be("SelfMessage");
     }

--- a/python/docs/src/user-guide/core-user-guide/design-patterns/multi-agent-debate.ipynb
+++ b/python/docs/src/user-guide/core-user-guide/design-patterns/multi-agent-debate.ipynb
@@ -228,7 +228,7 @@
                 "\n",
                 "The aggregator subscribes to the default topic using\n",
                 "{py:meth}`~autogen_core.components.default_subscription`. The default topic is used to\n",
-                "recieve user question, receive the final responses from the solver agents,\n",
+                "receive the user question and final responses from the solver agents,\n",
                 "and publish the final answer back to the user.\n",
                 "\n",
                 "In a more complex application when you want to isolate the multi-agent debate into a\n",


### PR DESCRIPTION
## Why are these changes needed?

Fixes a few minor misspellings in documentation/comment text:

- `recieve` -> `receive` in the multi-agent debate notebook text
- `sucessfully` -> `successfully` in a .NET test comment
- `seperated` -> `separated` in an Ollama sample comment

No runtime behavior changes.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. (Not relevant: docs/comments only.)
- [ ] I've made sure all auto checks have passed.

Validation run locally:

- `git diff --check`
- Parsed `python/docs/src/user-guide/core-user-guide/design-patterns/multi-agent-debate.ipynb` as JSON
- Targeted typo check confirmed `recieve`, `sucessfully`, and `seperated` are absent from the touched files
