### PR TITLE
docs: fix typos and grammatical inconsistencies across core documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ We use GitHub issues and milestones to track our roadmap. You can view the upcom
 
 The set of `autogen-*` packages are generally all versioned together. When a change is made to one package, all packages are updated to the same version. This is to ensure that all packages are in sync with each other.
 
-We will update verion numbers according to the following rules:
+We will update version numbers according to the following rules:
 
 - Increase minor version (0.X.0) upon breaking changes
 - Increase patch version (0.0.X) upon new features or bug fixes
@@ -49,14 +49,14 @@ We will update verion numbers according to the following rules:
 
 1. Create a PR that updates the version numbers across the codebase ([example](https://github.com/microsoft/autogen/pull/4359))
 2. The docs CI will fail for the PR, but this is expected and will be resolved in the next step
-3. After merging the PR, create and push a tag that corresponds to the new verion. For example, for `0.4.0.dev13`:
+3. After merging the PR, create and push a tag that corresponds to the new version. For example, for `0.4.0.dev13`:
     - `git tag v0.4.0.dev13 && git push origin v0.4.0.dev13`
 4. Restart the docs CI by finding the failed [job corresponding to the `push` event](https://github.com/microsoft/autogen/actions/workflows/docs.yml) and restarting all jobs
 5. Run [this](https://github.com/microsoft/autogen/actions/workflows/single-python-package.yml) workflow for each of the packages that need to be released and get an approval for the release for it to run
 
 ## Triage process
 
-To help ensure the health of the project and community the AutoGen committers have a weekly triage process to ensure that all issues and pull requests are reviewed and addressed in a timely manner. The following documents the responsibilites while on triage duty:
+To help ensure the health of the project and community the AutoGen committers have a weekly triage process to ensure that all issues and pull requests are reviewed and addressed in a timely manner. The following documents the responsibilities while on triage duty:
 
 - Issues
   - Review all new issues - these will be tagged with [`needs-triage`](https://github.com/microsoft/autogen/issues?q=is%3Aissue%20state%3Aopen%20label%3Aneeds-triage).
@@ -79,7 +79,7 @@ To help ensure the health of the project and community the AutoGen committers ha
 - Discussions
   - Look for recently updated discussions and reply as needed or find someone on the team to reply.
 - Security
-  - Look through any securty alerts and file issues or dismiss as needed.
+  - Look through any security alerts and file issues or dismiss as needed.
 
 ## Becoming a Reviewer
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -20,7 +20,7 @@ programming model and better scalability.
 
 We want to reaffirm our commitment to supporting both the original version of AutoGen (0.2) and the redesign (0.4). AutoGen 0.4 is still work-in-progress, and we shared the code now to build with the community. There are no plans to deprecate the original AutoGen anytime soon, and both versions will be actively maintained.
 
-### Who should use it 0.4?
+### Who should use 0.4?
 
 This code is still experimental, so expect changes and bugs while we work towards a stable 0.4 release. We encourage early adopters to
 try it out, give us feedback, and contribute.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 >
 > New users should start with [Microsoft Agent Framework](https://github.com/microsoft/agent-framework). Existing users are encouraged to migrate using the [AutoGen → Microsoft Agent Framework migration guide](https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-autogen/).
 >
-> Microsoft Agent Framework (MAF) is the enterprise‑ready successor to AutoGen. Microsoft Agent FrameworkAF in now available as a production-ready release: stable APIs, and a commitment to long-term support. Whether you're building a single assistant or orchestrating a fleet of specialized agents, Microsoft Agent Framework 1.0 gives you enterprise-grade multi-agent orchestration, multi-provider model support, and cross-runtime interoperability via A2A and MCP.
+> Microsoft Agent Framework (MAF) is the enterprise‑ready successor to AutoGen. Microsoft Agent Framework is now available as a production-ready release: stable APIs, and a commitment to long-term support. Whether you're building a single assistant or orchestrating a fleet of specialized agents, Microsoft Agent Framework 1.0 gives you enterprise-grade multi-agent orchestration, multi-provider model support, and cross-runtime interoperability via A2A and MCP.
 
 ## Installation
 

--- a/TRANSPARENCY_FAQS.md
+++ b/TRANSPARENCY_FAQS.md
@@ -4,7 +4,7 @@
 AutoGen is a framework for simplifying the orchestration, optimization, and automation of LLM workflows. It offers customizable and conversable agents that leverage the strongest capabilities of the most advanced LLMs, like GPT-4, while addressing their limitations by integrating with humans and tools and having conversations between multiple agents via automated chat.
 
 ## What can AutoGen do?
-AutoGen is an experimentational framework for building a complex multi-agent conversation system by:
+AutoGen is an experimental framework for building a complex multi-agent conversation system by:
 - Defining a set of agents with specialized capabilities and roles.
 -	Defining the interaction behavior between agents, i.e., what to reply when an agent receives messages from another agent.
 
@@ -14,8 +14,8 @@ The agent conversation-centric design has numerous benefits, including that it:
 -	Allows users to seamlessly opt in or opt out via an agent in the chat.
 -	Achieves a collective goal with the cooperation of multiple specialists.
 
-## 	What is/are AutoGen’s intended use(s)?
-Please note that AutoGen is an open-source library under active development and intended for  use for research purposes. It should not be used in any downstream applications without additional detailed evaluation of robustness, safety issues and assessment of any potential harm or bias in the proposed application.
+## What is/are AutoGen’s intended use(s)?
+Please note that AutoGen is an open-source library under active development and intended for use for research purposes. It should not be used in any downstream applications without additional detailed evaluation of robustness, safety issues and assessment of any potential harm or bias in the proposed application.
 
 AutoGen is a generic infrastructure that can be used in multiple scenarios. The system’s intended uses include:
 


### PR DESCRIPTION
## Why are these changes needed?

I noticed a few minor spelling typos, grammatical errors, and inconsistencies across multiple core documentation files and fixed them to improve readability and professionalism:

- **README.md**: Fixed a duplicate word/typo in the maintenance banner (`FrameworkAF in now` -> `Framework is now`).
- **CONTRIBUTING.md**: Fixed spelling typos including `verion` -> `version`, `responsibilites` -> `responsibilities`, and `securty` -> `security`.
- **FAQ.md**: Fixed a grammatical typo in the heading (`Who should use it 0.4?` -> `Who should use 0.4?`).
- **TRANSPARENCY_FAQS.md**: Fixed the non-standard word `experimentational` to `experimental`.

No logical or functional changes, just routine documentation maintenance.

## Related issue number

Fixes typos left in #7521

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.