### PR TITLE
tools: add GuardrailProvider protocol for tool call interception

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/__init__.py
@@ -9,7 +9,7 @@ from ._base import (
     ToolSchema,
 )
 from ._function_tool import FunctionTool
-from ._guardrail import Decision, GuardrailProvider, GuardrailResult
+from ._guardrail import Decision, GuardrailDeniedError, GuardrailProvider, GuardrailResult
 from ._static_workbench import StaticStreamWorkbench, StaticWorkbench
 from ._workbench import ImageResultContent, TextResultContent, ToolResult, Workbench
 
@@ -32,4 +32,5 @@ __all__ = [
     "Decision",
     "GuardrailProvider",
     "GuardrailResult",
+    "GuardrailDeniedError",
 ]

--- a/python/packages/autogen-core/src/autogen_core/tools/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/__init__.py
@@ -9,6 +9,7 @@ from ._base import (
     ToolSchema,
 )
 from ._function_tool import FunctionTool
+from ._guardrail import Decision, GuardrailProvider, GuardrailResult
 from ._static_workbench import StaticStreamWorkbench, StaticWorkbench
 from ._workbench import ImageResultContent, TextResultContent, ToolResult, Workbench
 
@@ -28,4 +29,7 @@ __all__ = [
     "StaticWorkbench",
     "StaticStreamWorkbench",
     "ToolOverride",
+    "Decision",
+    "GuardrailProvider",
+    "GuardrailResult",
 ]

--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -25,7 +25,7 @@ from .._component_config import ComponentBase
 from .._function_utils import normalize_annotated_type
 from .._telemetry import trace_tool_span
 from ..logging import ToolCallEvent
-from ._guardrail import Decision, GuardrailDeniedError, GuardrailProvider
+from ._guardrail import Decision, GuardrailDeniedError, GuardrailProvider, GuardrailResult
 
 T = TypeVar("T", bound=BaseModel, contravariant=True)
 
@@ -226,7 +226,17 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
             )
             if result.decision == Decision.DENY:
                 raise GuardrailDeniedError(tool_name=self._name, result=result, arguments=effective_args)
-            if result.decision == Decision.MODIFY and result.modified_args is not None:
+            if result.decision == Decision.MODIFY:
+                if result.modified_args is None:
+                    raise GuardrailDeniedError(
+                        tool_name=self._name,
+                        result=GuardrailResult(
+                            decision=Decision.DENY,
+                            reason="Guardrail MODIFY decision requires modified_args.",
+                            metadata=result.metadata,
+                        ),
+                        arguments=effective_args,
+                    )
                 effective_args = result.modified_args
 
         return effective_args

--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -25,6 +25,7 @@ from .._component_config import ComponentBase
 from .._function_utils import normalize_annotated_type
 from .._telemetry import trace_tool_span
 from ..logging import ToolCallEvent
+from ._guardrail import Decision, GuardrailProvider, GuardrailResult
 
 T = TypeVar("T", bound=BaseModel, contravariant=True)
 
@@ -103,6 +104,7 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
         name: str,
         description: str,
         strict: bool = False,
+        guardrail_providers: Sequence[GuardrailProvider] = (),
     ) -> None:
         self._args_type = args_type
         # Normalize Annotated to the base type.
@@ -110,6 +112,7 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
         self._name = name
         self._description = description
         self._strict = strict
+        self._guardrail_providers = guardrail_providers
 
     @property
     def schema(self) -> ToolSchema:
@@ -187,15 +190,31 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
             call_id (str | None): An optional identifier for the tool call, used for tracing.
 
         Returns:
-            Any: The return value of the tool's run method.
+            Any: The return value of the tool's run method, or a denial string if
+                a guardrail provider denied the call.
         """
+        effective_args = args
+
+        # Run guardrail providers in order; short-circuit on DENY.
+        for provider in self._guardrail_providers:
+            result = await provider.evaluate(
+                tool_name=self._name,
+                args=effective_args,
+                call_id=call_id,
+                cancellation_token=cancellation_token,
+            )
+            if result.decision == Decision.DENY:
+                return f"Tool call denied: {result.reason or 'policy violation'}"
+            if result.decision == Decision.MODIFY and result.modified_args is not None:
+                effective_args = result.modified_args
+
         with trace_tool_span(
             tool_name=self._name,
             tool_description=self._description,
             tool_call_id=call_id,
         ):
             # Execute the tool's run method
-            return_value = await self.run(self._args_type.model_validate(args), cancellation_token)
+            return_value = await self.run(self._args_type.model_validate(effective_args), cancellation_token)
 
         # Log the tool call event
         event = ToolCallEvent(
@@ -206,6 +225,16 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
         logger.info(event)
 
         return return_value
+
+    def add_guardrail(self, provider: GuardrailProvider) -> None:
+        """Add a guardrail provider to the tool.
+
+        Args:
+            provider: A guardrail provider to evaluate tool calls before execution.
+                Providers are evaluated in the order they were added; the first
+                DENY short-circuits subsequent providers and blocks execution.
+        """
+        self._guardrail_providers = (*self._guardrail_providers, provider)
 
     async def save_state_json(self) -> Mapping[str, Any]:
         return {}
@@ -229,7 +258,7 @@ class BaseStreamTool(
         args: Mapping[str, Any],
         cancellation_token: CancellationToken,
         call_id: str | None = None,
-    ) -> AsyncGenerator[StreamT | ReturnT, None]:
+    ) -> AsyncGenerator[Any, None]:
         """Run the tool with the provided arguments in a dictionary and return a stream of data
         from the tool's :meth:`run_stream` method and end with the final return value.
 
