### PR TITLE
Support CRLF fenced JSON extraction

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/utils/_load_json.py
+++ b/python/packages/autogen-core/src/autogen_core/utils/_load_json.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 def extract_json_from_str(content: str) -> List[Dict[str, Any]]:
     """Extract JSON objects from a string. Supports backtick enclosed JSON objects"""
-    pattern = re.compile(r"```(?:\s*([\w\+\-]+))?\n([\s\S]*?)```")
+    pattern = re.compile(r"```(?:\s*([\w\+\-]+))?\r?\n([\s\S]*?)```")
     matches = pattern.findall(content)
     ret: List[Dict[str, Any]] = []
     # If no matches found, assume the entire content is a JSON object

--- a/python/packages/autogen-core/tests/test_json_extraction.py
+++ b/python/packages/autogen-core/tests/test_json_extraction.py
@@ -1,4 +1,5 @@
 import pytest
+
 from autogen_core.utils import extract_json_from_str
 
 
@@ -71,6 +72,10 @@ def test_extract_json_from_str_codeblock() -> None:
     assert no_lang_resp == code_block_resp
     multi_resp = extract_json_from_str(multi_json_str)
     assert multi_resp == multi_json_resp
+
+    crlf_code_block_str = '```json\r\n{"name": "Alice", "age": 28, "city": "Seattle"}\r\n```'
+    crlf_resp = extract_json_from_str(crlf_code_block_str)
+    assert crlf_resp == code_block_resp
 
     invalid_lang_code_block_str = """
   ```notjson


### PR DESCRIPTION
## What changed

This allows `extract_json_from_str()` to parse fenced JSON code blocks that use CRLF line endings after the opening fence.

## Why

The extractor already supports markdown-style fenced JSON blocks, but the regex only accepted `\n` immediately after the opening fence. A valid block such as ```json\r\n...``` was not matched, so the function fell back to parsing the entire markdown string as JSON and failed.

## Validation

- `.\.venv\Scripts\python -m pytest python/packages/autogen-core/tests/test_json_extraction.py -q`
- `python -m ruff check python/packages/autogen-core/src/autogen_core/utils/_load_json.py python/packages/autogen-core/tests/test_json_extraction.py`
- `git diff --check`