### PR TITLE
docs: add DaoXE OpenAI-compatible client example

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
+++ b/python/docs/src/user-guide/agentchat-user-guide/tutorial/models.ipynb
@@ -127,6 +127,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## DaoXE (OpenAI-compatible gateway)\n",
+    "\n",
+    "[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway. AgentChat can use it through\n",
+    "{py:class}`~autogen_ext.models.openai.OpenAIChatCompletionClient` with a custom `base_url`.\n",
+    "\n",
+    "DaoXE exposes OpenAI Chat Completions at `https://daoxe.com/v1` (and other protocols such as OpenAI Responses\n",
+    "and Anthropic Messages for other clients). Use an exact model ID from your DaoXE account catalog rather than a\n",
+    "hard-coded public list. DaoXE is not available in mainland China.\n",
+    "\n",
+    "```{note}\n",
+    "This uses the same OpenAI-compatible client path documented above. Confirm model capabilities (tools, vision,\n",
+    "JSON) for the specific model ID you select in your DaoXE account.\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from autogen_core.models import UserMessage\n",
+    "from autogen_ext.models.openai import OpenAIChatCompletionClient\n",
+    "\n",
+    "daoxe_client = OpenAIChatCompletionClient(\n",
+    "    model=\"YOUR_DAOXE_MODEL_ID\",  # exact ID from your DaoXE account / GET /v1/models\n",
+    "    api_key=os.environ[\"DAOXE_API_KEY\"],\n",
+    "    base_url=\"https://daoxe.com/v1\",\n",
+    "    # Optional: declare capabilities if the model id is not in the built-in OpenAI model info table\n",
+    "    model_info={\n",
+    "        \"vision\": False,\n",
+    "        \"function_calling\": True,\n",
+    "        \"json_output\": True,\n",
+    "        \"family\": \"unknown\",\n",
+    "        \"structured_output\": True,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "# result = await daoxe_client.create(\n",
+    "#     [UserMessage(content=\"What is the capital of France?\", source=\"user\")]\n",
+    "# )\n",
+    "# print(result)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Azure OpenAI\n",
     "\n",
     "Similarly, install the `azure` and `openai` extensions to use the {py:class}`~autogen_ext.models.openai.AzureOpenAIChatCompletionClient`."


### PR DESCRIPTION
## Summary
- Add a short **DaoXE** section to the AgentChat models tutorial notebook.
- Shows `OpenAIChatCompletionClient` with `base_url=\"https://daoxe.com/v1\"` and an account-scoped model ID placeholder.
- Notes multi-protocol gateway context without hardcoding a public model price list.

DaoXE is a multi-model multi-protocol API gateway. This uses the existing OpenAI-compatible client path already documented in the tutorial.

I am a DaoXE maintainer. Examples: https://github.com/seven7763/DaoXE-AI

## Checklist
- [x] Docs only
- [x] No static model/price table