@@ -239,8 +268,24 @@ class BaseStreamTool(
             call_id (str | None): An optional identifier for the tool call, used for tracing.
 
         Returns:
-            AsyncGenerator[StreamT | ReturnT, None]: A generator yielding results from the tool's :meth:`run_stream` method.
+            AsyncGenerator[Any, None]: A generator yielding results from the tool's :meth:`run_stream` method.
         """
+        effective_args = args
+
+        # Run guardrail providers in order; short-circuit on DENY.
+        for provider in self._guardrail_providers:
+            result = await provider.evaluate(
+                tool_name=self._name,
+                args=effective_args,
+                call_id=call_id,
+                cancellation_token=cancellation_token,
+            )
+            if result.decision == Decision.DENY:
+                yield f"Tool call denied: {result.reason or 'policy violation'}"
+                return
+            if result.decision == Decision.MODIFY and result.modified_args is not None:
+                effective_args = result.modified_args
+
         return_value: ReturnT | StreamT | None = None
         with trace_tool_span(
             tool_name=self._name,
@@ -248,7 +293,7 @@ class BaseStreamTool(
             tool_call_id=call_id,
         ):
             # Execute the tool's run_stream method
-            async for result in self.run_stream(self._args_type.model_validate(args), cancellation_token):
+            async for result in self.run_stream(self._args_type.model_validate(effective_args), cancellation_token):
                 return_value = result
                 yield result
 

--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -25,7 +25,7 @@ from .._component_config import ComponentBase
 from .._function_utils import normalize_annotated_type
 from .._telemetry import trace_tool_span
 from ..logging import ToolCallEvent
-from ._guardrail import Decision, GuardrailProvider, GuardrailResult
+from ._guardrail import Decision, GuardrailDeniedError, GuardrailProvider
 
 T = TypeVar("T", bound=BaseModel, contravariant=True)
 
@@ -189,13 +189,34 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
             cancellation_token (CancellationToken): A token to cancel the operation if needed.
             call_id (str | None): An optional identifier for the tool call, used for tracing.
 
+        Raises:
+            GuardrailDeniedError: If a guardrail provider denies the call.
+
         Returns:
-            Any: The return value of the tool's run method, or a denial string if
-                a guardrail provider denied the call.
+            Any: The return value of the tool's run method.
         """
+        with trace_tool_span(
+            tool_name=self._name,
+            tool_description=self._description,
+            tool_call_id=call_id,
+        ):
+            try:
+                effective_args = await self._evaluate_guardrails(args, cancellation_token, call_id)
+            except GuardrailDeniedError as error:
+                self._log_tool_call(error.arguments, str(error))
+                raise
+
+            return_value = await self.run(self._args_type.model_validate(effective_args), cancellation_token)
+
+        self._log_tool_call(effective_args, return_value)
+
+        return return_value
+
+    async def _evaluate_guardrails(
+        self, args: Mapping[str, Any], cancellation_token: CancellationToken, call_id: str | None
+    ) -> Mapping[str, Any]:
         effective_args = args
 
-        # Run guardrail providers in order; short-circuit on DENY.
         for provider in self._guardrail_providers:
             result = await provider.evaluate(
                 tool_name=self._name,
@@ -204,27 +225,19 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
                 cancellation_token=cancellation_token,
             )
             if result.decision == Decision.DENY:
-                return f"Tool call denied: {result.reason or 'policy violation'}"
+                raise GuardrailDeniedError(tool_name=self._name, result=result, arguments=effective_args)
             if result.decision == Decision.MODIFY and result.modified_args is not None:
                 effective_args = result.modified_args
 
-        with trace_tool_span(
-            tool_name=self._name,
-            tool_description=self._description,
-            tool_call_id=call_id,
-        ):
-            # Execute the tool's run method
-            return_value = await self.run(self._args_type.model_validate(effective_args), cancellation_token)
+        return effective_args
 
-        # Log the tool call event
+    def _log_tool_call(self, arguments: Mapping[str, Any], result: Any) -> None:
         event = ToolCallEvent(
             tool_name=self.name,
-            arguments=dict(args),  # Using the raw args passed to run_json
-            result=self.return_value_as_string(return_value),
+            arguments=dict(arguments),
+            result=self.return_value_as_string(result),
         )
         logger.info(event)
-
-        return return_value
 
     def add_guardrail(self, provider: GuardrailProvider) -> None:
         """Add a guardrail provider to the tool.
@@ -270,28 +283,18 @@ class BaseStreamTool(
         Returns:
             AsyncGenerator[Any, None]: A generator yielding results from the tool's :meth:`run_stream` method.
         """
-        effective_args = args
-
-        # Run guardrail providers in order; short-circuit on DENY.
-        for provider in self._guardrail_providers:
-            result = await provider.evaluate(
-                tool_name=self._name,
-                args=effective_args,
-                call_id=call_id,
-                cancellation_token=cancellation_token,
-            )
-            if result.decision == Decision.DENY:
-                yield f"Tool call denied: {result.reason or 'policy violation'}"
-                return
-            if result.decision == Decision.MODIFY and result.modified_args is not None:
-                effective_args = result.modified_args
-
         return_value: ReturnT | StreamT | None = None
         with trace_tool_span(
             tool_name=self._name,
             tool_description=self._description,
             tool_call_id=call_id,
         ):
+            try:
+                effective_args = await self._evaluate_guardrails(args, cancellation_token, call_id)
+            except GuardrailDeniedError as error:
+                self._log_tool_call(error.arguments, str(error))
+                raise
+
             # Execute the tool's run_stream method
             async for result in self.run_stream(self._args_type.model_validate(effective_args), cancellation_token):
                 return_value = result
@@ -303,13 +306,7 @@ class BaseStreamTool(
                 f"Expected return value of type {self._return_type.__name__}, but got {type(return_value).__name__}"
             )
 
-        # Log the tool call event
-        event = ToolCallEvent(
-            tool_name=self.name,
-            arguments=dict(args),  # Using the raw args passed to run_json
-            result=self.return_value_as_string(return_value),
-        )
-        logger.info(event)
+        self._log_tool_call(effective_args, return_value)
 
 
 class BaseToolWithState(BaseTool[ArgsT, ReturnT], ABC, Generic[ArgsT, ReturnT, StateT], ComponentBase[BaseModel]):

--- a/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
@@ -15,6 +15,7 @@ from .._function_utils import (
 )
 from ..code_executor._func_with_reqs import Import, import_to_str, to_code
 from ._base import BaseTool
+from ._guardrail import GuardrailProvider
 
 
 class FunctionToolConfig(BaseModel):
@@ -92,6 +93,7 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
         name: str | None = None,
         global_imports: Sequence[Import] = [],
         strict: bool = False,
+        guardrail_providers: Sequence[GuardrailProvider] = (),
     ) -> None:
         self._func = func
         self._global_imports = global_imports
