### PR TITLE
docs: use explicit utf-8 encoding in redirects script

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:


### PR DESCRIPTION
## Why are these changes needed?

This PR updates the docs redirect generation script to use explicit UTF-8 encoding when reading and writing text files.

Currently, `python/docs/redirects/redirects.py` relies on Python's default system encoding when:

- reading `redirect_template.html`
- reading `redirect_urls.txt`
- writing generated redirect `index.html` files

This can be less portable on environments where the default encoding is not UTF-8, such as some Windows locales.

## Related issue number

Closes #7749

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Local check:

```bash
python -m py_compile python/docs/redirects/redirects.py```