### PR TITLE
fix: raise a clear RuntimeError instead of a bare assert when streaming speaker selection yields no final result

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -248,7 +248,7 @@ class SelectorGroupChatManager(BaseGroupChatManager):
         while num_attempts < max_attempts:
             num_attempts += 1
             if self._model_client_streaming:
-                chunk: CreateResult | str = ""
+                chunk: Optional[CreateResult | str] = None
                 async for _chunk in self._model_client.create_stream(messages=select_speaker_messages):
                     chunk = _chunk
                     if self._emit_team_events:
@@ -262,8 +262,8 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                             await self._output_message_queue.put(
                                 SelectorEvent(content=chunk.content, source=self._name)
                             )
-                # The last chunk must be CreateResult.
-                assert isinstance(chunk, CreateResult)
+                if not isinstance(chunk, CreateResult):
+                    raise RuntimeError("No final model result in streaming mode while selecting the next speaker.")
                 response = chunk
             else:
                 response = await self._model_client.create(messages=select_speaker_messages)

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -1944,3 +1944,30 @@ async def test_selector_group_chat_streaming(runtime: AgentRuntime | None) -> No
 
     # Content-based verification instead of index-based
     # Note: The streaming test verifies the streaming behavior, not the final result content
+
+
+@pytest.mark.asyncio
+async def test_selector_group_chat_streaming_no_final_result(runtime: AgentRuntime | None) -> None:
+    """Streaming speaker selection raises a clear error when the stream yields no final CreateResult."""
+    # Replay payload is unused: create_stream is overridden below to simulate an empty stream.
+    model_client = ReplayChatCompletionClient(["unused"])
+
+    async def mock_create_stream(*args: Any, **kwargs: Any) -> AsyncGenerator[str | CreateResult, None]:
+        yield "agent"
+        yield "2"
+        # No final CreateResult.
+
+    model_client.create_stream = mock_create_stream  # type: ignore[method-assign]
+
+    agent1 = _EchoAgent("agent1", description="echo agent 1")
+    agent2 = _EchoAgent("agent2", description="echo agent 2")
+    team = SelectorGroupChat(
+        participants=[agent1, agent2],
+        model_client=model_client,
+        termination_condition=MaxMessageTermination(2),
+        runtime=runtime,
+        model_client_streaming=True,
+    )
+
+    with pytest.raises(RuntimeError, match="No final model result"):
+        await team.run(task="Say hello")


### PR DESCRIPTION
### What

`SelectorGroupChatManager._select_speaker` (`autogen_agentchat/teams/_group_chat/_selector_group_chat.py`) seeds `chunk: CreateResult | str = ""` before iterating `self._model_client.create_stream(...)` for speaker selection. If the stream yields no final `CreateResult` (a legitimate edge case: a provider hiccup, a cancelled/truncated stream, or a custom `ChatCompletionClient` implementation), `chunk` is never a `CreateResult`, and the following line:

```python
# The last chunk must be CreateResult.
assert isinstance(chunk, CreateResult)
```

raises a bare, message-less `AssertionError`. Under `-O`/`PYTHONOPTIMIZE=1`, assertions are stripped entirely, so the code instead falls through to `response = ""` and crashes moments later with an unrelated `AttributeError: 'str' object has no attribute 'content'`.

### Fix

Seed `chunk` with `None` (a sentinel that can't be confused with real stream output) and replace the bare `assert` with an explicit `if not isinstance(chunk, CreateResult): raise RuntimeError(...)`. This mirrors the sibling streaming call site, `AssistantAgent._call_llm` (`autogen_agentchat/agents/_assistant_agent.py`), which already handles this exact situation the same way. No behavior change on the happy path: when `create_stream` yields a final `CreateResult`, `chunk` ends up being that result exactly as before.

### Test

Added `test_selector_group_chat_streaming_no_final_result` to `tests/test_group_chat.py`, parallel to the existing `AssistantAgent` regression test `test_streaming_without_final_result`. It overrides `create_stream` to yield chunks with no terminal `CreateResult` and asserts the clear `RuntimeError`. The existing selector suite (`-k selector`) passes unchanged.

### Scope

Single-function fix, matching an idiom already established elsewhere in the same package. Does not touch `AssistantAgent._call_llm` or any other streaming call site.

### Note

This package currently carries a "maintenance mode" banner (#7521) as the org consolidates into a newer Agent Framework. Submitting anyway since the fix is small, correct, and cheap to review; happy to close without hard feelings if maintainer bandwidth doesn't allow a look.