### PR TITLE
fix(agentchat): retry MagenticOne ledger parsing when next_speaker is missing

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_magentic_one/_magentic_one_orchestrator.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_magentic_one/_magentic_one_orchestrator.py
@@ -365,9 +365,13 @@ class MagenticOneOrchestrator(BaseGroupChatManager):
                         key_error = True
                         break
 
-                # Validate the next speaker if the task is not yet complete
+                # Validate the next speaker if the task is not yet complete.
+                # Skip this check if a required key is already missing or malformed,
+                # otherwise accessing ``progress_ledger["next_speaker"]`` below would
+                # raise an unhandled ``KeyError`` instead of triggering a retry.
                 if (
-                    not progress_ledger["is_request_satisfied"]["answer"]
+                    not key_error
+                    and not progress_ledger["is_request_satisfied"]["answer"]
                     and progress_ledger["next_speaker"]["answer"] not in self._participant_names
                 ):
                     key_error = True

--- a/python/packages/autogen-agentchat/tests/test_magentic_one_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_magentic_one_group_chat.py
@@ -219,3 +219,52 @@ async def test_magentic_one_group_chat_with_stalls(runtime: AgentRuntime | None)
     assert isinstance(result.messages[4], TextMessage)
     assert result.messages[4].content.startswith("\nWe are working to address the following user request:")
     assert result.stop_reason is not None and result.stop_reason == "test"
+
+
+@pytest.mark.asyncio
+async def test_magentic_one_group_chat_ledger_missing_next_speaker_retries(runtime: AgentRuntime | None) -> None:
+    # Regression test: when the model returns a valid progress-ledger JSON object
+    # that is missing the ``next_speaker`` field, the orchestrator should treat it
+    # as a parse failure and retry (up to ``_max_json_retries``), rather than
+    # raising an unhandled ``KeyError`` when the post-loop validation accesses
+    # ``progress_ledger["next_speaker"]``.
+    agent_1 = _EchoAgent("agent_1", description="echo agent 1")
+    agent_2 = _EchoAgent("agent_2", description="echo agent 2")
+    agent_3 = _EchoAgent("agent_3", description="echo agent 3")
+    agent_4 = _EchoAgent("agent_4", description="echo agent 4")
+
+    model_client = ReplayChatCompletionClient(
+        chat_completions=[
+            "No facts",
+            "No plan",
+            # First ledger attempt: valid JSON but missing "next_speaker".
+            # This must trigger a retry instead of crashing with KeyError.
+            json.dumps(
+                {
+                    "is_request_satisfied": {"answer": False, "reason": "test"},
+                    "is_progress_being_made": {"answer": True, "reason": "test"},
+                    "is_in_loop": {"answer": False, "reason": "test"},
+                    "instruction_or_question": {"answer": "Continue task", "reason": "test"},
+                }
+            ),
+            # Second ledger attempt: complete and well-formed, task is satisfied.
+            json.dumps(
+                {
+                    "is_request_satisfied": {"answer": True, "reason": "Because"},
+                    "is_progress_being_made": {"answer": True, "reason": "test"},
+                    "is_in_loop": {"answer": False, "reason": "test"},
+                    "instruction_or_question": {"answer": "Task completed", "reason": "Because"},
+                    "next_speaker": {"answer": "agent_1", "reason": "test"},
+                }
+            ),
+            "print('Hello, world!')",
+        ],
+    )
+
+    team = MagenticOneGroupChat(
+        participants=[agent_1, agent_2, agent_3, agent_4], model_client=model_client, runtime=runtime
+    )
+    # Before the fix this raised KeyError: 'next_speaker'. After the fix the
+    # missing field is treated as a parse failure and the retry succeeds.
+    result = await team.run(task="Write a program that prints 'Hello, world!'")
+    assert result.stop_reason is not None and result.stop_reason == "Because"


### PR DESCRIPTION
## Why are these changes needed?

In `MagenticOneOrchestrator._orchestrate_step`, when the model returns a valid progress-ledger JSON object that is **missing the `next_speaker` field** (or the field is malformed), the `for key in required_keys` loop correctly sets `key_error = True` and `break`s — intending to trigger a retry.

However, the `next_speaker` validation that runs **after** that loop unconditionally accesses `progress_ledger["next_speaker"]["answer"]`:

```python
# Validate the next speaker if the task is not yet complete
if (
    not progress_ledger["is_request_satisfied"]["answer"]
    and progress_ledger["next_speaker"]["answer"] not in self._participant_names  # <- KeyError
):
    key_error = True
    break
```

When `next_speaker` is the missing key, this raises `KeyError`, which is **not** caught by the surrounding `except (json.JSONDecodeError, TypeError)`. The exception propagates and crashes the orchestrator instead of retrying up to `_max_json_retries` (10) as designed.

This is a real-world failure mode: some models occasionally omit a field from the progress-ledger JSON. The existing retries exist precisely to tolerate this, but the unhandled `KeyError` bypasses them.

### Fix

Add a `not key_error` guard so the `next_speaker` validation is skipped when a required key is already missing/malformed, letting the retry path run as designed:

```python
if (
    not key_error
    and not progress_ledger["is_request_satisfied"]["answer"]
    and progress_ledger["next_speaker"]["answer"] not in self._participant_names
):
    key_error = True
    break
```

## Related issue number

N/A — no existing issue covers this code path. (Related issues #6599 / #6547 describe a *different* root cause — markdown-wrapped JSON — which was already fixed via `extract_json_from_str`.) Happy to open a tracking issue if the maintainers prefer.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. _(No doc changes needed — internal fix.)_
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. _(Added `test_magentic_one_group_chat_ledger_missing_next_speaker_retries`, which feeds a ledger missing `next_speaker` and asserts the team run completes via retry instead of raising `KeyError`. This test fails on `main` with `KeyError: 'next_speaker'` and passes with the fix.)_
- [x] I've made sure all auto checks have passed. _(Local verification below.)_

### Local verification

```sh
cd python
uv run pytest packages/autogen-agentchat/tests/test_magentic_one_group_chat.py -q   # 8 passed
uv run ruff format --check packages/autogen-agentchat/src packages/autogen-agentchat/tests   # already formatted
uv run ruff check packages/autogen-agentchat/src packages/autogen-agentchat/tests   # all checks passed
uv run pyright packages/autogen-agentchat/src packages/autogen-agentchat/tests      # 0 errors
uv run mypy --config-file pyproject.toml packages/autogen-agentchat/src packages/autogen-agentchat/tests   # no issues
```