### PR TITLE
Fix nested $defs resolution in JSON schema conversion

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/utils/_json_to_pydantic.py
+++ b/python/packages/autogen-core/src/autogen_core/utils/_json_to_pydantic.py
@@ -104,11 +104,12 @@ def _make_field(
 
 class _JSONSchemaToPydantic:
     def __init__(self) -> None:
-        self._model_cache: Dict[str, Optional[Union[Type[BaseModel], ForwardRef]]] = {}
+        self._definition_schemas: Dict[str, Dict[str, Any]] = {}
+        self._model_cache: Dict[str, Optional[Any]] = {}
 
     def _resolve_ref(self, ref: str, schema: Dict[str, Any]) -> Dict[str, Any]:
         ref_key = ref.split("/")[-1]
-        definitions = cast(dict[str, dict[str, Any]], schema.get("$defs", {}))
+        definitions = {**cast(dict[str, dict[str, Any]], schema.get("$defs", {})), **self._definition_schemas}
 
         if ref_key not in definitions:
             raise ReferenceNotFoundError(
@@ -139,15 +140,42 @@ class _JSONSchemaToPydantic:
         # Use field name as-is with hash suffix
         return f"{array_field_name}_{hash_suffix}"
 
-    def _process_definitions(self, root_schema: Dict[str, Any]) -> None:
-        if "$defs" in root_schema:
-            for model_name in root_schema["$defs"]:
-                if model_name not in self._model_cache:
-                    self._model_cache[model_name] = None
+    def _collect_definitions(self, schema: Any) -> None:
+        if isinstance(schema, dict):
+            definitions = schema.get("$defs", {})
+            if isinstance(definitions, dict):
+                for model_name, model_schema in definitions.items():
+                    if isinstance(model_schema, dict):
+                        self._definition_schemas.setdefault(model_name, model_schema)
 
-            for model_name, model_schema in root_schema["$defs"].items():
-                if self._model_cache[model_name] is None:
-                    self._model_cache[model_name] = self.json_schema_to_pydantic(model_schema, model_name, root_schema)
+            for value in schema.values():
+                self._collect_definitions(value)
+        elif isinstance(schema, list):
+            for value in schema:
+                self._collect_definitions(value)
+
+    def _definition_to_type(self, model_name: str, model_schema: Dict[str, Any], root_schema: Dict[str, Any]) -> Any:
+        if "$ref" in model_schema:
+            return self.get_ref(model_schema["$ref"].split("/")[-1])
+        if "anyOf" in model_schema:
+            return Union[tuple(self._resolve_union_types(model_schema["anyOf"]))]
+        if "oneOf" in model_schema:
+            return Union[tuple(self._resolve_union_types(model_schema["oneOf"]))]
+        if "enum" in model_schema:
+            return Literal[tuple(model_schema["enum"])] if len(model_schema["enum"]) > 0 else Any
+        if "allOf" in model_schema or (model_schema.get("type") == "object" and "properties" in model_schema):
+            return self.json_schema_to_pydantic(model_schema, model_name, root_schema)
+        return self._extract_field_type(model_name, model_schema, model_name, root_schema)
+
+    def _process_definitions(self, root_schema: Dict[str, Any]) -> None:
+        self._collect_definitions(root_schema)
+        for model_name in self._definition_schemas:
+            if model_name not in self._model_cache:
+                self._model_cache[model_name] = None
+
+        for model_name, model_schema in self._definition_schemas.items():
+            if self._model_cache[model_name] is None:
+                self._model_cache[model_name] = self._definition_to_type(model_name, model_schema, root_schema)
 
     def json_schema_to_pydantic(
         self, schema: Dict[str, Any], model_name: str = "GeneratedModel", root_schema: Optional[Dict[str, Any]] = None

--- a/python/packages/autogen-core/tests/test_json_to_pydantic.py
+++ b/python/packages/autogen-core/tests/test_json_to_pydantic.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Literal, Optional, Type, get_args, get_origi
 from uuid import UUID, uuid4
 
 import pytest
+from pydantic import BaseModel, EmailStr, Field, Json, ValidationError
+
 from autogen_core.utils._json_to_pydantic import (
     FORMAT_MAPPING,
     TYPE_MAPPING,
@@ -11,7 +13,6 @@ from autogen_core.utils._json_to_pydantic import (
     UnsupportedKeywordError,
     _JSONSchemaToPydantic,  # pyright: ignore[reportPrivateUsage]
 )
-from pydantic import BaseModel, EmailStr, Field, Json, ValidationError
 
 
 # ✅ Define Pydantic models for testing
@@ -368,9 +369,9 @@ def test_valid_data_model_nested(
     instance = Model(**valid_data)
     assert instance
     for field, value in valid_data.items():
-        assert (
-            getattr(instance, field) == value
-        ), f"Mismatch in field `{field}`: expected `{value}`, got `{getattr(instance, field)}`"
+        assert getattr(instance, field) == value, (
+            f"Mismatch in field `{field}`: expected `{value}`, got `{getattr(instance, field)}`"
+        )
 
 
 # ✅ **Invalid Data Tests**
@@ -419,6 +420,39 @@ def test_reference_not_found(converter: _JSONSchemaToPydantic) -> None:
     schema = {"type": "object", "properties": {"manager": {"$ref": "#/$defs/MissingRef"}}}
     with pytest.raises(ReferenceNotFoundError):
         converter.json_schema_to_pydantic(schema, "MissingRefModel")
+
+
+def test_nested_defs_reference_is_resolved(converter: _JSONSchemaToPydantic) -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "windows_params": {
+                "type": "object",
+                "$defs": {
+                    "WindowsSortOption": {
+                        "description": "Sort options for Windows search.",
+                        "enum": [1, 2, 3],
+                        "type": "integer",
+                    }
+                },
+                "properties": {
+                    "sort_by": {
+                        "$ref": "#/$defs/WindowsSortOption",
+                        "default": 1,
+                        "description": "Sort order for results.",
+                    }
+                },
+            }
+        },
+    }
+
+    Model = converter.json_schema_to_pydantic(schema, "SearchToolInput")
+
+    instance = Model(windows_params={"sort_by": 2})
+    assert instance.windows_params.sort_by == 2  # type: ignore[attr-defined]
+
+    with pytest.raises(ValidationError):
+        Model(windows_params={"sort_by": 4})
 
 
 def test_format_not_supported(converter: _JSONSchemaToPydantic) -> None:


### PR DESCRIPTION
## Summary
- collect `$defs` recursively before resolving JSON Schema references
- allow referenced primitive/enum definitions to become field types instead of empty generated models
- add a regression test for nested MCP-style `$defs` used by tool input schemas

## Motivation
`mcp_server_tools` can fail when an MCP tool input schema contains a nested `$defs` block and a property references it, for example `#/$defs/WindowsSortOption`. The converter only registered root-level `$defs`, so the reference was missing from the cache even though the definition existed inside the nested object schema.

Fixes #7129.
Refs #6663.

## Validation
- `python -m ruff check python/packages/autogen-core/src/autogen_core/utils/_json_to_pydantic.py python/packages/autogen-core/tests/test_json_to_pydantic.py`
- `python -m ruff format --check python/packages/autogen-core/src/autogen_core/utils/_json_to_pydantic.py python/packages/autogen-core/tests/test_json_to_pydantic.py`
- `PYTHONPATH=D:\code\autogen-pr-7129\python\packages\autogen-core\src python -m pytest packages/autogen-core/tests/test_json_to_pydantic.py -q`

AI assistance disclosure: I used AI assistance to help prepare this patch and reviewed the final diff.