### PR TITLE
fix(core): serialize structured tool results as JSON

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -2,6 +2,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from dataclasses import asdict, is_dataclass
 from typing import (
     Any,
     AsyncGenerator,
@@ -170,6 +171,15 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
             if isinstance(dumped, dict):
                 return json.dumps(dumped)
             return str(dumped)
+
+        if is_dataclass(value) and not isinstance(value, type):
+            value = asdict(value)
+
+        if isinstance(value, (dict, list)):
+            try:
+                return json.dumps(value)
+            except (TypeError, ValueError):
+                return str(value)
 
         return str(value)
 

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -1,15 +1,17 @@
 import inspect
+import json
 from dataclasses import dataclass
 from functools import partial
 from typing import Annotated, List
 
 import pytest
+from pydantic import BaseModel, Field, ValidationError, model_serializer
+from pydantic_core import PydanticUndefined
+
 from autogen_core import CancellationToken
 from autogen_core._function_utils import get_typed_signature
 from autogen_core.tools import BaseTool, FunctionTool
 from autogen_core.tools._base import ToolSchema
-from pydantic import BaseModel, Field, ValidationError, model_serializer
-from pydantic_core import PydanticUndefined
 
 
 class MyArgs(BaseModel):
@@ -478,6 +480,59 @@ async def test_func_tool_return_list() -> None:
     assert isinstance(result, list)
     assert result == [1, 2]
     assert tool.return_value_as_string(result) == "[1, 2]"
+
+
+@pytest.mark.asyncio
+async def test_func_tool_return_dict_serializes_to_json() -> None:
+    def my_function() -> dict[str, object]:
+        return {"status": "success", "items": ["alpha", "beta"], "count": 2}
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    assert isinstance(result, dict)
+    assert json.loads(tool.return_value_as_string(result)) == {
+        "status": "success",
+        "items": ["alpha", "beta"],
+        "count": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_func_tool_return_nested_list_serializes_to_json() -> None:
+    def my_function() -> list[dict[str, int]]:
+        return [{"count": 1}, {"count": 2}]
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    assert isinstance(result, list)
+    assert json.loads(tool.return_value_as_string(result)) == [{"count": 1}, {"count": 2}]
+
+
+@pytest.mark.asyncio
+async def test_func_tool_return_dataclass_serializes_to_json() -> None:
+    @dataclass
+    class ToolPayload:
+        status: str
+        count: int
+
+    def my_function() -> ToolPayload:
+        return ToolPayload(status="success", count=2)
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    assert isinstance(result, ToolPayload)
+    assert json.loads(tool.return_value_as_string(result)) == {"status": "success", "count": 2}
+
+
+@pytest.mark.asyncio
+async def test_func_tool_return_non_json_serializable_value_falls_back_to_str() -> None:
+    def my_function() -> dict[str, object]:
+        return {"ids": {1, 2}}
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    assert isinstance(result, dict)
+    assert tool.return_value_as_string(result) == str(result)
 
 
 def test_nested_tool_schema_generation() -> None:


### PR DESCRIPTION
## Summary
- serialize `dict` and `list` tool return values as JSON instead of Python repr strings
- serialize dataclass tool return values via `asdict()` before JSON encoding
- preserve the existing `str(value)` fallback for non-JSON-serializable values
- add regression coverage for dict, nested list, dataclass, and fallback behavior

Fixes #7867
Related: #7873

## Why this shape
#7873 handles the immediate dict/list case, but this PR also covers dataclass return values and explicitly tests the fallback path for values that cannot be JSON encoded. Scalar/string behavior and the existing BaseModel behavior are unchanged.

## Testing
- `/tmp/autogen-pr-test-venv/bin/python -m pytest python/packages/autogen-core/tests/test_tools.py -q` (`42 passed`)
- `uvx ruff check python/packages/autogen-core/src/autogen_core/tools/_base.py python/packages/autogen-core/tests/test_tools.py`
- `uvx ruff format --check python/packages/autogen-core/src/autogen_core/tools/_base.py python/packages/autogen-core/tests/test_tools.py`

Note: I first tried the full workspace command `uv run --directory python/packages/autogen-core pytest tests/test_tools.py -q`, but local dependency downloads repeatedly retried and did not complete. The package-level isolated environment above verifies this change without pulling the full workspace dev stack.
