### PR TITLE
fix: include tool_choice in ChatCompletionCache cache key

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
@@ -179,6 +179,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         tools: Sequence[Tool | ToolSchema],
         json_output: Optional[bool | type[BaseModel]],
         extra_create_args: Mapping[str, Any],
+        tool_choice: Tool | Literal["auto", "required", "none"] = "auto",
     ) -> tuple[Optional[Union[CreateResult, List[Union[str, CreateResult]]]], str]:
         """
         Helper function to check the cache for a result.
@@ -192,11 +193,16 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         elif isinstance(json_output, bool):
             json_output_data = json_output
 
+        # tool_choice is forwarded to the underlying client and changes the model output,
+        # so it must be part of the cache key. Represent a forced Tool by its name.
+        tool_choice_data = tool_choice if isinstance(tool_choice, str) else tool_choice.schema["name"]
+
         data = {
             "messages": [message.model_dump() for message in messages],
             "tools": [(tool.schema if isinstance(tool, Tool) else tool) for tool in tools],
             "json_output": json_output_data,
             "extra_create_args": extra_create_args,
+            "tool_choice": tool_choice_data,
         }
         serialized_data = json.dumps(data, sort_keys=True)
         cache_key = hashlib.sha256(serialized_data.encode()).hexdigest()
@@ -270,7 +276,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
 
         NOTE: cancellation_token is ignored for cached results.
         """
-        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args)
+        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args, tool_choice)
         if cached_result is not None:
             if isinstance(cached_result, CreateResult):
                 # Cache hit from previous non-streaming call
@@ -319,6 +325,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
                 tools,
                 json_output,
                 extra_create_args,
+                tool_choice,
             )
             if cached_result is not None:
                 if isinstance(cached_result, list):

--- a/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
+++ b/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
@@ -956,3 +956,34 @@ async def test_create_stream_with_cached_non_streaming_result_non_string_content
     assert stream_results[0].content == [expected_function_call]
     assert stream_results[0].finish_reason == "function_calls"
     assert stream_results[0].cached is True
+
+
+def test_check_cache_key_includes_tool_choice() -> None:
+    """Different ``tool_choice`` values must produce different cache keys.
+
+    Regression test: ``tool_choice`` is forwarded to the underlying client and changes the
+    model output, but it was omitted from the cache key, so calls that differed only in
+    ``tool_choice`` collided and returned each other's cached results.
+    """
+    from autogen_core.tools import FunctionTool
+
+    def _dummy_tool(value: str) -> str:
+        return value
+
+    tool = FunctionTool(_dummy_tool, description="dummy", name="my_tool")
+
+    replay_client = ReplayChatCompletionClient(["response"])
+    cached_client = ChatCompletionCache(replay_client)
+    messages: List[LLMMessage] = [UserMessage(content="hello", source="user")]
+
+    _, key_auto = cached_client._check_cache(messages, [tool], None, {}, "auto")  # type: ignore[reportPrivateUsage]
+    _, key_required = cached_client._check_cache(messages, [tool], None, {}, "required")  # type: ignore[reportPrivateUsage]
+    _, key_none = cached_client._check_cache(messages, [tool], None, {}, "none")  # type: ignore[reportPrivateUsage]
+    _, key_tool = cached_client._check_cache(messages, [tool], None, {}, tool)  # type: ignore[reportPrivateUsage]
+
+    # All four tool_choice values must yield distinct cache keys.
+    assert len({key_auto, key_required, key_none, key_tool}) == 4
+
+    # The default (no tool_choice passed) matches the explicit "auto" default.
+    _, key_default = cached_client._check_cache(messages, [tool], None, {})  # type: ignore[reportPrivateUsage]
+    assert key_default == key_auto


### PR DESCRIPTION
## Why are these changes needed?

`ChatCompletionCache` forwards `tool_choice` to the underlying client, where it
materially changes the model's output (`"auto"` vs `"required"` vs `"none"` vs a
specific forced `Tool`). However `_check_cache` did not include `tool_choice`
when computing the cache key, so two otherwise-identical calls that differ only
in `tool_choice` collide on the same key — the second call silently returns the
first call's cached result:

```python
r1 = await cached_client.create(messages, tools=[tool], tool_choice="none")
r2 = await cached_client.create(messages, tools=[tool], tool_choice="required")
# r2 is r1's cached result: no tool call, despite tool_choice="required"
```

This PR includes `tool_choice` in the cache-key data (representing a forced
`Tool` by its schema name) and passes it through from both `create` and
`create_stream`. A regression test asserts the four `tool_choice` forms produce
distinct cache keys and that the default matches explicit `"auto"`.

Note: existing caches are effectively invalidated by the key change (same as any
cache-key fix); entries were ambiguous between `tool_choice` values anyway.

## Related issue number

N/A — found during review of the cache key computation.

## Related PRs

The same bug has since been reported and fixed independently three more times, which suggests it bites in practice: #8096 (2026-08-25), #8185 (2026-09-04, bundled with unrelated doc changes), #8213 (2026-09-09). This PR is the earliest and is limited to the cache module plus a regression test.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/> (none required for this change).
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed (ran `ruff`, `mypy`, and the relevant `pytest` locally).

