### PR TITLE
docs: clarify runaway team safeguards

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/termination.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/termination.ipynb
@@ -290,6 +290,24 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
+                "## Guarding Against Runaway Teams\n",
+                "\n",
+                "AutoGen does not currently expose a built-in agent or team capacity declaration, such as a maximum queue depth or a retry-after contract for callers. If your application needs backpressure, enforce it at the orchestration boundary instead of relying on every caller to retry correctly.\n",
+                "\n",
+                "Practical safeguards include:\n",
+                "\n",
+                "- Use {py:class}`~autogen_agentchat.conditions.MaxMessageTermination`, {py:class}`~autogen_agentchat.conditions.TokenUsageTermination`, and {py:class}`~autogen_agentchat.conditions.TimeoutTermination` together so a retry loop has hard message, token, and time ceilings.\n",
+                "- Use {py:class}`~autogen_agentchat.conditions.ExternalTermination` when your application observes saturation, provider rate limits, or queue growth outside the team and needs to stop the run programmatically.\n",
+                "- Implement a custom termination condition when overload is visible in the messages produced by your agents or tools, for example when a tool returns a rate-limit result or a caller receives too many retry requests.\n",
+                "- Keep tool loops bounded with agent settings such as `max_tool_iterations` so one overloaded tool cannot create an unbounded cascade.\n",
+                "\n",
+                "These safeguards are hard stop conditions. They do not advertise capacity to other agents, but they prevent a saturated team from running indefinitely while the application decides whether to retry later, fall back to another provider, or hand off to a human."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
                 "## Custom Termination Condition\n",
                 "\n",
                 "The built-in termination conditions are sufficient for most use cases.\n",


### PR DESCRIPTION
## Summary
- Document that AgentChat does not currently provide built-in capacity declarations for agents or teams
- Add practical safeguards for runaway multi-agent retries using existing termination conditions, external termination, custom termination, and bounded tool loops

## Test Plan
- `python3 -m json.tool python/docs/src/user-guide/agentchat-user-guide/tutorial/termination.ipynb >/tmp/termination.ipynb.jsoncheck`
- Python check that the new notebook cell is present
- `git diff --check`

Refs #7321
