### PR TITLE
fix: resolve AWS Bedrock / cross-region Anthropic model IDs in model-info lookup

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_model_info.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict
 
 from autogen_core.models import ModelFamily, ModelInfo
@@ -126,20 +127,48 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
 }
 
 # Model token limits (context window size)
+# Keep in sync with the keys of _MODEL_INFO above so that every known model has a limit.
 _MODEL_TOKEN_LIMITS: Dict[str, int] = {
+    "claude-opus-4-20250514": 200000,
+    "claude-opus-4-0": 200000,
+    "claude-sonnet-4-20250514": 200000,
+    "claude-sonnet-4-0": 200000,
+    "claude-3-7-sonnet-20250219": 200000,
+    "claude-3-7-sonnet-latest": 200000,
     "claude-3-opus-20240229": 200000,
     "claude-3-sonnet-20240229": 200000,
     "claude-3-haiku-20240307": 200000,
     "claude-3-5-sonnet-20240620": 200000,
-    "claude-3-7-sonnet-20250219": 200000,
     "claude-instant-1.2": 100000,
     "claude-2.0": 100000,
     "claude-2.1": 200000,
 }
 
 
+def _normalize_model(model: str) -> str:
+    """Normalize a model identifier so AWS Bedrock IDs map to first-party model names.
+
+    Bedrock exposes Anthropic models with a provider namespace and a version suffix,
+    optionally prefixed with a cross-region inference code, for example::
+
+        anthropic.claude-3-5-sonnet-20240620-v1:0
+        us.anthropic.claude-3-5-sonnet-20240620-v1:0
+
+    Stripping the ``[<region>.]anthropic.`` prefix and the trailing ``-vN:M`` version
+    suffix yields the first-party model name (``claude-3-5-sonnet-20240620``) used as the
+    key in the lookup tables above. First-party IDs have neither part and are unchanged.
+    """
+    # Strip the (optionally region-prefixed) Bedrock provider namespace.
+    if "anthropic." in model:
+        model = model.split("anthropic.", 1)[1]
+    # Strip the Bedrock version suffix, e.g. "-v1:0".
+    model = re.sub(r"-v\d+:\d+$", "", model)
+    return model
+
+
 def get_info(model: str) -> ModelInfo:
     """Get the model information for a specific model."""
+    model = _normalize_model(model)
     # Check for exact match first
     if model in _MODEL_INFO:
         return _MODEL_INFO[model]
@@ -154,6 +183,7 @@ def get_info(model: str) -> ModelInfo:
 
 def get_token_limit(model: str) -> int:
     """Get the token limit for a specific model."""
+    model = _normalize_model(model)
     # Check for exact match first
     if model in _MODEL_TOKEN_LIMITS:
         return _MODEL_TOKEN_LIMITS[model]

--- a/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
@@ -1254,3 +1254,47 @@ async def test_anthropic_thinking_mode_with_tools() -> None:
     # Should have thinking content even with tool calls
     assert result.thought is not None
     assert len(result.thought) > 10
