### PR TITLE
Fix Anthropic requests ending with assistant messages

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -540,14 +540,16 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
 
     def _rstrip_last_assistant_message(self, messages: Sequence[LLMMessage]) -> Sequence[LLMMessage]:
         """
-        Remove the last assistant message if it is empty.
+        Remove trailing assistant messages before sending Anthropic requests.
         """
-        # When Claude models last message is AssistantMessage, It could not end with whitespace
-        if isinstance(messages[-1], AssistantMessage):
-            if isinstance(messages[-1].content, str):
-                messages[-1].content = messages[-1].content.rstrip()
+        trimmed_messages = list(messages)
+        while trimmed_messages and isinstance(trimmed_messages[-1], AssistantMessage):
+            trimmed_messages.pop()
 
-        return messages
+        if len(trimmed_messages) == len(messages):
+            return messages
+
+        return trimmed_messages
 
     async def create(
         self,

--- a/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
@@ -800,8 +800,8 @@ async def test_anthropic_empty_assistant_content_string() -> None:
 
 
 @pytest.mark.asyncio
-async def test_anthropic_trailing_whitespace_at_last_assistant_content() -> None:
-    """Test that an empty assistant content string is handled correctly."""
+async def test_anthropic_trailing_assistant_message() -> None:
+    """Test that a trailing assistant message is handled correctly."""
     api_key = os.getenv("ANTHROPIC_API_KEY")
     if not api_key:
         pytest.skip("ANTHROPIC_API_KEY not found in environment variables")
@@ -821,19 +821,35 @@ async def test_anthropic_trailing_whitespace_at_last_assistant_content() -> None
     assert isinstance(result.content, str)
 
 
-def test_mock_rstrip_trailing_whitespace_at_last_assistant_content() -> None:
+def test_mock_rstrip_removes_trailing_assistant_messages() -> None:
     messages: list[LLMMessage] = [
         UserMessage(content="foo", source="user"),
         UserMessage(content="bar", source="user"),
         AssistantMessage(content="foobar ", source="assistant"),
+        AssistantMessage(content="baz", source="assistant"),
     ]
 
-    # This will crash if _rstrip_railing_whitespace_at_last_assistant_content is not applied to "content"
     dummy_client = AnthropicChatCompletionClient(model="claude-3-5-haiku-20241022", api_key="dummy-key")
     result = dummy_client._rstrip_last_assistant_message(messages)  # pyright: ignore[reportPrivateUsage]
 
-    assert isinstance(result[-1].content, str)
-    assert result[-1].content == "foobar"
+    assert result == messages[:2]
+    assert len(messages) == 4
+    assert messages[-1].content == "baz"
+
+
+def test_mock_rstrip_preserves_non_trailing_assistant_messages() -> None:
+    messages: list[LLMMessage] = [
+        UserMessage(content="foo", source="user"),
+        AssistantMessage(content="bar", source="assistant"),
+        UserMessage(content="baz", source="user"),
+    ]
+
+    dummy_client = AnthropicChatCompletionClient(model="claude-3-5-haiku-20241022", api_key="dummy-key")
+    result = dummy_client._rstrip_last_assistant_message(messages)  # pyright: ignore[reportPrivateUsage]
+
+    assert list(result) == messages
+    assert result[-1].content == "baz"
+    assert result[-2].content == "bar"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why are these changes needed?

Anthropic rejects requests when the final conversation turn is an assistant message. The current `_rstrip_last_assistant_message` helper only strips trailing whitespace from that message, so a non-empty trailing assistant response still gets sent to Anthropic unchanged.

This updates the helper to drop trailing assistant messages before request conversion. It also avoids mutating the caller's original message history and adds coverage for both consecutive trailing assistant messages and assistant messages that appear earlier in the conversation.

## Related issue number

Closes #7768

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Local validation:

- `uv run --extra anthropic pytest tests/models/test_anthropic_model_client.py -q`
- `uv run ruff format --check src/autogen_ext/models/anthropic/_anthropic_client.py tests/models/test_anthropic_model_client.py`
- `uv run ruff check src/autogen_ext/models/anthropic/_anthropic_client.py tests/models/test_anthropic_model_client.py`
- `uv run pyright src/autogen_ext/models/anthropic/_anthropic_client.py tests/models/test_anthropic_model_client.py`
- `uv run python -m py_compile src/autogen_ext/models/anthropic/_anthropic_client.py`
- `git diff --check`
