### PR TITLE
Fix typos found by codespell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ We use GitHub issues and milestones to track our roadmap. You can view the upcom
 
 The set of `autogen-*` packages are generally all versioned together. When a change is made to one package, all packages are updated to the same version. This is to ensure that all packages are in sync with each other.
 
-We will update verion numbers according to the following rules:
+We will update version numbers according to the following rules:
 
 - Increase minor version (0.X.0) upon breaking changes
 - Increase patch version (0.0.X) upon new features or bug fixes
@@ -49,14 +49,14 @@ We will update verion numbers according to the following rules:
 
 1. Create a PR that updates the version numbers across the codebase ([example](https://github.com/microsoft/autogen/pull/4359))
 2. The docs CI will fail for the PR, but this is expected and will be resolved in the next step
-3. After merging the PR, create and push a tag that corresponds to the new verion. For example, for `0.4.0.dev13`:
+3. After merging the PR, create and push a tag that corresponds to the new version. For example, for `0.4.0.dev13`:
     - `git tag v0.4.0.dev13 && git push origin v0.4.0.dev13`
 4. Restart the docs CI by finding the failed [job corresponding to the `push` event](https://github.com/microsoft/autogen/actions/workflows/docs.yml) and restarting all jobs
 5. Run [this](https://github.com/microsoft/autogen/actions/workflows/single-python-package.yml) workflow for each of the packages that need to be released and get an approval for the release for it to run
 
 ## Triage process
 
-To help ensure the health of the project and community the AutoGen committers have a weekly triage process to ensure that all issues and pull requests are reviewed and addressed in a timely manner. The following documents the responsibilites while on triage duty:
+To help ensure the health of the project and community the AutoGen committers have a weekly triage process to ensure that all issues and pull requests are reviewed and addressed in a timely manner. The following documents the responsibilities while on triage duty:
 
 - Issues
   - Review all new issues - these will be tagged with [`needs-triage`](https://github.com/microsoft/autogen/issues?q=is%3Aissue%20state%3Aopen%20label%3Aneeds-triage).
@@ -72,14 +72,14 @@ To help ensure the health of the project and community the AutoGen committers ha
   - Bonus: there is a backlog of old issues that need to be reviewed - if you have time, review these as well and close or refresh as many as you can.
 - PRs
   - The UX on GH flags all recently updated PRs. Draft PRs can be ignored, otherwise review all recently updated PRs.
-  - If a PR is ready for review and you can provide one please go ahead. If you cant, please assign someone. You can quickly spin up a codespace with the PR to test it out.
+  - If a PR is ready for review and you can provide one please go ahead. If you can't, please assign someone. You can quickly spin up a codespace with the PR to test it out.
   - If a PR is needing a reply from the op, please tag it `awaiting-op-response`.
   - If a PR is approved and passes CI, its ready to merge, please do so.
   - If it looks like there is a possibly transient CI failure, re-run failed jobs.
 - Discussions
   - Look for recently updated discussions and reply as needed or find someone on the team to reply.
 - Security
-  - Look through any securty alerts and file issues or dismiss as needed.
+  - Look through any security alerts and file issues or dismiss as needed.
 
 ## Becoming a Reviewer
 

--- a/docs/design/01 - Programming Model.md
+++ b/docs/design/01 - Programming Model.md
@@ -2,7 +2,7 @@
 
 Understanding your workflow and mapping it to agents is the key to building an agent system in AutoGen.
 
-The programming model is basically publish-subscribe. Agents subscribe to events they care about and also can publish events that other agents may care about. Agents may also have additonal assets such as Memory, prompts, data sources, and skills (external APIs).
+The programming model is basically publish-subscribe. Agents subscribe to events they care about and also can publish events that other agents may care about. Agents may also have additional assets such as Memory, prompts, data sources, and skills (external APIs).
 
 ## Events Delivered as CloudEvents
 
@@ -15,7 +15,7 @@ Each event in the system is defined using the [CloudEvents Specification](https:
 
 ## Event Handlers
 
-Each agent has a set of event handlers, that are bound to a specific match against a CloudEvents *type*. Event Handlers could match against an exact type or match for a pattern of events of a particular level in the type heirarchy (eg: `com.Microsoft.AutoGen.Agents.System.*` for all Events in the `System` namespace) Each event handler is a function that can change state, call models, access memory, call external tools, emit other events, and flow data to/from other systems. Each event handler can be a simple function or a more complex function that uses a state machine or other control logic.
+Each agent has a set of event handlers, that are bound to a specific match against a CloudEvents *type*. Event Handlers could match against an exact type or match for a pattern of events of a particular level in the type hierarchy (eg: `com.Microsoft.AutoGen.Agents.System.*` for all Events in the `System` namespace) Each event handler is a function that can change state, call models, access memory, call external tools, emit other events, and flow data to/from other systems. Each event handler can be a simple function or a more complex function that uses a state machine or other control logic.
 
 ## Orchestrating Agents
 

--- a/dotnet/src/AutoGen.Gemini/AutoGen.Gemini.csproj
+++ b/dotnet/src/AutoGen.Gemini/AutoGen.Gemini.csproj
@@ -10,7 +10,7 @@
     <!-- NuGet Package Settings -->
     <Title>AutoGen.Gemini</Title>
     <Description>
-      This package provides the intergration with Gemini.
+      This package provides the integration with Gemini.
     </Description>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet/src/AutoGen.Gemini/Extension/FunctionContractExtension.cs
+++ b/dotnet/src/AutoGen.Gemini/Extension/FunctionContractExtension.cs
@@ -15,7 +15,7 @@ namespace AutoGen.Gemini.Extension;
 public static class FunctionContractExtension
 {
     /// <summary>
-    /// Convert a <see cref="FunctionContract"/> to a <see cref="FunctionDeclaration"/> that can be used in gpt funciton call.
+    /// Convert a <see cref="FunctionContract"/> to a <see cref="FunctionDeclaration"/> that can be used in gpt function call.
     /// </summary>
     public static FunctionDeclaration ToFunctionDeclaration(this FunctionContract function)
     {

--- a/dotnet/src/AutoGen.Gemini/Middleware/GeminiMessageConnector.cs
+++ b/dotnet/src/AutoGen.Gemini/Middleware/GeminiMessageConnector.cs
@@ -21,7 +21,7 @@ namespace AutoGen.Gemini;
 public class GeminiMessageConnector : IStreamingMiddleware
 {
     /// <summary>
-    /// if true, the connector will throw an exception if it encounters an unsupport message type.
+    /// if true, the connector will throw an exception if it encounters an unsupported message type.
     /// Otherwise, it will ignore processing the message and return the message as is.
     /// </summary>
     private readonly bool strictMode;
@@ -29,8 +29,8 @@ public class GeminiMessageConnector : IStreamingMiddleware
     /// <summary>
     /// Initializes a new instance of the <see cref="GeminiMessageConnector"/> class.
     /// </summary>
-    /// <param name="strictMode">whether to throw an exception if it encounters an unsupport message type.
-    /// If true, the connector will throw an exception if it encounters an unsupport message type.
+    /// <param name="strictMode">whether to throw an exception if it encounters an unsupported message type.
+    /// If true, the connector will throw an exception if it encounters an unsupported message type.
     /// If false, it will ignore processing the message and return the message as is.</param>
     public GeminiMessageConnector(bool strictMode = false)
     {

--- a/dotnet/src/Microsoft.AutoGen/AgentChat/Abstractions/ChatAgent.cs
+++ b/dotnet/src/Microsoft.AutoGen/AgentChat/Abstractions/ChatAgent.cs
@@ -65,7 +65,7 @@ public struct AgentName
     00B7          ; Other_ID_Continue # Po       MIDDLE DOT
     0387          ; Other_ID_Continue # Po       GREEK ANO TELEIA
     1369..1371    ; Other_ID_Continue # No   [9] ETHIOPIC DIGIT ONE..ETHIOPIC DIGIT NINE
-    19DA          ; Other_ID_Continue # No       NEW TAI LUE THAM DIGIT ONE
+    19DA          ; Other_ID_Continue # No       NEW TAI LUE THAN DIGIT ONE
     200C..200D    ; Other_ID_Continue # Cf   [2] ZERO WIDTH NON-JOINER..ZERO WIDTH JOINER
     30FB          ; Other_ID_Continue # Po       KATAKANA MIDDLE DOT
     FF65          ; Other_ID_Continue # Po       HALFWIDTH KATAKANA MIDDLE DOT

--- a/dotnet/src/Microsoft.AutoGen/AgentChat/Abstractions/Messages.cs
+++ b/dotnet/src/Microsoft.AutoGen/AgentChat/Abstractions/Messages.cs
@@ -467,7 +467,7 @@ public class HandoffMessage : ChatMessage
 public class FunctionCall
 {
     // TODO: Should this be part of the Autogen "Core" (and what does that even mean on the .NET side?)
-    // It is unfortuante that we have to duplicate this type, but in order to be compatible with Python, it is necessary for
+    // It is unfortunate that we have to duplicate this type, but in order to be compatible with Python, it is necessary for
     // us to be able to process incoming FunctionCalls with parameters in the form of a JSON string. This means that without
     // knowing the target function, and unless the types are specified inline in the JSON, we cannot deserialize them in a
     // generic manner (or we need to have a central registry of function calls, which is undesirable).

--- a/dotnet/src/Microsoft.AutoGen/Contracts/IAgentRuntime.cs
+++ b/dotnet/src/Microsoft.AutoGen/Contracts/IAgentRuntime.cs
@@ -15,14 +15,14 @@ public interface IAgentRuntime : ISaveState
     /// This method should be used to communicate directly with an agent.
     /// </summary>
     /// <param name="message">The message to send.</param>
-    /// <param name="recepient">The agent to send the message to.</param>
+    /// <param name="recipient">The agent to send the message to.</param>
     /// <param name="sender">The agent sending the message. Should be <c>null</c> if sent from an external source.</param>
     /// <param name="messageId">A unique identifier for the message. If <c>null</c>, a new ID will be generated.</param>
     /// <param name="cancellationToken">A token to cancel the operation if needed.</param>
     /// <returns>A task representing the asynchronous operation, returning the response from the agent.</returns>
     /// <exception cref="CantHandleException">Thrown if the recipient cannot handle the message.</exception>
     /// <exception cref="UndeliverableException">Thrown if the message cannot be delivered.</exception>
-    public ValueTask<object?> SendMessageAsync(object message, AgentId recepient, AgentId? sender = null, string? messageId = null, CancellationToken cancellationToken = default);
+    public ValueTask<object?> SendMessageAsync(object message, AgentId recipient, AgentId? sender = null, string? messageId = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publishes a message to all agents subscribed to the given topic.

--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentRuntime.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentRuntime.cs
@@ -313,7 +313,7 @@ public sealed class GrpcAgentRuntime : IHostedService, IAgentRuntime, IMessageSi
         return this._messageRouter.StopAsync();
     }
 
-    public async ValueTask<object?> SendMessageAsync(object message, Contracts.AgentId recepient, Contracts.AgentId? sender = null, string? messageId = null, CancellationToken cancellationToken = default)
+    public async ValueTask<object?> SendMessageAsync(object message, Contracts.AgentId recipient, Contracts.AgentId? sender = null, string? messageId = null, CancellationToken cancellationToken = default)
     {
         if (!SerializationRegistry.Exists(message.GetType()))
         {
@@ -326,7 +326,7 @@ public sealed class GrpcAgentRuntime : IHostedService, IAgentRuntime, IMessageSi
             RequestId = Guid.NewGuid().ToString(),
 
             Source = sender?.ToProtobuf() ?? null,
-            Target = recepient.ToProtobuf(),
+            Target = recipient.ToProtobuf(),
             Payload = payload,
         };
 

--- a/dotnet/src/Microsoft.AutoGen/Core/BaseAgent.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/BaseAgent.cs
@@ -92,9 +92,9 @@ public abstract class BaseAgent : IHostableAgent, ISaveState
         return null;
     }
 
-    public ValueTask<object?> SendMessageAsync(object message, AgentId recepient, string? messageId = null, CancellationToken cancellationToken = default)
+    public ValueTask<object?> SendMessageAsync(object message, AgentId recipient, string? messageId = null, CancellationToken cancellationToken = default)
     {
-        return this.Runtime.SendMessageAsync(message, recepient, sender: this.Id, messageId: messageId, cancellationToken: cancellationToken);
+        return this.Runtime.SendMessageAsync(message, recipient, sender: this.Id, messageId: messageId, cancellationToken: cancellationToken);
 
     }
 

--- a/dotnet/src/Microsoft.AutoGen/Core/InProcessRuntime.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core/InProcessRuntime.cs
@@ -119,13 +119,13 @@ public sealed class InProcessRuntime : IAgentRuntime, IHostedService
         return await agent.OnMessageAsync(envelope.Message, messageContext);
     }
 
-    public ValueTask<object?> SendMessageAsync(object message, AgentId recepient, AgentId? sender = null, string? messageId = null, CancellationToken cancellationToken = default)
+    public ValueTask<object?> SendMessageAsync(object message, AgentId recipient, AgentId? sender = null, string? messageId = null, CancellationToken cancellationToken = default)
     {
         return this.ExecuteTracedAsync(async () =>
         {
             MessageDelivery delivery = new MessageEnvelope(message, messageId, cancellationToken)
                                             .WithSender(sender)
-                                            .ForSend(recepient, this.SendMessageServicer);
+                                            .ForSend(recipient, this.SendMessageServicer);
 
             this.messageDeliveryQueue.Enqueue(delivery);
 

--- a/dotnet/src/Microsoft.AutoGen/Extensions/MEAI/MEAIHostingExtensions.cs
+++ b/dotnet/src/Microsoft.AutoGen/Extensions/MEAI/MEAIHostingExtensions.cs
@@ -28,7 +28,7 @@ public static class MEAIHostingExtensions
         }
         else
         {
-            throw new InvalidOperationException("Did not find a valid model implementation for the given service name ${serviceName}, valid supported implemenation types are ollama, openai, azureopenai, azureaiinference");
+            throw new InvalidOperationException("Did not find a valid model implementation for the given service name ${serviceName}, valid supported implementation types are ollama, openai, azureopenai, azureaiinference");
         }
         return builder;
     }

--- a/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelAgent-support-more-messages.md
+++ b/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelAgent-support-more-messages.md
@@ -1,6 +1,6 @@
 @AutoGen.SemanticKernel.SemanticKernelAgent only supports the original `ChatMessageContent` type via `IMessage<ChatMessageContent>`. To support more AutoGen built-in message types like @AutoGen.Core.TextMessage, @AutoGen.Core.ImageMessage, @AutoGen.Core.MultiModalMessage, you can register the agent with @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector. The @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector will convert the message from AutoGen built-in message types to `ChatMessageContent` and vice versa.
 > [!NOTE]
-> At the current stage, @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector only supports conversation for the followng built-in @AutoGen.Core.IMessage
+> At the current stage, @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector only supports conversation for the following built-in @AutoGen.Core.IMessage
 > - @AutoGen.Core.TextMessage
 > - @AutoGen.Core.ImageMessage
 > - @AutoGen.Core.MultiModalMessage

--- a/dotnet/website/articles/Built-in-messages.md
+++ b/dotnet/website/articles/Built-in-messages.md
@@ -2,7 +2,7 @@
 
 Start from 0.0.9, AutoGen introduces the @AutoGen.Core.IMessage and @AutoGen.Core.IMessage`1 types to provide a unified message interface for different agents. The @AutoGen.Core.IMessage is a non-generic interface that represents a message. The @AutoGen.Core.IMessage`1 is a generic interface that represents a message with a specific `T` where `T` can be any type.
 
-Besides, AutoGen also provides a set of built-in message types that implement the @AutoGen.Core.IMessage and @AutoGen.Core.IMessage`1 interfaces. These built-in message types are designed to cover different types of messages as much as possilbe. The built-in message types include:
+Besides, AutoGen also provides a set of built-in message types that implement the @AutoGen.Core.IMessage and @AutoGen.Core.IMessage`1 interfaces. These built-in message types are designed to cover different types of messages as much as possible. The built-in message types include:
 
 > [!NOTE]
 > The minimal requirement for an agent to be used as admin in @AutoGen.Core.GroupChat is to support @AutoGen.Core.TextMessage.

--- a/dotnet/website/articles/Group-chat-overview.md
+++ b/dotnet/website/articles/Group-chat-overview.md
@@ -2,7 +2,7 @@
 
 In AutoGen, there are two types of group chat:
 - @AutoGen.Core.RoundRobinGroupChat : This group chat runs agents in a round-robin sequence. The chat history plus the most recent reply from the previous agent will be passed to the next agent.
-- @AutoGen.Core.GroupChat : This group chat provides a more dynamic yet controlable way to determine the next speaker agent. You can either use a llm agent as group admin, or use a @AutoGen.Core.Graph, which is introduced by [this PR](https://github.com/microsoft/autogen/pull/1761), or both to determine the next speaker agent.
+- @AutoGen.Core.GroupChat : This group chat provides a more dynamic yet controllable way to determine the next speaker agent. You can either use a llm agent as group admin, or use a @AutoGen.Core.Graph, which is introduced by [this PR](https://github.com/microsoft/autogen/pull/1761), or both to determine the next speaker agent.
 
 > [!NOTE]
-> In @AutoGen.Core.GroupChat, when only the group admin is used to determine the next speaker agent, it's recommented to use a more powerful llm model, such as `gpt-4` to ensure the best experience.
+> In @AutoGen.Core.GroupChat, when only the group admin is used to determine the next speaker agent, it's recommended to use a more powerful llm model, such as `gpt-4` to ensure the best experience.

--- a/dotnet/website/articles/Group-chat.md
+++ b/dotnet/website/articles/Group-chat.md
@@ -1,7 +1,7 @@
-@AutoGen.Core.GroupChat invokes agents in a dynamic way. On one hand, It relies on its admin agent to intellegently determines the next speaker based on conversation context, and on the other hand, it also allows you to control the conversation flow by using a @AutoGen.Core.Graph. This makes it a more dynamic yet controlable way to determine the next speaker agent. You can use @AutoGen.Core.GroupChat to create a dynamic group chat with multiple agents working together to resolve a given task.
+@AutoGen.Core.GroupChat invokes agents in a dynamic way. On one hand, It relies on its admin agent to intellegently determines the next speaker based on conversation context, and on the other hand, it also allows you to control the conversation flow by using a @AutoGen.Core.Graph. This makes it a more dynamic yet controllable way to determine the next speaker agent. You can use @AutoGen.Core.GroupChat to create a dynamic group chat with multiple agents working together to resolve a given task.
 
 > [!NOTE]
-> In @AutoGen.Core.GroupChat, when only the group admin is used to determine the next speaker agent, it's recommented to use a more powerful llm model, such as `gpt-4` to ensure the best experience.
+> In @AutoGen.Core.GroupChat, when only the group admin is used to determine the next speaker agent, it's recommended to use a more powerful llm model, such as `gpt-4` to ensure the best experience.
 
 ## Use @AutoGen.Core.GroupChat to implement a code interpreter chat flow
 The following example shows how to create a dynamic group chat with @AutoGen.Core.GroupChat. In this example, we will create a dynamic group chat with 4 agents: `admin`, `coder`, `reviewer` and `runner`. Each agent has its own role in the group chat:

--- a/dotnet/website/release_note/update.md
+++ b/dotnet/website/release_note/update.md
@@ -14,7 +14,7 @@
 - [Issue 2649](https://github.com/microsoft/autogen/issues/2649) Deprecate `Workflow` type.
 ###### Bug Fixes
 - [Issue 2735](https://github.com/microsoft/autogen/issues/2735) Fix tool call issue in AutoGen.Mistral package.
-- [Issue 2722](https://github.com/microsoft/autogen/issues/2722) Fix parallel funciton call in function call middleware.
+- [Issue 2722](https://github.com/microsoft/autogen/issues/2722) Fix parallel function call in function call middleware.
 - [Issue 2633](https://github.com/microsoft/autogen/issues/2633) Set up `name` field in `OpenAIChatMessageConnector`
 - [Issue 2660](https://github.com/microsoft/autogen/issues/2660) Fix dotnet interactive restoring issue when system language is Chinese
 - [Issue 2687](https://github.com/microsoft/autogen/issues/2687) Add `global::` prefix to generated code to avoid conflict with user-defined types. 
@@ -55,7 +55,7 @@
 - Graph chat support with conditional transition workflow [#1761](https://github.com/microsoft/autogen/pull/1761)
 - AutoGen.SourceGenerator: Generate `FunctionContract` from `FunctionAttribute` [#1736](https://github.com/microsoft/autogen/pull/1736)
 ##### Update on 0.0.7 (2024-02-11)
-- Add `AutoGen.LMStudio` to support comsume openai-like API from LMStudio local server
+- Add `AutoGen.LMStudio` to support consume openai-like API from LMStudio local server
 ##### Update on 0.0.6 (2024-01-23)
 - Add `MiddlewareAgent`
 - Use `MiddlewareAgent` to implement existing agent hooks (RegisterPreProcess, RegisterPostProcess, RegisterReply)

--- a/python/packages/agbench/README.md
+++ b/python/packages/agbench/README.md
@@ -14,7 +14,7 @@ AutoGenBench also requires Docker (Desktop or Engine). **It will not run in GitH
 
 If you are working in WSL, you can follow the instructions below to set up your environment:
 
-1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Ressources, WSL Integration, Enable integration with additional distros – Ubuntu
+1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Resources, WSL Integration, Enable integration with additional distros – Ubuntu
 2. Clone autogen and export `AUTOGEN_REPO_BASE`. This environment variable enables the Docker containers to use the correct version agents.
     ```bash
     git clone git@github.com:microsoft/autogen.git

--- a/python/packages/agbench/benchmarks/README.md
+++ b/python/packages/agbench/benchmarks/README.md
@@ -4,7 +4,7 @@ This directory provides ability to benchmarks agents (e.g., built using Autogen)
 
 ## Setup on WSL
 
-1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Ressources, WSL Integration, Enable integration with additional distros – Ubuntu
+1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Resources, WSL Integration, Enable integration with additional distros – Ubuntu
 2. Clone autogen and export `AUTOGEN_REPO_BASE`. This environment variable enables the Docker containers to use the correct version agents.
     ```bash
     git clone git@github.com:microsoft/autogen.git

--- a/python/packages/agbench/src/agbench/tabulate_cmd.py
+++ b/python/packages/agbench/src/agbench/tabulate_cmd.py
@@ -219,9 +219,9 @@ def default_tabulate(
         # Count the number of failures when the value is False.
         failures: pd.Series = df[score_columns].apply(_check_false).sum(axis=0)  # type: ignore
         # Count the number of missing
-        missings = df[score_columns].isna().sum(axis=0)  # type: ignore
+        missing = df[score_columns].isna().sum(axis=0)  # type: ignore
         # Count the total number of instances
-        totals = successes + failures + missings  # type: ignore
+        totals = successes + failures + missing  # type: ignore
         # Calculate the average success rates
         avg_success_rates = successes / (successes + failures)  # type: ignore
         time_columns = ["Trial " + str(i) + " Time" for i in range(num_instances)]  # type: ignore
@@ -243,7 +243,7 @@ def default_tabulate(
             {
                 "Successes": _list(successes),  # type: ignore
                 "Failures": _list(failures),  # type: ignore
-                "Missing": _list(missings),  # type: ignore
+                "Missing": _list(missing),  # type: ignore
                 "Total": _list(totals),  # type: ignore
                 "Average Success Rate": _list(avg_success_rates),  # type: ignore
                 "Average Time": _list(avg_times),  # type: ignore

--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -64,10 +64,10 @@ async def test_head_and_tail_model_context() -> None:
     for msg in messages:
         await model_context.add_message(msg)
 
-    retrived = await model_context.get_messages()
-    assert len(retrived) == 3  # 1 head, 1 tail + 1 placeholder.
-    assert retrived[0] == messages[0]
-    assert retrived[2] == messages[-1]
+    retrieved = await model_context.get_messages()
+    assert len(retrieved) == 3  # 1 head, 1 tail + 1 placeholder.
+    assert retrieved[0] == messages[0]
+    assert retrieved[2] == messages[-1]
 
     await model_context.clear()
     retrieved = await model_context.get_messages()
@@ -79,10 +79,10 @@ async def test_head_and_tail_model_context() -> None:
     state = await model_context.save_state()
     await model_context.clear()
     await model_context.load_state(state)
-    retrived = await model_context.get_messages()
-    assert len(retrived) == 3
-    assert retrived[0] == messages[0]
-    assert retrived[2] == messages[-1]
+    retrieved = await model_context.get_messages()
+    assert len(retrieved) == 3
+    assert retrieved[0] == messages[0]
+    assert retrieved[2] == messages[-1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes various typos found by running `codespell` on the codebase.

Changes include corrections for:
- Spelling mistakes in comments, docstrings, and documentation
- Variable name corrections (`retrived` -> `retrieved`, `missings` -> `missing`)
- Documentation typos (`verion` -> `version`, `possilbe` -> `possible`, etc.)
- Code comment corrections (`recepient` -> `recipient`, `unsupport` -> `unsupported`, etc.)

False positives in yarn.lock (package names), SVG files (base64), shell scripts (regex patterns), and variable names like `totalY` were excluded.