+
+
+def test_bedrock_model_info_resolution() -> None:
+    """Bedrock / cross-region inference model IDs should resolve to first-party model info.
+
+    Regression test for https://github.com/microsoft/autogen/issues/7833 — previously these
+    IDs raised ``KeyError`` from ``get_info`` and silently fell back to the default token
+    limit in ``get_token_limit``.
+    """
+    from autogen_ext.models.anthropic import _model_info
+
+    bedrock_to_first_party = {
+        "anthropic.claude-3-5-sonnet-20240620-v1:0": "claude-3-5-sonnet-20240620",
+        "us.anthropic.claude-3-5-sonnet-20240620-v1:0": "claude-3-5-sonnet-20240620",
+        "eu.anthropic.claude-3-7-sonnet-20250219-v1:0": "claude-3-7-sonnet-20250219",
+        "apac.anthropic.claude-3-haiku-20240307-v1:0": "claude-3-haiku-20240307",
+        "us.anthropic.claude-opus-4-20250514-v1:0": "claude-opus-4-20250514",
+    }
+    for bedrock_id, first_party_id in bedrock_to_first_party.items():
+        # Must not raise KeyError and must resolve to the same info as the first-party ID.
+        assert _model_info.get_info(bedrock_id) == _model_info.get_info(first_party_id)
+        assert _model_info.get_info(bedrock_id)["function_calling"] is True
+        # Must return the real context window, not the 100000 default-fallback.
+        assert _model_info.get_token_limit(bedrock_id) == 200000
+
+
+def test_first_party_model_info_unchanged() -> None:
+    """First-party model IDs (no Bedrock prefix/suffix) keep resolving as before."""
+    from autogen_ext.models.anthropic import _model_info
+
+    assert _model_info.get_info("claude-3-haiku-20240307")["function_calling"] is True
+    assert _model_info.get_token_limit("claude-3-5-sonnet-20240620") == 200000
+    # Claude 4 models were previously missing from the token-limit table and fell back to
+    # the 100000 default; they should now report their real context window.
+    assert _model_info.get_token_limit("claude-opus-4-20250514") == 200000
+    assert _model_info.get_token_limit("claude-sonnet-4-0") == 200000
+
+
+def test_model_info_and_token_limit_tables_in_sync() -> None:
+    """Every model with capability info should also have an explicit token limit."""
+    from autogen_ext.models.anthropic import _model_info
+
+    missing = set(_model_info._MODEL_INFO) - set(_model_info._MODEL_TOKEN_LIMITS)  # pyright: ignore[reportPrivateUsage]
+    assert not missing, f"Models missing from _MODEL_TOKEN_LIMITS: {sorted(missing)}"


### PR DESCRIPTION
## Why are these changes needed?

`anthropic._model_info.get_info()` and `get_token_limit()` resolve a model's
capabilities / context window with an anchored `str.startswith` prefix match
against bare first-party model keys. AWS Bedrock model IDs carry a provider
namespace (`anthropic.`), an optional cross-region inference prefix (`us.`,
`eu.`, `apac.`, `global.`), and a `-vN:M` version suffix, e.g.
`us.anthropic.claude-3-5-sonnet-20240620-v1:0`. None of these match the bare
keys, so:

- `get_info()` raises `KeyError`, which breaks `AnthropicBedrockChatCompletionClient`
  construction when `model_info` is not passed explicitly (re-raised as
  "model_info is required when model name is not recognized").
- `get_token_limit()` silently returns the `100000` default instead of the real
  context window.

This PR normalizes the model id (strips the `[<region>.]anthropic.` prefix and
the trailing `-vN:M` suffix) before the lookup, so Bedrock IDs resolve to their
first-party model info. First-party IDs have neither part and are unaffected.

It also completes `_MODEL_TOKEN_LIMITS` with the Claude 4 models and `-latest`
aliases that were present in `_MODEL_INFO` but missing here, so `get_token_limit()`
no longer returns the default fallback for Claude 4 and the two tables stay in
sync (guarded by a new test).

## Related issue number

Closes #7833

## Related PRs

Three other PRs address #7833 by normalizing the model id before lookup. Leaving the comparison here so triage does not have to diff them:

- #7834 (2026-06-13): same normalization approach (generic region-prefix regex). Does not fix the `_MODEL_TOKEN_LIMITS` gaps.
- #7886 (2026-06-25): prefix regex is `[a-z]+\.`, so a cross-region prefix containing a hyphen (e.g. `us-gov.`) is not normalized. Does not fix the token-limit gaps.
- #7940 (closed): fixed whitelist of region prefixes; see @ErenAta16's comparison in the review below.

This PR is the only one that also backfills the Claude 4 / 3.7 entries missing from `_MODEL_TOKEN_LIMITS` and adds a test keeping the two tables in sync. Happy to defer to whichever the maintainers prefer.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/> (none required for this change).
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed (ran `ruff`, `mypy`, and the relevant `pytest` locally).

