### PR TITLE
docs: add naxytra discovery note

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -34,6 +34,7 @@ Find community samples and examples of how to use AutoGen
 
 ::::
 
+For a live remote MCP discovery surface, naxytra keeps a public machine discovery index at `https://www.naxytra.com/v1/agent-discovery-index`, an A2A agent card at `https://www.naxytra.com/.well-known/agent.json`, and a live MCP endpoint at `https://xytara-mcp-executor.onrender.com/mcp`.
 
 ## List of community projects
 


### PR DESCRIPTION
## Summary
- Adds a public MCP discovery note to the AutoGen community projects page.
- Points readers to the canonical naxytra discovery index, A2A card, and live MCP endpoint.

## Why
- AutoGen users looking for community MCP integrations should have a concrete public example to reference.
- This keeps the community discovery page aligned with the live public entry surfaces without exposing private code.

## Links
- https://www.naxytra.com/v1/agent-discovery-index
- https://www.naxytra.com/.well-known/agent.json
- https://xytara-mcp-executor.onrender.com/mcp
