### PR TITLE
fix(openai): preserve extra_body in component config

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Dict, List, Literal, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Union
 
 from autogen_core import ComponentModel
 from autogen_core.models import ModelCapabilities, ModelInfo  # type: ignore
@@ -50,6 +50,7 @@ class CreateArguments(TypedDict, total=False):
     user: str
     stream_options: Optional[StreamOptions]
     parallel_tool_calls: Optional[bool]
+    extra_body: Optional[Dict[str, Any]]
     reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]]
     """Controls the amount of effort the model uses for reasoning.
     Only applicable to reasoning models like o1 and o3-mini.
@@ -106,6 +107,7 @@ class CreateArgumentsConfigModel(BaseModel):
     user: str | None = None
     stream_options: StreamOptions | None = None
     parallel_tool_calls: bool | None = None
+    extra_body: Dict[str, Any] | None = None
     # Controls the amount of effort the model uses for reasoning (reasoning models only)
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
 

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -12,6 +12,7 @@ from autogen_agentchat.messages import MultiModalMessage
 from autogen_core import CancellationToken, FunctionCall, Image
 from autogen_core.models import (
     AssistantMessage,
+    ChatCompletionClient,
     CreateResult,
     FunctionExecutionResult,
     FunctionExecutionResultMessage,
@@ -203,6 +204,32 @@ async def test_openai_chat_completion_client_serialization() -> None:
     assert "sk-password" not in serialized_config
     client2 = OpenAIChatCompletionClient.load_component(config)
     assert client2
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_completion_client_config_preserves_extra_body() -> None:
+    extra_body = {"enable_thinking": False, "chat_template_kwargs": {"reasoning": False}}
+
+    client = OpenAIChatCompletionClient(model="gpt-4.1-nano", api_key="sk-password", extra_body=extra_body)
+    config = client.dump_component()
+
+    assert config.config["extra_body"] == extra_body
+    loaded_client = OpenAIChatCompletionClient.load_component(config)
+    assert loaded_client._create_args["extra_body"] == extra_body  # pyright: ignore[reportPrivateUsage]
+    assert loaded_client._raw_config["extra_body"] == extra_body  # pyright: ignore[reportPrivateUsage]
+
+    studio_config = {
+        "provider": "autogen_ext.models.openai.OpenAIChatCompletionClient",
+        "config": {
+            "model": "gpt-4.1-nano",
+            "api_key": "sk-password",
+            "extra_body": extra_body,
+        },
+    }
+    loaded_from_json = ChatCompletionClient.load_component(studio_config)
+    assert isinstance(loaded_from_json, OpenAIChatCompletionClient)
+    assert loaded_from_json._create_args["extra_body"] == extra_body  # pyright: ignore[reportPrivateUsage]
+    assert loaded_from_json._raw_config["extra_body"] == extra_body  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #7418.

`OpenAIChatCompletionClient` already accepts `extra_body` at runtime and includes it in the valid create kwargs, but the component config schema did not include the field. As a result, Studio/component JSON loading and `dump_component()` round-trips silently dropped provider-specific request body values before they could reach `_create_args`.

This PR adds `extra_body` to the OpenAI create-argument config types and adds regression coverage for both direct component dump/load and Studio-style `ChatCompletionClient.load_component()` JSON.

## Testing

```sh
uv run --project python pytest -q python/packages/autogen-ext/tests/models/test_openai_model_client.py -k "extra_body"
uv run --project python pytest -q python/packages/autogen-ext/tests/models/test_openai_model_client.py::test_openai_chat_completion_client_serialization python/packages/autogen-ext/tests/models/test_openai_model_client.py::test_openai_chat_completion_client_config_preserves_extra_body
uv run --project python ruff check python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py python/packages/autogen-ext/tests/models/test_openai_model_client.py
uv run --project python pyright python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py python/packages/autogen-ext/tests/models/test_openai_model_client.py
git diff --check
```