### PR TITLE
fix(docs): correct RedisCacheStore class name to RedisStore in migration guide

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -214,7 +214,7 @@ async def main():
         # from autogen_ext.cache_store.redis import RedisStore
         # import redis
         # redis_instance = redis.Redis()
-        # cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
+        # cache_store = RedisStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
         cache_store = DiskCacheStore[CHAT_CACHE_VALUE_TYPE](Cache(tmpdirname))
         cache_client = ChatCompletionCache(openai_model_client, cache_store)
 


### PR DESCRIPTION
## Summary

The code comment in the migration guide (`migration-guide.md`, line 217) referenced `RedisCacheStore` — the old class name before it was renamed to `RedisStore` in the `autogen-ext` cache store module.

The surrounding prose (line 188) and the import comment (line 214) already used the correct `RedisStore` name. This fixes the one remaining inconsistency.

**Before:**
```python
# cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
```

**After:**
```python
# cache_store = RedisStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
```

## Related issue

Closes #7084

## Testing

Documentation-only change. No logic, no imports affected.