### PR TITLE
Serialize dict and list tool results as JSON in return_value_as_string

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -171,6 +171,16 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
                 return json.dumps(dumped)
             return str(dumped)
 
+        if isinstance(value, (dict, list)):
+            # Serialize structured return values as valid JSON instead of their
+            # Python repr (e.g. ``str``) so downstream consumers receive
+            # double-quoted JSON rather than single-quoted repr strings. Fall
+            # back to ``str`` for values that are not JSON serializable.
+            try:
+                return json.dumps(value)
+            except (TypeError, ValueError):
+                return str(value)
+
         return str(value)
 
     @abstractmethod


### PR DESCRIPTION
## Why

Fixes #7867.

`BaseTool.return_value_as_string` already serializes Pydantic `BaseModel` return
values to JSON, but plain `dict` and `list` return values fell through to
`str()`, producing single-quoted Python `repr` strings instead of valid JSON.
For a tool returning `{"status": "success"}`, the message history got
`"{'status': 'success'}"` — not valid JSON — so downstream agents and message
processors had to parse `repr` strings to recover structured data.

## What

- Serialize `dict` and `list` return values with `json.dumps`, mirroring the
  existing `BaseModel` branch.
- Fall back to `str()` for values that are not JSON serializable, so behavior is
  preserved for those cases.
- Strings and other scalar return types are unchanged.

No public API change: `return_value_as_string` still returns `str`; this only
changes the textual form of `dict`/`list` results from Python `repr` to JSON.

## Verification

- `python -m py_compile` on the edited file.
- Manual checks: dicts/lists now emit `json.loads`-parseable JSON; strings and
  ints unchanged; a `dict` holding a non-serializable object falls back to
  `str()` without raising.
