### PR TITLE
Add group chat thread accessor

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -27,11 +27,13 @@ from ...messages import (
 from ...state import TeamState
 from ._chat_agent_container import ChatAgentContainer
 from ._events import (
+    GroupChatGetThread,
     GroupChatPause,
     GroupChatReset,
     GroupChatResume,
     GroupChatStart,
     GroupChatTermination,
+    GroupChatThread,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -653,6 +655,34 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
 
             # Indicate that the team is no longer running.
             self._is_running = False
+
+    async def get_thread(self) -> List[BaseAgentEvent | BaseChatMessage]:
+        """Get the current message thread for the group chat.
+
+        .. versionadded:: v0.7.5
+
+        Returns:
+            List[BaseAgentEvent | BaseChatMessage]: The messages that have happened so far in the group chat.
+        """
+        if not self._initialized:
+            await self._init(self._runtime)
+
+        should_manage_runtime = self._embedded_runtime and not self._is_running
+        if should_manage_runtime:
+            assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+            self._runtime.start()
+
+        try:
+            result = await self._runtime.send_message(
+                GroupChatGetThread(),
+                recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
+            )
+            thread = GroupChatThread.model_validate(result)
+            return list(thread.messages)
+        finally:
+            if should_manage_runtime:
+                assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+                await self._runtime.stop_when_idle()
 
     async def pause(self) -> None:
         """Pause its participants when the team is running by calling their

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -9,6 +9,7 @@ from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory, SelectS
 from ._events import (
     GroupChatAgentResponse,
     GroupChatError,
+    GroupChatGetThread,
     GroupChatMessage,
     GroupChatPause,
     GroupChatRequestPublish,
@@ -17,6 +18,7 @@ from ._events import (
     GroupChatStart,
     GroupChatTeamResponse,
     GroupChatTermination,
+    GroupChatThread,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -55,6 +57,7 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
                 GroupChatAgentResponse,
                 GroupChatTeamResponse,
                 GroupChatMessage,
+                GroupChatGetThread,
                 GroupChatReset,
             ],
         )
@@ -268,6 +271,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
     async def handle_group_chat_error(self, message: GroupChatError, ctx: MessageContext) -> None:
         """Handle a group chat error by logging the error and signaling termination."""
         await self._signal_termination_with_error(message.error)
+
+    @rpc
+    async def handle_get_thread(self, message: GroupChatGetThread, ctx: MessageContext) -> GroupChatThread:
+        """Return the messages that have happened so far in the group chat."""
+        return GroupChatThread(messages=list(self._message_thread))
 
     @rpc
     async def handle_reset(self, message: GroupChatReset, ctx: MessageContext) -> None:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
@@ -78,6 +78,19 @@ class GroupChatMessage(BaseModel):
     """The message that was published."""
 
 
+class GroupChatGetThread(BaseModel):
+    """A request to get the current group chat message thread."""
+
+    ...
+
+
+class GroupChatThread(BaseModel):
+    """The current group chat message thread."""
+
+    messages: List[SerializeAsAny[BaseAgentEvent | BaseChatMessage]]
+    """The messages that have happened so far in the group chat."""
+
+
 class GroupChatTermination(BaseModel):
     """A message indicating that a group chat has terminated."""
 

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -565,6 +565,32 @@ async def test_round_robin_group_chat_state(task: TaskType, runtime: AgentRuntim
 
 
 @pytest.mark.asyncio
+async def test_round_robin_group_chat_get_thread(runtime: AgentRuntime | None) -> None:
+    agent1 = _EchoAgent("agent1", description="echo agent 1")
+    agent2 = _EchoAgent("agent2", description="echo agent 2")
+    termination = MaxMessageTermination(3)
+    team = RoundRobinGroupChat(
+        participants=[agent1, agent2],
+        termination_condition=termination,
+        runtime=runtime,
+    )
+
+    assert await team.get_thread() == []
+
+    result = await team.run(task="Write a program that prints 'Hello, world!'", output_task_messages=False)
+    thread = await team.get_thread()
+
+    assert len(thread) == 3
+    assert isinstance(thread[0], TextMessage)
+    assert thread[0].content == "Write a program that prints 'Hello, world!'"
+    for thread_message, expected_message in zip(thread[1:], result.messages, strict=True):
+        assert compare_messages(thread_message, expected_message)
+
+    await team.reset()
+    assert await team.get_thread() == []
+
+
+@pytest.mark.asyncio
 async def test_round_robin_group_chat_with_tools(runtime: AgentRuntime | None) -> None:
     model_client = ReplayChatCompletionClient(
         chat_completions=[


### PR DESCRIPTION
## Summary
- add GroupChatGetThread/GroupChatThread RPC messages
- expose BaseGroupChat.get_thread() to retrieve the manager message thread
- cover initial, populated, and reset thread states across embedded and supplied runtimes

Fixes #6085

## Tests
- uv run --directory python pytest packages/autogen-agentchat/tests/test_group_chat.py -k get_thread
- uv run --directory python ruff format packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py packages/autogen-agentchat/tests/test_group_chat.py
- uv run --directory python ruff check packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py packages/autogen-agentchat/tests/test_group_chat.py
- uv run --directory python pyright packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py packages/autogen-agentchat/tests/test_group_chat.py