### PR TITLE
fix: drop trailing assistant message when it is empty after rstrip

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -540,13 +540,28 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
 
     def _rstrip_last_assistant_message(self, messages: Sequence[LLMMessage]) -> Sequence[LLMMessage]:
         """
-        Remove the last assistant message if it is empty.
-        """
-        # When Claude models last message is AssistantMessage, It could not end with whitespace
-        if isinstance(messages[-1], AssistantMessage):
-            if isinstance(messages[-1].content, str):
-                messages[-1].content = messages[-1].content.rstrip()
+        Strip trailing whitespace from the last assistant message, dropping it entirely
+        if it becomes empty.
 
+        The Anthropic API rejects a final assistant message whose text content ends with
+        trailing whitespace, and also rejects one whose text content is empty. This
+        normalizes both cases without mutating the caller's messages.
+        """
+        if not messages or not isinstance(messages[-1], AssistantMessage):
+            return messages
+        last_message = messages[-1]
+        if not isinstance(last_message.content, str):
+            return messages
+
+        stripped_content = last_message.content.rstrip()
+        # Copy rather than mutate the caller's message objects in place.
+        messages = list(messages)
+        if stripped_content:
+            messages[-1] = last_message.model_copy(update={"content": stripped_content})
+        else:
+            # Drop the now-empty trailing assistant message instead of sending an empty
+            # one; a preceding non-empty assistant message (prefill) is preserved.
+            messages.pop()
         return messages
 
     async def create(

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -489,13 +489,28 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
     def _rstrip_last_assistant_message(self, messages: Sequence[LLMMessage]) -> Sequence[LLMMessage]:
         """
