### PR TITLE
fix(agentchat): MessageFilterAgent count=0 returns no messages instead of all

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
@@ -1,7 +1,7 @@
 from typing import AsyncGenerator, List, Literal, Optional, Sequence, Union
 
 from autogen_core import CancellationToken, Component, ComponentModel
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from autogen_agentchat.agents import BaseChatAgent
 from autogen_agentchat.base import Response
@@ -13,9 +13,22 @@ from autogen_agentchat.messages import BaseAgentEvent, BaseChatMessage
 
 
 class PerSourceFilter(BaseModel):
+    """Filter configuration for a single message source.
+
+    Args:
+        source (str): The source name to match against ``BaseChatMessage.source``.
+        position (Optional[Literal["first", "last"]]): When set, keep only the
+            ``first`` or ``last`` N messages from this source. When ``None``,
+            all messages from this source are kept (no slicing).
+        count (Optional[int]): The number of messages to keep when ``position``
+            is set. ``0`` means *no* messages; ``None`` means *do not slice*
+            (all messages from this source are kept, regardless of ``position``).
+            Must be ``>= 0``.
+    """
+
     source: str
     position: Optional[Literal["first", "last"]] = None
-    count: Optional[int] = None
+    count: Optional[int] = Field(default=None, ge=0)
 
 
 class MessageFilterConfig(BaseModel):
@@ -157,9 +170,10 @@ class MessageFilterAgent(BaseChatAgent, Component[MessageFilterAgentConfig]):
         for source_filter in self._filter.per_source:
             msgs = [m for m in messages if m.source == source_filter.source]
 
-            if source_filter.count is not None and source_filter.count <= 0:
-                # count == 0 means "no messages" (and negative values are not meaningful).
-                # Note: msgs[-0:] would return the whole list, so handle this explicitly.
+            if source_filter.count == 0:
+                # count == 0 means "no messages". Negative values are rejected at
+                # construction (PerSourceFilter.count has ge=0). Handle 0 explicitly
+                # because msgs[-0:] would otherwise return the whole list.
                 msgs = []
             elif source_filter.position == "first" and source_filter.count is not None:
                 msgs = msgs[: source_filter.count]

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
@@ -157,9 +157,13 @@ class MessageFilterAgent(BaseChatAgent, Component[MessageFilterAgentConfig]):
         for source_filter in self._filter.per_source:
             msgs = [m for m in messages if m.source == source_filter.source]
 
-            if source_filter.position == "first" and source_filter.count:
+            if source_filter.count is not None and source_filter.count <= 0:
+                # count == 0 means "no messages" (and negative values are not meaningful).
+                # Note: msgs[-0:] would return the whole list, so handle this explicitly.
+                msgs = []
+            elif source_filter.position == "first" and source_filter.count is not None:
                 msgs = msgs[: source_filter.count]
-            elif source_filter.position == "last" and source_filter.count:
+            elif source_filter.position == "last" and source_filter.count is not None:
                 msgs = msgs[-source_filter.count :]
 
             result.extend(msgs)

