### PR TITLE
fix: use except BaseException for async queue cleanup handlers in _queue.py

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_queue.py
+++ b/python/packages/autogen-core/src/autogen_core/_queue.py
@@ -122,7 +122,7 @@ class Queue(_LoopBoundMixin, Generic[T]):
             self._putters.append(putter)
             try:
                 await putter
-            except:
+            except BaseException:
                 putter.cancel()  # Just in case putter is not done yet.
                 try:
                     # Clean self._putters from canceled putters.
@@ -169,10 +169,9 @@ class Queue(_LoopBoundMixin, Generic[T]):
             self._getters.append(getter)
             try:
                 await getter
-            except:
+            except BaseException:
                 getter.cancel()  # Just in case getter is not done yet.
                 try:
-                    # Clean self._getters from canceled getters.
                     self._getters.remove(getter)
                 except ValueError:
                     # The getter could be removed from self._getters by a


### PR DESCRIPTION
## Description

The put() and get() methods in _queue.py use bare except: for cleanup handlers that cancel futures and clean up _putters/_getters lists during async shutdown.

## Fix

Replace bare except: with except BaseException: to be explicit while still catching asyncio.CancelledError (which derives from BaseException in Python 3.9+). Using except Exception: would let CancelledError bypass cleanup, leaving stale entries in the queue internals.

The cleanup block already re-raises, so no exceptions are silenced.

## Changes

- 1 file, 2 lines changed (python/packages/autogen-core/src/autogen_core/_queue.py)

Credit to @avinashkamat48 for identifying the CancelledError issue in #7627.