### PR TITLE
fix(azure): expose api_version in AzureAIChatCompletionClient typed kwargs

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
@@ -188,6 +188,7 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
         credential (union, AzureKeyCredential, AsyncTokenCredential): The credentials to use. **Required**
         model_info (ModelInfo): The model family and capabilities of the model. **Required.**
         model (str): The name of the model. **Required if model is hosted on GitHub Models.**
+        api_version (optional, str): API version for the Azure AI Inference service. Defaults to the value used by the underlying ``azure-ai-inference`` SDK.
         frequency_penalty: (optional,float)
         presence_penalty: (optional,float)
         temperature: (optional,float)

--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/config/__init__.py
@@ -25,6 +25,7 @@ class AzureAIClientArguments(TypedDict, total=False):
     endpoint: str
     credential: Union[AzureKeyCredential, AsyncTokenCredential]
     model_info: ModelInfo
+    api_version: str
 
 
 class AzureAICreateArguments(TypedDict, total=False):

--- a/python/packages/autogen-ext/tests/models/test_azure_ai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_azure_ai_model_client.py
@@ -3,7 +3,7 @@ import logging
 import os
 from datetime import datetime
 from typing import Any, AsyncGenerator, List, Type, Union
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from autogen_core import CancellationToken, FunctionCall, Image
@@ -973,3 +973,29 @@ async def test_azure_ai_tool_choice_specific_tool_streaming(
     assert final_result.content[0].name == "process_text"
     assert final_result.content[0].arguments == '{"input": "hello"}'
     assert final_result.thought == "Let me process this for you."
+
+
+def test_api_version_is_forwarded_to_underlying_client() -> None:
+    """api_version passed to AzureAIChatCompletionClient must reach ChatCompletionsClient.
+
+    Regression test for #6705: the typed kwargs accept ``api_version`` so users can
+    target newer Azure AI Inference API versions without bypassing the type contract.
+    """
+    custom_api_version = "2024-08-01-preview"
+    with patch("autogen_ext.models.azure._azure_ai_client.ChatCompletionsClient") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock()
+        AzureAIChatCompletionClient(
+            endpoint="https://example.test/inference",
+            credential=AzureKeyCredential("k"),
+            model="model",
+            model_info={
+                "json_output": False,
+                "function_calling": False,
+                "vision": False,
+                "family": "unknown",
+                "structured_output": False,
+            },
+            api_version=custom_api_version,
+        )
+        mock_client_cls.assert_called_once()
+        assert mock_client_cls.call_args.kwargs.get("api_version") == custom_api_version


### PR DESCRIPTION
## Summary

- Adds `api_version: str` to `AzureAIClientArguments` TypedDict so the field is part of the public typed surface of `AzureAIChatCompletionClient`.
- Documents the parameter in the client docstring.
- Adds a unit test verifying the value is forwarded to the underlying `azure.ai.inference.aio.ChatCompletionsClient`.

## Why

The underlying `ChatCompletionsClient` accepts `api_version`, and `AzureAIChatCompletionClient._create_client` already forwards every non-`model_info` kwarg to it. The TypedDict typing the constructor's `**kwargs` did not declare the field, so callers couldn't pass it without a `# type: ignore`/cast, and it was absent from the public docs. Users could not access newer Azure AI Inference API versions through the typed contract.

## Relation to prior PR #6718

PR #6718 (closed) attempted the same fix but also rewrote `_create_client`, which `@ekzhu` correctly noted was unnecessary — the existing dict-filter implementation already forwards the value at runtime. The actual gap was the **type contract**, not the runtime path. This PR addresses only that gap:

- No change to `_create_client`.
- No change to `_validate_config`.
- No version bump.
- TypedDict has `total=False`, so `api_version` is optional; `str` (not `Optional[str]`) because the SDK does not accept `None`.

Diff: +29 / -1, 3 files.

## Test plan

- [x] `uv run --package autogen-ext pytest packages/autogen-ext/tests/models/test_azure_ai_model_client.py -v` — 19/19 pass (1 new test + 18 prior).
- [x] `uv run --package autogen-ext pyright packages/autogen-ext/src/autogen_ext/models/azure/ packages/autogen-ext/tests/models/test_azure_ai_model_client.py` — 0 errors.
- [x] `uv run --package autogen-ext ruff check` / `ruff format --check` — clean.

Closes #6705.

cc @ekzhu @victordibia