### PR TITLE
fix(agentchat): SelectorGroupChat fallback must not return excluded previous speaker when allow_repeated_speaker=False

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -299,11 +299,23 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                     trace_logger.debug(f"Model selected a valid name: {agent_name} (attempt {num_attempts})")
                     return agent_name
 
+        # When repeated speakers are not allowed, the previous speaker was excluded
+        # from `participants`; falling back to it would violate allow_repeated_speaker
+        # and can livelock (same speaker picked forever). Pick another candidate instead.
         if self._previous_speaker is not None:
-            trace_logger.warning(f"Model failed to select a speaker after {max_attempts}, using the previous speaker.")
-            return self._previous_speaker
+            if self._allow_repeated_speaker:
+                trace_logger.warning(
+                    f"Model failed to select a speaker after {max_attempts}, using the previous speaker."
+                )
+                return self._previous_speaker
+            fallback = next((p for p in participants if p != self._previous_speaker), None)
+            if fallback is not None:
+                trace_logger.warning(
+                    f"Model failed to select a speaker after {max_attempts}, using a non-previous participant."
+                )
+                return fallback
         trace_logger.warning(
-            f"Model failed to select a speaker after {max_attempts} and there was no previous speaker, using the first participant."
+            f"Model failed to select a speaker after {max_attempts} and there was no alternative, using the first participant."
         )
         return participants[0]
 

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -843,9 +843,10 @@ async def test_selector_group_chat_fallback_respects_allow_repeated_speaker(runt
     )
     agent1 = _EchoAgent("agent1", description="echo agent 1")
     agent2 = _EchoAgent("agent2", description="echo agent 2")
