### PR TITLE
Fix: Handle unknown models gracefully and add extra_body to config

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -511,16 +511,14 @@ def get_info(model: str) -> ModelInfo:
         resolved_model,
         {
             "vision": False,
-            "function_calling": False,
-            "json_output": False,
-            "family": "FAILED",
+            "function_calling": True,
+            "json_output": True,
+            "family": ModelFamily.UNKNOWN,
             "structured_output": False,
         },
     )
-    if model_info.get("family") == "FAILED":
-        raise ValueError("model_info is required when model name is not a valid OpenAI model")
     if model_info.get("family") == ModelFamily.UNKNOWN:
-        trace_logger.warning(f"Model info not found for model: {model}")
+        trace_logger.warning(f"Model info not found for model: {model}. Defaulting to basic capabilities (function_calling=True, json_output=True).")
 
     return model_info
 

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Dict, List, Literal, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Union
 
 from autogen_core import ComponentModel
 from autogen_core.models import ModelCapabilities, ModelInfo  # type: ignore
@@ -50,6 +50,7 @@ class CreateArguments(TypedDict, total=False):
     user: str
     stream_options: Optional[StreamOptions]
     parallel_tool_calls: Optional[bool]
+    extra_body: Optional[Dict[str, Any]]
     reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]]
     """Controls the amount of effort the model uses for reasoning.
     Only applicable to reasoning models like o1 and o3-mini.
@@ -106,6 +107,7 @@ class CreateArgumentsConfigModel(BaseModel):
     user: str | None = None
     stream_options: StreamOptions | None = None
     parallel_tool_calls: bool | None = None
+    extra_body: Dict[str, Any] | None = None
     # Controls the amount of effort the model uses for reasoning (reasoning models only)
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
 


### PR DESCRIPTION
Closes #7418 and Closes #6189. Added `extra_body` to `CreateArguments` and `CreateArgumentsConfigModel` so it is no longer silently ignored when loaded via config/Studio. Updated `get_info` to fallback to `ModelFamily.UNKNOWN` with basic capabilities (function calling, json output) instead of raising `ValueError` for unrecognized model names (e.g., Azure deployments).