### PR TITLE
fix: preserve TextMentionTermination.sources across serialization round-trip

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -106,6 +106,7 @@ class MaxMessageTermination(TerminationCondition, Component[MaxMessageTerminatio
 
 class TextMentionTerminationConfig(BaseModel):
     text: str
+    sources: List[str] | None = None
 
 
 class TextMentionTermination(TerminationCondition, Component[TextMentionTerminationConfig]):
@@ -148,11 +149,14 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
         self._terminated = False
 
     def _to_config(self) -> TextMentionTerminationConfig:
-        return TextMentionTerminationConfig(text=self._termination_text)
+        return TextMentionTerminationConfig(
+            text=self._termination_text,
+            sources=list(self._sources) if self._sources is not None else None,
+        )
 
     @classmethod
     def _from_config(cls, config: TextMentionTerminationConfig) -> Self:
-        return cls(text=config.text)
+        return cls(text=config.text, sources=config.sources)
 
 
 class FunctionalTermination(TerminationCondition):

--- a/python/packages/autogen-agentchat/tests/test_declarative_components.py
+++ b/python/packages/autogen-agentchat/tests/test_declarative_components.py
@@ -102,6 +102,31 @@ async def test_termination_declarative() -> None:
 
 
 @pytest.mark.asyncio
+async def test_text_mention_termination_sources_round_trip() -> None:
+    """TextMentionTermination should preserve its ``sources`` restriction across serialization.
+
+    Previously ``sources`` was dropped by ``dump_component``/``load_component``, so a
+    reloaded condition fired on any source instead of only the configured ones (unlike the
+    sibling SourceMatchTermination, which round-trips ``sources`` correctly).
+    """
+    term = TextMentionTermination("stop", sources=["assistant"])
+
+    config = term.dump_component()
+    assert config.config.get("sources") == ["assistant"]
+
+    loaded = ComponentLoader.load_component(config, TextMentionTermination)
+    assert isinstance(loaded, TextMentionTermination)
+    assert loaded._sources == ["assistant"]  # type: ignore[reportPrivateUsage]
+
+    # A condition configured without sources still round-trips as unrestricted (None).
+    unrestricted = TextMentionTermination("stop")
+    unrestricted_config = unrestricted.dump_component()
+    assert unrestricted_config.config.get("sources") is None
+    loaded_unrestricted = ComponentLoader.load_component(unrestricted_config, TextMentionTermination)
+    assert loaded_unrestricted._sources is None  # type: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_context_declarative() -> None:
     unbounded_context = UnboundedChatCompletionContext()
     buffered_context = BufferedChatCompletionContext(buffer_size=5)


### PR DESCRIPTION
## Why are these changes needed?

`TextMentionTermination` accepts a `sources` argument that restricts which
message sources are checked for the termination text:

```python
term = TextMentionTermination("stop", sources=["assistant"])
```

However `TextMentionTerminationConfig` only stored `text`, and
`_to_config`/`_from_config` only serialized/restored `text`. So a condition
configured with `sources` silently loses that restriction after a declarative
`dump_component()` / `load_component()` round-trip, and the reloaded condition
then fires on **any** source (including `user` or other agents) — a behavior
change on save/load.

The sibling `SourceMatchTermination` already round-trips its `sources` field
correctly (and the existing declarative test asserts it), which makes this an
inconsistency rather than an intentional omission.

This PR adds `sources` to `TextMentionTerminationConfig` and serializes/restores
it in `_to_config`/`_from_config`, with a regression test covering both the
sources-restricted and unrestricted cases.

## Related issue number

N/A — found during review. Fixes a serialization round-trip data loss;
`SourceMatchTermination` is the correct reference behavior.

## Related PRs

- #7837 (2026-06-15) predates this PR and makes the equivalent change (adds `sources` to the config and round-trips it). I did not find it before opening this one. Differences are minor: #7837 normalizes `sources` to a list in `__init__`, this PR does so in `_to_config`, and this PR's test also covers the unrestricted (`sources=None`) case. Either fixes the bug; happy for maintainers to merge whichever and close the other.
- #8088 (2026-08-23) bundles the same fix with unrelated changes across several other files.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/> (none required for this change).
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed (ran `ruff`, `mypy`, and the relevant `pytest` locally).

