### PR TITLE
fix: remove orphaned FunctionExecutionResultMessages after truncation

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/model_context/_token_limited_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_token_limited_chat_completion_context.py
@@ -4,7 +4,8 @@ from pydantic import BaseModel
 from typing_extensions import Self
 
 from .._component_config import Component, ComponentModel
-from ..models import ChatCompletionClient, FunctionExecutionResultMessage, LLMMessage
+from .._types import FunctionCall
+from ..models import AssistantMessage, ChatCompletionClient, FunctionExecutionResultMessage, LLMMessage
 from ..tools import ToolSchema
 from ._chat_completion_context import ChatCompletionContext
 
@@ -70,10 +71,25 @@ class TokenLimitedChatCompletionContext(ChatCompletionContext, Component[TokenLi
                 middle_index = len(messages) // 2
                 messages.pop(middle_index)
                 token_count = self._model_client.count_tokens(messages, tools=self._tool_schema)
-        if messages and isinstance(messages[0], FunctionExecutionResultMessage):
-            # Handle the first message is a function call result message.
-            # Remove the first message from the list.
-            messages = messages[1:]
+        # Remove orphaned FunctionExecutionResultMessages whose call_ids
+        # no longer have a matching AssistantMessage with FunctionCalls.
+        # After truncation, an AssistantMessage containing FunctionCalls may
+        # be removed while its paired FunctionExecutionResultMessage remains.
+        if messages:
+            # Collect all call_ids from remaining AssistantMessages with FunctionCalls
+            active_call_ids: set[str] = set()
+            for msg in messages:
+                if isinstance(msg, AssistantMessage) and isinstance(msg.content, list):
+                    for fc in msg.content:
+                        if isinstance(fc, FunctionCall):
+                            active_call_ids.add(fc.id)
+            # Filter out FunctionExecutionResultMessages with no matching call
+            messages = [
+                msg
+                for msg in messages
+                if not isinstance(msg, FunctionExecutionResultMessage)
+                or any(r.call_id in active_call_ids for r in msg.content)
+            ]
         return messages
 
     def _to_config(self) -> TokenLimitedChatCompletionContextConfig:


### PR DESCRIPTION
## Summary

`TokenLimitedChatCompletionContext.get_messages()` truncates by repeatedly popping the message at `len(messages) // 2` until the token budget is satisfied. The old cleanup only checked if `messages[0]` was a `FunctionExecutionResultMessage`. If truncation removed an `AssistantMessage` containing `FunctionCall`s while its paired `FunctionExecutionResultMessage` sat elsewhere in the list, the orphan was never repaired — leaving a tool result with no matching tool call.

## Fix

Replace the index-0-only check with a full pass: collect all `call_id`s from remaining `AssistantMessage`s with `FunctionCall`s, then filter out any `FunctionExecutionResultMessage`s whose `call_id`s have no matching call.

## Reproduction

With 7 messages and `token_limit=6`, exactly one pop is needed: `middle_index = 7 // 2 = 3`, which removes the `AssistantMessage` holding `call_1`. The old post-loop check only looks at index 0 (a `UserMessage`), so nothing gets fixed. The returned list still contains the orphaned `FunctionExecutionResultMessage`.

Closes #7955
