### PR TITLE
fix(openai): normalize list content from reasoning models

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -20,6 +20,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     Type,
     Union,
     cast,
@@ -303,6 +304,33 @@ def normalize_name(name: str) -> str:
     Prefer _assert_valid_name for validating user configuration or input
     """
     return re.sub(r"[^a-zA-Z0-9_-]", "_", name)[:64]
+
+
+def _normalize_list_content(content: List[Any]) -> Tuple[str, str | None]:
+    """Flatten a list of content blocks into visible text and reasoning text.
+
+    Some OpenAI-compatible reasoning endpoints (e.g. gpt-5, o1) return
+    ``message.content`` as a list of typed blocks instead of a string, such as
+    ``[{"type": "reasoning", "text": ...}, {"type": "text", "text": ...}]``.
+    Visible text comes from ``text``/``output_text`` blocks; reasoning comes from
+    ``reasoning``/``thinking`` blocks. Unknown block types are ignored.
+    """
+    text_parts: List[str] = []
+    reasoning_parts: List[str] = []
+    for block in content:
+        if not isinstance(block, Mapping):
+            continue
+        typed_block = cast(Mapping[str, Any], block)
+        block_text = typed_block.get("text")
+        if not isinstance(block_text, str):
+            continue
+        block_type = typed_block.get("type")
+        if block_type in ("text", "output_text"):
+            text_parts.append(block_text)
+        elif block_type in ("reasoning", "thinking"):
+            reasoning_parts.append(block_text)
+    thought = "".join(reasoning_parts) if reasoning_parts else None
+    return "".join(text_parts), thought
 
 
 def count_tokens_openai(
@@ -775,7 +803,14 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
         else:
             # if not tool_calls, then it is a text response and we populate the content and thought fields.
             finish_reason = choice.finish_reason
-            content = choice.message.content or ""
+            message_content = choice.message.content
+            if isinstance(message_content, list):
+                # Some OpenAI-compatible reasoning endpoints (e.g. gpt-5, o1) return content
+                # as a list of typed blocks instead of a string. Flatten it so downstream
+                # callers receive a string rather than the raw list.
+                content, thought = _normalize_list_content(cast(List[Any], message_content))
+            else:
+                content = message_content or ""
             # if there is a reasoning_content field, then we populate the thought field. This is for models such as R1 - direct from deepseek api.
             if choice.message.model_extra is not None:
                 reasoning_content = choice.message.model_extra.get("reasoning_content")

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -1115,6 +1115,35 @@ async def test_r1_reasoning_content(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_normalizes_list_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Some OpenAI-compatible reasoning endpoints return content as a list of blocks."""
+
+    async def _mock_create(*args: Any, **kwargs: Any) -> ChatCompletion:
+        message = ChatCompletionMessage(role="assistant", content=None)
+        # Reasoning endpoints (gpt-5, o1) may return a list of typed blocks.
+        message.content = [  # type: ignore[assignment]
+            {"type": "reasoning", "text": "let me think"},
+            {"type": "text", "text": "the answer"},
+            {"type": "image", "text": "ignored"},
+        ]
+        return ChatCompletion(
+            id="test_id",
+            model="gpt-4o",
+            object="chat.completion",
+            created=0,
+            choices=[Choice(index=0, finish_reason="stop", message=message)],
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+        )
+
+    monkeypatch.setattr(AsyncCompletions, "create", _mock_create)
+    model_client = OpenAIChatCompletionClient(model="gpt-4o", api_key="")
+    result = await model_client.create([UserMessage(content="Test message", source="user")])
+
+    assert result.content == "the answer"
+    assert result.thought == "let me think"
+
+
+@pytest.mark.asyncio
 async def test_r1_reasoning_content_streaming(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that reasoning_content in model_extra is correctly extracted and streamed."""
 


### PR DESCRIPTION
## Why are these changes needed?

Some OpenAI-compatible reasoning endpoints (e.g. gpt-5, o1) return `choice.message.content` as a list of typed blocks instead of a string, for example:

```json
[
  {"type": "reasoning", "text": "..."},
  {"type": "text", "text": "the actual response"}
]
```

In the non-streaming `create()` path, the text branch does `content = choice.message.content or ""`. A non-empty list is truthy, so the raw list is assigned to `content` and passed straight into `CreateResult`, whose `content` field expects `str | list[FunctionCall]`. Callers then either get the raw list of dicts upstream or hit a Pydantic validation error, resulting in empty/malformed responses.

Repro (mocking an endpoint that returns list content) raises:

```
ValidationError: ... content.str
  Input should be a valid string [type=string_type, input_value=[{'type': 'reasoning', ...}], input_type=list]
```

This adds a small helper that, when `content` is a list, flattens `text`/`output_text` blocks into the content string and collects `reasoning`/`thinking` blocks into `thought` (matching the existing content/thought split used for `reasoning_content`). Unknown block types are ignored. String content is unchanged.

## Related issue number

Fixes #7410

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Verified locally with `ruff check`, `ruff format --check`, `mypy`, and `pyright` on the touched files, plus `pytest packages/autogen-ext/tests/models/test_openai_model_client.py` (54 passed). The added test `test_create_normalizes_list_content` fails on `main` and passes with this change.