### PR TITLE
fix(core): include tool call id in structured logs

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/logging.py
+++ b/python/packages/autogen-core/src/autogen_core/logging.py
@@ -164,6 +164,7 @@ class ToolCallEvent:
         tool_name: str,
         arguments: Dict[str, Any],
         result: str,
+        call_id: str | None = None,
     ) -> None:
         """Used by subclasses of :class:`~autogen_core.tools.BaseTool` to log executions of tools.
 
@@ -171,6 +172,7 @@ class ToolCallEvent:
             tool_name (str): The name of the tool.
             arguments (Dict[str, Any]): The arguments of the tool. Must be json serializable.
             result (str): The result of the tool. Must be a string.
+            call_id (str | None): An optional identifier for the tool call.
 
         Example:
 
@@ -180,7 +182,7 @@ class ToolCallEvent:
                 from autogen_core.logging import ToolCallEvent
 
                 logger = logging.getLogger(EVENT_LOGGER_NAME)
-                logger.info(ToolCallEvent(tool_name="Tool1", call_id="123", arguments={"arg1": "value1"}))
+                logger.info(ToolCallEvent(tool_name="Tool1", call_id="123", arguments={"arg1": "value1"}, result="done"))
 
         """
         self.kwargs: Dict[str, Any] = {}
@@ -188,6 +190,8 @@ class ToolCallEvent:
         self.kwargs["tool_name"] = tool_name
         self.kwargs["arguments"] = arguments
         self.kwargs["result"] = result
+        if call_id is not None:
+            self.kwargs["call_id"] = call_id
         try:
             agent_id = MessageHandlerContext.agent_id()
         except RuntimeError:

--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -202,6 +202,7 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
             tool_name=self.name,
             arguments=dict(args),  # Using the raw args passed to run_json
             result=self.return_value_as_string(return_value),
+            call_id=call_id,
         )
         logger.info(event)
 
@@ -263,6 +264,7 @@ class BaseStreamTool(
             tool_name=self.name,
             arguments=dict(args),  # Using the raw args passed to run_json
             result=self.return_value_as_string(return_value),
+            call_id=call_id,
         )
         logger.info(event)
 

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -1,10 +1,12 @@
 import inspect
+import json
+import logging
 from dataclasses import dataclass
 from functools import partial
 from typing import Annotated, List
 
 import pytest
-from autogen_core import CancellationToken
+from autogen_core import EVENT_LOGGER_NAME, CancellationToken
 from autogen_core._function_utils import get_typed_signature
 from autogen_core.tools import BaseTool, FunctionTool
 from autogen_core.tools._base import ToolSchema
@@ -397,6 +399,46 @@ async def test_func_call_tool() -> None:
     tool = FunctionTool(my_function, description="Function tool.")
     result = await tool.run_json({}, CancellationToken())
     assert result == "result"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_event_includes_call_id() -> None:
+    def my_function() -> str:
+        return "result"
+
+    class CapturingHandler(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.records: list[logging.LogRecord] = []
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.records.append(record)
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    handler = CapturingHandler()
+    logger = logging.getLogger(EVENT_LOGGER_NAME)
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    try:
+        await tool.run_json({}, CancellationToken(), call_id="payment-intent-123")
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+    logged_events = [json.loads(record.getMessage()) for record in handler.records if record.name == EVENT_LOGGER_NAME]
+    tool_call_events = [event for event in logged_events if event.get("type") == "ToolCall"]
+    assert tool_call_events == [
+        {
+            "type": "ToolCall",
+            "tool_name": "my_function",
+            "arguments": {},
+            "result": "result",
+            "agent_id": None,
+            "call_id": "payment-intent-123",
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why are these changes needed?

Payment-capable and other money-moving tools need a stable audit key in both traces and structured logs. `BaseTool.run_json()` and `BaseStreamTool.run_json_stream()` already accept `call_id` and attach it to the OpenTelemetry tool span, but the structured `ToolCallEvent` omitted the same identifier.

This makes downstream audit processors correlate a tool execution from structured logs with the original tool call, payment intent, retry, or settlement record without scraping trace-only data.

This PR keeps the change narrow and additive:
- adds optional `call_id` to `ToolCallEvent`
- forwards the existing tool `call_id` into structured tool-call logs
- preserves current log output when `call_id` is not supplied
- adds a regression test for the emitted `ToolCall` event

## Related issue number

Related to #7492

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
  - No docs page change needed; this aligns structured logs with an existing `call_id` argument and fixes the existing `ToolCallEvent` example.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
  - Local focused checks passed; GitHub checks pending after draft PR creation.

## Verification

RED:
- `uv run pytest packages/autogen-core/tests/test_tools.py::test_tool_call_event_includes_call_id -q`
  - Failed before the fix because the emitted `ToolCall` event did not include `call_id`.

GREEN:
- `uv run pytest packages/autogen-core/tests/test_tools.py::test_tool_call_event_includes_call_id -q`
- `uv run pytest packages/autogen-core/tests/test_tools.py -q`
- `uv run ruff check packages/autogen-core/src/autogen_core/logging.py packages/autogen-core/src/autogen_core/tools/_base.py packages/autogen-core/tests/test_tools.py`
- `uv run pyright packages/autogen-core/src/autogen_core/logging.py packages/autogen-core/src/autogen_core/tools/_base.py packages/autogen-core/tests/test_tools.py`
- `uv run mypy packages/autogen-core/src/autogen_core/logging.py packages/autogen-core/src/autogen_core/tools/_base.py packages/autogen-core/tests/test_tools.py --config-file pyproject.toml`

Second-agent review:
- Preferred reviewer: `claude -p` attempted, but local Claude auth returned 401.
- Fallback reviewer: `hermes chat -Q` on `/tmp/oss-pr-second-agent-review.diff`.
- Result: CLEAN after fixing the first blocking finding about using `LogRecord.getMessage()` in the regression test.

Created with: Hermes Agent