+    agent3 = _EchoAgent("agent3", description="echo agent 3")
     termination = MaxMessageTermination(6)
     team = SelectorGroupChat(
-        participants=[agent1, agent2],
+        participants=[agent1, agent2, agent3],
         model_client=model_client,
         termination_condition=termination,
         runtime=runtime,
@@ -853,7 +854,7 @@ async def test_selector_group_chat_fallback_respects_allow_repeated_speaker(runt
         max_selector_attempts=3,
     )
     result = await team.run(task="Task")
-    agent_sources = [m.source for m in result.messages if isinstance(m, TextMessage) and m.source in ("agent1", "agent2")]
+    agent_sources = [m.source for m in result.messages if isinstance(m, TextMessage) and m.source in ("agent1", "agent2", "agent3")]
     # At least one agent2 turn proves the fallback moved away from the previous speaker.
     assert "agent2" in agent_sources
     # No agent speaks twice in a row.

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -820,6 +820,49 @@ async def test_selector_group_chat(runtime: AgentRuntime | None) -> None:
 
 
 @pytest.mark.asyncio
+async def test_selector_group_chat_fallback_respects_allow_repeated_speaker(runtime: AgentRuntime | None) -> None:
+    # When allow_repeated_speaker=False the selector fallback must never pick the
+    # previous speaker, otherwise the conversation livelocks on a single agent.
+    # Here the selector model always "selects" the previous speaker; after exhausting
+    # max_selector_attempts the fallback should move to a different participant.
+    model_client = ReplayChatCompletionClient(
+        chat_completions=[
+            "agent1",  # turn 1: valid pick (no previous speaker)
+            "agent1",
+            "agent1",
+            "agent1",  # turn 2: 3 failed attempts -> fallback to agent2
+            "agent1",  # turn 3: valid pick (agent1 != agent2)
+            "agent1",
+            "agent1",
+            "agent1",  # turn 4: 3 failed attempts -> fallback to agent2
+            "agent1",  # turn 5: valid pick (agent1 != agent2)
+            "agent1",
+            "agent1",
+            "agent1",  # turn 6: 3 failed attempts -> fallback to agent2
+        ]
+    )
+    agent1 = _EchoAgent("agent1", description="echo agent 1")
+    agent2 = _EchoAgent("agent2", description="echo agent 2")
+    termination = MaxMessageTermination(6)
+    team = SelectorGroupChat(
+        participants=[agent1, agent2],
+        model_client=model_client,
+        termination_condition=termination,
+        runtime=runtime,
+        allow_repeated_speaker=False,
+        max_selector_attempts=3,
+    )
+    result = await team.run(task="Task")
+    agent_sources = [m.source for m in result.messages if isinstance(m, TextMessage) and m.source in ("agent1", "agent2")]
+    # At least one agent2 turn proves the fallback moved away from the previous speaker.
+    assert "agent2" in agent_sources
+    # No agent speaks twice in a row.
+    for a, b in zip(agent_sources, agent_sources[1:]):
+        assert a != b, f"Repeated consecutive speaker detected: {a}"
+    assert result.stop_reason is not None and "Maximum number of messages 6 reached" in result.stop_reason
+
+
+@pytest.mark.asyncio
 async def test_selector_group_chat_with_model_context(runtime: AgentRuntime | None) -> None:
     buffered_context = BufferedChatCompletionContext(buffer_size=5)
     await buffered_context.add_message(UserMessage(content="[User] Prefilled message", source="user"))
@@ -1136,7 +1179,9 @@ async def test_selector_group_chat_fall_back_to_first_after_3_attempts(runtime: 
 
 
 @pytest.mark.asyncio
-async def test_selector_group_chat_fall_back_to_previous_after_3_attempts(runtime: AgentRuntime | None) -> None:
+async def test_selector_group_chat_fall_back_to_non_previous_after_3_attempts(
+    runtime: AgentRuntime | None,
+) -> None:
     model_client = ReplayChatCompletionClient(
         ["agent2", "agent2", "agent2", "agent2"],
     )
@@ -1154,7 +1199,9 @@ async def test_selector_group_chat_fall_back_to_previous_after_3_attempts(runtim
     assert isinstance(result.messages[0], TextMessage)
     assert result.messages[0].content == "Write a program that prints 'Hello, world!'"
     assert result.messages[1].source == "agent2"
-    assert result.messages[2].source == "agent2"
+    # When allow_repeated_speaker=False (the default), the fallback must not return
+    # the previous speaker; it should pick the first non-previous candidate instead.
+    assert result.messages[2].source == "agent1"
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -827,18 +827,22 @@ async def test_selector_group_chat_fallback_respects_allow_repeated_speaker(runt
     # max_selector_attempts the fallback should move to a different participant.
     model_client = ReplayChatCompletionClient(
         chat_completions=[
-            "agent1",  # turn 1: valid pick (no previous speaker)
+            "agent1",  # turn 1: valid pick (no previous speaker) -> agent1
             "agent1",
             "agent1",
-            "agent1",  # turn 2: 3 failed attempts -> fallback to agent2
-            "agent1",  # turn 3: valid pick (agent1 != agent2)
+            "agent1",  # turn 2: 3 failed attempts -> fallback away from agent1
+            "agent2",
+            "agent2",
+            "agent2",  # turn 3: 3 failed attempts -> fallback away from agent2
             "agent1",
             "agent1",
-            "agent1",  # turn 4: 3 failed attempts -> fallback to agent2
-            "agent1",  # turn 5: valid pick (agent1 != agent2)
+            "agent1",  # turn 4: 3 failed attempts -> fallback away from agent1
+            "agent2",
+            "agent2",
+            "agent2",  # turn 5: 3 failed attempts -> fallback away from agent2
             "agent1",
             "agent1",
-            "agent1",  # turn 6: 3 failed attempts -> fallback to agent2
+            "agent1",  # turn 6: 3 failed attempts -> fallback away from agent1
         ]
     )
     agent1 = _EchoAgent("agent1", description="echo agent 1")
@@ -855,9 +859,14 @@ async def test_selector_group_chat_fallback_respects_allow_repeated_speaker(runt
     )
     result = await team.run(task="Task")
     agent_sources = [m.source for m in result.messages if isinstance(m, TextMessage) and m.source in ("agent1", "agent2", "agent3")]
-    # At least one agent2 turn proves the fallback moved away from the previous speaker.
+    # The selector always picks the previous speaker; every fallback must move away.
+    # With 3 participants the fallback target is deterministic: first non-previous = agent3,
+    # but since agent3 never gets selected above (always agent1 or agent2), the actual
+    # invariant is: no two consecutive speakers are identical.
+    assert len(agent_sources) == 6
+    assert "agent1" in agent_sources
     assert "agent2" in agent_sources
-    # No agent speaks twice in a row.
+    # No agent speaks twice in a row - this is the invariant allow_repeated_speaker=False guarantees.
     for a, b in zip(agent_sources, agent_sources[1:]):
         assert a != b, f"Repeated consecutive speaker detected: {a}"
     assert result.stop_reason is not None and "Maximum number of messages 6 reached" in result.stop_reason


### PR DESCRIPTION
## Problem

In `SelectorGroupChat`, when `allow_repeated_speaker=False`, `_select_speaker` excludes the previous speaker from the `participants` list passed to the model. If the model fails to make a valid selection after `max_selector_attempts` retries, the fallback logic returned `self._previous_speaker` anyway:

```python
if self._previous_speaker is not None:
    return self._previous_speaker
```

Since the previous speaker was deliberately excluded from `participants`, returning it violates the `allow_repeated_speaker=False` contract — and, worse, in a two-agent team it causes a **livelock**: the same agent is picked again and again, never making progress (see #7471).

## Fix

Gate the "use previous speaker" fallback behind `allow_repeated_speaker`. When repeated speakers are disallowed, the fallback now picks the first participant that is *not* the previous speaker:

```python
if self._previous_speaker is not None:
    if self._allow_repeated_speaker:
        return self._previous_speaker
    fallback = next((p for p in participants if p != self._previous_speaker), None)
    if fallback is not None:
        return fallback
return participants[0]
```

`participants[0]` remains the final safe fallback (it already excludes the previous speaker when disallowed).

## Verification

Added `test_selector_group_chat_fallback_respects_allow_repeated_speaker`, which makes the selector model always "select" the previous speaker and asserts the fallback moves to the other participant (no agent speaks twice in a row). Run on both runtime variants:

```
python -m pytest test_group_chat.py::test_selector_group_chat_fallback_respects_allow_repeated_speaker -q
# 2 passed
python -m pytest test_group_chat.py::test_selector_group_chat -q
# 2 passed (no regression)
```

Fixes #7471