### PR TITLE
Fix OpenAI assistant resource ownership after state restore

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/openai/_openai_assistant_agent.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/openai/_openai_assistant_agent.py
@@ -302,6 +302,8 @@ class OpenAIAssistantAgent(BaseChatAgent):
         self._top_p = top_p
         self._vector_store_id: Optional[str] = None
         self._uploaded_file_ids: List[str] = []
+        self._owned_vector_store_id: Optional[str] = None
+        self._owned_uploaded_file_ids: List[str] = []
 
         # Variables to track initial state
         self._initial_message_ids: Set[str] = set()
@@ -590,6 +592,7 @@ class OpenAIAssistantAgent(BaseChatAgent):
             )
             file_ids.append(file.id)
             self._uploaded_file_ids.append(file.id)
+            self._owned_uploaded_file_ids.append(file.id)
 
         return file_ids
 
@@ -640,6 +643,7 @@ class OpenAIAssistantAgent(BaseChatAgent):
                 asyncio.ensure_future(self._client.vector_stores.create())
             )
             self._vector_store_id = vector_store.id
+            self._owned_vector_store_id = vector_store.id
 
             # Update assistant with vector store ID
             await cancellation_token.link_future(
@@ -665,12 +669,15 @@ class OpenAIAssistantAgent(BaseChatAgent):
     async def delete_uploaded_files(self, cancellation_token: CancellationToken) -> None:
         """Delete all files that were uploaded by this agent instance."""
         await self._ensure_initialized()
-        for file_id in self._uploaded_file_ids:
+        for file_id in self._owned_uploaded_file_ids:
             try:
                 await cancellation_token.link_future(asyncio.ensure_future(self._client.files.delete(file_id=file_id)))
             except Exception as e:
                 event_logger.error(f"Failed to delete file {file_id}: {str(e)}")
-        self._uploaded_file_ids = []
+        self._uploaded_file_ids = [
+            file_id for file_id in self._uploaded_file_ids if file_id not in self._owned_uploaded_file_ids
+        ]
+        self._owned_uploaded_file_ids = []
 
     async def delete_assistant(self, cancellation_token: CancellationToken) -> None:
         """Delete the assistant if it was created by this instance."""
@@ -687,12 +694,16 @@ class OpenAIAssistantAgent(BaseChatAgent):
     async def delete_vector_store(self, cancellation_token: CancellationToken) -> None:
         """Delete the vector store if it was created by this instance."""
         await self._ensure_initialized()
-        if self._vector_store_id is not None:
+        if self._owned_vector_store_id is not None:
             try:
                 await cancellation_token.link_future(
-                    asyncio.ensure_future(self._client.vector_stores.delete(vector_store_id=self._vector_store_id))
+                    asyncio.ensure_future(
+                        self._client.vector_stores.delete(vector_store_id=self._owned_vector_store_id)
+                    )
                 )
-                self._vector_store_id = None
+                if self._vector_store_id == self._owned_vector_store_id:
+                    self._vector_store_id = None
+                self._owned_vector_store_id = None
             except Exception as e:
                 event_logger.error(f"Failed to delete vector store: {str(e)}")
 

--- a/python/packages/autogen-ext/tests/test_openai_assistant_agent.py
+++ b/python/packages/autogen-ext/tests/test_openai_assistant_agent.py
@@ -400,3 +400,60 @@ async def test_save_and_load_state(mock_openai_client: AsyncOpenAI) -> None:
     assert new_agent._initial_message_ids == {"msg1", "msg2"}  # type: ignore
     assert new_agent._vector_store_id == "vector-789"  # type: ignore
     assert new_agent._uploaded_file_ids == ["file-abc", "file-def"]  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_loaded_state_resources_are_not_deleted_as_owned(mock_openai_client: AsyncOpenAI) -> None:
+    agent = OpenAIAssistantAgent(
+        name="assistant",
+        description="Dummy assistant for state testing",
+        client=mock_openai_client,
+        model="dummy-model",
+        instructions="dummy instructions",
+        tools=[],
+    )
+    await agent.load_state(
+        {
+            "type": "OpenAIAssistantAgentState",
+            "assistant_id": "assistant-123",
+            "thread_id": "thread-456",
+            "initial_message_ids": [],
+            "vector_store_id": "vector-restored",
+            "uploaded_file_ids": ["file-restored-a", "file-restored-b"],
+        }
+    )
+
+    await agent.delete_uploaded_files(CancellationToken())
+    await agent.delete_vector_store(CancellationToken())
+
+    mock_openai_client.files.delete.assert_not_awaited()  # type: ignore
+    mock_openai_client.vector_stores.delete.assert_not_awaited()  # type: ignore
+    assert agent._vector_store_id == "vector-restored"  # type: ignore
+    assert agent._uploaded_file_ids == ["file-restored-a", "file-restored-b"]  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_current_instance_resources_are_still_deleted(mock_openai_client: AsyncOpenAI) -> None:
+    agent = OpenAIAssistantAgent(
+        name="assistant",
+        description="Dummy assistant for state testing",
+        client=mock_openai_client,
+        model="dummy-model",
+        instructions="dummy instructions",
+        tools=[],
+    )
+    agent._assistant = MagicMock(id="assistant-current")  # type: ignore
+    agent._thread = MagicMock(id="thread-current")  # type: ignore
+    agent._initial_state_retrieved = True  # type: ignore
+    agent._uploaded_file_ids = ["file-current"]  # type: ignore
+    agent._owned_uploaded_file_ids = ["file-current"]  # type: ignore
+    agent._vector_store_id = "vector-current"  # type: ignore
+    agent._owned_vector_store_id = "vector-current"  # type: ignore
+
+    await agent.delete_uploaded_files(CancellationToken())
+    await agent.delete_vector_store(CancellationToken())
+
+    mock_openai_client.files.delete.assert_awaited_once_with(file_id="file-current")  # type: ignore
+    mock_openai_client.vector_stores.delete.assert_awaited_once_with(vector_store_id="vector-current")  # type: ignore
+    assert agent._vector_store_id is None  # type: ignore
+    assert agent._uploaded_file_ids == []  # type: ignore


### PR DESCRIPTION
## Summary

- track OpenAI assistant vector stores and uploaded files created by the current agent instance
- avoid deleting resource ids that were only restored from saved agent state
- keep deletion behavior unchanged for resources created by the live instance
- add regression coverage for restored-state and current-instance cleanup paths

## Details

`OpenAIAssistantAgent` persists provider resource ids in saved state so a restored agent can continue using an existing assistant setup. Cleanup should only delete resources that the current live agent instance created, not ids that were restored from state and may still be owned by another running agent or lifecycle manager.

This change separates observed/restored resource ids from resources created by the current instance, then uses the owned-resource set for cleanup.

## Validation

From `python/`:

- `uv run pytest -q packages/autogen-ext/tests/test_openai_assistant_agent.py`
- `uv run ruff check packages/autogen-ext/src/autogen_ext/agents/openai/_openai_assistant_agent.py packages/autogen-ext/tests/test_openai_assistant_agent.py`
- `uv run ruff format --check packages/autogen-ext/src/autogen_ext/agents/openai/_openai_assistant_agent.py packages/autogen-ext/tests/test_openai_assistant_agent.py`
- `uv run python -m py_compile packages/autogen-ext/src/autogen_ext/agents/openai/_openai_assistant_agent.py packages/autogen-ext/tests/test_openai_assistant_agent.py`
- `git diff --check`
