### PR TITLE
fix(core): use running loop for FunctionTool executors

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
@@ -115,8 +115,9 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
             else:
                 result = await self._func(**kwargs)
         else:
+            loop = asyncio.get_running_loop()
             if self._has_cancellation_support:
-                result = await asyncio.get_event_loop().run_in_executor(
+                result = await loop.run_in_executor(
                     None,
                     functools.partial(
                         self._func,
@@ -125,7 +126,7 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
                     ),
                 )
             else:
-                future = asyncio.get_event_loop().run_in_executor(None, functools.partial(self._func, **kwargs))
+                future = loop.run_in_executor(None, functools.partial(self._func, **kwargs))
                 cancellation_token.link_future(future)
                 result = await future
 


### PR DESCRIPTION
Problem: `FunctionTool.run()` is already executing inside an async method, but the sync-function path asks the event loop policy via `asyncio.get_event_loop()` before dispatching work to the executor.

Before / after: before, both executor calls used `asyncio.get_event_loop().run_in_executor(...)`. After, the method captures the active running loop once with `asyncio.get_running_loop()` and reuses it for both executor paths, while preserving cancellation-token linking and the existing executor behavior.

Verification:
- `python -m py_compile python\packages\autogen-core\src\autogen_core\tools\_function_tool.py`