### PR TITLE
fix(agentchat): persist GraphFlow triggered_activation_groups across save/load_state

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_graph/_digraph_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_graph/_digraph_group_chat.py
@@ -517,6 +517,9 @@ class GraphFlowManager(BaseGroupChatManager):
             "remaining": {target: dict(counter) for target, counter in self._remaining.items()},
             "enqueued_any": dict(self._enqueued_any),
             "ready": list(self._ready),
+            "triggered_activation_groups": {
+                target: list(groups) for target, groups in self._triggered_activation_groups.items()
+            },
         }
         return state
 
@@ -527,6 +530,9 @@ class GraphFlowManager(BaseGroupChatManager):
         self._remaining = {target: Counter(groups) for target, groups in state["remaining"].items()}
         self._enqueued_any = state["enqueued_any"]
         self._ready = deque(state["ready"])
+        self._triggered_activation_groups = {
+            target: set(groups) for target, groups in state["triggered_activation_groups"].items()
+        }
 
     async def reset(self) -> None:
         """Reset execution state to the start of the graph."""

--- a/python/packages/autogen-agentchat/tests/test_group_chat_graph.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat_graph.py
@@ -1766,3 +1766,66 @@ async def test_digraph_group_chat_resume_with_termination_condition(runtime: Age
     assert agent_a.total_messages == 1  # Still only ran once
     assert agent_b.total_messages == 1  # Still only ran once
     assert agent_c.total_messages == 1  # Now ran once
+
+
+@pytest.mark.asyncio
+async def test_graph_flow_cyclic_pause_resume_reaches_exit() -> None:
+    # Regression test for https://github.com/microsoft/autogen/issues/7043
+    #
+    # In a cyclic graph (B can loop back to A), pausing mid-traversal and then
+    # resuming via save_state/load_state used to terminate immediately with
+    # "Digraph execution is complete", never reaching the exit node.
+    #
+    # Root cause: GraphFlowManager.save_state/load_state did not persist
+    # _triggered_activation_groups, which tracks how a re-entry node (A) was
+    # queued. On resume, _reset_triggered_activation_groups became a no-op for
+    # the re-entry target, so its _remaining count was never restored and got
+    # decremented below zero on the next loop iteration, silently draining the
+    # ready queue.
+    graph = DiGraph(
+        nodes={
+            "A": DiGraphNode(name="A", edges=[DiGraphEdge(target="B")]),
+            "B": DiGraphNode(
+                name="B",
+                edges=[
+                    DiGraphEdge(target="C", condition="exit"),
+                    DiGraphEdge(target="A", condition="loop"),
+                ],
+            ),
+            "C": DiGraphNode(name="C", edges=[]),
+        },
+        default_start_node="A",
+    )
+
+    def build_team(max_messages: int) -> GraphFlow:
+        # Fresh agent instances per team — resume must work across independent
+        # processes/objects, just like a real save-to-disk and reload flow.
+        a = AssistantAgent("A", model_client=ReplayChatCompletionClient(["a"] * 10))
+        b = AssistantAgent("B", model_client=ReplayChatCompletionClient(["loop", "exit"]))
+        c = AssistantAgent("C", model_client=ReplayChatCompletionClient(["c"]))
+        return GraphFlow(
+            participants=[a, b, c],
+            graph=graph,
+            runtime=None,
+            termination_condition=MaxMessageTermination(max_messages),
+        )
+
+    # Phase 1: run one loop iteration (user, A, B="loop"), then stop at 3 messages
+    # before A's re-entry is consumed.
+    team = build_team(max_messages=3)
+    result = await team.run(task="Start")
+    assert [m.source for m in result.messages] == ["user", "A", "B"]
+
+    state = await team.save_state()
+
+    # Phase 2: load into a fresh team (fresh agent instances) and resume. Before
+    # the fix this stopped immediately ("Digraph execution is complete") after
+    # just [A, B] and never reached C. After the fix the loop continues and the
+    # exit node C runs: ['A', 'B', 'A', 'B', 'C'].
+    new_team = build_team(max_messages=10)
+    await new_team.load_state(state)
+    resume_result = await new_team.run()
+    resume_sources = [m.source for m in resume_result.messages]
+
+    assert "C" in resume_sources, f"Loop did not reach the exit node; got {resume_sources}"
+    assert len(resume_sources) >= 3, f"Loop terminated prematurely; got {resume_sources}"


### PR DESCRIPTION
Closes #7043.

## Why are these changes needed?

`GraphFlow` workflows become unrecoverable when paused mid-traversal in a **cyclic graph** (e.g. `A → B` with `B` looping back to `A`). After `save_state` → `load_state` into a fresh team, the resume terminates immediately with `"Digraph execution is complete"` and never reaches the exit node.

### Root cause

`GraphFlowManager.save_state` / `load_state` (`_digraph_group_chat.py`, lines 512-529) persisted `message_thread`, `current_turn`, `remaining`, `enqueued_any`, and `ready` — but **not `_triggered_activation_groups`**.

`_triggered_activation_groups` (a `Dict[str, Set[str]]`) records which activation group caused a node to be enqueued. `_reset_triggered_activation_groups` (line 438) uses it during `select_speaker` (line 466) to restore a re-entry node's `_remaining` count to its original value, so the node can be re-triggered on the next loop iteration.

On resume, `_triggered_activation_groups` is `{}` (only initialized in `__init__`), so `_reset_triggered_activation_groups` becomes a no-op for the re-entry target. Its `_remaining` stays at 0 (the value saved mid-traversal) and gets decremented to **-1** on the next loop iteration → the node is never re-enqueued → `_ready` drains → `_apply_termination_condition` sees `not self._ready` and emits *"Digraph execution is complete"* (lines 488-501).

### Failure trace (cyclic A→B, B loops to A)

1. Phase 1: run `A → B="loop"`. `update_message_thread` decrements `_remaining["A"]["A"]` to 0, enqueues A, records `_triggered_activation_groups["A"]={"A"}`.
2. `MaxMessageTermination(3)` fires **before** `select_speaker` runs, so `_reset_triggered_activation_groups("A")` is never called. In-memory state: `_triggered={"A":{"A"}}`, `_remaining["A"]["A"]=0`, `_ready=["A"]`.
3. `save_state` writes `_remaining["A"]["A"]=0` and `_ready=["A"]` but drops `_triggered_activation_groups`.
4. `load_state` into a fresh team: `_triggered={}`, `_remaining["A"]["A"]=0`, `_ready=["A"]`.
5. Resume: `select_speaker` pops A, calls `_reset_triggered("A")` → **no-op** (A not in the empty dict) → `_remaining["A"]["A"]` stays 0 → next loop iteration decrements it to -1 → A never re-enqueued → premature *"Digraph execution is complete"*.

### Fix

Persist `_triggered_activation_groups` in `save_state` (serializing each `Set` as a `list`) and restore it in `load_state` (rebuilding the `set`s):

```python
# save_state
"triggered_activation_groups": {
    target: list(groups) for target, groups in self._triggered_activation_groups.items()
},
# load_state
self._triggered_activation_groups = {
    target: set(groups) for target, groups in state["triggered_activation_groups"].items()
}
```

Fields derived purely from graph structure (`_activation`, `_origin_remaining`, `_edges`, `_parents`) are already reconstructed by `__init__` on the new manager and need no persistence — verified they are never mutated at runtime.

### Scope

Only **cyclic / looping** graphs are affected. Linear graphs are unaffected because the reset mechanism only matters for re-entry nodes. The existing `test_graph_flow_stateful_pause_and_resume_with_termination` (linear A→B) already passed and continues to pass.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. _(None — internal state-serialization fix.)_
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. _(New `test_graph_flow_cyclic_pause_resume_reaches_exit`: runs one loop iteration → `save_state` → `load_state` into a fresh team with fresh agent instances → asserts the exit node C is reached. Verified the test **fails on the unfixed code** — sources `[A, B]` with stop_reason `\"Digraph execution is complete\"` — and **passes with the fix** — sources `[A, B, A, B, C]`.)_
- [x] I've made sure all auto checks have passed. _(Local verification below.)_

### Local verification

```sh
cd python
uv run pytest packages/autogen-agentchat/tests/test_group_chat_graph.py -q   # 77 passed (was 76)
uv run ruff format --check packages/autogen-agentchat/src packages/autogen-agentchat/tests   # already formatted
uv run ruff check packages/autogen-agentchat/src packages/autogen-agentchat/tests            # all checks passed
uv run pyright packages/autogen-agentchat/src packages/autogen-agentchat/tests               # 0 errors
uv run mypy --config-file pyproject.toml packages/autogen-agentchat/src packages/autogen-agentchat/tests  # no issues
```