### PR TITLE
docs: add governed third-party OpenAI endpoint example

### DIFF
--- a/dotnet/samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Tuning_Engines.cs
+++ b/dotnet/samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Tuning_Engines.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Connect_To_Tuning_Engines.cs
+
+#region using_statement
+using System.ClientModel;
+using AutoGen.Core;
+using AutoGen.OpenAI.Extension;
+using OpenAI;
+#endregion using_statement
+
+namespace AutoGen.OpenAI.Sample;
+
+public class Connect_To_Tuning_Engines
+{
+    public static async Task RunAsync()
+    {
+        #region create_agent
+        var apiKey = Environment.GetEnvironmentVariable("TUNING_ENGINES_API_KEY")
+            ?? throw new InvalidOperationException("TUNING_ENGINES_API_KEY is not set.");
+        var model = Environment.GetEnvironmentVariable("TUNING_ENGINES_MODEL") ?? "your-model-alias";
+
+        var openAIClient = new OpenAIClient(new ApiKeyCredential(apiKey), new OpenAIClientOptions
+        {
+            Endpoint = new Uri("https://api.tuningengines.com/v1/"),
+        });
+
+        var agent = new OpenAIChatAgent(
+            chatClient: openAIClient.GetChatClient(model),
+            name: "assistant",
+            systemMessage: "You are a helpful assistant.",
+            seed: 0)
+            .RegisterMessageConnector()
+            .RegisterPrintMessage();
+        #endregion create_agent
+
+        #region send_message
+        await agent.SendAsync("Can you explain how governed model access helps production agent systems?");
+        #endregion send_message
+    }
+}

--- a/dotnet/website/articles/OpenAIChatAgent-connect-to-third-party-api.md
+++ b/dotnet/website/articles/OpenAIChatAgent-connect-to-third-party-api.md
@@ -1,9 +1,11 @@
 The following example shows how to connect to third-party OpenAI API using @AutoGen.OpenAI.OpenAIChatAgent.
 
-[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs)
+[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs)
 
 ## Overview
 A lot of LLM applications/platforms support spinning up a chat server that is compatible with OpenAI API, such as LM Studio, Ollama, Mistral etc. This means that you can connect to these servers using the @AutoGen.OpenAI.OpenAIChatAgent.
+
+You can also connect to a governed OpenAI-compatible endpoint when your organization wants AutoGen to own the agent workflow while a centralized control plane handles model access, policy, audit trails, quotas, routing, and cost reporting. For example, [Tuning Engines](https://www.tuningengines.com/) exposes an OpenAI-compatible inference endpoint that can be configured with `OpenAIClientOptions.Endpoint`.
 
 > [!NOTE]
 > Some platforms might not support all the features of OpenAI API. For example, Ollama does not support `function call` when using it's openai API according to its [document](https://github.com/ollama/ollama/blob/main/docs/openai.md#v1chatcompletions) (as of 2024/05/07).
@@ -24,24 +26,22 @@ ollama serve
 
 ## Steps
 - Import the required namespaces:
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=using_statement)]
-
-- Create a `CustomHttpClientHandler` class.
-
-The `CustomHttpClientHandler` class is used to customize the HttpClientHandler. In this example, we override the `SendAsync` method to redirect the request to local Ollama server, which is running on `http://localhost:11434`.
-
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=CustomHttpClientHandler)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=using_statement)]
 
 - Create an `OpenAIChatAgent` instance and connect to the third-party API.
 
-Then create an @AutoGen.OpenAI.OpenAIChatAgent instance and connect to the OpenAI API from Ollama. You can customize the transport behavior of `OpenAIClient` by passing a customized `HttpClientTransport` instance. In the customized `HttpClientTransport` instance, we pass the `CustomHttpClientHandler` we just created which redirects all openai chat requests to the local Ollama server.
+Then create an @AutoGen.OpenAI.OpenAIChatAgent instance and connect to the OpenAI API from Ollama. You can customize the endpoint by passing `OpenAIClientOptions` to `OpenAIClient`.
 
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=create_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=create_agent)]
+
+For a governed OpenAI-compatible endpoint such as Tuning Engines, set `TUNING_ENGINES_API_KEY` and optionally `TUNING_ENGINES_MODEL`, then point the OpenAI client at the gateway endpoint:
+
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Tuning_Engines.cs?name=create_agent)]
 
 - Chat with the `OpenAIChatAgent`.
 Finally, you can start chatting with the agent. In this example, we send a coding question to the agent and get the response.
 
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=send_message)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=send_message)]
 
 ## Sample Output
 The following is the sample output of the code snippet above:

--- a/dotnet/website/articles/OpenAIChatAgent-connect-to-third-party-api.md
+++ b/dotnet/website/articles/OpenAIChatAgent-connect-to-third-party-api.md
@@ -1,6 +1,6 @@
 The following example shows how to connect to third-party OpenAI API using @AutoGen.OpenAI.OpenAIChatAgent.
 
-[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs)
+[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Tuning_Engines.cs)
 
 ## Overview
 A lot of LLM applications/platforms support spinning up a chat server that is compatible with OpenAI API, such as LM Studio, Ollama, Mistral etc. This means that you can connect to these servers using the @AutoGen.OpenAI.OpenAIChatAgent.
@@ -41,7 +41,7 @@ For a governed OpenAI-compatible endpoint such as Tuning Engines, set `TUNING_EN
 - Chat with the `OpenAIChatAgent`.
 Finally, you can start chatting with the agent. In this example, we send a coding question to the agent and get the response.
 
-[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=send_message)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Tuning_Engines.cs?name=send_message)]
 
 ## Sample Output
 The following is the sample output of the code snippet above:


### PR DESCRIPTION
This updates the third-party OpenAI API guide with a governed OpenAI-compatible endpoint example and adds a small sample using OpenAIClientOptions.Endpoint.\n\nWhy this may be useful:\n- AutoGen already supports third-party OpenAI-compatible APIs through OpenAIClient endpoint configuration.\n- Teams running production agents often need centralized model access, policy enforcement, audit trails, quotas, routing, and cost reporting while AutoGen remains responsible for agent behavior.\n- The existing article also referenced an older sample path and a CustomHttpClientHandler region that no longer exists in the current Ollama sample; this PR updates that doc section to match the current sample style.\n\nThe change is docs/sample only and uses placeholder environment variables.