### PR TITLE
fix(docker-jupyter): restrict bind directory to 0o700

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_jupyter_server.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_jupyter_server.py
@@ -325,7 +325,11 @@ class DockerJupyterServer(JupyterConnectable):
         if bind_dir:
             self._bind_dir = Path(bind_dir) if isinstance(bind_dir, str) else bind_dir
             self._bind_dir.mkdir(exist_ok=True)
-            os.chmod(bind_dir, 0o777)
+            # Owner-only (0o700). Docker bind-mount preserves ownership, so the
+            # container retains read/write regardless of host-side mode. 0o777
+            # unnecessarily exposed agent-generated code and session artifacts to
+            # any local user on the host.
+            os.chmod(bind_dir, 0o700)
 
         # Determine and prepare Docker image
         image_name = custom_image_name or "autogen-jupyterkernelgateway"


### PR DESCRIPTION
The DockerJupyterServer bind directory was created with 0o777 (world read/write/execute), exposing agent-generated code and Jupyter session artifacts to any local user on the host.

Docker bind mounts preserve host ownership, so the container process (uid 1000 / jovyan) retains the access it needs regardless of host-side mode. 0o700 keeps the container fully functional while removing the unnecessary host-side exposure.

Refs CWE-732 (Incorrect Permission Assignment for Critical Resource).

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
