### PR TITLE
Fix typos: overriden -> overridden, independantly -> independently

### DIFF
--- a/python/docs/src/user-guide/core-user-guide/faqs.md
+++ b/python/docs/src/user-guide/core-user-guide/faqs.md
@@ -33,7 +33,7 @@ host = GrpcWorkerAgentRuntimeHost(address=host_address, extra_grpc_config=extra_
 worker1 = GrpcWorkerAgentRuntime(host_address=host_address, extra_grpc_config=extra_grpc_config)
 ```
 
-**Note**: When `GrpcWorkerAgentRuntime` creates a host connection for the clients, it uses `DEFAULT_GRPC_CONFIG` from `HostConnection` class as default set of values which will can be overriden if you pass parameters with the same name using `extra_grpc_config`.
+**Note**: When `GrpcWorkerAgentRuntime` creates a host connection for the clients, it uses `DEFAULT_GRPC_CONFIG` from `HostConnection` class as default set of values which will can be overridden if you pass parameters with the same name using `extra_grpc_config`.
 
 ## What are model capabilities and how do I specify them?
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/config/__init__.py
@@ -21,7 +21,7 @@ class BaseOllamaClientConfiguration(CreateArguments, total=False):
     headers: Optional[Mapping[str, str]]
     model_capabilities: ModelCapabilities  # type: ignore
     model_info: ModelInfo
-    """What functionality the model supports, determined by default from model name but is overriden if value passed."""
+    """What functionality the model supports, determined by default from model name but is overridden if value passed."""
     options: Optional[Union[Mapping[str, Any], Options]]
 
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -70,7 +70,7 @@ class BaseOpenAIClientConfiguration(CreateArguments, total=False):
     model_capabilities: ModelCapabilities  # type: ignore
     model_info: ModelInfo
     add_name_prefixes: bool
-    """What functionality the model supports, determined by default from model name but is overriden if value passed."""
+    """What functionality the model supports, determined by default from model name but is overridden if value passed."""
     include_name_in_message: bool
     """Whether to include the 'name' field in user message parameters. Defaults to True. Set to False for providers that don't support the 'name' field."""
     default_headers: Dict[str, str] | None

--- a/python/samples/core_semantic_router/README.md
+++ b/python/samples/core_semantic_router/README.md
@@ -13,7 +13,7 @@ In this example, we have a simple scenario where we have a set of distributed ag
 
 The way this system is designed, when a user initiates a session, the semantic router agent will identify the intent of the user (currently using the overly simple method of string matching), identify the most relevant agent, and then route the user to that agent. The agent will then manage the conversation with the user, and the user will be able to interact with the agent in a conversational manner.
 
-While the logic of the agents is simple in this example, the goal is to show how the distributed runtime capabilities of autogen supports this scenario independantly of the capabilities of the agents themselves.
+While the logic of the agents is simple in this example, the goal is to show how the distributed runtime capabilities of autogen supports this scenario independently of the capabilities of the agents themselves.
 
 ## Getting Started
 


### PR DESCRIPTION
Replaces PR #7251 (by verreaa) — rebased on current main.

Fixed minor spelling typos across the codebase:
- `overriden` → `overridden` in OpenAI and Ollama config docstrings
- `overriden` → `overridden` in FAQ docs
- `independantly` → `independently` in semantic router sample README

CC: @verreaa (original author) @anandfresh (original reviewer)