### PR TITLE
Add dependency check to CI

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,31 @@
+name: Dependency Check
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+    branches:
+      - main
+      - staging
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: uv sync --locked --all-extras
+        working-directory: ./python
+      - name: Check for dependency issues
+        run: |
+          source ${{ github.workspace }}/python/.venv/bin/activate
+          pip check
+        working-directory: ./python


### PR DESCRIPTION
Adds a dependency check job to CI that runs `pip check` to verify there are no broken dependency requirements.