### PR TITLE
fix(agentchat): remove dead typo attribute in CodeExecutorAgent

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -482,7 +482,6 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
         else:
             self._model_context = UnboundedChatCompletionContext()
 
-        self._system_messaages: List[SystemMessage] = []
         if system_message is None:
             self._system_messages = []
         else:


### PR DESCRIPTION
## Why are these changes needed?

`CodeExecutorAgent.__init__` assigns a misspelled attribute `self._system_messaages` (note the extra `a` in **messaages**) that is never read anywhere in the codebase:

```python
self._system_messaages: List[SystemMessage] = []   # <- typo, never read
if system_message is None:
    self._system_messages = []                      # <- this is the one actually used
else:
    self._system_messages = [SystemMessage(content=system_message)]
```

The agent consistently uses the correctly-spelled `self._system_messages` (assigned on the very next lines, read at lines 525, 756, 757). A `grep -rn "_system_messaages"` across the whole repo confirms the misspelled form appears only on this single line — it is dead state created on every instantiation.

This removes the dead attribute. No behavior change.

## Related issue number

N/A — trivial dead-code cleanup.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. _(None — internal cleanup.)_
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. _(No new test — the change is a pure deletion of unreferenced state with no observable behavior. Existing `CodeExecutorAgent` tests still pass.)_
- [x] I've made sure all auto checks have passed. _(Local verification below.)_

### Local verification

```sh
cd python
uv run pytest packages/autogen-agentchat/tests/test_code_executor_agent.py -q   # 26 passed
uv run ruff format --check packages/autogen-agentchat/src packages/autogen-agentchat/tests   # already formatted
uv run ruff check packages/autogen-agentchat/src packages/autogen-agentchat/tests   # all checks passed
uv run pyright packages/autogen-agentchat/src packages/autogen-agentchat/tests      # 0 errors
uv run mypy --config-file pyproject.toml packages/autogen-agentchat/src packages/autogen-agentchat/tests   # no issues
```