### PR TITLE
autogen-studio: pin utf-8 encoding on production text-file open() calls (refs #5566)

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/cli.py
+++ b/python/packages/autogen-studio/autogenstudio/cli.py
@@ -69,7 +69,7 @@ def ui(
 
     # Create temporary env file to share configuration with uvicorn workers
     env_file_path = get_env_file_path()
-    with open(env_file_path, "w") as temp_env:
+    with open(env_file_path, "w", encoding="utf-8") as temp_env:
         for key, value in env_vars.items():
             temp_env.write(f"{key}={value}\n")
 

--- a/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
+++ b/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
@@ -75,7 +75,7 @@ class SchemaManager:
 
         # Update alembic.ini
         config_content = self._generate_alembic_ini_content()
-        with open(self.alembic_ini_path, "w") as f:
+        with open(self.alembic_ini_path, "w", encoding="utf-8") as f:
             f.write(config_content)
 
         # Update env.py
@@ -115,7 +115,7 @@ class SchemaManager:
 
             # Create initial config file for alembic init
             config_content = self._generate_alembic_ini_content()
-            with open(self.alembic_ini_path, "w") as f:
+            with open(self.alembic_ini_path, "w", encoding="utf-8") as f:
                 f.write(config_content)
 
             # Use the config we just created
@@ -187,7 +187,7 @@ if context.is_offline_mode():
 else:
     run_migrations_online()"""
 
-        with open(env_path, "w") as f:
+        with open(env_path, "w", encoding="utf-8") as f:
             f.write(content)
 
     def _generate_alembic_ini_content(self) -> str:
@@ -239,7 +239,7 @@ datefmt = %H:%M:%S
         """Update the Alembic script template to include SQLModel."""
         template_path = self.alembic_dir / "script.py.mako"
         try:
-            with open(template_path, "r") as f:
+            with open(template_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
             # Add sqlmodel import to imports section
@@ -248,7 +248,7 @@ datefmt = %H:%M:%S
 
             content = content.replace(import_section, new_imports)
 
-            with open(template_path, "w") as f:
+            with open(template_path, "w", encoding="utf-8") as f:
                 f.write(content)
 
             return True
@@ -265,7 +265,7 @@ datefmt = %H:%M:%S
             self._create_minimal_env_py(env_path)
             return
         try:
-            with open(env_path, "r") as f:
+            with open(env_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
             # Add SQLModel import if not present
@@ -303,7 +303,7 @@ datefmt = %H:%M:%S
             )""",
             )
 
-            with open(env_path, "w") as f:
+            with open(env_path, "w", encoding="utf-8") as f:
                 f.write(content)
         except Exception as e:
             logger.error(f"Failed to update env.py: {e}")

--- a/python/packages/autogen-studio/autogenstudio/gallery/builder.py
+++ b/python/packages/autogen-studio/autogenstudio/gallery/builder.py
@@ -630,5 +630,5 @@ if __name__ == "__main__":
     gallery = create_default_gallery()
 
     # Save to file
-    with open("gallery_default.json", "w") as f:
+    with open("gallery_default.json", "w", encoding="utf-8") as f:
         f.write(gallery.model_dump_json(indent=2))

--- a/python/packages/autogen-studio/autogenstudio/lite/studio.py
+++ b/python/packages/autogen-studio/autogenstudio/lite/studio.py
@@ -151,7 +151,7 @@ class LiteStudio:
         }
 
         env_file_path = self._get_env_file_path()
-        with open(env_file_path, "w") as temp_env:
+        with open(env_file_path, "w", encoding="utf-8") as temp_env:
             for key, value in env_vars.items():
                 temp_env.write(f"{key}={value}\n")
 

--- a/python/packages/autogen-studio/autogenstudio/web/auth/manager.py
+++ b/python/packages/autogen-studio/autogenstudio/web/auth/manager.py
@@ -117,7 +117,7 @@ class AuthManager:
     def from_yaml(cls, yaml_path: str) -> Self:
         """Create AuthManager from YAML config file."""
         try:
-            with open(yaml_path, "r") as f:
+            with open(yaml_path, "r", encoding="utf-8") as f:
                 config_data = yaml.safe_load(f)
             config = AuthConfig(**config_data)
             return cls(config)


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

## Why

Refs #5566. Continuation of the encoding sweep started in #6094
(`playwright_controller.py`) and continued in
[the `magentic-one-cli` PR](https://github.com/microsoft/autogen/pull/7722).

The original report explicitly flagged that *"there will be some
similar issues in the codebase while using open function"*. On a
non-UTF-8 default locale (cp950 on Traditional Chinese Windows, cp1252
on Western European Windows, …), Python's `open(..., \"r\")` falls back
to the platform encoding and crashes with `UnicodeDecodeError` on any
non-ASCII byte.

This PR closes the autogen-studio **production code** paths that read
or write text files without an explicit encoding.

## What changed

5 files, 11 `open()` call sites, all of the same shape:

```diff
- with open(path, \"r\") as f:
+ with open(path, \"r\", encoding=\"utf-8\") as f:
```

| File | sites |
|------|-------|
| `autogenstudio/cli.py` | 1 (writes runtime `.env`) |
| `autogenstudio/lite/studio.py` | 1 (writes runtime `.env`) |
| `autogenstudio/database/schema_manager.py` | 6 (Alembic `env.py` / `script.py.mako` / `alembic.ini`) |
| `autogenstudio/web/auth/manager.py` | 1 (user-supplied YAML config) |
| `autogenstudio/gallery/builder.py` | 1 (writes `gallery_default.json`) |

## Why these specific sites

- **Alembic templates and `env.py`** can legitimately contain non-ASCII
  comments / paths and are read+rewritten on schema upgrades.
- **`.env` writers** are called with the *user's* project path. Folder
  names with accented characters (very common on Windows) would crash
  the first run.
- **YAML auth config** is user-supplied.
- **`gallery_default.json`** can contain non-ASCII strings.

## Scope deliberately narrowed

- **Production-code only.** Test fixtures left out for a separate PR.
- **Skipped `aiofiles.open` in `teammanager.py`** — async API signature
  is slightly different, deserves its own audited PR.
- **Did NOT sweep `agbench/benchmarks/*`** — those are scenario scripts
  that consume JSONL produced by other agents; forcing UTF-8 there
  could mask issues upstream.

## Verification

- `ast.parse(...)` clean on all 5 touched files (no syntax break).
- No `encoding=...encoding=` (double-add) anywhere.
- 11 insertions, 11 deletions (same-line edits only).
- No behaviour change for users already on UTF-8 locales.

## Recommended next sweep (for a separate PR)

- `agbench` (mixed: some files read agent-emitted JSONL, others are
  user scripts — needs case-by-case audit)
- async `aiofiles.open` sites

---

AI-assisted via Cursor (Claude Opus 4.7). Personal token-burn
initiative by @adv0r to use up an expiring Cursor subscription budget on
small, useful upstream contributions.

Made with [Cursor](https://cursor.com)
