### PR TITLE
samples: add Synap long-term memory AgentChat sample

### DIFF
--- a/python/samples/agentchat_synap_memory/README.md
+++ b/python/samples/agentchat_synap_memory/README.md
@@ -1,0 +1,30 @@
+# AgentChat Synap Memory
+
+This sample shows how to give an AutoGen `AssistantAgent` persistent, cross-session memory via [Synap](https://maximem.ai) — a managed long-term memory layer for AI agents.
+
+## Setup
+
+```bash
+pip install synap-autogen maximem-synap "autogen-agentchat" "autogen-ext[openai]"
+```
+
+Set environment variables:
+
+```bash
+export SYNAP_API_KEY=<your-key>     # get one free at https://synap.maximem.ai
+export OPENAI_API_KEY=<your-key>
+```
+
+## Run
+
+```bash
+python main.py
+```
+
+The agent is wired with `SynapSearchTool` and `SynapStoreTool` — it can semantically search the user's existing memories and persist new facts the user mentions. Memories are scoped to the `user_id` and `customer_id` you provide, so they persist across conversation runs.
+
+## Resources
+
+- [Synap documentation](https://docs.maximem.ai)
+- [PyPI: `synap-autogen`](https://pypi.org/project/synap-autogen/)
+- [Open source integration package](https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations/synap-autogen)

--- a/python/samples/agentchat_synap_memory/README.md
+++ b/python/samples/agentchat_synap_memory/README.md
@@ -5,7 +5,7 @@ This sample shows how to give an AutoGen `AssistantAgent` persistent, cross-sess
 ## Setup
 
 ```bash
-pip install synap-autogen maximem-synap "autogen-agentchat" "autogen-ext[openai]"
+pip install maximem-synap-autogen maximem-synap "autogen-agentchat" "autogen-ext[openai]"
 ```
 
 Set environment variables:
@@ -26,5 +26,5 @@ The agent is wired with `SynapSearchTool` and `SynapStoreTool` — it can semant
 ## Resources
 
 - [Synap documentation](https://docs.maximem.ai)
-- [PyPI: `synap-autogen`](https://pypi.org/project/synap-autogen/)
+- [PyPI: `maximem-synap-autogen`](https://pypi.org/project/maximem-synap-autogen/)
 - [Open source integration package](https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations/synap-autogen)

--- a/python/samples/agentchat_synap_memory/main.py
+++ b/python/samples/agentchat_synap_memory/main.py
@@ -1,0 +1,64 @@
+"""AgentChat sample: persistent long-term memory via Synap.
+
+[Synap](https://maximem.ai) is a managed long-term memory layer for AI agents.
+The `synap-autogen` package exposes Synap as AutoGen `BaseTool` implementations
+so an `AssistantAgent` can search and store memories across conversations.
+
+Setup:
+    pip install synap-autogen maximem-synap "autogen-agentchat" "autogen-ext[openai]"
+    export SYNAP_API_KEY=<your-key>     # https://synap.maximem.ai
+    export OPENAI_API_KEY=<your-key>
+
+Run:
+    python main.py
+
+Open source integration package:
+https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations/synap-autogen
+"""
+
+import asyncio
+import os
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from maximem_synap import MaximemSynapSDK
+from synap_autogen import SynapSearchTool, SynapStoreTool
+
+
+async def main() -> None:
+    sdk = MaximemSynapSDK(api_key=os.environ["SYNAP_API_KEY"])
+    await sdk.initialize()
+
+    user_id = "demo-user-001"
+    customer_id = "demo-customer"
+
+    tools = [
+        SynapSearchTool(sdk=sdk, user_id=user_id, customer_id=customer_id),
+        SynapStoreTool(sdk=sdk, user_id=user_id, customer_id=customer_id),
+    ]
+
+    agent = AssistantAgent(
+        name="memory_assistant",
+        model_client=OpenAIChatCompletionClient(model="gpt-4o-mini"),
+        tools=tools,
+        system_message=(
+            "You are a helpful assistant with long-term memory. "
+            "Call synap_search to recall what you know about the user. "
+            "Call synap_store to save important new facts."
+        ),
+    )
+
+    await Console(
+        agent.run_stream(
+            task="I'm a software engineer who's allergic to peanuts. Remember this."
+        )
+    )
+
+    await Console(
+        agent.run_stream(task="What do you know about my dietary restrictions?")
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/samples/agentchat_synap_memory/main.py
+++ b/python/samples/agentchat_synap_memory/main.py
@@ -1,11 +1,12 @@
 """AgentChat sample: persistent long-term memory via Synap.
 
 [Synap](https://maximem.ai) is a managed long-term memory layer for AI agents.
-The `synap-autogen` package exposes Synap as AutoGen `BaseTool` implementations
-so an `AssistantAgent` can search and store memories across conversations.
+The `maximem-synap-autogen` package exposes Synap as AutoGen `BaseTool`
+implementations so an `AssistantAgent` can search and store memories across
+conversations.
 
 Setup:
-    pip install synap-autogen maximem-synap "autogen-agentchat" "autogen-ext[openai]"
+    pip install maximem-synap-autogen maximem-synap "autogen-agentchat" "autogen-ext[openai]"
     export SYNAP_API_KEY=<your-key>     # https://synap.maximem.ai
     export OPENAI_API_KEY=<your-key>
 


### PR DESCRIPTION
## Summary

Adds `python/samples/agentchat_synap_memory/` — a sample showing how to give an AutoGen `AssistantAgent` persistent, cross-session memory via [Synap](https://maximem.ai).

The agent is wired with `SynapSearchTool` and `SynapStoreTool` from `synap-autogen` — it can semantically search the user's existing memories and persist new facts the user mentions.

PyPI: https://pypi.org/project/synap-autogen/
Open source: https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations/synap-autogen