### PR TITLE
[security] Correct false docstring claim about command sanitization in LocalCommandLineCodeExecutor

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -54,8 +54,10 @@ class LocalCommandLineCodeExecutor(CodeExecutor, Component[LocalCommandLineCodeE
     the working directory, and a unique file is generated and saved in the
     working directory for each code block.
     The code blocks are executed in the order they are received.
-    Command line code is sanitized using regular expression match against a list of dangerous commands in order to prevent self-destructive
-    commands from being executed which may potentially affect the users environment.
+    .. warning::
+        No dangerous-command sanitization is performed. LLM-generated code
+        (including destructive commands like rm -rf) will be executed directly
+        on the local machine. Use Docker-based executors for untrusted code.
     Currently the only supported languages is Python and shell scripts.
     For Python code, use the language "python" for the code block.
     For shell scripts, use the language "bash", "shell", "sh", "pwsh", "powershell", or "ps1" for the code


### PR DESCRIPTION
## Summary

The `LocalCommandLineCodeExecutor` docstring (line 57) claims:

> Command line code is sanitized using regular expression match against a list of dangerous commands in order to prevent self-destructive commands from being executed which may potentially affect the users environment.

**This sanitization does not exist.** Tracing the full execution path (`_execute_code_dont_check_setup`, lines 341-435), the only processing of LLM-generated code before execution is `silence_pip` (adding `-qqq` to pip install commands). No dangerous-command filtering, no regex matching, no blocklist.

**Severity:** MEDIUM
**Class:** False security claim creating a false sense of security

## Impact

An operator reading the docstring would believe destructive commands are filtered. In reality, LLM-generated code (including `rm -rf /`, `curl | sh`, etc.) executes directly on the local machine with zero filtering.

## Fix

Replace the false claim with a clear `.. warning::` that states no sanitization is performed and recommends Docker-based executors for untrusted code.

## Verification

- Traced full execution path: `execute_code_blocks` -> `_execute_code_dont_check_setup` -> file write -> `asyncio.create_subprocess_exec`
- Only processing: `silence_pip(code, lang)` at line 357
- No `DANGEROUS`, `sanitize`, `block_list`, or command filtering anywhere in the path
- Single-file docstring change

## Dedup

Issues #7662 (WebSocket RCE) and #4873 (eval injection) are different surfaces. Nobody has reported the docstring/code mismatch specifically.

---

_Generated by redthread. Single-purpose documentation fix._
