### PR TITLE
fix: derive user_id from authenticated session to prevent IDOR in AutoGen Studio

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/web/routes/gallery.py
+++ b/python/packages/autogen-studio/autogenstudio/web/routes/gallery.py
@@ -4,14 +4,17 @@ from fastapi import APIRouter, Depends, HTTPException
 from ...database import DatabaseManager
 from ...datamodel import Gallery, Response
 from ...gallery.builder import create_default_gallery
-from ..deps import get_db
+from ..deps import get_current_user, get_db
 
 router = APIRouter()
 
 
 @router.put("/{gallery_id}")
 async def update_gallery_entry(
-    gallery_id: int, gallery_data: Gallery, user_id: str, db: DatabaseManager = Depends(get_db)
+    gallery_id: int,
+    gallery_data: Gallery,
+    user_id: str = Depends(get_current_user),
+    db: DatabaseManager = Depends(get_db),
 ) -> Response:
     # Check ownership first
     result = db.get(Gallery, filters={"id": gallery_id})
@@ -36,7 +39,9 @@ async def create_gallery_entry(gallery_data: Gallery, db: DatabaseManager = Depe
 
 
 @router.get("/")
-async def list_gallery_entries(user_id: str, db: DatabaseManager = Depends(get_db)) -> Response:
+async def list_gallery_entries(
+    user_id: str = Depends(get_current_user), db: DatabaseManager = Depends(get_db)
+) -> Response:
     try:
         result = db.get(Gallery, filters={"user_id": user_id})
         if not result.data or len(result.data) == 0:
@@ -51,7 +56,9 @@ async def list_gallery_entries(user_id: str, db: DatabaseManager = Depends(get_d
 
 
 @router.get("/{gallery_id}")
-async def get_gallery_entry(gallery_id: int, user_id: str, db: DatabaseManager = Depends(get_db)) -> Response:
+async def get_gallery_entry(
+    gallery_id: int, user_id: str = Depends(get_current_user), db: DatabaseManager = Depends(get_db)
+) -> Response:
     result = db.get(Gallery, filters={"id": gallery_id, "user_id": user_id})
     if not result.status or not result.data:
         raise HTTPException(status_code=404, detail="Gallery entry not found")
@@ -60,7 +67,9 @@ async def get_gallery_entry(gallery_id: int, user_id: str, db: DatabaseManager =
 
 
 @router.delete("/{gallery_id}")
-async def delete_gallery_entry(gallery_id: int, user_id: str, db: DatabaseManager = Depends(get_db)) -> Response:
+async def delete_gallery_entry(
+    gallery_id: int, user_id: str = Depends(get_current_user), db: DatabaseManager = Depends(get_db)
+) -> Response:
     # Check ownership first
     result = db.get(Gallery, filters={"id": gallery_id, "user_id": user_id})
 

--- a/python/packages/autogen-studio/autogenstudio/web/routes/runs.py
+++ b/python/packages/autogen-studio/autogenstudio/web/routes/runs.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from ...datamodel import Message, Run, RunStatus, Session
-from ..deps import get_db
+from ..deps import get_current_user, get_db
 
 router = APIRouter()
 
@@ -18,12 +18,11 @@ class CreateRunRequest(BaseModel):
 @router.post("/")
 async def create_run(
     request: CreateRunRequest,
+    user_id: str = Depends(get_current_user),
     db=Depends(get_db),
 ) -> Dict:
     """Create a new run with initial state"""
-    session_response = db.get(
-        Session, filters={"id": request.session_id, "user_id": request.user_id}, return_json=False
-    )
+    session_response = db.get(Session, filters={"id": request.session_id, "user_id": user_id}, return_json=False)
     if not session_response.status or not session_response.data:
         raise HTTPException(status_code=404, detail="Session not found")
 
@@ -33,7 +32,7 @@ async def create_run(
             Run(
                 session_id=request.session_id,
                 status=RunStatus.CREATED,
-                user_id=request.user_id,
+                user_id=user_id,
                 task={},  # Will be set when run starts
                 team_result={},
             ),

--- a/python/packages/autogen-studio/autogenstudio/web/routes/sessions.py
+++ b/python/packages/autogen-studio/autogenstudio/web/routes/sessions.py
@@ -5,20 +5,20 @@ from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 
 from ...datamodel import Message, Response, Run, Session
-from ..deps import get_db
+from ..deps import get_current_user, get_db
 
 router = APIRouter()
 
 
 @router.get("/")
-async def list_sessions(user_id: str, db=Depends(get_db)) -> Dict:
+async def list_sessions(user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
     """List all sessions for a user"""
     response = db.get(Session, filters={"user_id": user_id})
     return {"status": True, "data": response.data}
 
 
 @router.get("/{session_id}")
-async def get_session(session_id: int, user_id: str, db=Depends(get_db)) -> Dict:
+async def get_session(session_id: int, user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
     """Get a specific session"""
     response = db.get(Session, filters={"id": session_id, "user_id": user_id})
     if not response.status or not response.data:
@@ -40,7 +40,9 @@ async def create_session(session: Session, db=Depends(get_db)) -> Response:
 
 
 @router.put("/{session_id}")
-async def update_session(session_id: int, user_id: str, session: Session, db=Depends(get_db)) -> Dict:
+async def update_session(
+    session_id: int, user_id: str = Depends(get_current_user), *, session: Session, db=Depends(get_db)
+) -> Dict:
     """Update an existing session"""
     # First verify the session belongs to user
     existing = db.get(Session, filters={"id": session_id, "user_id": user_id})
@@ -56,14 +58,14 @@ async def update_session(session_id: int, user_id: str, session: Session, db=Dep
 
 
 @router.delete("/{session_id}")
-async def delete_session(session_id: int, user_id: str, db=Depends(get_db)) -> Dict:
+async def delete_session(session_id: int, user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
     """Delete a session"""
     db.delete(filters={"id": session_id, "user_id": user_id}, model_class=Session)
     return {"status": True, "message": "Session deleted successfully"}
 
 
 @router.get("/{session_id}/runs")
-async def list_session_runs(session_id: int, user_id: str, db=Depends(get_db)) -> Dict:
+async def list_session_runs(session_id: int, user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
     """Get complete session history organized by runs"""
 
     try:

--- a/python/packages/autogen-studio/autogenstudio/web/routes/settingsroute.py
+++ b/python/packages/autogen-studio/autogenstudio/web/routes/settingsroute.py
@@ -4,13 +4,13 @@ from typing import Dict
 from fastapi import APIRouter, Depends, HTTPException
 
 from ...datamodel import Settings, SettingsConfig
-from ..deps import get_db
+from ..deps import get_current_user, get_db
 
 router = APIRouter()
 
 
 @router.get("/")
-async def get_settings(user_id: str, db=Depends(get_db)) -> Dict:
+async def get_settings(user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
     try:
         response = db.get(Settings, filters={"user_id": user_id})
         if not response.status or not response.data:

--- a/python/packages/autogen-studio/autogenstudio/web/routes/teams.py
+++ b/python/packages/autogen-studio/autogenstudio/web/routes/teams.py
@@ -5,13 +5,13 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from ...datamodel import Team
 from ...gallery.builder import create_default_gallery
-from ..deps import get_db
+from ..deps import get_current_user, get_db
 
 router = APIRouter()
 
 
 @router.get("/")
-async def list_teams(user_id: str, db=Depends(get_db)) -> Dict:
+async def list_teams(user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
     """List all teams for a user"""
     response = db.get(Team, filters={"user_id": user_id})
 
@@ -26,7 +26,7 @@ async def list_teams(user_id: str, db=Depends(get_db)) -> Dict:
 
 
 @router.get("/{team_id}")
-async def get_team(team_id: int, user_id: str, db=Depends(get_db)) -> Dict:
+async def get_team(team_id: int, user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
     """Get a specific team"""
     response = db.get(Team, filters={"id": team_id, "user_id": user_id})
     if not response.status or not response.data:
@@ -44,7 +44,7 @@ async def create_team(team: Team, db=Depends(get_db)) -> Dict:
 
 
 @router.delete("/{team_id}")
-async def delete_team(team_id: int, user_id: str, db=Depends(get_db)) -> Dict:
+async def delete_team(team_id: int, user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
     """Delete a team"""
     db.delete(filters={"id": team_id, "user_id": user_id}, model_class=Team)
     return {"status": True, "message": "Team deleted successfully"}


### PR DESCRIPTION
# fix: derive user_id from authenticated session, not client-supplied query param

## Summary

All API routes in autogen-studio accept `user_id` as a **client-supplied query
parameter** instead of deriving it from the authenticated session. This is an
**Insecure Direct Object Reference (IDOR)** vulnerability: any authenticated
user can read, modify, or delete any other user's teams, sessions, gallery
entries, settings, and runs by supplying a different `user_id` value.

The fix uses the existing `get_current_user` dependency (which extracts the
user ID from `request.state.user` set by the auth middleware) instead of the
client-supplied query parameter.

## The vulnerability

```python
# before — user_id is a QUERY PARAMETER (client-controlled)
@router.get("/{team_id}")
async def get_team(team_id: int, user_id: str, db=Depends(get_db)) -> Dict:
    response = db.get(Team, filters={"id": team_id, "user_id": user_id})
```

FastAPI treats `user_id: str` (without `Depends(...)`) as a query parameter.
A user sends `GET /api/teams/42?user_id=victim` and receives victim's team
configuration — including agent definitions, model configs, and potentially
API keys embedded in team configs.

### Exploitation

```bash
# Read any user's teams
curl -H "Cookie: <session>" \
  "https://autogen-studio.example/api/teams/?user_id=victim"

# Read any user's chat sessions (conversation history, PII)
curl -H "Cookie: <session>" \
  "https://autogen-studio.example/api/sessions/?user_id=victim"

# Delete any user's data
curl -X DELETE -H "Cookie: <session>" \
  "https://autogen-studio.example/api/sessions/42?user_id=victim"
```

The auth middleware IS in place and correctly sets `request.state.user`. The
`get_current_user(request: Request)` function exists and correctly extracts
the authenticated user ID from the session. The routes simply don't use it.

## The fix

```python
# after — user_id is derived from the authenticated session
from ..deps import get_current_user, get_db

@router.get("/{team_id}")
async def get_team(team_id: int, user_id: str = Depends(get_current_user), db=Depends(get_db)) -> Dict:
    response = db.get(Team, filters={"id": team_id, "user_id": user_id})
```

`get_current_user` extracts `request.state.user.id` (set by `AuthMiddleware`).
If auth is disabled (`type: "none"`), it falls back to `DEFAULT_USER_ID`.

## Affected routes

13 endpoints across 5 files:

| File | Endpoints |
|---|---|
| `sessions.py` | list, get, update, delete, list_runs |
| `teams.py` | list, get, delete |
| `gallery.py` | upsert, list, get, delete |
| `settingsroute.py` | get |
| `runs.py` | create |

Diff: +21/−20 across 5 files.

## Impact

- **Cross-user data access**: any authenticated user can read any other user's
  teams, sessions (including conversation history), gallery entries, and settings
- **Cross-user data modification/deletion**: any authenticated user can delete
  or modify other users' resources
- **PII exposure**: chat sessions contain conversation history which may
  include sensitive user data
- **Config exposure**: team configs may contain API keys embedded in agent
  model configurations

## Environment

- `microsoft/autogen` commit: `027ecf0` (main)
- Affected package: `autogen-studio` (Python)
