### PR TITLE
fix: serialize structured (dict/list) tool return values as JSON

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -171,6 +171,16 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
                 return json.dumps(dumped)
             return str(dumped)
 
+        # Serialize structured return values (dict / list) as JSON so that tools returning
+        # structured data produce valid JSON in the message history rather than a Python
+        # repr (e.g. '{"a": 1}' instead of "{'a': 1}"). Fall back to str() for values that
+        # are not JSON-serializable.
+        if isinstance(value, (dict, list)):
+            try:
+                return json.dumps(value)
+            except (TypeError, ValueError):
+                return str(value)
+
         return str(value)
 
     @abstractmethod

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -1,7 +1,8 @@
 import inspect
+import json
 from dataclasses import dataclass
 from functools import partial
-from typing import Annotated, List
+from typing import Annotated, Any, Dict, List
 
 import pytest
 from autogen_core import CancellationToken
@@ -478,6 +479,37 @@ async def test_func_tool_return_list() -> None:
     assert isinstance(result, list)
     assert result == [1, 2]
     assert tool.return_value_as_string(result) == "[1, 2]"
+
+
+@pytest.mark.asyncio
+async def test_func_tool_return_dict_as_json() -> None:
+    """A dict return value is serialized as valid JSON, not a Python repr.
+
+    Regression test for https://github.com/microsoft/autogen/issues/7867.
+    """
+
+    def my_function() -> Dict[str, Any]:
+        return {"status": "success", "items": ["a", "b"], "count": 2}
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    as_string = tool.return_value_as_string(result)
+    # Must be valid JSON (double-quoted), not a Python repr like "{'status': 'success'}".
+    assert as_string == '{"status": "success", "items": ["a", "b"], "count": 2}'
+    assert json.loads(as_string) == result
+
+
+@pytest.mark.asyncio
+async def test_func_tool_return_list_of_strings_as_json() -> None:
+    """A list-of-strings return value is serialized as valid JSON, not a Python repr."""
+
+    def my_function() -> List[str]:
+        return ["a", "b"]
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    # Previously str(["a", "b"]) produced "['a', 'b']" (invalid JSON).
+    assert tool.return_value_as_string(result) == '["a", "b"]'
 
 
 def test_nested_tool_schema_generation() -> None:


### PR DESCRIPTION
## Why are these changes needed?

`BaseTool.return_value_as_string` JSON-encodes Pydantic model return values, but
`dict` and `list` return values fall through to `str(value)`, producing a Python
repr rather than valid JSON:

```python
def my_tool() -> dict:
    return {"status": "success", "items": ["a", "b"]}

# return_value_as_string(...) currently yields:
#   {'status': 'success', 'items': ['a', 'b']}   <- single quotes, not valid JSON
```

As a result, tools returning structured data do not produce valid JSON in the
message history, and downstream agents/consumers must parse Python-repr strings
to recover the data (per #7867).

This PR serializes `dict` and `list` return values with `json.dumps` (falling
back to `str()` for values that are not JSON-serializable):

```python
#   {"status": "success", "items": ["a", "b"]}   <- valid JSON
```

This is intentionally the narrow, compatibility-preserving slice discussed in the
issue: the public `content: str` text projection is kept unchanged (no
message-schema change, so provider adapters, serializers, summary formatting,
termination conditions, and user code that expects text are unaffected). Scalars
and other types keep their existing `str()` behavior; only `dict`/`list` (the
structured types the issue is about) now emit valid JSON. Pydantic returns were
already JSON-encoded and are unchanged.

## Related issue number

Refs #7867 (addresses the "structured outputs are not valid JSON" part; does not
change `content` from `str` to a structured type).

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/> (none required for this change).
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed (ran `ruff`, `mypy`, and `pytest tests/test_tools.py` locally).
