### PR TITLE
docs(agentchat): add missing TextMessage import in custom agents docs

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/custom-agents.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/custom-agents.ipynb
@@ -137,7 +137,7 @@
                 "from autogen_agentchat.agents import BaseChatAgent\n",
                 "from autogen_agentchat.base import Response\n",
                 "from autogen_agentchat.conditions import MaxMessageTermination\n",
-                "from autogen_agentchat.messages import BaseChatMessage\n",
+                "from autogen_agentchat.messages import BaseChatMessage, TextMessage\n",
                 "from autogen_agentchat.teams import SelectorGroupChat\n",
                 "from autogen_agentchat.ui import Console\n",
                 "from autogen_core import CancellationToken\n",


### PR DESCRIPTION
## Summary
This PR fixes a documentation issue in the AgentChat Custom Agents guide.

Specifically, the ArithmeticAgent example uses TextMessage but did not import it in the same code cell.
This update adds the missing import so the snippet is self-consistent and runnable when copied.

## Changes
- Updated python/docs/src/user-guide/agentchat-user-guide/custom-agents.ipynb
- In the ArithmeticAgent import section:
  - changed:
    - from autogen_agentchat.messages import BaseChatMessage
  - to:
    - from autogen_agentchat.messages import BaseChatMessage, TextMessage

## Issue
Fixes #6277

## Notes
- Documentation-only change.