### PR TITLE
fix: resolve Bedrock and cross-region Anthropic model IDs in model info lookup

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_model_info.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict
 
 from autogen_core.models import ModelFamily, ModelInfo
@@ -138,8 +139,26 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
 }
 
 
+def _normalize_model(model: str) -> str:
+    """Normalize a Bedrock or cross-region inference model id to its bare Anthropic id.
+
+    AWS Bedrock exposes Claude models with an ``anthropic.`` provider prefix, an optional
+    cross-region inference prefix (e.g. ``us.``, ``eu.``, ``apac.``, ``global.``), and a
+    ``-v<major>:<minor>`` version suffix, e.g. ``us.anthropic.claude-sonnet-4-20250514-v1:0``.
+    Stripping these yields the bare id (``claude-sonnet-4-20250514``) so the lookup below can
+    resolve it the same way it resolves the native Anthropic id. Non-Bedrock ids are returned
+    unchanged.
+    """
+    # Strip the optional cross-region prefix and the ``anthropic.`` provider prefix.
+    model = re.sub(r"^(?:[a-z0-9-]+\.)?anthropic\.", "", model)
+    # Strip the trailing Bedrock version suffix (e.g. ``-v1:0``).
+    model = re.sub(r"-v\d+:\d+$", "", model)
+    return model
+
+
 def get_info(model: str) -> ModelInfo:
     """Get the model information for a specific model."""
+    model = _normalize_model(model)
     # Check for exact match first
     if model in _MODEL_INFO:
         return _MODEL_INFO[model]
@@ -154,6 +173,7 @@ def get_info(model: str) -> ModelInfo:
 
 def get_token_limit(model: str) -> int:
     """Get the token limit for a specific model."""
+    model = _normalize_model(model)
     # Check for exact match first
     if model in _MODEL_TOKEN_LIMITS:
         return _MODEL_TOKEN_LIMITS[model]

--- a/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
@@ -41,6 +41,26 @@ def _ask_for_input() -> str:
     return "Further input from user"
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "global.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    ],
+)
+def test_model_info_resolves_bedrock_ids(model: str) -> None:
+    """Bedrock and cross-region inference ids resolve to the same entry as the bare Anthropic id."""
+    from autogen_ext.models.anthropic import _model_info
+
+    bare = "claude-3-5-sonnet-20240620"
+    assert _model_info.get_info(model) == _model_info.get_info(bare)
+    # The token limit is looked up from the table (200000), not the 100000 fallback.
+    assert _model_info.get_token_limit(model) == _model_info.get_token_limit(bare) == 200000
+
+
 @pytest.mark.asyncio
 async def test_mock_tool_choice_specific_tool() -> None:
     """Test tool_choice parameter with a specific tool using mocks."""


### PR DESCRIPTION
Thanks to the maintainers. Small bug fix (no new features — consistent with maintenance-mode scope). This fills a gap so Bedrock-hosted Claude IDs resolve like the native ones — native Anthropic IDs already resolve; only the Bedrock/cross-region forms were missing.

Fixes #7833.

### Problem / cause

The matcher in `_model_info.py` is prefix-anchored (`model.startswith(model_id.split("-2")[0])`), so `anthropic.` / `us./eu./apac./global.anthropic.` prefixes and the `-vN:M` suffix never match → `get_info` raises `KeyError`, `get_token_limit` silently returns the 100000 fallback.

### Change

A small shared `_normalize_model()` helper, called by both `get_info` and `get_token_limit`, strips the optional `[region.]anthropic.` prefix and `-vN:M` suffix. Native IDs and table values unchanged.

| Item | Before | After |
|------|--------|-------|
| `get_info("us.anthropic.claude-3-5-sonnet-20240620-v1:0")` | ❌ KeyError | ✅ resolves to `claude-3-5-sonnet-20240620` entry |
| `get_token_limit("anthropic.claude-…-v1:0")` | ❌ 100000 fallback | ✅ 200000 (table) |
| `global.`/`eu.`/`apac.` prefixes | ❌ KeyError | ✅ resolve |
| Native IDs (`claude-3-5-sonnet-20240620`, `claude-opus-4-0`) | ✅ | ✅ unchanged |
| Public API / function signatures | — | unchanged |
| `_MODEL_INFO` / `_MODEL_TOKEN_LIMITS` table values | — | unchanged (out of scope) |

### Tests

Added a parametrized no-network test; reverting the source (test kept) → 5 failures with the KeyError above; restored → 5 pass; full no-network anthropic suite 23 passed. `ruff format/check` clean, `pyright` 0 errors.

Out of scope / follow-up: correcting individual table values (context windows etc.) is a separate data concern, intentionally left out to keep this minimal.

---

_This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, rationale, and test results before submission._