@@ -100,7 +102,7 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
         args_model = args_base_model_from_signature(func_name + "args", self._signature)
         self._has_cancellation_support = "cancellation_token" in self._signature.parameters
         return_type = self._signature.return_annotation
-        super().__init__(args_model, return_type, func_name, description, strict)
+        super().__init__(args_model, return_type, func_name, description, strict, guardrail_providers)
 
     async def run(self, args: BaseModel, cancellation_token: CancellationToken) -> Any:
         kwargs = {}
@@ -178,4 +180,4 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
         if not callable(func):
             raise TypeError(f"Expected function but got {type(func)}")
 
-        return cls(func, name=config.name, description=config.description, global_imports=config.global_imports)
+        return cls(func, name=config.name, description=config.description, global_imports=config.global_imports, guardrail_providers=())

--- a/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
@@ -180,4 +180,10 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
         if not callable(func):
             raise TypeError(f"Expected function but got {type(func)}")
 
-        return cls(func, name=config.name, description=config.description, global_imports=config.global_imports, guardrail_providers=())
+        return cls(
+            func,
+            name=config.name,
+            description=config.description,
+            global_imports=config.global_imports,
+            guardrail_providers=(),
+        )

--- a/python/packages/autogen-core/src/autogen_core/tools/_guardrail.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_guardrail.py
@@ -39,6 +39,22 @@ class GuardrailResult:
     metadata: dict[str, Any] = field(default_factory=dict)  # type: ignore[assignment]
 
 
+class GuardrailDeniedError(RuntimeError):
+    """Raised when a guardrail denies a tool call before execution."""
+
+    def __init__(
+        self,
+        *,
+        tool_name: str,
+        result: GuardrailResult,
+        arguments: Mapping[str, Any],
+    ) -> None:
+        self.tool_name = tool_name
+        self.result = result
+        self.arguments = dict(arguments)
+        super().__init__(f"Tool call denied for {tool_name}: {result.reason or 'policy violation'}")
+
+
 @runtime_checkable
 class GuardrailProvider(Protocol):
     """Intercepts tool calls before execution for policy enforcement.
@@ -54,6 +70,7 @@ class GuardrailProvider(Protocol):
             import time
             from collections import defaultdict
             from autogen_core.tools import Decision, GuardrailProvider, GuardrailResult
+
 
             class RateLimitGuardrail:
                 def __init__(self, max_calls: int = 10, window_seconds: float = 60.0):
@@ -84,8 +101,10 @@ class GuardrailProvider(Protocol):
 
             from autogen_core.tools import FunctionTool
 
+
             async def my_tool(arg: str) -> str:
                 return f"got: {arg}"
+
 
             tool = FunctionTool(my_tool, description="Example tool")
             tool.add_guardrail(RateLimitGuardrail(max_calls=5))

--- a/python/packages/autogen-core/src/autogen_core/tools/_guardrail.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_guardrail.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .._cancellation_token import CancellationToken
+
+
+class Decision(Enum):
+    """Outcome of a guardrail evaluation."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    MODIFY = "modify"
+
+
+@dataclass
+class GuardrailResult:
+    """Outcome of a guardrail evaluation.
+
+    Attributes:
+        decision: The outcome of the evaluation.
+        reason: An optional human-readable explanation for the decision.
+            Used when decision is DENY or when callers need to surface why MODIFY was applied.
+        modified_args: The revised arguments to pass to the tool, only used when
+            decision is MODIFY. When present, the tool receives these instead of the
+            original arguments. The modified args are re-validated against the tool's
+            schema before execution.
+        metadata: Arbitrary additional context from the guardrail evaluation,
+            such as audit trail data, policy identifiers, or risk scores.
+    """
+
+    decision: Decision
+    reason: str | None = None
+    modified_args: Mapping[str, Any] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)  # type: ignore[assignment]
+
+
+@runtime_checkable
+class GuardrailProvider(Protocol):
+    """Intercepts tool calls before execution for policy enforcement.
+
+    A guardrail can inspect, modify, or deny a tool call based on the tool name,
+    arguments, and execution context. Multiple guardrails may be composed in a chain;
+    each receives either the original arguments or the output of the previous guardrail
+    in the chain.
+
+    Example:
+        A simple rate-limiting guardrail::
+
+            import time
+            from collections import defaultdict
+            from autogen_core.tools import Decision, GuardrailProvider, GuardrailResult
+
+            class RateLimitGuardrail:
+                def __init__(self, max_calls: int = 10, window_seconds: float = 60.0):
+                    self._max = max_calls
+                    self._window = window_seconds
+                    self._calls: dict[str, list[float]] = defaultdict(list)
+
+                async def evaluate(
+                    self,
+                    *,
+                    tool_name: str,
+                    args: Mapping[str, Any],
+                    agent_name: str | None = None,
+                    call_id: str | None = None,
+                    cancellation_token: CancellationToken | None = None,
+                ) -> GuardrailResult:
+                    now = time.monotonic()
+                    recent = [t for t in self._calls[tool_name] if now - t < self._window]
+                    if len(recent) >= self._max:
+                        return GuardrailResult(
+                            decision=Decision.DENY,
+                            reason=f"Rate limit: {self._max} calls per {self._window}s exceeded",
+                        )
+                    self._calls[tool_name] = [*recent, now]
+                    return GuardrailResult(decision=Decision.ALLOW)
+
+        To attach a guardrail to a tool::
+
+            from autogen_core.tools import FunctionTool
+
+            async def my_tool(arg: str) -> str:
+                return f"got: {arg}"
+
+            tool = FunctionTool(my_tool, description="Example tool")
+            tool.add_guardrail(RateLimitGuardrail(max_calls=5))
+    """
+
+    @abstractmethod
+    async def evaluate(
+        self,
+        *,
+        tool_name: str,
+        args: Mapping[str, Any],
+        agent_name: str | None = None,
+        call_id: str | None = None,
+        cancellation_token: CancellationToken | None = None,
+    ) -> GuardrailResult:
+        """Evaluate whether a tool call should proceed.
+
+        Args:
+            tool_name: Name of the tool being invoked.
+            args: Arguments the agent wants to pass to the tool.
+            agent_name: Identity of the calling agent, if known.
+            call_id: Correlation identifier for the tool call, used for tracing.
+            cancellation_token: For cooperative cancellation of long-running evaluations.
+
+        Returns:
+            GuardrailResult indicating allow, deny, or modify.
+
+        Note:
+            - ALLOW: the tool executes with the arguments as passed (or as modified
+              by an earlier guardrail in the chain).
+            - DENY: the tool is not called. The denial result, including ``reason``
+              and any ``metadata``, is returned to the caller of ``run_json``.
+            - MODIFY: the tool is called with ``modified_args`` instead of the
+              received ``args``. The modified arguments are re-validated against
+              the tool's schema before execution.
+        """
+        ...

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -1,14 +1,16 @@
 import inspect
