### PR TITLE
fix: use timezone-aware websocket timestamps

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/web/routes/ws.py
+++ b/python/packages/autogen-studio/autogenstudio/web/routes/ws.py
@@ -1,7 +1,7 @@
 # api/ws.py
 import asyncio
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from fastapi.websockets import WebSocketState
@@ -55,7 +55,7 @@ async def run_websocket(
                     {
                         "type": "error",
                         "error": "Authentication failed",
-                        "timestamp": datetime.utcnow().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                     }
                 )
                 # Close the connection with a specific code
@@ -67,7 +67,7 @@ async def run_websocket(
                     {
                         "type": "error",
                         "error": "Authentication failed",
-                        "timestamp": datetime.utcnow().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                     }
                 )
                 logger.warning(f"User {user.id} not authorized to access run {run_id}")
@@ -97,7 +97,7 @@ async def run_websocket(
                             {
                                 "type": "error",
                                 "error": "Invalid start message format",
-                                "timestamp": datetime.utcnow().isoformat(),
+                                "timestamp": datetime.now(timezone.utc).isoformat(),
                             }
                         )
 
@@ -108,7 +108,7 @@ async def run_websocket(
                     break
 
                 elif message.get("type") == "ping":
-                    await websocket.send_json({"type": "pong", "timestamp": datetime.utcnow().isoformat()})
+                    await websocket.send_json({"type": "pong", "timestamp": datetime.now(timezone.utc).isoformat()})
 
                 elif message.get("type") == "input_response":
                     # Handle input response from client
@@ -121,7 +121,7 @@ async def run_websocket(
             except json.JSONDecodeError:
                 logger.warning(f"Invalid JSON received: {raw_message}")
                 await websocket.send_json(
-                    {"type": "error", "error": "Invalid message format", "timestamp": datetime.utcnow().isoformat()}
+                    {"type": "error", "error": "Invalid message format", "timestamp": datetime.now(timezone.utc).isoformat()}
                 )
 
     except WebSocketDisconnect:


### PR DESCRIPTION
## Summary
- Replace `datetime.utcnow()` in AutoGen Studio websocket responses with timezone-aware UTC timestamps
- Keep websocket error/pong payload timestamps explicit about UTC

## Problem
`datetime.utcnow()` returns a naive datetime and is deprecated in Python 3.12. These websocket payloads are timestamped as UTC values, so using `datetime.now(timezone.utc)` makes that timezone explicit in the serialized ISO string.

## Before / After
Before:

```py
datetime.utcnow().isoformat()
```

After:

```py
datetime.now(timezone.utc).isoformat()
```

## Verification
- `python -m compileall -q python\packages\autogen-studio\autogenstudio\web\routes\ws.py`
- `git diff --check`

The local sparse checkout had Windows long-path limitations for the full repository, so I verified the touched Python file directly.