### PR TITLE
Add autogen-scavio to community extensions

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -46,7 +46,7 @@ Find community samples and examples of how to use AutoGen
 | [autogen-oaiapi](https://github.com/SongChiYoung/autogen-oaiapi)  | [PyPi](https://pypi.org/project/autogen-oaiapi/) | an OpenAI-style API server built on top of AutoGen |
 | [autogen-contextplus](https://github.com/SongChiYoung/autogen-contextplus)  | [PyPi](https://pypi.org/project/autogen-contextplus/) | Enhanced model_context implementations, with features such as automatic summarization and truncation of model context. |
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
-| [autogen-scavio](https://github.com/scavio-ai/autogen-scavio) | [PyPi](https://pypi.org/project/autogen-scavio/) | Real-time search tools for Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram via the [Scavio](https://scavio.dev) API |
+| [autogen-scavio](https://github.com/scavio-ai/autogen-scavio) | [PyPi](https://pypi.org/project/autogen-scavio/) | Real-time search tools for Google, YouTube, Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X, and LinkedIn via the [Scavio](https://scavio.dev) API |
 
 
 <!-- Example -->

--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -46,7 +46,7 @@ Find community samples and examples of how to use AutoGen
 | [autogen-oaiapi](https://github.com/SongChiYoung/autogen-oaiapi)  | [PyPi](https://pypi.org/project/autogen-oaiapi/) | an OpenAI-style API server built on top of AutoGen |
 | [autogen-contextplus](https://github.com/SongChiYoung/autogen-contextplus)  | [PyPi](https://pypi.org/project/autogen-contextplus/) | Enhanced model_context implementations, with features such as automatic summarization and truncation of model context. |
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
-| [autogen-scavio](https://github.com/scavio-ai/autogen-scavio) | [PyPi](https://pypi.org/project/autogen-scavio/) | Real-time search tools for Google, YouTube, Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X, and LinkedIn via the [Scavio](https://scavio.dev) API |
+| [autogen-scavio](https://github.com/scavio-ai/autogen-scavio) | [PyPi](https://pypi.org/project/autogen-scavio/) | Real-time web data tools across 30+ platforms (search, retail, real estate, travel, jobs, app stores, company filings, ad libraries, social), plus reading any URL as clean Markdown, via the [Scavio](https://scavio.dev) API |
 
 
 <!-- Example -->

--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -46,6 +46,7 @@ Find community samples and examples of how to use AutoGen
 | [autogen-oaiapi](https://github.com/SongChiYoung/autogen-oaiapi)  | [PyPi](https://pypi.org/project/autogen-oaiapi/) | an OpenAI-style API server built on top of AutoGen |
 | [autogen-contextplus](https://github.com/SongChiYoung/autogen-contextplus)  | [PyPi](https://pypi.org/project/autogen-contextplus/) | Enhanced model_context implementations, with features such as automatic summarization and truncation of model context. |
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
+| [autogen-scavio](https://github.com/scavio-ai/autogen-scavio) | [PyPi](https://pypi.org/project/autogen-scavio/) | Real-time search tools for Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram via the [Scavio](https://scavio.dev) API |
 
 
 <!-- Example -->


### PR DESCRIPTION
Adds `autogen-scavio` to the Discover community extensions list.

It gives AutoGen agents real-time web data tools across 30+ platforms (search, retail, real estate, travel, jobs, app stores, company filings, ad libraries, social), plus `scavio_extract`, which reads any URL as clean Markdown, via the [Scavio](https://scavio.dev) API.

The description is deliberately written by category rather than by platform name, so the row does not go stale every time the package adds a source.

Package: https://pypi.org/project/autogen-scavio/
Repo: https://github.com/scavio-ai/autogen-scavio

One-line docs change; no code touched.
