### PR TITLE
docs: fix Composio register_tools agent order

### DIFF
--- a/notebook/agentchat_function_call_with_composio.ipynb
+++ b/notebook/agentchat_function_call_with_composio.ipynb
@@ -187,7 +187,7 @@
    "source": [
     "## Initialize Composio's Toolset\n",
     "\n",
-    "Now, we initialize Composio's toolset and get the tools and actions we need for the agent. Then, we register the tools with the `UserProxyAgent`.\n",
+    "Now, we initialize Composio's toolset and get the tools and actions we need for the agent. Then, we register the tools so the assistant can call them and the `UserProxyAgent` can execute them.\n",
     "\n",
     "The agent can then call the tools using function calling."
    ]
@@ -205,8 +205,8 @@
     "\n",
     "# Get the required tools and register them with the agents\n",
     "email_tools = composio_toolset.register_tools(\n",
-    "    caller=user_proxy,\n",
-    "    executor=chatbot,\n",
+    "    caller=chatbot,\n",
+    "    executor=user_proxy,\n",
     "    actions=[\n",
     "        Action.GMAIL_REPLY_TO_THREAD,\n",
     "    ],\n",


### PR DESCRIPTION
Fixes #5572

## Summary

- Updates the Composio email-agent notebook on the `0.2` branch.
- Registers the assistant as the `caller` and the `UserProxyAgent` as the `executor`.
- Adjusts the surrounding explanation to match the corrected agent roles.

## Duplicate-work check

- Checked `microsoft/autogen#5572`.
- Checked open PRs with `5572 OR Composio caller executor`: no matches.
- Checked open PRs with `Composio notebook example`: no matches.

## Validation

- `python -m json.tool notebook\agentchat_function_call_with_composio.ipynb`
- `git diff --check`
- Local text check confirmed `caller=chatbot` and `executor=user_proxy`.

I did not execute the notebook locally because it requires external Composio and Gmail credentials.

## AI assistance

I used OpenAI Codex to inspect the issue, check for duplicate PRs, make the notebook edit, and run the validation above. I reviewed the final diff before submitting.
