### PR TITLE
fix(agentchat): use running loop for sync input callbacks

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py
@@ -193,7 +193,7 @@ class UserProxyAgent(BaseChatAgent, Component[UserProxyAgentConfig]):
             else:
                 # Cast to SyncInputFunc for proper typing
                 sync_func = cast(SyncInputFunc, self.input_func)
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(None, sync_func, prompt)
 
         except asyncio.CancelledError:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
@@ -62,7 +62,7 @@ class UserInputManager:
             else:
                 # Cast to SyncInputFunc for proper typing
                 sync_func = cast(SyncInputFunc, self.callback)
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(None, sync_func, prompt)
 
         return user_input_func_wrapper


### PR DESCRIPTION
## Summary
- replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` when sync user-input callbacks are executed from async AgentChat paths
- update both `UserProxyAgent._get_input()` and `UserInputManager` so they use the already-running event loop before dispatching work to the executor

## Problem
These code paths run inside coroutines and only need the active event loop to call `run_in_executor()`. `asyncio.get_event_loop()` is a legacy lookup API whose behavior has become stricter across Python versions, while `get_running_loop()` is the intended API when a coroutine is already executing.

## Before / After
Before: sync input callbacks in AgentChat and Console used `asyncio.get_event_loop()` from async functions.

After: the same callbacks use `asyncio.get_running_loop()`, preserving behavior while avoiding the legacy event-loop lookup.

## Verification
- `python -m compileall python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py`
- `git diff --check`
- `uv run pytest tests/test_userproxy_agent.py -q` (`5 passed`)