### PR TITLE
fix: guard against None chunks in OpenAI streaming client

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -906,6 +906,11 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         # Process the stream of chunks.
         async for chunk in chunks:
+            # Guard against None chunks which can be yielded by some endpoints.
+            # https://github.com/microsoft/autogen/issues/7130
+            if chunk is None:
+                continue
+
             if first_chunk:
                 first_chunk = False
                 # Emit the start event.
@@ -946,7 +951,6 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             # for liteLLM chunk usage, do the following hack keeping the pervious chunk.stop_reason (if set).
             # set the stop_reason for the usage chunk to the prior stop_reason
             stop_reason = choice.finish_reason if chunk.usage is None and stop_reason is None else stop_reason
-            maybe_model = chunk.model
 
             reasoning_content: str | None = None
             if choice.delta.model_extra is not None and "reasoning_content" in choice.delta.model_extra:

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -424,6 +424,72 @@ async def test_openai_chat_completion_client_create_stream_cancel(monkeypatch: p
 
 
 @pytest.mark.asyncio
+async def test_openai_chat_completion_client_create_stream_none_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression test for https://github.com/microsoft/autogen/issues/7130.
+
+    Ensures that None chunks yielded by some streaming endpoints do not cause
+    an AttributeError when the loop accesses chunk.model before a None guard.
+    """
+
+    async def _mock_create_stream_with_none_chunks(
+        *args: Any, **kwargs: Any
+    ) -> AsyncGenerator[ChatCompletionChunk | None, None]:  # type: ignore[misc]
+        model = resolve_model(kwargs.get("model", "gpt-4.1-nano"))
+        # Yield a None sentinel chunk first (simulates certain streaming endpoints).
+        yield None  # type: ignore[misc]
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[
+                ChunkChoice(
+                    finish_reason=None,
+                    index=0,
+                    delta=ChoiceDelta(content="Hello", role="assistant"),
+                )
+            ],
+            created=0,
+            model=model,
+            object="chat.completion.chunk",
+            usage=None,
+        )
+        # Yield another None between real chunks.
+        yield None  # type: ignore[misc]
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[
+                ChunkChoice(
+                    finish_reason="stop",
+                    index=0,
+                    delta=ChoiceDelta(content=None, role="assistant"),
+                )
+            ],
+            created=0,
+            model=model,
+            object="chat.completion.chunk",
+            usage=None,
+        )
+
+    async def _mock_create_with_none_chunks(
+        *args: Any, **kwargs: Any
+    ) -> ChatCompletion | AsyncGenerator[ChatCompletionChunk | None, None]:  # type: ignore[misc]
+        if kwargs.get("stream", False):
+            return _mock_create_stream_with_none_chunks(*args, **kwargs)
+        return await _mock_create(*args, **kwargs)
+
+    monkeypatch.setattr(AsyncCompletions, "create", _mock_create_with_none_chunks)
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="api_key")
+    chunks: List[str | CreateResult] = []
+    # Should not raise AttributeError when None chunks are in the stream.
+    async for chunk in client.create_stream(
+        messages=[UserMessage(content="Hello", source="user")],
+    ):
+        chunks.append(chunk)
+
+    assert chunks[0] == "Hello"
+    assert isinstance(chunks[-1], CreateResult)
+    assert chunks[-1].content == "Hello"
+
+
+@pytest.mark.asyncio
 async def test_openai_chat_completion_client_count_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
     client = OpenAIChatCompletionClient(model="gpt-4o", api_key="api_key")
     messages: List[LLMMessage] = [


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'NoneType' object has no attribute 'model'` that occurs when the OpenAI streaming response yields a `None` chunk.

- Adds a `None` guard at the top of the streaming loop (before any attribute access) so `None` chunks are silently skipped.
- Removes a redundant duplicate `maybe_model = chunk.model` assignment that appeared later in the same loop body (the assignment already happens earlier in the loop).

## Root Cause

In `_openai_client.py`, `chunk.model` was accessed before checking if `chunk` is `None`. When the API yields a `None` sentinel chunk (observed in compiled binaries and under heavy endpoint load), this caused an unhandled `AttributeError` that crashed the streaming session:

```python
# Line 908: Iterate over stream chunks
async for chunk in chunks:
    if first_chunk:
        ...
    # Line 919: chunk.model accessed with NO None guard — crashes if chunk is None
    maybe_model = chunk.model

    # Line 923: Empty chunk check comes AFTER — too late
    if len(chunk.choices) == 0:
        ...
```

The type annotation on line 893 (`chunk: ChatCompletionChunk | None = None`) already documents that `chunk` can be `None`, but the guard was missing.

## Fix

```python
async for chunk in chunks:
    # Guard against None chunks which can be yielded by some endpoints.
    # https://github.com/microsoft/autogen/issues/7130
    if chunk is None:
        continue
    ...
    # Set the model from the latest chunk (only runs after None guard)
    maybe_model = chunk.model
```

## Testing

- Added `test_openai_chat_completion_client_create_stream_none_chunk` in `test_openai_model_client.py` which injects `None` chunks at both the start and in the middle of the stream and verifies the stream completes successfully without raising `AttributeError`.
- All existing streaming tests continue to pass.

Fixes #7130