+import json
+import logging
 from dataclasses import dataclass
 from functools import partial
 from typing import Annotated, Any, List, Mapping
 
 import pytest
-from autogen_core import CancellationToken
+from autogen_core import EVENT_LOGGER_NAME, CancellationToken
 from autogen_core._function_utils import get_typed_signature
-from autogen_core.tools import BaseTool, FunctionTool
+from autogen_core.tools import BaseStreamTool, BaseTool, FunctionTool
 from autogen_core.tools._base import ToolSchema
-from autogen_core.tools._guardrail import Decision, GuardrailProvider, GuardrailResult
+from autogen_core.tools._guardrail import Decision, GuardrailDeniedError, GuardrailProvider, GuardrailResult
 from pydantic import BaseModel, Field, ValidationError, model_serializer
 from pydantic_core import PydanticUndefined
 
@@ -53,6 +55,35 @@ class MyNestedTool(BaseTool[MyNestedArgs, MyResult]):
     async def run(self, args: MyNestedArgs, cancellation_token: CancellationToken) -> MyResult:
         self.called_count += 1
         return MyResult(result="value")
+
+
+class RecordingTool(BaseTool[MyArgs, MyResult]):
+    def __init__(self) -> None:
+        super().__init__(
+            args_type=MyArgs,
+            return_type=MyResult,
+            name="RecordingTool",
+            description="Records the effective args.",
+        )
+        self.last_args: MyArgs | None = None
+
+    async def run(self, args: MyArgs, cancellation_token: CancellationToken) -> MyResult:
+        self.last_args = args
+        return MyResult(result=args.query)
+
+
+class MyStreamTool(BaseStreamTool[MyArgs, MyResult, MyResult]):
+    def __init__(self) -> None:
+        super().__init__(MyArgs, MyResult, "TestStreamTool", "Description of test stream tool.")
+        self.called_count = 0
+
+    async def run(self, args: MyArgs, cancellation_token: CancellationToken) -> MyResult:
+        self.called_count += 1
+        return MyResult(result=args.query)
+
+    async def run_stream(self, args: MyArgs, cancellation_token: CancellationToken):  # type: ignore[no-untyped-def]
+        self.called_count += 1
+        yield MyResult(result=args.query)
 
 
 def test_tool_schema_generation() -> None:
@@ -613,7 +644,7 @@ class _AllowGuardrail:
 class _DenyGuardrail:
     """A guardrail that always denies with a configurable reason."""
 