-        Remove the last assistant message if it is empty.
-        """
-        # When Claude models last message is AssistantMessage, It could not end with whitespace
-        if isinstance(messages[-1], AssistantMessage):
-            if isinstance(messages[-1].content, str):
-                messages[-1].content = messages[-1].content.rstrip()
+        Strip trailing whitespace from the last assistant message, dropping it entirely
+        if it becomes empty.
 
+        The Anthropic API rejects a final assistant message whose text content ends with
+        trailing whitespace, and also rejects one whose text content is empty. This
+        normalizes both cases without mutating the caller's messages.
+        """
+        if not messages or not isinstance(messages[-1], AssistantMessage):
+            return messages
+        last_message = messages[-1]
+        if not isinstance(last_message.content, str):
+            return messages
+
+        stripped_content = last_message.content.rstrip()
+        # Copy rather than mutate the caller's message objects in place.
+        messages = list(messages)
+        if stripped_content:
+            messages[-1] = last_message.model_copy(update={"content": stripped_content})
+        else:
+            # Drop the now-empty trailing assistant message instead of sending an empty
+            # one; a preceding non-empty assistant message (prefill) is preserved.
+            messages.pop()
         return messages
 
     def _process_create_args(

--- a/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
@@ -836,6 +836,37 @@ def test_mock_rstrip_trailing_whitespace_at_last_assistant_content() -> None:
     assert result[-1].content == "foobar"
 
 
+def test_mock_rstrip_drops_empty_last_assistant_message() -> None:
+    """A trailing assistant message that is only whitespace is dropped, not sent empty.
+
+    Regression test for https://github.com/microsoft/autogen/issues/7768.
+    """
+    dummy_client = AnthropicChatCompletionClient(model="claude-3-5-haiku-20241022", api_key="dummy-key")
+    messages: list[LLMMessage] = [
+        UserMessage(content="foo", source="user"),
+        AssistantMessage(content="   \n  ", source="assistant"),
+    ]
+
+    result = dummy_client._rstrip_last_assistant_message(messages)  # pyright: ignore[reportPrivateUsage]
+
+    assert len(result) == 1
+    assert isinstance(result[-1], UserMessage)
+
+
+def test_mock_rstrip_does_not_mutate_input_messages() -> None:
+    """Stripping the trailing assistant message must not mutate the caller's objects."""
+    dummy_client = AnthropicChatCompletionClient(model="claude-3-5-haiku-20241022", api_key="dummy-key")
+    original = AssistantMessage(content="foobar ", source="assistant")
+    messages: list[LLMMessage] = [UserMessage(content="foo", source="user"), original]
+
+    result = dummy_client._rstrip_last_assistant_message(messages)  # pyright: ignore[reportPrivateUsage]
+
+    assert result[-1].content == "foobar"
+    # The caller's original message object and list are left untouched.
+    assert original.content == "foobar "
+    assert messages[-1] is original
+
+
 @pytest.mark.asyncio
 async def test_anthropic_tool_choice_with_actual_api() -> None:
     """Test tool_choice parameter with actual Anthropic API endpoints."""

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -2643,6 +2643,37 @@ def test_rstrip_railing_whitespace_at_last_assistant_content() -> None:
     assert result[-1].content == "foobar"
 
 
+def test_rstrip_drops_empty_last_assistant_message() -> None:
+    """A trailing assistant message that is only whitespace is dropped, not sent empty.
+
+    Regression test for https://github.com/microsoft/autogen/issues/7768.
+    """
+    messages: list[LLMMessage] = [
+        UserMessage(content="foo", source="user"),
+        AssistantMessage(content="   \n  ", source="assistant"),
+    ]
+
+    dummy_client = OpenAIChatCompletionClient(model="claude-3-5-haiku-20241022", api_key="dummy-key")
+    result = dummy_client._rstrip_last_assistant_message(messages)  # pyright: ignore[reportPrivateUsage]
+
+    assert len(result) == 1
+    assert isinstance(result[-1], UserMessage)
+
+
+def test_rstrip_does_not_mutate_input_messages() -> None:
+    """Stripping the trailing assistant message must not mutate the caller's objects."""
+    original = AssistantMessage(content="foobar ", source="assistant")
+    messages: list[LLMMessage] = [UserMessage(content="foo", source="user"), original]
+
+    dummy_client = OpenAIChatCompletionClient(model="claude-3-5-haiku-20241022", api_key="dummy-key")
+    result = dummy_client._rstrip_last_assistant_message(messages)  # pyright: ignore[reportPrivateUsage]
+
+    assert result[-1].content == "foobar"
+    # The caller's original message object and list are left untouched.
+    assert original.content == "foobar "
+    assert messages[-1] is original
+
+
 def test_find_model_family() -> None:
     assert _find_model_family("openai", "gpt-4") == ModelFamily.GPT_4
     assert _find_model_family("openai", "gpt-4-latest") == ModelFamily.GPT_4


### PR DESCRIPTION
## Why are these changes needed?

`_rstrip_last_assistant_message` (used for Claude models in both the Anthropic
and OpenAI clients) is documented to "Remove the last assistant message if it is
empty", but it only stripped trailing whitespace from the content. A trailing
assistant message that is empty — or that becomes empty after stripping — was
still sent, and the Anthropic API rejects a final assistant message with empty
text content. The method also mutated the caller's message objects in place.

This PR strips the trailing whitespace and, when the content becomes empty,
drops the message instead of sending an empty one. A preceding non-empty
assistant message (intentional prefill) is preserved, so this does not regress
prefill use cases. The input messages are copied rather than mutated.

Note: the issue's suggested fix (drop *all* trailing assistant messages) would
break legitimate assistant-prefill flows; this change only drops the message
when it is actually empty, matching the method's documented intent.

## Related issue number

Closes #7768

## Related PRs

- #7781 (2026-05-31) takes the approach suggested in the issue: drop *every* trailing assistant message, Anthropic client only. As noted above, that breaks intentional assistant prefill, which the Anthropic API supports, so this PR deliberately drops the message only when it is empty after stripping, and applies the same fix to the OpenAI client's copy of the helper.
- #8029 (2026-08-07) later implements the same empty-after-rstrip behavior via a shared helper, but still mutates the caller's message objects in place.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/> (none required for this change).
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed (ran `ruff`, `mypy`, and the relevant `pytest` locally).

