### PR TITLE
fix(agentchat): avoid UserInputManager event-order deadlock

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
@@ -72,6 +72,7 @@ class UserInputManager:
             self.input_events[request_id].set()
         else:
             event = asyncio.Event()
+            event.set()
             self.input_events[request_id] = event
 
 

--- a/python/packages/autogen-agentchat/tests/test_userproxy_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_userproxy_agent.py
@@ -5,6 +5,7 @@ import pytest
 from autogen_agentchat.agents import UserProxyAgent
 from autogen_agentchat.base import Response
 from autogen_agentchat.messages import BaseChatMessage, HandoffMessage, TextMessage
+from autogen_agentchat.ui import Console, UserInputManager
 from autogen_core import CancellationToken
 
 
@@ -118,3 +119,17 @@ async def test_error_handling() -> None:
     with pytest.raises(RuntimeError) as exc_info:
         await agent.on_messages(messages, CancellationToken())
     assert "Failed to get user input" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_console_user_input_manager_handles_event_before_input_waiter() -> None:
+    manager = UserInputManager(lambda _: "console response")
+    agent = UserProxyAgent(name="test_user", input_func=manager.get_wrapped_callback())
+
+    response = await asyncio.wait_for(
+        Console(agent.on_messages_stream([], CancellationToken()), user_input_manager=manager),
+        timeout=1,
+    )
+
+    assert isinstance(response.chat_message, TextMessage)
+    assert response.chat_message.content == "console response"


### PR DESCRIPTION
## Summary

Fix a `Console` / `UserInputManager` event-order race where `Console` can receive `UserInputRequestedEvent` before the wrapped input callback starts waiting for the same request id.

In that ordering, `notify_event_received()` creates an unset event for the request id. The later callback then finds that existing event and waits forever.

## Fix

When `notify_event_received()` observes a request id before the callback registered its waiter, create the event in the already-set state. This preserves the existing behavior where a registered waiter is set directly, while also handling the event-first ordering.

## Tests

- `uv run pytest packages/autogen-agentchat/tests/test_userproxy_agent.py -q`
- `uv run ruff check packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py packages/autogen-agentchat/tests/test_userproxy_agent.py`
- `uv run python -m py_compile packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py packages/autogen-agentchat/tests/test_userproxy_agent.py`
- `git diff --check`
