### PR TITLE
fix: validation error messages for invalid participants in BaseGroupChat

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -78,8 +78,17 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
     ):
         self._name = name
         self._description = description
+        if participants is None:
+            raise TypeError("participants must be a non-empty sequence of ChatAgent or Team instances.")
+        if not isinstance(participants, (list, tuple)):
+            raise TypeError("participants must be a list or tuple of ChatAgent or Team instances.")
         if len(participants) == 0:
             raise ValueError("At least one participant is required.")
+        for i, participant in enumerate(participants):
+            if not isinstance(participant, (ChatAgent, Team)):
+                raise TypeError(
+                    f"participants[{i}] must be a ChatAgent or Team instance, got {type(participant).__name__}."
+                )
         if len(participants) != len(set(participant.name for participant in participants)):
             raise ValueError("The participant names must be unique.")
         self._participants = participants


### PR DESCRIPTION
Fixed the bug described in issue #7580. Here's what was wrong and how I fixed it:

**What was broken:**
When invalid participants (None, wrong types, or lists containing non-agent objects) were passed to `RoundRobinGroupChat` (or any `BaseGroupChat` subclass), the constructor raised raw low-level Python errors like `TypeError: object of type 'NoneType' has no len()`, `AttributeError: 'str' object has no attribute 'name'`, instead of a clear validation message.

**How I fixed it:**
Added explicit input validation at the top of `BaseGroupChat.__init__` that checks:
1. `participants` is not `None` → raises `TypeError`
2. `participants` is a list or tuple → raises `TypeError` if not
3. `participants` is non-empty → raises `ValueError` if empty
4. All items are `ChatAgent` or `Team` instances → raises `TypeError` with index and actual type name if not

This replaces opaque internal errors with clear, actionable messages that point users directly to the problem.

**Testing:**
Verified all 5 error cases from the issue now produce descriptive errors:
- `RoundRobinGroupChat(participants=None)` → `TypeError: participants must be a non-empty sequence of ChatAgent or Team instances.`
- `RoundRobinGroupChat(participants="not a list")` → `TypeError: participants must be a list or tuple of ChatAgent or Team instances.`
- `RoundRobinGroupChat(participants=42)` → `TypeError: participants must be a list or tuple of ChatAgent or Team instances.`
- `RoundRobinGroupChat(participants=[])` → `ValueError: At least one participant is required.`
- `RoundRobinGroupChat(participants=[UserProxyAgent(name="valid"), "bad"])` → `TypeError: participants[1] must be a ChatAgent or Team instance, got str.`

**Files changed:**
- `python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py` — added 9 lines of validation

Link to issue: https://github.com/microsoft/autogen/issues/7580