### PR TITLE
fix(agbench): close console_log.txt file handle in run_scenario_in_docker

### DIFF
--- a/python/packages/agbench/src/agbench/run_cmd.py
+++ b/python/packages/agbench/src/agbench/run_cmd.py
@@ -641,53 +641,53 @@ echo RUN.SH COMPLETE !#!#
     docker_timeout: float = timeout + 60  # One full minute after the bash timeout command should have already triggered
     start_time = time.time()
     logs = container.logs(stream=True)
-    log_file = open(os.path.join(work_dir, "console_log.txt"), "wt", encoding="utf-8")
     stopping = False
     exiting = False
 
-    while True:
-        try:
-            chunk = next(logs)  # Manually step the iterator so it is captures with the try-catch
+    with open(os.path.join(work_dir, "console_log.txt"), "wt", encoding="utf-8") as log_file:
+        while True:
+            try:
+                chunk = next(logs)  # Manually step the iterator so it is captures with the try-catch
 
-            # Stream the data to the log file and the console
-            chunk_str = chunk.decode("utf-8")
-            log_file.write(chunk_str)
-            log_file.flush()
-            sys.stdout.reconfigure(encoding="utf-8")  # type: ignore
-            sys.stdout.write(chunk_str)
-            sys.stdout.flush()
+                # Stream the data to the log file and the console
+                chunk_str = chunk.decode("utf-8")
+                log_file.write(chunk_str)
+                log_file.flush()
+                sys.stdout.reconfigure(encoding="utf-8")  # type: ignore
+                sys.stdout.write(chunk_str)
+                sys.stdout.flush()
 
-            # Check if we need to terminate
-            if not stopping and time.time() - start_time >= docker_timeout:
+                # Check if we need to terminate
+                if not stopping and time.time() - start_time >= docker_timeout:
+                    container.stop()
+
+                    # Don't exit the loop right away, as there are things we may still want to read from the logs
+                    # but remember how we got here.
+                    stopping = True
+            except KeyboardInterrupt:
+                log_file.write("\nKeyboard interrupt (Ctrl-C). Attempting to exit gracefully.\n")
+                log_file.flush()
+                sys.stdout.write("\nKeyboard interrupt (Ctrl-C). Attempting to exit gracefully.\n")
+                sys.stdout.flush()
+
+                # Start the exit process, and give it a minute, but keep iterating
                 container.stop()
+                exiting = True
+                docker_timeout = time.time() - start_time + 60
+            except StopIteration:
+                break
 
-                # Don't exit the loop right away, as there are things we may still want to read from the logs
-                # but remember how we got here.
-                stopping = True
-        except KeyboardInterrupt:
-            log_file.write("\nKeyboard interrupt (Ctrl-C). Attempting to exit gracefully.\n")
+        # Clean up the container
+        try:
+            container.remove()
+        except APIError:
+            pass
+
+        if stopping:  # By this line we've exited the loop, and the container has actually stopped.
+            log_file.write("\nDocker timed out.\n")
             log_file.flush()
-            sys.stdout.write("\nKeyboard interrupt (Ctrl-C). Attempting to exit gracefully.\n")
+            sys.stdout.write("\nDocker timed out.\n")
             sys.stdout.flush()
-
-            # Start the exit process, and give it a minute, but keep iterating
-            container.stop()
-            exiting = True
-            docker_timeout = time.time() - start_time + 60
-        except StopIteration:
-            break
-
-    # Clean up the container
-    try:
-        container.remove()
-    except APIError:
-        pass
-
-    if stopping:  # By this line we've exited the loop, and the container has actually stopped.
-        log_file.write("\nDocker timed out.\n")
-        log_file.flush()
-        sys.stdout.write("\nDocker timed out.\n")
-        sys.stdout.flush()
 
     if exiting:  # User hit ctrl-C
         sys.exit(1)


### PR DESCRIPTION
## Why

`run_scenario_in_docker` (in `agbench/run_cmd.py`) opens `console_log.txt` with a bare `open()` and **never closes it**:

```python
log_file = open(os.path.join(work_dir, "console_log.txt"), "wt", encoding="utf-8")
...
# function returns / sys.exit(1) — log_file.close() is never called
```

This function is called once per scenario **and** per repetition during a benchmark run (`run_scenario_in_docker` is invoked inside the per-instance / per-repetition loop). The leaked write handles therefore accumulate over the course of a run. On large benchmark suites this can exhaust the process file-descriptor limit, and on Windows the unclosed handle keeps `console_log.txt` locked.

Note the sibling handle in the same module (`file_handle` in `run_scenario`) *is* closed explicitly — this one was simply missed.

## Fix

Wrap the streaming / log-writing block in a `with` statement so the handle is always released:
- on the normal `StopIteration` path,
- when the Docker timeout path returns,
- and when exiting via `sys.exit(1)` after a `KeyboardInterrupt` (the `finally` from the context manager runs before the process exits).

No behavior changes other than guaranteed handle release. The `if exiting: sys.exit(1)` check is intentionally kept outside the `with` block so the file is flushed and closed before the process exits.

## Verification

- `python -m py_compile` passes.
- AST check confirms the log-writing block (including the `if stopping:` epilogue) is now nested under the `with open(...) as log_file:` context manager.