### PR TITLE
fix(openai): guard None chunks and None delta in create_stream

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -906,6 +906,11 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         # Process the stream of chunks.
         async for chunk in chunks:
+            # Some providers (e.g. Azure) send None keepalive chunks.
+            # https://github.com/microsoft/autogen/issues/7130
+            if chunk is None:
+                continue
+
             if first_chunk:
                 first_chunk = False
                 # Emit the start event.
@@ -949,7 +954,11 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             maybe_model = chunk.model
 
             reasoning_content: str | None = None
-            if choice.delta.model_extra is not None and "reasoning_content" in choice.delta.model_extra:
+            if (
+                choice.delta is not None
+                and choice.delta.model_extra is not None
+                and "reasoning_content" in choice.delta.model_extra
+            ):
                 # If there is a reasoning_content field, then we populate the thought field. This is for models such as R1.
                 reasoning_content = choice.delta.model_extra.get("reasoning_content")
 
@@ -968,7 +977,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                 yield reasoning_content
 
             # First try get content
-            if choice.delta.content:
+            if choice.delta is not None and choice.delta.content:
                 content_deltas.append(choice.delta.content)
                 if len(choice.delta.content) > 0:
                     yield choice.delta.content
@@ -976,7 +985,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                 # However, this may not be the case for other APIs -- we should expect this may need to be updated.
                 continue
             # Otherwise, get tool calls
-            if choice.delta.tool_calls is not None:
+            if choice.delta is not None and choice.delta.tool_calls is not None:
                 for tool_call_chunk in choice.delta.tool_calls:
                     idx = tool_call_chunk.index
                     if idx not in full_tool_calls:

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -396,6 +396,62 @@ async def test_openai_chat_completion_client_none_usage(monkeypatch: pytest.Monk
 
 
 @pytest.mark.asyncio
+async def test_openai_chat_completion_client_stream_none_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """None chunks in a stream must be silently skipped without AttributeError.
+
+    Some providers (e.g. Azure) emit None keepalive chunks between real ones.
+    https://github.com/microsoft/autogen/issues/7130
+    """
+
+    async def _gen_none_chunks() -> AsyncGenerator[Any, None]:
+        model = "gpt-4o"
+        # Interleave real chunks with None keepalives.
+        yield None
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[
+                ChunkChoice(
+                    finish_reason=None,
+                    index=0,
+                    delta=ChoiceDelta(content="Hello", role="assistant"),
+                )
+            ],
+            created=0,
+            model=model,
+            object="chat.completion.chunk",
+        )
+        yield None
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[
+                ChunkChoice(
+                    finish_reason="stop",
+                    index=0,
+                    delta=ChoiceDelta(content=None, role="assistant"),
+                )
+            ],
+            created=0,
+            model=model,
+            object="chat.completion.chunk",
+        )
+
+    async def _mock_create_with_none_chunks(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:
+        return _gen_none_chunks()
+
+    monkeypatch.setattr(AsyncCompletions, "create", _mock_create_with_none_chunks)
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="api_key")
+    chunks: List[str | CreateResult] = []
+    async for chunk in client.create_stream(messages=[UserMessage(content="Hello", source="user")]):
+        chunks.append(chunk)
+
+    content_chunks = [c for c in chunks if isinstance(c, str)]
+    assert content_chunks == ["Hello"]
+    result = chunks[-1]
+    assert isinstance(result, CreateResult)
+    assert result.content == "Hello"
+
+
+@pytest.mark.asyncio
 async def test_openai_chat_completion_client_create_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(AsyncCompletions, "create", _mock_create)
     client = OpenAIChatCompletionClient(model="gpt-4o", api_key="api_key")


### PR DESCRIPTION
## Summary

Fixes #7130

Two related null-deref bugs in the `create_stream` streaming path:

**Bug 1 — None keepalive chunks** (the #7130 report):
`chunk` is typed `ChatCompletionChunk | None`. Some providers (e.g. Azure) emit `None` keepalive chunks between real ones. `chunk.model` at line 919 raised `AttributeError` before any None check. The `if len(chunk.choices) == 0` guard at line 923 was too late — it also crashes on a None chunk.

**Fix:** Add `if chunk is None: continue` immediately after the `async for chunk in chunks:` loop header, before any attribute access.

**Bug 2 — None delta in choices** (related to #6465):
`choice.delta` can be `None` in Azure annotation-style chunks. Three sites lacked a `choice.delta is not None` guard:
- `choice.delta.model_extra` (reasoning_content extraction)  
- `choice.delta.content` (content accumulation)
- `choice.delta.tool_calls` (tool call accumulation)

**Fix:** Guard all three sites with `choice.delta is not None and ...`.

## Test plan

- [x] New test `test_openai_chat_completion_client_stream_none_chunk` injects `None` keepalives between real `ChatCompletionChunk` objects and asserts the stream completes cleanly, producing the expected content
- [x] Existing streaming tests continue to pass (verified locally)

## Verification

Static safety proof via [pact](https://github.com/qizwiz/pact) sheaf-cohomological checker (Z3 UNSAT certificate): the fix reduces the guard-deficit Ȟ¹ rank from 1 → 0, meaning Z3 can prove no execution path reaches `chunk.model` when `chunk is None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)