### PR TITLE
fix: add explicit encoding=utf-8 when reading/writing text resources

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:

--- a/python/docs/src/_extension/gallery_directive.py
+++ b/python/docs/src/_extension/gallery_directive.py
@@ -79,7 +79,7 @@ class GalleryGridDirective(SphinxDirective):
                 logger.info(f"Could not find grid data at {path_data}.")
                 nodes.text("No grid data found at {path_data}.")
                 return
-            yaml_string = path_data.read_text()
+            yaml_string = path_data.read_text(encoding="utf-8")
         else:
             yaml_string = "\n".join(self.content)
 

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
@@ -73,7 +73,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
             # Load the previously recorded messages and responses from disk.
             self.logger.info("Replay mode enabled.\nRetrieving session from: " + self.session_file_path)
             try:
-                with open(self.session_file_path, "r") as f:
+                with open(self.session_file_path, "r", encoding="utf-8") as f:
                     self.records = json.load(f)
             except Exception as e:
                 error_str = f"\nFailed to load recorded session: '{self.session_file_path}': {e}"
@@ -211,7 +211,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
                 # Create the directory if it doesn't exist.
                 os.makedirs(os.path.dirname(self.session_file_path), exist_ok=True)
                 # Write the records to disk.
-                with open(self.session_file_path, "w") as f:
+                with open(self.session_file_path, "w", encoding="utf-8") as f:
                     json.dump(self.records, f, indent=2)
                     self.logger.info("\nRecorded session was saved to: " + self.session_file_path)
             except Exception as e:

--- a/python/packages/autogen-ext/tests/task_centric_memory/test_chat_completion_client_recorder.py
+++ b/python/packages/autogen-ext/tests/task_centric_memory/test_chat_completion_client_recorder.py
@@ -65,6 +65,79 @@ async def test_replay() -> None:
     logger.leave_function()
 
 
+@pytest.mark.asyncio
+async def test_record_and_replay_with_utf8_characters() -> None:
+    """Test that session files containing raw UTF-8 bytes round-trip correctly.
+
+    On Windows with a non-UTF-8 default encoding (e.g. cp936/gbk), opening
+    a text file without ``encoding="utf-8"`` can corrupt data or raise
+    ``UnicodeDecodeError``. We guard this by explicitly using UTF-8 when
+    reading and writing the session file.
+    """
+    import json
+    import os
+    import tempfile
+
+    logger = PageLogger(config={"level": "DEBUG", "path": "./logs"})
+    logger.enter_function()
+
+    # Create a session file that contains *raw* UTF-8 bytes (not \uXXXX escapes).
+    # This simulates a file produced on a Linux/macOS machine or by a tool
+    # that writes JSON with ensure_ascii=False.
+    session_data = [
+        {
+            "mode": "create",
+            "messages": [{"content": "Bonjour 你好", "source": "User", "type": "UserMessage"}],
+            "response": {
+                "content": "Réponse en français: café 你好世界",
+                "finish_reason": "stop",
+                "usage": {"prompt_tokens": 2, "completion_tokens": 5},
+                "cached": True,
+                "logprobs": None,
+                "thought": None,
+            },
+            "stream": [],
+        }
+    ]
+
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".json", delete=False) as f:
+        json.dump(session_data, f, ensure_ascii=False, indent=2)
+        session_file = f.name
+
+    # Replay mode: must be able to load the raw-UTF-8 session file.
+    mock_client = ReplayChatCompletionClient(["ignored"])
+    recorder = ChatCompletionClientRecorder(
+        mock_client, mode="replay", session_file_path=session_file, logger=logger
+    )
+    messages = [UserMessage(content="Bonjour 你好", source="User")]
+    response = await recorder.create(messages)
+    assert response.content == "Réponse en français: café 你好世界"
+    recorder.finalize()
+
+    # Record mode: finalize() must also succeed with UTF-8 encoding.
+    # We test this by recording new non-ASCII content and reloading it.
+    mock_client2 = ReplayChatCompletionClient(["新回复"])
+    recorder2 = ChatCompletionClientRecorder(
+        mock_client2, mode="record", session_file_path=session_file, logger=logger
+    )
+    messages2 = [UserMessage(content="新消息", source="User")]
+    response2 = await recorder2.create(messages2)
+    assert response2.content == "新回复"
+    recorder2.finalize()
+
+    # Verify the recorded file can be replayed.
+    recorder3 = ChatCompletionClientRecorder(
+        mock_client2, mode="replay", session_file_path=session_file, logger=logger
+    )
+    response3 = await recorder3.create(messages2)
+    assert response3.content == "新回复"
+    recorder3.finalize()
+
+    os.unlink(session_file)
+    logger.leave_function()
+
+
 if __name__ == "__main__":
     asyncio.run(test_record())
     asyncio.run(test_replay())
+    asyncio.run(test_record_and_replay_with_utf8_characters())


### PR DESCRIPTION
## Summary

Fixes potential UnicodeDecodeError / mojibake on non-UTF-8 Windows locales by adding explicit "encoding=utf-8" to text file operations in ChatCompletionClientRecorder and two docs build scripts.

## Motivation

On Windows with a cp936 (GBK) default locale, open(..., "r") and open(..., "w") do not assume UTF-8. This causes:

- Replay mode in ChatCompletionClientRecorder to silently corrupt UTF-8 session files.
- Record mode to crash with UnicodeEncodeError when the recorded content contains characters outside the GBK range.

The codebase already follows this pattern in playwright_controller.py (see page_script.js loading). This PR brings the remaining locations into consistency.

## Changes

- python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
  - open(..., "r") -> open(..., "r", encoding="utf-8") (replay read)
  - open(..., "w") -> open(..., "w", encoding="utf-8") (record write)

- python/docs/src/_extension/gallery_directive.py
  - path_data.read_text() -> path_data.read_text(encoding="utf-8")

- python/docs/redirects/redirects.py
  - HTML_PAGE_TEMPLATE_FILE.open("r") -> open("r", encoding="utf-8")
  - open(REDIRECT_URLS_FILE, "r") -> open(..., "r", encoding="utf-8")

## Tests

- Added test_record_and_replay_with_utf8_characters to python/packages/autogen-ext/tests/task_centric_memory/test_chat_completion_client_recorder.py.
- The test creates a raw UTF-8 session file (simulating an externally generated file), verifies replay loads it correctly, then verifies record -> replay round-trips non-ASCII content.
- All three tests in the file pass locally.
- ruff and mypy checks pass on the modified source file.
