### PR TITLE
Don't ship 'strict': false on tool definitions when the tool didn't opt in

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -252,19 +252,19 @@ def convert_tools(
             assert isinstance(tool, dict)
             tool_schema = tool
 
-        result.append(
-            ChatCompletionToolParam(
-                type="function",
-                function=FunctionDefinition(
-                    name=tool_schema["name"],
-                    description=(tool_schema["description"] if "description" in tool_schema else ""),
-                    parameters=(
-                        cast(FunctionParameters, tool_schema["parameters"]) if "parameters" in tool_schema else {}
-                    ),
-                    strict=(tool_schema["strict"] if "strict" in tool_schema else False),
-                ),
-            )
+        # Only emit ``strict`` when the tool explicitly opts in. OpenAI-compatible
+        # servers (vLLM, Qwen-Tongyi, Mistral via LiteLLM, ...) reject any
+        # ``strict`` field on function definitions with ``extra_forbidden`` errors,
+        # and OpenAI itself treats the field as optional with a default of False.
+        # See https://github.com/microsoft/autogen/issues/5814.
+        function_def = FunctionDefinition(
+            name=tool_schema["name"],
+            description=(tool_schema["description"] if "description" in tool_schema else ""),
+            parameters=(cast(FunctionParameters, tool_schema["parameters"]) if "parameters" in tool_schema else {}),
         )
+        if tool_schema.get("strict"):
+            function_def["strict"] = True
+        result.append(ChatCompletionToolParam(type="function", function=function_def))
     # Check if all tools have valid names.
     for tool_param in result:
         assert_valid_name(tool_param["function"]["name"])

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -539,6 +539,57 @@ def test_convert_tools_accepts_both_tool_and_schema() -> None:
     assert converted_tool_schema[0] == converted_tool_schema[1]
 
 
+def test_convert_tools_omits_strict_when_not_enabled() -> None:
+    """Regression test for #5814.
+
+    OpenAI-compatible servers (vLLM, Qwen-Tongyi, Mistral via LiteLLM, etc.)
+    reject the ``strict`` field on function tool definitions with
+    ``'type': 'extra_forbidden', 'loc': ('body', 'tools', 0, 'function', 'strict')``.
+    When ``strict`` is not explicitly enabled, ``convert_tools`` must omit the
+    key entirely from the emitted ``function`` payload — sending ``strict: false``
+    breaks these servers and OpenAI's own default is "omitted".
+    """
+
+    def my_function(arg: str, other: Annotated[int, "int arg"]) -> MyResult:
+        return MyResult(result="test")
+
+    tool = FunctionTool(my_function, description="Function tool.")  # strict defaults to False
+    converted = convert_tools([tool])
+
+    assert len(converted) == 1
+    function_def = converted[0]["function"]
+    assert "strict" not in function_def, (
+        "convert_tools must not emit 'strict' on function definitions when the tool "
+        "did not opt into strict mode; some OpenAI-compatible servers reject "
+        "unknown fields. Got: " + repr(dict(function_def))
+    )
+
+    # Passing the raw schema (without 'strict') must also omit the key.
+    schema_only = {
+        "name": "raw_schema_tool",
+        "description": "schema-only",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    }
+    converted_schema = convert_tools([schema_only])  # type: ignore[list-item]
+    assert "strict" not in converted_schema[0]["function"]
+
+
+def test_convert_tools_includes_strict_when_enabled() -> None:
+    """When a tool explicitly opts in to ``strict`` mode, ``convert_tools``
+    must propagate ``strict=True`` so that OpenAI's structured-output guarantees
+    are preserved."""
+
+    def my_function(arg: str, other: Annotated[int, "int arg"]) -> MyResult:
+        return MyResult(result="test")
+
+    tool = FunctionTool(my_function, description="Strict tool.", strict=True)
+    converted = convert_tools([tool])
+
+    assert len(converted) == 1
+    function_def = converted[0]["function"]
+    assert function_def.get("strict") is True
+
+
 @pytest.mark.asyncio
 async def test_json_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     model = "gpt-4.1-nano-2025-04-14"
@@ -1535,12 +1586,17 @@ async def test_tool_calling(monkeypatch: pytest.MonkeyPatch) -> None:
     echo_tool = FunctionTool(_echo_function, description="echo tool.")
     model_client = OpenAIChatCompletionClient(model=model, api_key="")
 
+    def _expected_function_payload(tool: FunctionTool) -> Dict[str, Any]:
+        # ``strict`` is intentionally omitted by ``convert_tools`` when the tool
+        # does not opt in (see #5814 and convert_tools tests above).
+        return {k: v for k, v in tool.schema.items() if k != "strict"}
+
     # Single tool call
     create_result = await model_client.create(messages=[UserMessage(content="Hello", source="user")], tools=[pass_tool])
     assert create_result.content == [FunctionCall(id="1", arguments=r'{"input": "task"}', name="_pass_function")]
     # Verify that the tool schema was passed to the model client.
     kwargs = mock.calls[0]
-    assert kwargs["tools"] == [{"function": pass_tool.schema, "type": "function"}]
+    assert kwargs["tools"] == [{"function": _expected_function_payload(pass_tool), "type": "function"}]
     # Verify finish reason
     assert create_result.finish_reason == "function_calls"
 
@@ -1556,9 +1612,9 @@ async def test_tool_calling(monkeypatch: pytest.MonkeyPatch) -> None:
     # Verify that the tool schema was passed to the model client.
     kwargs = mock.calls[1]
     assert kwargs["tools"] == [
-        {"function": pass_tool.schema, "type": "function"},
-        {"function": fail_tool.schema, "type": "function"},
-        {"function": echo_tool.schema, "type": "function"},
+        {"function": _expected_function_payload(pass_tool), "type": "function"},
+        {"function": _expected_function_payload(fail_tool), "type": "function"},
+        {"function": _expected_function_payload(echo_tool), "type": "function"},
     ]
     # Verify finish reason
     assert create_result.finish_reason == "function_calls"


### PR DESCRIPTION
Was poking at AgentChat 0.4.7+ with vLLM and got hit by #5814 — `extra_forbidden — loc=('body','tools',0,'function','strict')`. Same story other folks have been reporting with Qwen/DashScope and Mistral via LiteLLM.

`convert_tools()` in `autogen-ext`'s OpenAI client always shipped `strict` in the function payload. The dead-looking guard `if "strict" in tool_schema` at line 264 was, well, dead — `BaseTool.schema` always sets `strict=<bool>`, so every request went out with the key. OpenAI accepts it. Almost nobody else does.

@ekzhu had agreed in the thread that `strict` should be optional. This patch just makes the serialization match: build the `FunctionDefinition` without `strict`, then add `function_def["strict"] = True` only when the tool actually opted in. `FunctionDefinition` is `TypedDict(total=False)` so absence is valid, and OpenAI's documented default for the missing key is `False` — same semantics, just doesn't trip the other servers' schema validators.

### Reproduction in test

`test_convert_tools_omits_strict_when_not_enabled` builds a `FunctionTool` with no strict flag and asserts `"strict" not in function_def`. Companion `test_convert_tools_includes_strict_when_enabled` covers the opt-in case.

Without the fix:

```
AssertionError: convert_tools must not emit 'strict' on function definitions
Got: {'name': 'echo', 'description': '...', 'parameters': {...}, 'strict': False}
```

After the fix: 2/2 pass. Updated `test_tool_calling`'s `_expected_function_payload` helper to strip `strict` from the expected dict so the existing assertions still hold. Full `pytest tests/models/`: **161 passed, 64 skipped**. `ruff check` + `ruff format` clean. `pyright` delta: 0 (24 pre-existing errors unchanged).

### Notes

- Strict-tool tests (`test_create_args_with_strict_tools`) keep emitting `strict=True` and stay green.
- `count_tokens_openai` doesn't read `function["strict"]`, so the token-counting path is unaffected.
- Behaviour for an OpenAI endpoint with a non-strict tool: identical (omitted == False).
- Behaviour for OpenAI-compatible endpoints (vLLM/Qwen/Mistral): no longer rejected with `extra_forbidden`.

Refs #5814