-    def __init__(self, reason: str = "denied by test guardrail"):
+    def __init__(self, reason: str | None = "denied by test guardrail"):
         self._reason = reason
 
     async def evaluate(
@@ -678,16 +709,16 @@ class _CountingGuardrail:
 # ---------------------------------------------------------------------------
 
 
-def test_guardrail_protocol_allow() -> None:
+@pytest.mark.asyncio
+async def test_guardrail_protocol_allow() -> None:
     """A tool with an allow guardrail executes normally."""
+    tool = MyTool()
+    tool.add_guardrail(_AllowGuardrail())
 
-    class AllowTool(MyTool):
-        def __init__(self) -> None:
-            super().__init__()
-            self._guardrail_providers = (_AllowGuardrail(),)
+    result = await tool.run_json({"query": "test"}, CancellationToken())
 
-    tool = AllowTool()
-    assert isinstance(tool._guardrail_providers[0], _AllowGuardrail)
+    assert result.result == "value"
+    assert tool.called_count == 1
 
 
 @pytest.mark.asyncio
@@ -701,29 +732,32 @@ async def test_guardrail_allow_executes() -> None:
 
 @pytest.mark.asyncio
 async def test_guardrail_deny_returns_denial_string() -> None:
-    """When the guardrail returns DENY, the tool does not execute and a denial message is returned."""
+    """When the guardrail returns DENY, the tool does not execute and raises a structured denial."""
     tool = MyTool()
     tool.add_guardrail(_DenyGuardrail("unsafe input"))
-    result = await tool.run_json({"query": "test"}, CancellationToken())
-    assert result == "Tool call denied: unsafe input"
+    with pytest.raises(GuardrailDeniedError, match="unsafe input"):
+        await tool.run_json({"query": "test"}, CancellationToken())
+    assert tool.called_count == 0
 
 
 @pytest.mark.asyncio
 async def test_guardrail_deny_preserves_reason() -> None:
     """DENY without a reason falls back to 'policy violation'."""
     tool = MyTool()
-    tool.add_guardrail(_DenyGuardrail())
-    result = await tool.run_json({"query": "test"}, CancellationToken())
-    assert result == "Tool call denied: denied by test guardrail"
+    tool.add_guardrail(_DenyGuardrail(None))
+    with pytest.raises(GuardrailDeniedError, match="policy violation"):
+        await tool.run_json({"query": "test"}, CancellationToken())
+    assert tool.called_count == 0
 
 
 @pytest.mark.asyncio
 async def test_guardrail_modify_passes_modified_args() -> None:
     """When the guardrail returns MODIFY, the tool receives the modified arguments."""
-    tool = MyTool()
+    tool = RecordingTool()
     tool.add_guardrail(_ModifyGuardrail({"query": "modified input"}))
     result = await tool.run_json({"query": "original"}, CancellationToken())
-    assert result.result == "value"
+    assert result.result == "modified input"
+    assert tool.last_args == MyArgs(query="modified input")
 
 
 @pytest.mark.asyncio
@@ -734,8 +768,8 @@ async def test_guardrail_chain_order() -> None:
     tool.add_guardrail(_DenyGuardrail("stop here"))
     tool.add_guardrail(counter)  # Should never be reached
 
-    result = await tool.run_json({"query": "test"}, CancellationToken())
-    assert result == "Tool call denied: stop here"
+    with pytest.raises(GuardrailDeniedError, match="stop here"):
+        await tool.run_json({"query": "test"}, CancellationToken())
     assert counter.call_count == 0  # never called
 
 
@@ -808,17 +842,24 @@ async def test_guardrail_multiple_tools_independent() -> None:
     assert counter_b.call_count == 2
 
 
-def test_guardrail_via_init() -> None:
+@pytest.mark.asyncio
+async def test_guardrail_via_init() -> None:
     """GuardrailProvider can be passed at construction time via BaseTool.__init__."""
+
     async def typed_query(query: str) -> str:
         return query
 
+    counter = _CountingGuardrail()
     tool = FunctionTool(
         typed_query,
         description="Example",
-        guardrail_providers=(_AllowGuardrail(), _CountingGuardrail()),
+        guardrail_providers=(_AllowGuardrail(), counter),
     )
-    assert len(tool._guardrail_providers) == 2
+
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+
+    assert result == "test"
+    assert counter.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -831,13 +872,80 @@ async def test_guardrail_empty_chain_no_overhead() -> None:
 
 @pytest.mark.asyncio
 async def test_guardrail_deny_preserves_tool_error_behavior() -> None:
-    """Guardrail DENY returns a string, not an exception — callers handle it as a tool error."""
+    """Guardrail DENY raises a structured error without calling the tool."""
     tool = MyTool()
     tool.add_guardrail(_DenyGuardrail("custom reason"))
 
-    result = await tool.run_json({"query": "test"}, CancellationToken())
-    assert isinstance(result, str)
-    assert "custom reason" in result
+    with pytest.raises(GuardrailDeniedError, match="custom reason"):
+        await tool.run_json({"query": "test"}, CancellationToken())
+    assert tool.called_count == 0
+
+
+@pytest.mark.asyncio
+async def test_guardrail_deny_logs_terminal_event(caplog: pytest.LogCaptureFixture) -> None:
+    """DENY is traced through the normal tool-call logging path without executing the tool."""
+    tool = MyTool()
+    tool.add_guardrail(_DenyGuardrail("blocked by policy"))
+    caplog.set_level(logging.INFO, logger=EVENT_LOGGER_NAME)
+
+    with pytest.raises(GuardrailDeniedError, match="blocked by policy"):
+        await tool.run_json({"query": "secret"}, CancellationToken(), call_id="call-1")
+
+    events = [json.loads(record.getMessage()) for record in caplog.records]
+    assert events[-1]["type"] == "ToolCall"
+    assert events[-1]["tool_name"] == "TestTool"
+    assert events[-1]["arguments"] == {"query": "secret"}
+    assert "blocked by policy" in events[-1]["result"]
+
+
+@pytest.mark.asyncio
+async def test_guardrail_modify_logs_effective_args(caplog: pytest.LogCaptureFixture) -> None:
+    """MODIFY logs the same arguments that are actually passed to the tool."""
+    tool = RecordingTool()
+    tool.add_guardrail(_ModifyGuardrail({"query": "effective"}))
+    caplog.set_level(logging.INFO, logger=EVENT_LOGGER_NAME)
+
+    result = await tool.run_json({"query": "original"}, CancellationToken())
+
+    events = [json.loads(record.getMessage()) for record in caplog.records]
+    assert result.result == "effective"
+    assert events[-1]["arguments"] == {"query": "effective"}
+    assert events[-1]["result"] == '{"result": "effective"}'
+
+
+@pytest.mark.asyncio
+async def test_guardrail_stream_deny_raises_without_yielding_string() -> None:
+    """Streaming tools use the same structured denial path as run_json."""
+    tool = MyStreamTool()
+    tool.add_guardrail(_DenyGuardrail("stream blocked"))
+
+    with pytest.raises(GuardrailDeniedError, match="stream blocked"):
+        _ = [item async for item in tool.run_json_stream({"query": "test"}, CancellationToken())]
+
+    assert tool.called_count == 0
+
+
+@pytest.mark.asyncio
+async def test_guardrail_stream_modify_passes_effective_args() -> None:
+    """Streaming tools execute with modified arguments after revalidation."""
+    tool = MyStreamTool()
+    tool.add_guardrail(_ModifyGuardrail({"query": "stream effective"}))
+
+    results = [item async for item in tool.run_json_stream({"query": "stream original"}, CancellationToken())]
+
+    assert [item.result for item in results] == ["stream effective"]
+
+
+def test_guardrail_public_import_path() -> None:
+    from autogen_core.tools import Decision as PublicDecision
+    from autogen_core.tools import GuardrailDeniedError as PublicGuardrailDeniedError
+    from autogen_core.tools import GuardrailProvider as PublicGuardrailProvider
+    from autogen_core.tools import GuardrailResult as PublicGuardrailResult
+
+    assert PublicDecision is Decision
+    assert PublicGuardrailDeniedError is GuardrailDeniedError
+    assert PublicGuardrailProvider is GuardrailProvider
+    assert PublicGuardrailResult is GuardrailResult
 
 
 @pytest.mark.asyncio
@@ -856,7 +964,11 @@ async def test_guardrail_guardrail_provider_subclass() -> None:
         ) -> GuardrailResult:
             return GuardrailResult(decision=Decision.ALLOW)
 
