### PR TITLE
fix: log local executor security warning

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -30,6 +30,14 @@ from .._common import (
 
 __all__ = ("LocalCommandLineCodeExecutor",)
 
+logger = logging.getLogger(__name__)
+
+LOCAL_COMMAND_LINE_CODE_EXECUTOR_WARNING = (
+    "Using LocalCommandLineCodeExecutor may execute code on the local machine which can be unsafe. "
+    "For security, it is recommended to use DockerCommandLineCodeExecutor instead. "
+    "To install Docker, visit: https://docs.docker.com/get-docker/"
+)
+
 A = ParamSpec("A")
 
 
@@ -160,13 +168,8 @@ $functions"""
         virtual_env_context: Optional[SimpleNamespace] = None,
     ):
         # Issue warning about using LocalCommandLineCodeExecutor
-        warnings.warn(
-            "Using LocalCommandLineCodeExecutor may execute code on the local machine which can be unsafe. "
-            "For security, it is recommended to use DockerCommandLineCodeExecutor instead. "
-            "To install Docker, visit: https://docs.docker.com/get-docker/",
-            UserWarning,
-            stacklevel=2,
-        )
+        logger.warning(LOCAL_COMMAND_LINE_CODE_EXECUTOR_WARNING)
+        warnings.warn(LOCAL_COMMAND_LINE_CODE_EXECUTOR_WARNING, UserWarning, stacklevel=2)
 
         if timeout < 1:
             raise ValueError("Timeout must be greater than or equal to 1.")

--- a/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py
@@ -2,6 +2,7 @@
 # Credit to original authors
 
 import asyncio
+import logging
 import os
 import platform
 import shutil
@@ -10,6 +11,7 @@ import sys
 import tempfile
 import types
 import venv
+import warnings
 from pathlib import Path
 from typing import AsyncGenerator, TypeAlias
 from unittest.mock import patch
@@ -210,6 +212,20 @@ async def test_local_commandline_code_executor_restart() -> None:
     executor = LocalCommandLineCodeExecutor()
     with pytest.warns(UserWarning, match=r".*No action is taken."):
         await executor.restart()
+
+
+def test_local_commandline_code_executor_security_warning_is_logged_when_warnings_are_suppressed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with caplog.at_level(logging.WARNING, logger="autogen_ext.code_executors.local"):
+            LocalCommandLineCodeExecutor()
+
+    assert any(
+        "Using LocalCommandLineCodeExecutor may execute code on the local machine" in record.message
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a `logger.warning(...)` signal for `LocalCommandLineCodeExecutor`'s existing local-execution security notice.
- Keep the existing `UserWarning` behavior and message intact.
- Add a regression test proving the security notice still reaches logs when Python warnings are globally suppressed.

## Why

Fixes #7462 in a narrow, maintenance-friendly way. This does not add a new sandbox mode or change execution behavior. It closes the visibility gap where applications suppress Python warnings (`warnings.simplefilter("ignore")`, `-W ignore`, or similar) and then miss the warning that this executor can run generated code directly on the host.

Prior related attempts (#7467, #7598, #7611) are closed. #7611 grew into an opt-in sandbox feature and was closed as too large for AutoGen's maintenance-mode posture. This PR keeps only the small logging hardening that fits the existing warning design.

Overlap check: no open PR currently covers `LocalCommandLineCodeExecutor` sandbox/warning hardening for #7462. The daily-lane metadata also listed #7555, but that PR is an unrelated Plasmate fetch tool and is not superseded by this change.

## Tests

- RED: `uv run pytest packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py::test_local_commandline_code_executor_security_warning_is_logged_when_warnings_are_suppressed -q` failed before the source change because no log record was emitted.
- GREEN: `uv run pytest packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py::test_local_commandline_code_executor_security_warning_is_logged_when_warnings_are_suppressed -q` passed after the source change.
- `uv run pytest packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py -q` → 12 passed, 3 skipped.
- `uv run pytest packages/autogen-agentchat/tests/test_code_executor_agent.py -q` → 26 passed.
- `uv run ruff check packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py` → passed.
- `uv run ruff format --check packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py` → 2 files already formatted.
- `PYRIGHT_PYTHON_FORCE_VERSION=latest uv run pyright packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py packages/autogen-ext/tests/code_executors/test_commandline_code_executor.py` → 0 errors, 0 warnings.

## Second-agent review

Reviewer: `claude -p`

Result: CLEAN. Non-blocking note: `logger.warning` fires on every instantiation while `warnings.warn` is warning-filter/dedup aware. That noisier behavior is intentional here because the security notice should remain visible in logging pipelines even when warnings are suppressed.
