### PR TITLE
fix: remove duplicated words in log message and security warning

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -746,7 +746,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                                 _warn_if_none(temp_message, "on_publish")
                             except BaseException as e:
                                 # TODO: we should raise the intervention exception to the publisher.
-                                logger.error(f"Exception raised in in intervention handler: {e}", exc_info=True)
+                                logger.error(f"Exception raised in intervention handler: {e}", exc_info=True)
                                 return
                             if temp_message is DropMessage or isinstance(temp_message, DropMessage):
                                 event_logger.info(

--- a/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
@@ -144,7 +144,7 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
     def _from_config(cls, config: FunctionToolConfig) -> Self:
         warnings.warn(
             "\n⚠️  SECURITY WARNING ⚠️\n"
-            "Loading a FunctionTool from config will execute code to import the provided global imports and and function code.\n"
+            "Loading a FunctionTool from config will execute code to import the provided global imports and function code.\n"
             "Only load configs from TRUSTED sources to prevent arbitrary code execution.",
             UserWarning,
             stacklevel=2,


### PR DESCRIPTION
## Summary

Two small typos in Python source where a word is duplicated:

1. `python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py:749`
   - Before: `"Exception raised in in intervention handler: {e}"`
   - After:  `"Exception raised in intervention handler: {e}"`

2. `python/packages/autogen-core/src/autogen_core/tools/_function_tool.py:147`
   - Before: `"...import the provided global imports and and function code.\n"`
   - After:  `"...import the provided global imports and function code.\n"`

Both are user-visible strings (one is an error log, the other a `UserWarning` shown when loading a `FunctionTool` from config), so the duplicated words are surfaced to end users.

## Notes

- Pure string fix; no behavior change.
- Diff is 2 lines across 2 files.
- Existing duplicate-word PRs (#7690, #7733) only touched markdown docs; these Python source occurrences were not included.