### PR TITLE
Use running loop for agentchat input callbacks

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_user_proxy_agent.py
@@ -193,7 +193,7 @@ class UserProxyAgent(BaseChatAgent, Component[UserProxyAgentConfig]):
             else:
                 # Cast to SyncInputFunc for proper typing
                 sync_func = cast(SyncInputFunc, self.input_func)
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(None, sync_func, prompt)
 
         except asyncio.CancelledError:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/ui/_console.py
@@ -62,7 +62,7 @@ class UserInputManager:
             else:
                 # Cast to SyncInputFunc for proper typing
                 sync_func = cast(SyncInputFunc, self.callback)
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(None, sync_func, prompt)
 
         return user_input_func_wrapper


### PR DESCRIPTION
## Problem
`UserProxyAgent` and `UserInputManager` run synchronous input callbacks from async functions via `run_in_executor`, but they currently obtain the loop with `asyncio.get_event_loop()`.

Inside a coroutine there is already a running loop, and `asyncio.get_running_loop()` is the clearer modern API. It also avoids relying on event-loop policy fallback behavior.

## Before
The sync callback paths called `asyncio.get_event_loop()` before `run_in_executor(...)`.

## After
Those async code paths now call `asyncio.get_running_loop()` before submitting the sync callback to the executor. Runtime behavior stays the same for normal use, but the code uses the explicit running loop instead of policy lookup.

## Verification
```bash
uv run --directory python/packages/autogen-agentchat python -m pytest tests/test_userproxy_agent.py
```

Result: 5 passed.