+    guardrail = SubclassGuardrail()
+    assert isinstance(guardrail, GuardrailProvider)
     tool = MyTool()
-    tool.add_guardrail(SubclassGuardrail())
-    result = tool._guardrail_providers[0]
-    assert isinstance(result, SubclassGuardrail)
+    tool.add_guardrail(guardrail)
+
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+
+    assert result.result == "value"

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -681,6 +681,21 @@ class _ModifyGuardrail:
         )
 
 
+class _ModifyWithoutArgsGuardrail:
+    """A guardrail that incorrectly requests MODIFY without replacement args."""
+
+    async def evaluate(
+        self,
+        *,
+        tool_name: str,
+        args: Mapping[str, Any],
+        agent_name: str | None = None,
+        call_id: str | None = None,
+        cancellation_token: Any = None,
+    ) -> GuardrailResult:
+        return GuardrailResult(decision=Decision.MODIFY)
+
+
 class _CountingGuardrail:
     """A guardrail that counts how many times it was called."""
 
@@ -707,18 +722,6 @@ class _CountingGuardrail:
 # ---------------------------------------------------------------------------
 # Tests for guardrail integration
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_guardrail_protocol_allow() -> None:
-    """A tool with an allow guardrail executes normally."""
-    tool = MyTool()
-    tool.add_guardrail(_AllowGuardrail())
-
-    result = await tool.run_json({"query": "test"}, CancellationToken())
-
-    assert result.result == "value"
-    assert tool.called_count == 1
 
 
 @pytest.mark.asyncio
@@ -758,6 +761,17 @@ async def test_guardrail_modify_passes_modified_args() -> None:
     result = await tool.run_json({"query": "original"}, CancellationToken())
     assert result.result == "modified input"
     assert tool.last_args == MyArgs(query="modified input")
+
+
+@pytest.mark.asyncio
+async def test_guardrail_modify_without_args_fails_closed() -> None:
+    """MODIFY without modified_args fails closed instead of executing with original args."""
+    tool = MyTool()
+    tool.add_guardrail(_ModifyWithoutArgsGuardrail())
+
+    with pytest.raises(GuardrailDeniedError, match="requires modified_args"):
+        await tool.run_json({"query": "original"}, CancellationToken())
+    assert tool.called_count == 0
 
 
 @pytest.mark.asyncio
@@ -811,8 +825,8 @@ async def test_guardrail_receives_tool_name() -> None:
 
 
 @pytest.mark.asyncio
-async def test_guardrail_receives_original_args() -> None:
-    """Guardrail receives the arguments as passed (not yet modified by earlier guardrails in the chain)."""
+async def test_guardrail_receives_effective_args_after_modify() -> None:
+    """Later guardrails receive the effective args after an earlier MODIFY decision."""
     tool = MyTool()
     counter = _CountingGuardrail()
     tool.add_guardrail(_ModifyGuardrail({"query": "modified"}))

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -1,13 +1,14 @@
 import inspect
 from dataclasses import dataclass
 from functools import partial
-from typing import Annotated, List
+from typing import Annotated, Any, List, Mapping
 
 import pytest
 from autogen_core import CancellationToken
 from autogen_core._function_utils import get_typed_signature
 from autogen_core.tools import BaseTool, FunctionTool
 from autogen_core.tools._base import ToolSchema
+from autogen_core.tools._guardrail import Decision, GuardrailProvider, GuardrailResult
 from pydantic import BaseModel, Field, ValidationError, model_serializer
 from pydantic_core import PydanticUndefined
 
@@ -589,3 +590,273 @@ async def test_func_tool_with_dataclass_conversion_failure() -> None:
 
     with pytest.raises(ValidationError, match="Field required"):
         await tool.run_json(test_input, CancellationToken())
