### PR TITLE
docs: add mint-attest to community projects

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -46,6 +46,7 @@ Find community samples and examples of how to use AutoGen
 | [autogen-oaiapi](https://github.com/SongChiYoung/autogen-oaiapi)  | [PyPi](https://pypi.org/project/autogen-oaiapi/) | an OpenAI-style API server built on top of AutoGen |
 | [autogen-contextplus](https://github.com/SongChiYoung/autogen-contextplus)  | [PyPi](https://pypi.org/project/autogen-contextplus/) | Enhanced model_context implementations, with features such as automatic summarization and truncation of model context. |
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
+| [mint-attest](https://github.com/FoundryNet/mint-attest)  | [PyPi](https://pypi.org/project/mint-attest/) | Attests each agent reply on-chain via MINT Protocol work attestation (`MintAttestHook`). |
 
 
 <!-- Example -->


### PR DESCRIPTION
Adds one row to the community projects table for [mint-attest](https://pypi.org/project/mint-attest/), which ships \`MintAttestHook\` — attaches to an AutoGen agent and records a tamper-evident, on-chain (Solana) attestation of each agent reply via MINT Protocol.

Docs-only, single-row addition; package is published on PyPI.