### PR TITLE
docs: fix 2 broken external doc links (FAQ + Aspire dashboard)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -85,7 +85,7 @@ Our project remains fully open-source and accessible to everyone. We understand 
 
 ### Can you clarify the current state of the packages?
 
-Currently, we are unable to make releases to the `pyautogen` package via Pypi due to a change to package ownership that was done without our involvement. Additionally, we are moving to using multiple packages to align with the new design. Please see details [here](https://microsoft.github.io/autogen/dev/packages/index.html).
+Currently, we are unable to make releases to the `pyautogen` package via Pypi due to a change to package ownership that was done without our involvement. Additionally, we are moving to using multiple packages to align with the new design. Please see details [here](https://microsoft.github.io/autogen/stable/).
 
 ### Can I still be involved?
 

--- a/dotnet/samples/Hello/README.md
+++ b/dotnet/samples/Hello/README.md
@@ -1,6 +1,6 @@
 # Multiproject App Host for HelloAgent
 
-This is a [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview) App Host that starts up the HelloAgent project and the agents backend. Once the project starts up you will be able to view the telemetry and logs in the [Aspire Dashboard](https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-dashboard) using the link provided in the console.
+This is a [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview) App Host that starts up the HelloAgent project and the agents backend. Once the project starts up you will be able to view the telemetry and logs in the [Aspire Dashboard](https://learn.microsoft.com/en-us/dotnet/aspire/dashboard) using the link provided in the console.
 
 ```shell
 cd Hello.AppHost


### PR DESCRIPTION
## Summary

Two external doc links in the autogen repo 404 against the current upstream docs.

## Fixes

1. `FAQ.md`: `https://microsoft.github.io/autogen/dev/packages/index.html` → `https://microsoft.github.io/autogen/stable/` (the `dev/packages/index.html` page was removed during the 0.4 rewrite; the stable docs at `/stable/` are the canonical landing page).
2. `dotnet/samples/Hello/README.md`: `https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-dashboard` → `https://learn.microsoft.com/en-us/dotnet/aspire/dashboard` (the Aspire docs site restructured the Dashboard into the top-level /aspire/ namespace).

## Verification

- Old URLs confirmed 404 via HEAD.
- New URLs confirmed 200 via HEAD.

No code changes.