--- a/python/packages/autogen-agentchat/tests/test_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_message_filter_agent.py
@@ -1,0 +1,73 @@
+from typing import Sequence
+
+from autogen_agentchat.agents import BaseChatAgent, MessageFilterAgent
+from autogen_agentchat.agents._message_filter_agent import MessageFilterConfig, PerSourceFilter
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import BaseChatMessage, TextMessage
+from autogen_core import CancellationToken
+
+
+class _DummyAgent(BaseChatAgent):
+    """Minimal agent used only to satisfy MessageFilterAgent's wrapped_agent requirement."""
+
+    def __init__(self, name: str = "dummy") -> None:
+        super().__init__(name=name, description="dummy")
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        return Response(chat_message=TextMessage(content="ok", source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass
+
+
+def _make_messages(source: str, n: int) -> list[TextMessage]:
+    return [TextMessage(content=f"msg-{i}", source=source) for i in range(n)]
+
+
+def _apply(
+    per_source: Sequence[PerSourceFilter],
+    messages: Sequence[BaseChatMessage],
+) -> list[BaseChatMessage]:
+    agent = MessageFilterAgent(
+        name="filter",
+        wrapped_agent=_DummyAgent(),
+        filter=MessageFilterConfig(per_source=list(per_source)),
+    )
+    return list(agent._apply_filter(messages))  # pyright: ignore[reportPrivateUsage]
+
+
+def test_count_zero_returns_no_messages_first() -> None:
+    # Regression test: count=0 with position="first" must return zero messages,
+    # not all messages from that source. Previously the truthiness check
+    # (`and source_filter.count`) treated 0 the same as None and skipped slicing.
+    messages = _make_messages("user", 3)
+    result = _apply([PerSourceFilter(source="user", position="first", count=0)], messages)
+    assert result == []
+
+
+def test_count_zero_returns_no_messages_last() -> None:
+    messages = _make_messages("user", 3)
+    result = _apply([PerSourceFilter(source="user", position="last", count=0)], messages)
+    assert result == []
+
+
+def test_count_none_keeps_all_messages() -> None:
+    # count=None (default) means "do not slice" — all messages from that source
+    # are kept. This must remain unchanged by the fix.
+    messages = _make_messages("user", 3)
+    result = _apply([PerSourceFilter(source="user", position="first", count=None)], messages)
+    assert len(result) == 3
+
+
+def test_count_positive_first_and_last() -> None:
+    # Sanity check that normal positive counts still behave as before.
+    messages = _make_messages("user", 5)
+    first_two = _apply([PerSourceFilter(source="user", position="first", count=2)], messages)
+    assert [m.to_text() for m in first_two] == ["msg-0", "msg-1"]
+
+    last_two = _apply([PerSourceFilter(source="user", position="last", count=2)], messages)
+    assert [m.to_text() for m in last_two] == ["msg-3", "msg-4"]

--- a/python/packages/autogen-agentchat/tests/test_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_message_filter_agent.py
@@ -1,10 +1,12 @@
 from typing import Sequence
 
+import pytest
 from autogen_agentchat.agents import BaseChatAgent, MessageFilterAgent
 from autogen_agentchat.agents._message_filter_agent import MessageFilterConfig, PerSourceFilter
 from autogen_agentchat.base import Response
 from autogen_agentchat.messages import BaseChatMessage, TextMessage
 from autogen_core import CancellationToken
+from pydantic import ValidationError
 
 
 class _DummyAgent(BaseChatAgent):
@@ -71,3 +73,11 @@ def test_count_positive_first_and_last() -> None:
 
     last_two = _apply([PerSourceFilter(source="user", position="last", count=2)], messages)
     assert [m.to_text() for m in last_two] == ["msg-3", "msg-4"]
+
+
+def test_count_negative_rejected_at_construction() -> None:
+    # Negative counts are not meaningful and must be rejected at construction
+    # (PerSourceFilter.count is constrained to ge=0), failing fast at the system
+    # boundary rather than being silently coerced inside _apply_filter.
+    with pytest.raises(ValidationError):
+        PerSourceFilter(source="user", position="first", count=-1)


### PR DESCRIPTION
## Why are these changes needed?

In `MessageFilterAgent._apply_filter`, the per-source slice guards used a **truthiness check** on `count`:

```python
if source_filter.position == "first" and source_filter.count:   # <- 0 is falsy
    msgs = msgs[: source_filter.count]
elif source_filter.position == "last" and source_filter.count:  # <- 0 is falsy
    msgs = msgs[-source_filter.count :]
```

Since `0` is falsy, `count=0` **skipped slicing entirely and returned all messages** from that source — the opposite of the intended behavior.

The class docstring states:

> If position is `None`, all messages from that source are included.

So the intended way to keep *all* messages is `position=None`; a `count=0` with `position="first"/"last"` should mean *zero* messages. (`PerSourceFilter.count` is `Optional[int]`, so `0` is a valid, explicit user input.)

There is a second, subtler issue: even after switching to `is not None`, the `last` branch would still return all messages for `count=0`, because `msgs[-0:]` is equivalent to `msgs[0:]` (the whole list) in Python.

### Fix

Handle `count <= 0` explicitly by returning an empty list, and switch the remaining guards from truthiness to `is not None`:

```python
if source_filter.count is not None and source_filter.count <= 0:
    # count == 0 means "no messages" (and negative values are not meaningful).
    # Note: msgs[-0:] would return the whole list, so handle this explicitly.
    msgs = []
elif source_filter.position == "first" and source_filter.count is not None:
    msgs = msgs[: source_filter.count]
elif source_filter.position == "last" and source_filter.count is not None:
    msgs = msgs[-source_filter.count :]
```

Behavior summary:
| `count` | `position` | before | after |
|--------|-----------|--------|-------|
| `0` | `first` / `last` | all messages | **no messages** |
| `None` | any | unchanged (all messages) | unchanged (all messages) |
| `>0` | `first` / `last` | unchanged | unchanged |

## Related issue number

N/A — no existing issue. Edge-case correctness fix; happy to open a tracking issue if maintainers prefer.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. _(None — internal logic fix.)_
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. _(New `tests/test_message_filter_agent.py` covering `count=0` for both `first`/`last`, `count=None` preserving all messages, and positive-count sanity. The `count=0` last-position case fails on `main` and passes with the fix.)_
- [x] I've made sure all auto checks have passed. _(Local verification below.)_

### Local verification

```sh
cd python
uv run pytest packages/autogen-agentchat/tests/test_message_filter_agent.py -q                  # 4 passed
uv run pytest packages/autogen-agentchat/tests/test_group_chat_graph.py -q                       # 76 passed (no regressions)
uv run ruff format --check packages/autogen-agentchat/src packages/autogen-agentchat/tests       # already formatted
uv run ruff check packages/autogen-agentchat/src packages/autogen-agentchat/tests                # all checks passed
uv run pyright packages/autogen-agentchat/src packages/autogen-agentchat/tests                   # 0 errors
uv run mypy --config-file pyproject.toml packages/autogen-agentchat/src packages/autogen-agentchat/tests  # no issues
```