### PR TITLE
Include all assistant tool iterations in summaries

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -1228,8 +1228,9 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
                     raise RuntimeError(f"Unexpected event type: {type(event)}")
 
             # Wait for all tool calls to complete.
-            executed_calls_and_results = await task
-            exec_results = [result for _, result in executed_calls_and_results]
+            current_executed_calls_and_results = await task
+            executed_calls_and_results.extend(current_executed_calls_and_results)
+            exec_results = [result for _, result in current_executed_calls_and_results]
 
             # Yield ToolCallExecutionEvent
             tool_call_result_msg = ToolCallExecutionEvent(
@@ -1244,7 +1245,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
             # STEP 4C: Check for handoff
             handoff_output = cls._check_and_handle_handoff(
                 model_result=current_model_result,
-                executed_calls_and_results=executed_calls_and_results,
+                executed_calls_and_results=current_executed_calls_and_results,
                 inner_messages=inner_messages,
                 handoffs=handoffs,
                 agent_name=agent_name,

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -675,6 +675,51 @@ class TestAssistantAgentToolCallLoop:
         assert result is not None
 
     @pytest.mark.asyncio
+    async def test_tool_call_loop_summary_includes_all_iterations(self) -> None:
+        """Test that max-iteration summaries include every executed tool call."""
+        model_client = ReplayChatCompletionClient(
+            [
+                CreateResult(
+                    finish_reason="function_calls",
+                    content=[
+                        FunctionCall(
+                            id=str(i),
+                            arguments=json.dumps({"param": f"call_{i}"}),
+                            name="mock_tool_function",
+                        )
+                    ],
+                    usage=RequestUsage(prompt_tokens=10, completion_tokens=5),
+                    cached=False,
+                )
+                for i in range(3)
+            ],
+            model_info={
+                "function_calling": True,
+                "vision": False,
+                "json_output": False,
+                "family": ModelFamily.GPT_4O,
+                "structured_output": False,
+            },
+        )
+
+        agent = AssistantAgent(
+            name="test_agent",
+            model_client=model_client,
+            tools=[mock_tool_function],
+            max_tool_iterations=3,
+            reflect_on_tool_use=False,
+        )
+
+        result = await agent.run(task="Test max iteration summary")
+
+        final_message = result.messages[-1]
+        assert isinstance(final_message, ToolCallSummaryMessage)
+        assert len(final_message.tool_calls) == 3
+        assert len(final_message.results) == 3
+        for i in range(3):
+            assert f"Tool executed with: call_{i}" in final_message.content
+
+    @pytest.mark.asyncio
     async def test_tool_call_loop_with_handoff(self) -> None:
         """Test that tool call loop stops on handoff."""
         model_client = ReplayChatCompletionClient(


### PR DESCRIPTION
## Summary
- Accumulate AssistantAgent tool call results across max_tool_iterations for the final no-reflection summary.
- Preserve per-iteration ToolCallExecutionEvent contents and handoff handling scope.
- Add regression coverage for multi-iteration tool summaries.

## Root Cause
AssistantAgent._process_model_result replaced executed_calls_and_results on each tool-call loop iteration. When max_tool_iterations was greater than 1 and reflect_on_tool_use was false, the final ToolCallSummaryMessage only included the last iteration.

## Validation
- uv run pytest packages/autogen-agentchat/tests/test_assistant_agent.py -k "tool_call_loop_summary_includes_all_iterations or tool_call_loop_max_iterations or tool_call_loop_with_handoff"
- uv run pytest packages/autogen-agentchat/tests/test_assistant_agent.py
- uv run ruff check packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py packages/autogen-agentchat/tests/test_assistant_agent.py
- uv run ruff format --check packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py packages/autogen-agentchat/tests/test_assistant_agent.py
- uv run pyright src/autogen_agentchat/agents/_assistant_agent.py tests/test_assistant_agent.py
- git diff --check