### PR TITLE
fix: keep message queue accounting consistent when runtime is stopped with in-flight messages

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -463,7 +463,11 @@ class SingleThreadedAgentRuntime(AgentRuntime):
             if agent_id.type in self._known_agent_names:
                 await (await self._get_agent(agent_id)).load_state(state[str(agent_id)])
 
-    async def _process_send(self, message_envelope: SendMessageEnvelope) -> None:
+    async def _process_send(
+        self,
+        message_envelope: SendMessageEnvelope,
+        message_queue: Queue[PublishMessageEnvelope | SendMessageEnvelope | ResponseMessageEnvelope],
+    ) -> None:
         with self._tracer_helper.trace_block("send", message_envelope.recipient, parent=message_envelope.metadata):
             recipient = message_envelope.recipient
 
@@ -512,7 +516,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
             except CancelledError as e:
                 if not message_envelope.future.cancelled():
                     message_envelope.future.set_exception(e)
-                self._message_queue.task_done()
+                message_queue.task_done()
                 event_logger.info(
                     MessageHandlerExceptionEvent(
                         payload=self._try_serialize(message_envelope.message),
@@ -523,7 +527,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                 return
             except BaseException as e:
                 message_envelope.future.set_exception(e)
-                self._message_queue.task_done()
+                message_queue.task_done()
                 event_logger.info(
                     MessageHandlerExceptionEvent(
                         payload=self._try_serialize(message_envelope.message),
@@ -543,18 +547,28 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                 )
             )
 
-            await self._message_queue.put(
-                ResponseMessageEnvelope(
-                    message=response,
-                    future=message_envelope.future,
-                    sender=message_envelope.recipient,
-                    recipient=message_envelope.sender,
-                    metadata=get_telemetry_envelope_metadata(),
+            try:
+                await message_queue.put(
+                    ResponseMessageEnvelope(
+                        message=response,
+                        future=message_envelope.future,
+                        sender=message_envelope.recipient,
+                        recipient=message_envelope.sender,
+                        metadata=get_telemetry_envelope_metadata(),
+                    )
                 )
-            )
-            self._message_queue.task_done()
+            except QueueShutDown:
+                # The runtime was stopped while the handler was running.
+                # The response can no longer be delivered.
+                if not message_envelope.future.cancelled():
+                    message_envelope.future.set_exception(CancelledError())
+            message_queue.task_done()
 
-    async def _process_publish(self, message_envelope: PublishMessageEnvelope) -> None:
+    async def _process_publish(
+        self,
+        message_envelope: PublishMessageEnvelope,
+        message_queue: Queue[PublishMessageEnvelope | SendMessageEnvelope | ResponseMessageEnvelope],
+    ) -> None:
         with self._tracer_helper.trace_block("publish", message_envelope.topic_id, parent=message_envelope.metadata):
             try:
                 responses: List[Awaitable[Any]] = []
@@ -626,10 +640,14 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                 if not self._ignore_unhandled_handler_exceptions:
                     self._background_exception = e
             finally:
-                self._message_queue.task_done()
+                message_queue.task_done()
             # TODO if responses are given for a publish
 
-    async def _process_response(self, message_envelope: ResponseMessageEnvelope) -> None:
+    async def _process_response(
+        self,
+        message_envelope: ResponseMessageEnvelope,
+        message_queue: Queue[PublishMessageEnvelope | SendMessageEnvelope | ResponseMessageEnvelope],
+    ) -> None:
         with self._tracer_helper.trace_block(
             "ack",
             message_envelope.recipient,
@@ -659,7 +677,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
             )
             if not message_envelope.future.cancelled():
                 message_envelope.future.set_result(message_envelope.message)
-            self._message_queue.task_done()
+            message_queue.task_done()
 
     async def process_next(self) -> None:
         """Process the next message in the queue.
@@ -685,6 +703,11 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                 self._background_exception = None
                 raise e from None
             return
+
+        # Keep a reference to the queue the envelope came from: stop() replaces
+        # self._message_queue with a new queue, and in-flight processing tasks must
+        # call task_done() on the original queue to keep its accounting consistent.
+        message_queue = self._message_queue
 
         match message_envelope:
             case SendMessageEnvelope(message=message, sender=sender, recipient=recipient, future=future):
@@ -721,7 +744,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                                 return
 
                         message_envelope.message = temp_message
-                task = asyncio.create_task(self._process_send(message_envelope))
+                task = asyncio.create_task(self._process_send(message_envelope, message_queue))
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
             case PublishMessageEnvelope(
@@ -761,7 +784,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
 
                         message_envelope.message = temp_message
 
-                task = asyncio.create_task(self._process_publish(message_envelope))
+                task = asyncio.create_task(self._process_publish(message_envelope, message_queue))
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
             case ResponseMessageEnvelope(message=message, sender=sender, recipient=recipient, future=future):
@@ -786,7 +809,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                             future.set_exception(MessageDroppedException())
                             return
                         message_envelope.message = temp_message
-                task = asyncio.create_task(self._process_response(message_envelope))
+                task = asyncio.create_task(self._process_response(message_envelope, message_queue))
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
 

--- a/python/packages/autogen-core/tests/test_runtime.py
+++ b/python/packages/autogen-core/tests/test_runtime.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from dataclasses import dataclass
 
 import pytest
 from autogen_core import (
@@ -12,6 +14,7 @@ from autogen_core import (
     TopicId,
     TypeSubscription,
     event,
+    message_handler,
     try_get_known_serializers_for_type,
     type_subscription,
 )
@@ -363,4 +366,76 @@ async def test_event_handler_exception_multi_message() -> None:
         await runtime.publish_message(MessageType(), topic_id=DefaultTopicId())
         await runtime.stop_when_idle()
 
+    await runtime.close()
+
+
+@dataclass
+class BlockingMessageType: ...
+
+
+@default_subscription
+class BlockingAgent(RoutedAgent):
+    """An agent whose handler blocks until released, to keep a message in flight."""
+
+    def __init__(self, started: asyncio.Event, release: asyncio.Event) -> None:
+        super().__init__("A blocking agent.")
+        self._started = started
+        self._release = release
+
+    @message_handler
+    async def on_new_message(self, message: BlockingMessageType, ctx: MessageContext) -> BlockingMessageType:
+        self._started.set()
+        await self._release.wait()
+        return BlockingMessageType()
+
+
+@pytest.mark.asyncio
+async def test_stop_with_in_flight_publish_keeps_queue_accounting_consistent() -> None:
+    # Regression test for https://github.com/microsoft/autogen/issues/7007.
+    # stop() replaces the runtime's message queue. An in-flight handler task must
+    # call task_done() on the queue its message came from, not on the new queue,
+    # otherwise it raises ValueError("task_done() called too many times").
+    started = asyncio.Event()
+    release = asyncio.Event()
+    runtime = SingleThreadedAgentRuntime()
+    await BlockingAgent.register(runtime, "blocking", lambda: BlockingAgent(started, release))
+    runtime.start()
+    await runtime.publish_message(BlockingMessageType(), topic_id=DefaultTopicId())
+    await started.wait()
+    background_tasks = list(runtime._background_tasks)  # type: ignore[reportPrivateUsage]
+    # Stop while the handler is still running.
+    await runtime.stop()
+    release.set()
+    results = await asyncio.gather(*background_tasks, return_exceptions=True)
+    errors = [result for result in results if isinstance(result, BaseException)]
+    assert not errors, f"in-flight processing task raised: {errors!r}"
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_stop_with_in_flight_send_resolves_future_and_keeps_queue_clean() -> None:
+    # Companion to the test above for the RPC path: if the runtime is stopped while
+    # an RPC handler is running, the response can no longer be delivered. The sender's
+    # future must not hang forever, and the replaced queue must not receive the stale
+    # response envelope.
+    started = asyncio.Event()
+    release = asyncio.Event()
+    runtime = SingleThreadedAgentRuntime()
+    await BlockingAgent.register(runtime, "blocking", lambda: BlockingAgent(started, release))
+    runtime.start()
+    send_task = asyncio.ensure_future(runtime.send_message(BlockingMessageType(), AgentId("blocking", "default")))
+    await started.wait()
+    background_tasks = list(runtime._background_tasks)  # type: ignore[reportPrivateUsage]
+    # Stop while the handler is still running.
+    await runtime.stop()
+    release.set()
+    results = await asyncio.gather(*background_tasks, return_exceptions=True)
+    errors = [result for result in results if isinstance(result, BaseException)]
+    assert not errors, f"in-flight processing task raised: {errors!r}"
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(send_task, timeout=5)
+    # The new queue must be empty so a restarted runtime is not polluted by stale envelopes.
+    assert runtime.unprocessed_messages_count == 0
+    runtime.start()
+    await asyncio.wait_for(runtime.stop_when_idle(), timeout=5)
     await runtime.close()


### PR DESCRIPTION
## Why are these changes needed?

`SingleThreadedAgentRuntime.stop()` replaces `self._message_queue` with a fresh `Queue` while in-flight `_process_send` / `_process_publish` / `_process_response` tasks may still be running. When such a task finishes, it re-reads `self._message_queue` and calls `task_done()` on the new, empty queue, whose unfinished-task counter is 0. This raises `ValueError: task_done() called too many times` as an unretrieved task exception — exactly the traceback reported in #7007 (commonly triggered by pressing Ctrl+C while a team is running, which stops the runtime while handlers are still in flight).

There is a second consequence on the RPC path: an in-flight `_process_send` would `put()` its response envelope into the replacement queue. The sender's future then never resolves (the run loop that would deliver it has exited), and the stale envelope pollutes the new queue, so a restarted runtime crashes with the same `ValueError` when it processes the stale response.

### The fix

- `_process_next()` captures the queue an envelope was taken from and passes it to the processing task, so `task_done()` (and the response `put()`) always operate on the matching queue.
- If the queue was shut down while an RPC handler was running (i.e. the runtime was stopped), the response can no longer be delivered: the sender's future is resolved with `CancelledError` instead of being left pending forever. This matches the documented semantics of `stop()` ("The currently processing message will be completed, but all others following it will be discarded") and the existing `CancelledError` handling in `_process_send`.

Both new regression tests fail on `main` and pass with this change:

- the publish-path test reproduces the exact `ValueError('task_done() called too many times')` from the issue
- the send-path test hangs on `main` (sender future never resolves) and verifies the replaced queue stays clean so the runtime can be restarted

Verified locally: `pytest` (autogen-core: 222 passed; autogen-agentchat `test_group_chat.py`: 87 passed), `ruff check`, `ruff format --check`, `mypy`, and `pyright` all pass on the changed packages.

## Related issue number

Closes #7007

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally. (No doc changes needed — internal fix, no API change.)
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.