### PR TITLE
fix: catch CancelledError in StaticWorkbench to prevent deadlock

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/_static_workbench.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_static_workbench.py
@@ -118,6 +118,9 @@ class StaticWorkbench(Workbench, Component[StaticWorkbenchConfig]):
             actual_tool_output = await result_future
             is_error = False
             result_str = tool.return_value_as_string(actual_tool_output)
+        except asyncio.CancelledError:
+            result_str = "Tool call was cancelled."
+            is_error = True
         except Exception as e:
             result_str = self._format_errors(e)
             is_error = True
@@ -219,6 +222,9 @@ class StaticStreamWorkbench(StaticWorkbench, StreamWorkbench):
                 actual_tool_output = await result_future
             is_error = False
             result_str = tool.return_value_as_string(actual_tool_output)
+        except asyncio.CancelledError:
+            result_str = "Tool call was cancelled."
+            is_error = True
         except Exception as e:
             result_str = self._format_errors(e)
             is_error = True


### PR DESCRIPTION
## Summary

Both `call_tool` and `call_tool_stream` in `StaticWorkbench` and `StaticStreamWorkbench` wrapped the awaited tool future in `except Exception`. Since Python 3.8, `asyncio.CancelledError` inherits from `BaseException`, not `Exception`, so cancellation escapes the handler, propagates into `asyncio.gather` (which lacks `return_exceptions=True`), and the end-of-stream sentinel never reaches the consumer queue — permanently hanging `AssistantAgent.on_messages_stream`.

## Fix

Add explicit `except asyncio.CancelledError` handlers before the existing `except Exception` blocks in both `call_tool` and `call_tool_stream`, converting cancellation into an error `ToolResult` instead of letting it propagate.

## Testing

Verified that:
1. `asyncio.CancelledError` is NOT caught by `except Exception` (Python 3.8+)
2. `except asyncio.CancelledError` correctly catches it
3. Both `call_tool` and `call_tool_stream` now have the fix

Closes #7956