### PR TITLE
docs: fix duplicate words in documentation

### DIFF
--- a/docs/design/02 - Topics.md
+++ b/docs/design/02 - Topics.md
@@ -41,7 +41,7 @@ A subscription defines two things:
 - Matcher func of type `TopicId -> bool`, telling us "does this subscription match this topic"
 - Mapper func of type `TopicId -> AgentId`, telling us "given this subscription matches this topic, which agent does it map to"
 
-These functions MUST be be free of side effects such that the evaluation can be cached.
+These functions MUST be free of side effects such that the evaluation can be cached.
 
 ### Agent instance creation
 

--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -1033,7 +1033,7 @@ In `v0.2` group chat, when tools are involved, you need to register the tool fun
 and include the user proxy in the group chat. The tool calls made by other agents
 will be routed to the user proxy to execute.
 
-We have observed numerous issues with this approach, such as the the tool call
+We have observed numerous issues with this approach, such as the tool call
 routing not working as expected, and the tool call request and result cannot be
 accepted by models without support for function calling.
 

--- a/python/samples/agentchat_chess_game/README.md
+++ b/python/samples/agentchat_chess_game/README.md
@@ -24,7 +24,7 @@ To run this sample, you will need to install the following packages:
 pip install -U autogen-agentchat pyyaml
 ```
 
-Create a new file named `model_config.yaml` in the the same directory as the script
+Create a new file named `model_config.yaml` in the same directory as the script
 to configure the model you want to use.
 
 For example, to use `gpt-4o` model from OpenAI, you can use the following configuration:


### PR DESCRIPTION
## Why are these changes needed?

Fixes three duplicated words in documentation and sample setup instructions:

- `MUST be be` → `MUST be`
- `in the the same directory` → `in the same directory`
- `such as the the tool call` → `such as the tool call`

These are small documentation/readability fixes only; no code behavior changes.

## Related issue number

N/A

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. (Not relevant; documentation-only typo fixes.)
- [x] I've made sure all auto checks have passed. (`git diff --check`)
