### PR TITLE
docs: use utf-8 encoding in redirect generation script

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:


### PR DESCRIPTION
This updates the redirect generation helper to pass `encoding="utf-8"` for the template, redirect URL list, and generated redirect pages.

That keeps the script behavior explicit across environments where the platform default encoding may not be UTF-8.

Related to #7749.