### PR TITLE
fix(samples): use running loop for async input

### DIFF
--- a/python/samples/core_async_human_in_the_loop/main.py
+++ b/python/samples/core_async_human_in_the_loop/main.py
@@ -322,7 +322,7 @@ async def main(model_config: Dict[str, Any], latest_user_input: Optional[str] = 
 
 async def ainput(prompt: str = "") -> str:
     with ThreadPoolExecutor(1, "AsyncInput") as executor:
-        return await asyncio.get_event_loop().run_in_executor(executor, input, prompt)
+        return await asyncio.get_running_loop().run_in_executor(executor, input, prompt)
 
 
 if __name__ == "__main__":

--- a/python/samples/core_semantic_router/_agents.py
+++ b/python/samples/core_semantic_router/_agents.py
@@ -64,5 +64,5 @@ class UserProxyAgent(RoutedAgent):
 
     async def get_user_input(self, prompt: str) -> str:
         """Get user input from the console. Override this method to customize how user input is retrieved."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, input, prompt)


### PR DESCRIPTION
Problem: two async sample input helpers call asyncio.get_event_loop() from inside async functions before scheduling blocking input() calls in an executor. get_event_loop() is deprecated in this usage and can depend on event loop policy behavior.

Before / after: before, the samples asked the policy for an event loop even though a loop is already running. After, they use asyncio.get_running_loop(), preserving the executor behavior while binding to the active loop explicitly.

Verification:
- python -m py_compile python\samples\core_semantic_router\_agents.py python\samples\core_async_human_in_the_loop\main.py