### PR TITLE
fix: preserve TextMentionTermination sources in config

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -106,6 +106,7 @@ class MaxMessageTermination(TerminationCondition, Component[MaxMessageTerminatio
 
 class TextMentionTerminationConfig(BaseModel):
     text: str
+    sources: List[str] | None = None
 
 
 class TextMentionTermination(TerminationCondition, Component[TextMentionTerminationConfig]):
@@ -123,7 +124,7 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
     def __init__(self, text: str, sources: Sequence[str] | None = None) -> None:
         self._termination_text = text
         self._terminated = False
-        self._sources = sources
+        self._sources = list(sources) if sources is not None else None
 
     @property
     def terminated(self) -> bool:
@@ -148,11 +149,11 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
         self._terminated = False
 
     def _to_config(self) -> TextMentionTerminationConfig:
-        return TextMentionTerminationConfig(text=self._termination_text)
+        return TextMentionTerminationConfig(text=self._termination_text, sources=self._sources)
 
     @classmethod
     def _from_config(cls, config: TextMentionTerminationConfig) -> Self:
-        return cls(text=config.text)
+        return cls(text=config.text, sources=config.sources)
 
 
 class FunctionalTermination(TerminationCondition):

--- a/python/packages/autogen-agentchat/tests/test_termination_condition.py
+++ b/python/packages/autogen-agentchat/tests/test_termination_condition.py
@@ -26,6 +26,7 @@ from autogen_agentchat.messages import (
     ToolCallExecutionEvent,
     UserInputRequestedEvent,
 )
+from autogen_core import ComponentLoader
 from autogen_core.models import FunctionExecutionResult, RequestUsage
 from pydantic import BaseModel
 
@@ -155,6 +156,18 @@ async def test_mention_termination() -> None:
         await termination([TextMessage(content="stop", source="user"), TextMessage(content="stop", source="agent")])
         is not None
     )
+
+
+@pytest.mark.asyncio
+async def test_text_mention_termination_serializes_sources() -> None:
+    termination = TextMentionTermination("MISSION_DRIFT", sources=["mission_keeper"])
+
+    config = termination.dump_component()
+
+    assert config.config.get("sources") == ["mission_keeper"]
+    loaded_termination = ComponentLoader.load_component(config, TextMentionTermination)
+    assert await loaded_termination([TextMessage(content="MISSION_DRIFT", source="worker")]) is None
+    assert await loaded_termination([TextMessage(content="MISSION_DRIFT", source="mission_keeper")]) is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Preserve `TextMentionTermination` `sources` when dumping/loading component configs.
- Keep old configs compatible by making `sources` optional and omitted when unset.
- Add a regression test covering source-filtered termination after component round-trip.

## Why
Issue #7487 asks for a mission-keeper style goal-integrity node. A practical building block already exists: a read-only integrity agent can emit a drift marker, and `TextMentionTermination` can restrict that marker to the mission keeper source.

Before this fix, saving/loading the termination condition dropped `sources`, so any participant could trigger the marker after config round-trip.

Addresses #7487.

## Verification
- RED: `.venv-agentchat/bin/python -m pytest packages/autogen-agentchat/tests/test_termination_condition.py::test_text_mention_termination_serializes_sources -q` failed because `config.config.get("sources")` was `None`.
- GREEN: `.venv-agentchat/bin/python -m pytest packages/autogen-agentchat/tests/test_termination_condition.py::test_text_mention_termination_serializes_sources -q` passed.
- `.venv-agentchat/bin/python -m pytest packages/autogen-agentchat/tests/test_termination_condition.py -q` passed, 14 tests.
- `.venv-agentchat/bin/python -m ruff check packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py packages/autogen-agentchat/tests/test_termination_condition.py` passed.
- `.venv-agentchat/bin/python -m ruff format --check packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py packages/autogen-agentchat/tests/test_termination_condition.py` passed.
- `.venv-agentchat/bin/pyright --pythonpath .venv-agentchat/bin/python packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py packages/autogen-agentchat/tests/test_termination_condition.py` passed.
- `.venv-agentchat/bin/python -m build --wheel packages/autogen-agentchat` passed.
- Hermes autoreview of exact diff: CLEAN.

Note: local disk was too constrained for a full workspace `uv run` sync; verification used a minimal package-scoped venv with `autogen-core` and `autogen-agentchat` installed editable.
