### PR TITLE
Add group chat thread accessor

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -27,11 +27,13 @@ from ...messages import (
 from ...state import TeamState
 from ._chat_agent_container import ChatAgentContainer
 from ._events import (
+    GroupChatGetThread,
     GroupChatPause,
     GroupChatReset,
     GroupChatResume,
     GroupChatStart,
     GroupChatTermination,
+    GroupChatThread,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -653,6 +655,30 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
 
             # Indicate that the team is no longer running.
             self._is_running = False
+
+    async def get_thread(self) -> Sequence[BaseAgentEvent | BaseChatMessage]:
+        """Return the current message thread from the group chat manager."""
+        if not self._initialized:
+            await self._init(self._runtime)
+
+        should_stop_runtime = False
+        if self._embedded_runtime and not self._is_running:
+            assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+            self._runtime.start()
+            should_stop_runtime = True
+
+        try:
+            response = await self._runtime.send_message(
+                GroupChatGetThread(),
+                recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
+            )
+            if not isinstance(response, GroupChatThread):
+                raise RuntimeError(f"Unexpected response type from group chat manager: {type(response)}")
+            return response.messages
+        finally:
+            if should_stop_runtime:
+                assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+                await self._runtime.stop_when_idle()
 
     async def pause(self) -> None:
         """Pause its participants when the team is running by calling their

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -9,6 +9,7 @@ from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory, SelectS
 from ._events import (
     GroupChatAgentResponse,
     GroupChatError,
+    GroupChatGetThread,
     GroupChatMessage,
     GroupChatPause,
     GroupChatRequestPublish,
@@ -17,6 +18,7 @@ from ._events import (
     GroupChatStart,
     GroupChatTeamResponse,
     GroupChatTermination,
+    GroupChatThread,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -56,6 +58,7 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
                 GroupChatTeamResponse,
                 GroupChatMessage,
                 GroupChatReset,
+                GroupChatGetThread,
             ],
         )
         if max_turns is not None and max_turns <= 0:
@@ -284,6 +287,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
     async def handle_resume(self, message: GroupChatResume, ctx: MessageContext) -> None:
         """Resume the group chat manager. This is a no-op in the base class."""
         pass
+
+    @rpc
+    async def handle_get_thread(self, message: GroupChatGetThread, ctx: MessageContext) -> GroupChatThread:
+        """Return the current group chat message thread."""
+        return GroupChatThread(messages=list(self._message_thread))
 
     @abstractmethod
     async def validate_group_state(self, messages: List[BaseChatMessage] | None) -> None:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
@@ -71,6 +71,19 @@ class GroupChatRequestPublish(BaseModel):
     ...
 
 
+class GroupChatGetThread(BaseModel):
+    """A request to get the current message thread from a group chat."""
+
+    ...
+
+
+class GroupChatThread(BaseModel):
+    """A response containing the current message thread from a group chat."""
+
+    messages: List[SerializeAsAny[BaseAgentEvent | BaseChatMessage]]
+    """The messages that have been published to the group chat."""
+
+
 class GroupChatMessage(BaseModel):
     """A message from a group chat."""
 

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -565,6 +565,28 @@ async def test_round_robin_group_chat_state(task: TaskType, runtime: AgentRuntim
 
 
 @pytest.mark.asyncio
+async def test_round_robin_group_chat_get_thread(runtime: AgentRuntime | None) -> None:
+    model_client = ReplayChatCompletionClient(["Hello", "TERMINATE"])
+    agent1 = AssistantAgent("agent1", model_client=model_client)
+    agent2 = _EchoAgent("agent2", description="echo agent")
+    termination = TextMentionTermination("TERMINATE")
+    team = RoundRobinGroupChat(
+        participants=[agent1, agent2],
+        termination_condition=termination,
+        runtime=runtime,
+    )
+
+    assert await team.get_thread() == []
+
+    result = await team.run(task="Write a greeting")
+    thread = await team.get_thread()
+
+    assert len(thread) == len(result.messages)
+    for thread_message, result_message in zip(thread, result.messages, strict=True):
+        assert compare_messages(thread_message, result_message)
+
+
+@pytest.mark.asyncio
 async def test_round_robin_group_chat_with_tools(runtime: AgentRuntime | None) -> None:
     model_client = ReplayChatCompletionClient(
         chat_completions=[


### PR DESCRIPTION
## Summary
- add a `BaseGroupChat.get_thread()` method that asks the group chat manager for the current message thread
- add a serialized `GroupChatGetThread` RPC and `GroupChatThread` response model
- cover the accessor with a RoundRobinGroupChat regression test

Fixes #6085

## Tests
- `uv run --directory python pytest packages/autogen-agentchat/tests/test_group_chat.py -k get_thread -q`
- `uv run --directory python ruff format --check packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py packages/autogen-agentchat/tests/test_group_chat.py`
- `uv run --directory python ruff check packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py packages/autogen-agentchat/tests/test_group_chat.py`