### PR TITLE
cookbook: structured authority decisions for tool execution

### DIFF
--- a/python/docs/src/user-guide/core-user-guide/cookbook/index.md
+++ b/python/docs/src/user-guide/core-user-guide/cookbook/index.md
@@ -10,6 +10,7 @@ This section contains a collection of recipes that demonstrate how to use the Co
 azure-openai-with-aad-auth
 termination-with-intervention
 tool-use-with-intervention
+structured-authority-intervention
 extracting-results-with-an-agent
 openai-assistant-agent
 langgraph-agent

--- a/python/docs/src/user-guide/core-user-guide/cookbook/structured-authority-intervention.ipynb
+++ b/python/docs/src/user-guide/core-user-guide/cookbook/structured-authority-intervention.ipynb
@@ -1,0 +1,379 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Structured Authority Decisions for Tool Execution\n",
+    "\n",
+    "This cookbook shows how to intercept tool execution with a structured\n",
+    "authority policy that returns machine-parseable denials, distinguishes\n",
+    "recoverable from permanent rejections, and requires no model, API key,\n",
+    "or Docker dependency.\n",
+    "\n",
+    "Unlike the [basic user approval pattern](tool-use-with-intervention.ipynb)\n",
+    "which uses a yes/no prompt, this recipe separates three policy states:\n",
+    "\n",
+    "- `AIPOU_AUTHORITY_REQUIRED`: authority is missing but recoverable\n",
+    "- `AIPOU_AUTHORITY_ACCEPTED`: authority is present, execution proceeds\n",
+    "- `AIPOU_ACTION_FORBIDDEN`: action is permanently denied, no retry\n",
+    "\n",
+    "An agent loop can branch on the structured denial code without parsing\n",
+    "natural language, and the `canRequestAuthority` flag tells the loop whether\n",
+    "to request authority and retry or to stop immediately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import json\n",
+    "from dataclasses import dataclass\n",
+    "from typing import Any, Callable\n",
+    "\n",
+    "from autogen_core import AgentId, DefaultInterventionHandler, FunctionCall, MessageContext\n",
+    "from autogen_core.tool_agent import ToolException"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the authority decision\n",
+    "\n",
+    "`AuthorityDecision` is the structured result of a policy check. The\n",
+    "`can_request_authority` flag distinguishes recoverable denials (the\n",
+    "agent may request authority and retry) from permanent denials (the\n",
+    "agent must not retry)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dataclass(frozen=True)\n",
+    "class AuthorityDecision:\n",
+    "    allowed: bool\n",
+    "    code: str\n",
+    "    message: str\n",
+    "    action_ref: str\n",
+    "    can_request_authority: bool"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the authority policy\n",
+    "\n",
+    "`InMemoryAuthorityPolicy` is a synthetic policy store for the fixture.\n",
+    "It maintains a set of permanently forbidden tools and a map of granted\n",
+    "authority receipts. The `decide` method returns an `AuthorityDecision`\n",
+    "for a given `FunctionCall`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class InMemoryAuthorityPolicy:\n",
+    "    \"\"\"Synthetic policy store for a reproducible fixture.\"\"\"\n",
+    "\n",
+    "    def __init__(self, permanently_forbidden_tools: set[str] | None = None) -> None:\n",
+    "        self._permanently_forbidden_tools = permanently_forbidden_tools or set()\n",
+    "        self._authority_by_action: dict[str, str] = {}\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def action_ref(call: FunctionCall) -> str:\n",
+    "        return f\"autogen:tool:{call.name}:{call.id}\"\n",
+    "\n",
+    "    def grant(self, action_ref: str, authority_receipt_id: str) -> None:\n",
+    "        self._authority_by_action[action_ref] = authority_receipt_id\n",
+    "\n",
+    "    def decide(self, call: FunctionCall) -> AuthorityDecision:\n",
+    "        action_ref = self.action_ref(call)\n",
+    "        if call.name in self._permanently_forbidden_tools:\n",
+    "            return AuthorityDecision(\n",
+    "                allowed=False,\n",
+    "                code=\"AIPOU_ACTION_FORBIDDEN\",\n",
+    "                message=\"Tool action is permanently forbidden by orchestrator policy.\",\n",
+    "                action_ref=action_ref,\n",
+    "                can_request_authority=False,\n",
+    "            )\n",
+    "        if action_ref not in self._authority_by_action:\n",
+    "            return AuthorityDecision(\n",
+    "                allowed=False,\n",
+    "                code=\"AIPOU_AUTHORITY_REQUIRED\",\n",
+    "                message=\"Matching pre-action authority is required before tool execution.\",\n",
+    "                action_ref=action_ref,\n",
+    "                can_request_authority=True,\n",
+    "            )\n",
+    "        return AuthorityDecision(\n",
+    "            allowed=True,\n",
+    "            code=\"AIPOU_AUTHORITY_ACCEPTED\",\n",
+    "            message=\"Matching pre-action authority is present.\",\n",
+    "            action_ref=action_ref,\n",
+    "            can_request_authority=False,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the intervention handler\n",
+    "\n",
+    "`AuthorityInterventionHandler` intercepts `FunctionCall` messages before\n",
+    "they reach the tool agent. On denial, it raises `ToolException` with a\n",
+    "structured JSON body that an agent loop can parse without natural language\n",
+    "processing. On approval, it returns the original `FunctionCall` unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def parse_denial(exception: ToolException) -> dict[str, Any]:\n",
+    "    return json.loads(exception.content)\n",
+    "\n",
+    "\n",
+    "class AuthorityInterventionHandler(DefaultInterventionHandler):\n",
+    "    \"\"\"Intercept AutoGen FunctionCall messages before ToolAgent execution.\"\"\"\n",
+    "\n",
+    "    def __init__(self, policy: Callable[[FunctionCall], AuthorityDecision]) -> None:\n",
+    "        self._policy = policy\n",
+    "\n",
+    "    async def on_send(\n",
+    "        self,\n",
+    "        message: Any,\n",
+    "        *,\n",
+    "        message_context: MessageContext,\n",
+    "        recipient: AgentId,\n",
+    "    ) -> Any:\n",
+    "        if not isinstance(message, FunctionCall):\n",
+    "            return message\n",
+    "\n",
+    "        decision = self._policy(message)\n",
+    "        if decision.allowed:\n",
+    "            return message\n",
+    "\n",
+    "        denial = {\n",
+    "            \"code\": decision.code,\n",
+    "            \"message\": decision.message,\n",
+    "            \"actionRef\": decision.action_ref,\n",
+    "            \"canRequestAuthority\": decision.can_request_authority,\n",
+    "            \"enforcementPointKind\": \"orchestrator_policy\",\n",
+    "        }\n",
+    "        raise ToolException(content=json.dumps(denial, sort_keys=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test: missing authority returns a recoverable denial\n",
+    "\n",
+    "When no authority receipt exists for the action, the handler raises\n",
+    "`ToolException` with `AIPOU_AUTHORITY_REQUIRED` and `canRequestAuthority`\n",
+    "set to `true`. An agent loop receiving this denial knows it may request\n",
+    "authority and retry once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen_core import CancellationToken\n",
+    "\n",
+    "policy = InMemoryAuthorityPolicy()\n",
+    "handler = AuthorityInterventionHandler(policy.decide)\n",
+    "call = FunctionCall(id=\"call-1\", name=\"write_file\", arguments='{\"path\":\"fixture.txt\"}')\n",
+    "\n",
+    "try:\n",
+    "    await handler.on_send(\n",
+    "        call,\n",
+    "        message_context=MessageContext(\n",
+    "            sender=None,\n",
+    "            topic_id=None,\n",
+    "            is_rpc=True,\n",
+    "            cancellation_token=CancellationToken(),\n",
+    "            message_id=\"test-missing\",\n",
+    "        ),\n",
+    "        recipient=AgentId(\"tool_executor_agent\", \"default\"),\n",
+    "    )\n",
+    "except ToolException as error:\n",
+    "    denial = parse_denial(error)\n",
+    "    print(json.dumps(denial, indent=2))\n",
+    "    assert denial[\"code\"] == \"AIPOU_AUTHORITY_REQUIRED\"\n",
+    "    assert denial[\"canRequestAuthority\"] is True\n",
+    "    print(\"\\nPass: missing authority is recoverable\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test: granted authority allows the original call through\n",
+    "\n",
+    "After authority is granted (the receipt is stored in the policy), the\n",
+    "handler returns the original `FunctionCall` unchanged so execution\n",
+    "proceeds normally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "policy.grant(policy.action_ref(call), \"0x\" + \"11\" * 32)\n",
+    "\n",
+    "result = await handler.on_send(\n",
+    "    call,\n",
+    "    message_context=MessageContext(\n",
+    "        sender=None,\n",
+    "        topic_id=None,\n",
+    "        is_rpc=True,\n",
+    "        cancellation_token=CancellationToken(),\n",
+    "        message_id=\"test-granted\",\n",
+    "    ),\n",
+    "    recipient=AgentId(\"tool_executor_agent\", \"default\"),\n",
+    ")\n",
+    "\n",
+    "assert result is call\n",
+    "print(\"Pass: granted authority allows execution\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test: permanently forbidden tools cannot be executed even with authority\n",
+    "\n",
+    "A tool in the `permanently_forbidden_tools` set is denied regardless of\n",
+    "whether authority was granted. The denial code is `AIPOU_ACTION_FORBIDDEN`\n",
+    "with `canRequestAuthority` set to `false`. An agent loop receiving this\n",
+    "denial knows it must not retry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "forbidden_call = FunctionCall(id=\"call-3\", name=\"delete_production\", arguments=\"{}\")\n",
+    "policy.grant(policy.action_ref(forbidden_call), \"0x\" + \"22\" * 32)\n",
+    "\n",
+    "try:\n",
+    "    await handler.on_send(\n",
+    "        forbidden_call,\n",
+    "        message_context=MessageContext(\n",
+    "            sender=None,\n",
+    "            topic_id=None,\n",
+    "            is_rpc=True,\n",
+    "            cancellation_token=CancellationToken(),\n",
+    "            message_id=\"test-forbidden\",\n",
+    "        ),\n",
+    "        recipient=AgentId(\"tool_executor_agent\", \"default\"),\n",
+    "    )\n",
+    "except ToolException as error:\n",
+    "    denial = parse_denial(error)\n",
+    "    print(json.dumps(denial, indent=2))\n",
+    "    assert denial[\"code\"] == \"AIPOU_ACTION_FORBIDDEN\"\n",
+    "    assert denial[\"canRequestAuthority\"] is False\n",
+    "    print(\"\\nPass: permanent denial is not retryable\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test: non-tool messages pass through unchanged\n",
+    "\n",
+    "Messages that are not `FunctionCall` instances bypass the policy check\n",
+    "entirely. The handler returns them unchanged so regular agent-to-agent\n",
+    "communication is not affected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regular_message = {\"content\": \"hello from agent\"}\n",
+    "\n",
+    "result = await handler.on_send(\n",
+    "    regular_message,\n",
+    "    message_context=MessageContext(\n",
+    "        sender=None,\n",
+    "        topic_id=None,\n",
+    "        is_rpc=True,\n",
+    "        cancellation_token=CancellationToken(),\n",
+    "        message_id=\"test-passthrough\",\n",
+    "    ),\n",
+    "    recipient=AgentId(\"tool_executor_agent\", \"default\"),\n",
+    ")\n",
+    "\n",
+    "assert result is regular_message\n",
+    "print(\"Pass: non-tool messages bypass the policy gate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This pattern extends the basic [user approval intervention](tool-use-with-intervention.ipynb)\n",
+    "with three properties that make it suitable for autonomous agent loops:\n",
+    "\n",
+    "| Property | Basic approval | Structured authority |\n",
+    "|---|---|---|\n",
+    "| Denial format | Natural language | JSON with `code` and `canRequestAuthority` |\n",
+    "| Recoverable vs permanent | Single path (approve or drop) | Separate `AUTHORITY_REQUIRED` (retry once) vs `ACTION_FORBIDDEN` (no retry) |\n",
+    "| Dependencies | Requires model, API key, Docker | None (runs in seconds) |\n",
+    "\n",
+    "The structured denial lets an agent loop branch on `code` without parsing\n",
+    "natural language. The `canRequestAuthority` flag prevents infinite retry\n",
+    "loops on permanently forbidden actions while allowing one retry for\n",
+    "recoverable ones. The zero-dependency fixture makes the pattern easy to\n",
+    "reproduce and test in CI without external services."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Why are these changes needed?

The existing `tool-use-with-intervention` cookbook shows basic user approval for tool execution using a yes/no prompt with `gpt-4o-mini` and Docker. This new cookbook entry adds a complementary pattern: **structured authority decisions** with three properties the basic pattern does not cover:

1. **Machine-parseable denials** - Instead of a natural language yes/no, the handler returns a structured JSON denial (`AIPOU_AUTHORITY_REQUIRED`, `AIPOU_ACTION_FORBIDDEN`) that an agent loop can branch on programmatically.

2. **Recoverable vs permanent** - The basic pattern has one path (approve or drop). This pattern separates "missing authority, request it and retry once" (`canRequestAuthority: true`) from "permanently forbidden, do not retry" (`canRequestAuthority: false`). This prevents infinite retry loops on actions that will never be approved.

3. **Zero dependencies** - The existing cookbook requires an OpenAI API key, `gpt-4o-mini`, and a Docker executor to run end to end. This recipe runs in under 10 seconds with no model, no API key, and no Docker. That makes it easy to reproduce in CI and accessible to users who want to understand the intervention pattern without setting up infrastructure.

The recipe is self-contained in a single notebook with 8 code cells and 9 markdown cells. It uses real `autogen-core` types (`DefaultInterventionHandler`, `FunctionCall`, `ToolException`, `MessageContext`) and requires only `autogen-core` as a dependency.

This work originated from a technical discussion in #7752 about pre-action authority receipts for multi-agent delegated work. The fixture was independently reproduced and the pattern validated through the AIPOU project (https://github.com/0xddneto/AI-Proof-of-Us).

## Related issue number

Related discussion: #7752

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.