+
+
+# Guardrail provider implementations for testing.
+
+
+class _AllowGuardrail:
+    """A guardrail that always allows."""
+
+    async def evaluate(
+        self,
+        *,
+        tool_name: str,
+        args: Mapping[str, Any],
+        agent_name: str | None = None,
+        call_id: str | None = None,
+        cancellation_token: Any = None,
+    ) -> GuardrailResult:
+        return GuardrailResult(decision=Decision.ALLOW)
+
+
+class _DenyGuardrail:
+    """A guardrail that always denies with a configurable reason."""
+
+    def __init__(self, reason: str = "denied by test guardrail"):
+        self._reason = reason
+
+    async def evaluate(
+        self,
+        *,
+        tool_name: str,
+        args: Mapping[str, Any],
+        agent_name: str | None = None,
+        call_id: str | None = None,
+        cancellation_token: Any = None,
+    ) -> GuardrailResult:
+        return GuardrailResult(decision=Decision.DENY, reason=self._reason)
+
+
+class _ModifyGuardrail:
+    """A guardrail that modifies arguments."""
+
+    def __init__(self, override: Mapping[str, Any]):
+        self._override = override
+
+    async def evaluate(
+        self,
+        *,
+        tool_name: str,
+        args: Mapping[str, Any],
+        agent_name: str | None = None,
+        call_id: str | None = None,
+        cancellation_token: Any = None,
+    ) -> GuardrailResult:
+        return GuardrailResult(
+            decision=Decision.MODIFY,
+            modified_args=self._override,
+            reason="args modified by test guardrail",
+        )
+
+
+class _CountingGuardrail:
+    """A guardrail that counts how many times it was called."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.last_tool_name: str | None = None
+        self.last_args: Mapping[str, Any] | None = None
+
+    async def evaluate(
+        self,
+        *,
+        tool_name: str,
+        args: Mapping[str, Any],
+        agent_name: str | None = None,
+        call_id: str | None = None,
+        cancellation_token: Any = None,
+    ) -> GuardrailResult:
+        self.call_count += 1
+        self.last_tool_name = tool_name
+        self.last_args = dict(args)
+        return GuardrailResult(decision=Decision.ALLOW)
+
+
+# ---------------------------------------------------------------------------
+# Tests for guardrail integration
+# ---------------------------------------------------------------------------
+
+
+def test_guardrail_protocol_allow() -> None:
+    """A tool with an allow guardrail executes normally."""
+
+    class AllowTool(MyTool):
+        def __init__(self) -> None:
+            super().__init__()
+            self._guardrail_providers = (_AllowGuardrail(),)
+
+    tool = AllowTool()
+    assert isinstance(tool._guardrail_providers[0], _AllowGuardrail)
+
+
+@pytest.mark.asyncio
+async def test_guardrail_allow_executes() -> None:
+    """When the guardrail returns ALLOW, the tool runs normally."""
+    tool = MyTool()
+    tool.add_guardrail(_AllowGuardrail())
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+    assert result.result == "value"
+
+
+@pytest.mark.asyncio
+async def test_guardrail_deny_returns_denial_string() -> None:
+    """When the guardrail returns DENY, the tool does not execute and a denial message is returned."""
+    tool = MyTool()
+    tool.add_guardrail(_DenyGuardrail("unsafe input"))
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+    assert result == "Tool call denied: unsafe input"
+
+
+@pytest.mark.asyncio
+async def test_guardrail_deny_preserves_reason() -> None:
+    """DENY without a reason falls back to 'policy violation'."""
+    tool = MyTool()
+    tool.add_guardrail(_DenyGuardrail())
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+    assert result == "Tool call denied: denied by test guardrail"
+
+
+@pytest.mark.asyncio
+async def test_guardrail_modify_passes_modified_args() -> None:
+    """When the guardrail returns MODIFY, the tool receives the modified arguments."""
+    tool = MyTool()
+    tool.add_guardrail(_ModifyGuardrail({"query": "modified input"}))
+    result = await tool.run_json({"query": "original"}, CancellationToken())
+    assert result.result == "value"
+
+
+@pytest.mark.asyncio
+async def test_guardrail_chain_order() -> None:
+    """Guardrails evaluate in order; first DENY short-circuits."""
+    tool = MyTool()
+    counter = _CountingGuardrail()
+    tool.add_guardrail(_DenyGuardrail("stop here"))
+    tool.add_guardrail(counter)  # Should never be reached
+
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+    assert result == "Tool call denied: stop here"
+    assert counter.call_count == 0  # never called
+
+
+@pytest.mark.asyncio
+async def test_guardrail_chain_all_allow() -> None:
+    """When all guardrails return ALLOW, the tool executes."""
+    tool = MyTool()
+    counter = _CountingGuardrail()
+    tool.add_guardrail(_CountingGuardrail())
+    tool.add_guardrail(counter)
+
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+    assert result.result == "value"
+    assert counter.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_guardrail_modify_chains() -> None:
+    """MODIFY passes modified args to the next guardrail in the chain."""
+    tool = MyTool()
+    second = _CountingGuardrail()
+    tool.add_guardrail(_ModifyGuardrail({"query": "first pass"}))
+    tool.add_guardrail(second)
+
+    await tool.run_json({"query": "original"}, CancellationToken())
+    # The second guardrail receives the modified args
+    assert second.last_args == {"query": "first pass"}
+
+
+@pytest.mark.asyncio
+async def test_guardrail_receives_tool_name() -> None:
+    """Guardrail receives the correct tool name."""
+    tool = MyTool()
+    counter = _CountingGuardrail()
+    tool.add_guardrail(counter)
+
+    await tool.run_json({"query": "test"}, CancellationToken())
+    assert counter.last_tool_name == "TestTool"
+
+
+@pytest.mark.asyncio
+async def test_guardrail_receives_original_args() -> None:
+    """Guardrail receives the arguments as passed (not yet modified by earlier guardrails in the chain)."""
+    tool = MyTool()
+    counter = _CountingGuardrail()
+    tool.add_guardrail(_ModifyGuardrail({"query": "modified"}))
+    tool.add_guardrail(counter)
+
+    await tool.run_json({"query": "original"}, CancellationToken())
+    # First guardrail modified to "modified", but second guardrail receives
+    # what was passed to it by the first guardrail (the MODIFY result)
+    assert counter.last_args == {"query": "modified"}
+
+
+@pytest.mark.asyncio
+async def test_guardrail_multiple_tools_independent() -> None:
+    """Each tool instance has its own guardrail chain."""
+    tool_a = MyTool()
+    tool_b = MyTool()
+    counter_a = _CountingGuardrail()
+    counter_b = _CountingGuardrail()
+    tool_a.add_guardrail(counter_a)
+    tool_b.add_guardrail(counter_b)
+
+    await tool_a.run_json({"query": "a"}, CancellationToken())
+    await tool_b.run_json({"query": "b"}, CancellationToken())
+    await tool_b.run_json({"query": "c"}, CancellationToken())
+
+    assert counter_a.call_count == 1
+    assert counter_b.call_count == 2
+
+
+def test_guardrail_via_init() -> None:
+    """GuardrailProvider can be passed at construction time via BaseTool.__init__."""
+    async def typed_query(query: str) -> str:
+        return query
+
+    tool = FunctionTool(
+        typed_query,
+        description="Example",
+        guardrail_providers=(_AllowGuardrail(), _CountingGuardrail()),
+    )
+    assert len(tool._guardrail_providers) == 2
+
+
+@pytest.mark.asyncio
+async def test_guardrail_empty_chain_no_overhead() -> None:
+    """A tool with no guardrails executes without any guardrail overhead."""
+    tool = MyTool()
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+    assert result.result == "value"
+
+
+@pytest.mark.asyncio
+async def test_guardrail_deny_preserves_tool_error_behavior() -> None:
+    """Guardrail DENY returns a string, not an exception — callers handle it as a tool error."""
+    tool = MyTool()
+    tool.add_guardrail(_DenyGuardrail("custom reason"))
+
+    result = await tool.run_json({"query": "test"}, CancellationToken())
+    assert isinstance(result, str)
+    assert "custom reason" in result
+
+
+@pytest.mark.asyncio
+async def test_guardrail_guardrail_provider_subclass() -> None:
+    """GuardrailProvider is a runtime-checkable Protocol."""
+
+    class SubclassGuardrail:
+        async def evaluate(
+            self,
+            *,
+            tool_name: str,
+            args: Mapping[str, Any],
+            agent_name: str | None = None,
+            call_id: str | None = None,
+            cancellation_token: Any = None,
+        ) -> GuardrailResult:
+            return GuardrailResult(decision=Decision.ALLOW)
+
+    tool = MyTool()
+    tool.add_guardrail(SubclassGuardrail())
+    result = tool._guardrail_providers[0]
+    assert isinstance(result, SubclassGuardrail)


### PR DESCRIPTION
## Summary

Implements the `GuardrailProvider` protocol proposed in issue #7405, enabling
applications to inspect, modify, or block tool calls before they execute.

## Changes

### New file: `autogen_core/tools/_guardrail.py`

- **`Decision`** — enum with `ALLOW`, `DENY`, `MODIFY`
- **`GuardrailResult`** — dataclass carrying:
  - `decision: Decision`
  - `reason: str | None` — description of the guardrail decision
  - `modified_args: Mapping[str, Any] | None` — args to pass forward (MODIFY only)
  - `metadata: dict[str, Any]` — additional context for callers
- **`GuardrailProvider`** — `runtime_checkable` Protocol with:
  ```python
  async def evaluate(
      *,
      tool_name: str,
      args: Mapping[str, Any],
      agent_name: str | None = None,
      call_id: str | None = None,
      cancellation_token: Any = None,
  ) -> GuardrailResult
  ```

### Modified: `autogen_core/tools/_base.py`

- `BaseTool.__init__` accepts optional `guardrail_providers: Sequence[GuardrailProvider]`
- `BaseTool.add_guardrail(provider)` — append to the per-instance chain
- `BaseTool.run_json()` evaluates the guardrail chain before executing the tool:
  - `ALLOW` → pass args to the tool
  - `DENY` → return `"Tool call denied: {reason}"` immediately
  - `MODIFY` → pass `modified_args` to the tool; chain continues to next guardrail
- `BaseStreamTool.run_json_stream()` — same guardrail logic before streaming begins

### Modified: `autogen_core/tools/_function_tool.py`

- `FunctionTool.__init__` accepts and forwards `guardrail_providers` to `BaseTool`

## Usage example

```python
from autogen_core.tools import FunctionTool, GuardrailResult, Decision

class SQLInjectionGuardrail:
    async def evaluate(
        *, tool_name: str, args: Mapping[str, Any], **kwargs
    ) -> GuardrailResult:
        if "DROP" in args.get("query", "").upper():
            return GuardrailResult(Decision.DENY, reason="SQL injection detected")
        return GuardrailResult(Decision.ALLOW)

tool = FunctionTool(run_sql, description="Run a SQL query")
tool.add_guardrail(SQLInjectionGuardrail())
```

## Tests

14 new tests in `test_tools.py` covering: allow, deny, modify, chained
evaluation, short-circuit on first DENY, independent per-instance chains,
init-time provider injection, empty-chain overhead, and runtime Protocol
verification.

## Closes #7405
