### PR TITLE
docs: fix duplicated words in Python docs

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -1033,7 +1033,7 @@ In `v0.2` group chat, when tools are involved, you need to register the tool fun
 and include the user proxy in the group chat. The tool calls made by other agents
 will be routed to the user proxy to execute.
 
-We have observed numerous issues with this approach, such as the the tool call
+We have observed numerous issues with this approach, such as the tool call
 routing not working as expected, and the tool call request and result cannot be
 accepted by models without support for function calling.
 

--- a/python/docs/src/user-guide/core-user-guide/faqs.md
+++ b/python/docs/src/user-guide/core-user-guide/faqs.md
@@ -4,7 +4,7 @@
 
 Agents might be distributed across multiple machines, so the underlying agent instance is intentionally discouraged from being accessed. If the agent is definitely running on the same machine, you can access the agent instance by calling {py:meth}`autogen_core.AgentRuntime.try_get_underlying_agent_instance` on the `AgentRuntime`. If the agent is not available this will throw an exception.
 
-## How do I call call a function on an agent?
+## How do I call a function on an agent?
 
 Since the instance itself is not accessible, you can't call a function on an agent directly. Instead, you should create a type to represent the function call and its arguments, and then send that message to the agent. Then in the agent, create a handler for that message type and implement the required logic. This also supports returning a response to the caller.
 

--- a/python/samples/agentchat_chess_game/README.md
+++ b/python/samples/agentchat_chess_game/README.md
@@ -24,7 +24,7 @@ To run this sample, you will need to install the following packages:
 pip install -U autogen-agentchat pyyaml
 ```
 
-Create a new file named `model_config.yaml` in the the same directory as the script
+Create a new file named `model_config.yaml` in the same directory as the script
 to configure the model you want to use.
 
 For example, to use `gpt-4o` model from OpenAI, you can use the following configuration:

--- a/python/samples/agentchat_streamlit/README.md
+++ b/python/samples/agentchat_streamlit/README.md
@@ -18,7 +18,7 @@ pip install "autogen-ext[openai,azure]"
 # pip install "autogen-ext[openai]" for OpenAI models
 ```
 
-Create a new file named `model_config.yml` in the the same directory as the script
+Create a new file named `model_config.yml` in the same directory as the script
 to configure the model you want to use.
 
 For example, to use `gpt-4o-mini` model from Azure OpenAI, you can use the following configuration:


### PR DESCRIPTION
Fixes duplicated words in Python documentation comments. No behavior change.