### PR TITLE
magentic-one-cli: pin utf-8 encoding when loading YAML config (refs #5566)

### DIFF
--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -97,12 +97,12 @@ def main() -> None:
 
     if args.config is None:
         if os.path.isfile(DEFAULT_CONFIG_FILE):
-            with open(DEFAULT_CONFIG_FILE, "r") as f:
+            with open(DEFAULT_CONFIG_FILE, "r", encoding="utf-8") as f:
                 config = yaml.safe_load(f)
         else:
             config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)
     else:
-        with open(args.config if isinstance(args.config, str) else args.config[0], "r") as f:
+        with open(args.config if isinstance(args.config, str) else args.config[0], "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
     # Run the task


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

## Why

Refs #5566.

#5566 reported `m1` crashing with
`UnicodeDecodeError: 'cp950' codec can't decode byte ...` on a non-UTF-8
default locale (Traditional Chinese Windows). The original call site
(`playwright_controller.py`) was fixed in #6094, but the reporter
flagged that there were *"similar issues in the codebase while using
open function"*, and the issue was kept open to track the follow-up
sweep. This PR fixes the next two call sites on the same code path the
user actually hits when they type `m1 ...` on Windows.

## What

`python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py` loads its
YAML config in two places, both via `open(..., \"r\")` with no
`encoding=`:

| Line | Source | Used for |
|---|---|---|
| 100 | `DEFAULT_CONFIG_FILE` | default `~/.magentic_one_config.yaml` |
| 105 | `args.config[…]` | user-supplied `--config <path>` |

On non-UTF-8 locales (cp950, cp1252, …) any non-ASCII byte in the
config (comments in CJK, accented paths, …) would raise
`UnicodeDecodeError` *before* the CLI gets to build an agent.

This PR pins `encoding=\"utf-8\"` on both, matching YAML 1.2's default
stream encoding.

```diff
- with open(DEFAULT_CONFIG_FILE, \"r\") as f:
+ with open(DEFAULT_CONFIG_FILE, \"r\", encoding=\"utf-8\") as f:

- with open(args.config if isinstance(args.config, str) else args.config[0], \"r\") as f:
+ with open(args.config if isinstance(args.config, str) else args.config[0], \"r\", encoding=\"utf-8\") as f:
```

## Scope

Intentionally only these two call sites:

- Same package as the original crash (`magentic-one-cli`), same code
  path the bug report hits.
- A blanket sweep across `python/packages/` would touch >40 files
  including test fixtures and benchmark scenario scripts that read
  JSONL produced by the agents themselves — forcing UTF-8 there could
  in theory mask issues. Better to land focused, then iterate.

## Verification

- AST parses cleanly.
- Only two lines changed; no functional change for already-UTF-8-locale
  users.

---

AI-assisted via Cursor (Claude Opus 4.7). Personal token-burn
initiative by @adv0r to use up an expiring Cursor subscription budget on
small, useful upstream contributions.

Made with [Cursor](https://cursor.com)
