### PR TITLE
docs: add TokenLab OpenAI-compatible example

### DIFF
--- a/python/samples/agentchat_chess_game/README.md
+++ b/python/samples/agentchat_chess_game/README.md
@@ -61,6 +61,22 @@ config:
     family: r1
 ```
 
+To use TokenLab through its OpenAI-compatible Chat Completions endpoint, set
+`base_url` to TokenLab's `/v1` endpoint and use a TokenLab model ID:
+
+```yaml
+provider: autogen_ext.models.openai.OpenAIChatCompletionClient
+config:
+  model: claude-sonnet-5
+  base_url: https://api.tokenlab.sh/v1
+  api_key: replace with your TokenLab API key
+  model_info:
+    function_calling: true
+    json_output: true
+    vision: false
+    family: claude
+```
+
 For more information on how to configure the model and use other providers,
 please refer to the [Models documentation](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/models.html).
 


### PR DESCRIPTION
## Summary
- Document TokenLab as an OpenAI-compatible API provider for AutoGen's OpenAIChatCompletionClient YAML configuration.
- Use TokenLab's OpenAI-compatible base URL: https://api.tokenlab.sh/v1
- No runtime behavior changes; documentation only.

## Verification
- git diff --check


---

Supersedes #7934. The previous PR was closed while fixing contributor commit metadata; this replacement branch preserves the same scoped diff with commits authored by `hedging8563 <45883076+hedging8563@users.noreply.github.com>`.
