### PR TITLE
fix: return single-chunk streamed content in Ollama create_stream

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/ollama/_ollama_client.py
@@ -819,21 +819,17 @@ class BaseOllamaChatCompletionClient(ChatCompletionClient):
         content: Union[str, List[FunctionCall]]
         thought: Optional[str] = None
 
+        # Ollama reports the completion token usage on the final chunk's eval_count,
+        # regardless of whether the response is text, tool calls, or both.
+        completion_tokens = chunk.eval_count if chunk and chunk.eval_count else 0
+
         if len(content_chunks) > 0 and len(full_tool_calls) > 0:
             content = full_tool_calls
             thought = "".join(content_chunks)
-            if chunk and chunk.eval_count:
-                completion_tokens = chunk.eval_count
-            else:
-                completion_tokens = 0
-        elif len(content_chunks) > 1:
+        elif len(content_chunks) > 0:
+            # Any text content (including a single-chunk response) is the result.
             content = "".join(content_chunks)
-            if chunk and chunk.eval_count:
-                completion_tokens = chunk.eval_count
-            else:
-                completion_tokens = 0
         else:
-            completion_tokens = 0
             content = full_tool_calls
 
         usage = RequestUsage(

--- a/python/packages/autogen-ext/tests/models/test_ollama_chat_completion_client.py
+++ b/python/packages/autogen-ext/tests/models/test_ollama_chat_completion_client.py
@@ -158,6 +158,47 @@ async def test_create_stream(monkeypatch: pytest.MonkeyPatch, caplog: pytest.Log
 
 
 @pytest.mark.asyncio
+async def test_create_stream_single_chunk_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A streamed response delivered as a single content chunk must be returned in full.
+
+    Regression test: the final-result assembly previously required more than one content
+    chunk (``len(content_chunks) > 1``), so a short single-chunk text response fell through
+    to the tool-call branch and yielded an empty content list with zero completion tokens.
+    """
+    model = "llama3.2"
+    content_raw = "Hi!"
+
+    async def _mock_chat(*args: Any, **kwargs: Any) -> AsyncGenerator[ChatResponse, None]:
+        assert kwargs["stream"] is True
+
+        async def _mock_stream() -> AsyncGenerator[ChatResponse, None]:
+            # A single chunk that is also the final (done) chunk.
+            yield ChatResponse(
+                model=model,
+                done=True,
+                done_reason="stop",
+                message=Message(role="assistant", content=content_raw),
+                prompt_eval_count=10,
+                eval_count=12,
+            )
+
+        return _mock_stream()
+
+    monkeypatch.setattr(AsyncClient, "chat", _mock_chat)
+    client = OllamaChatCompletionClient(model=model)
+    stream = client.create_stream(messages=[UserMessage(content="hi", source="user")])
+    chunks: List[str | CreateResult] = []
+    async for chunk in stream:
+        chunks.append(chunk)
+
+    assert isinstance(chunks[-1], CreateResult)
+    assert chunks[-1].content == content_raw
+    assert chunks[-1].finish_reason == "stop"
+    assert chunks[-1].usage is not None
+    assert chunks[-1].usage.completion_tokens == 12
+
+
+@pytest.mark.asyncio
 async def test_create_tools(monkeypatch: pytest.MonkeyPatch) -> None:
     def add(x: int, y: int) -> str:
         return str(x + y)


### PR DESCRIPTION
## Why are these changes needed?

When a streamed Ollama completion produces exactly **one** content chunk and no
tool calls (a short response returned in a single chunk), the final-result
assembly in `create_stream` matches neither the tool-call branch
(`len(content_chunks) > 0 and full_tool_calls`) nor the text branch — which
required `len(content_chunks) > 1` — and falls through to the `else`, setting
`content` to the empty tool-call list and `completion_tokens` to 0.

The text has already been streamed to the consumer chunk-by-chunk, but the
returned `CreateResult` reports `content == []` and zero completion tokens, so
any consumer reading `result.content` from a short streamed response gets an
empty list instead of the text, and usage accounting under-reports.

This PR:
- changes the text branch to `len(content_chunks) > 0`, so single-chunk text
  responses return their content;
- reads `completion_tokens` from the final chunk's `eval_count` for all
  branches, which also fixes the token undercount for tool-call-only streamed
  responses (the old `else` hardcoded 0).

The existing multi-chunk streaming tests pass unchanged; a new regression test
covers the single-chunk case (which was previously untested — the existing test
always slices content into ≥2 chunks).

## Related issue number

N/A — found during review of the streaming result assembly.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/> (none required for this change).
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed (ran `ruff`, `mypy`, and the relevant `pytest` locally).
