### PR TITLE
fix: preserve logprobs in OpenAIChatCompletionClient.create_stream

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -967,6 +967,23 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                 is_reasoning = False
                 yield reasoning_content
 
+            # Collect logprobs before the content fast-path below, because content-bearing
+            # chunks are exactly the ones that carry the logprobs for their delta tokens.
+            # Accumulate across chunks instead of overwriting so that the final
+            # CreateResult.logprobs matches what the non-streaming path returns.
+            if choice.logprobs and choice.logprobs.content:
+                if logprobs is None:
+                    logprobs = []
+                logprobs.extend(
+                    ChatCompletionTokenLogprob(
+                        token=x.token,
+                        logprob=x.logprob,
+                        top_logprobs=[TopLogprob(logprob=y.logprob, bytes=y.bytes) for y in x.top_logprobs],
+                        bytes=x.bytes,
+                    )
+                    for x in choice.logprobs.content
+                )
+
             # First try get content
             if choice.delta.content:
                 content_deltas.append(choice.delta.content)
@@ -991,16 +1008,6 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                             full_tool_calls[idx].name += tool_call_chunk.function.name
                         if tool_call_chunk.function.arguments is not None:
                             full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
-            if choice.logprobs and choice.logprobs.content:
-                logprobs = [
-                    ChatCompletionTokenLogprob(
-                        token=x.token,
-                        logprob=x.logprob,
-                        top_logprobs=[TopLogprob(logprob=y.logprob, bytes=y.bytes) for y in x.top_logprobs],
-                        bytes=x.bytes,
-                    )
-                    for x in choice.logprobs.content
-                ]
 
         # Finalize the CreateResult.
 

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -41,6 +41,7 @@ from openai.types.chat.chat_completion_chunk import (
     ChoiceDelta,
     ChoiceDeltaToolCall,
     ChoiceDeltaToolCallFunction,
+    ChoiceLogprobs,
 )
 from openai.types.chat.chat_completion_chunk import (
     Choice as ChunkChoice,
@@ -50,6 +51,7 @@ from openai.types.chat.chat_completion_message_tool_call import (
     ChatCompletionMessageToolCall,
     Function,
 )
+from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob, TopLogprob
 from openai.types.chat.parsed_chat_completion import ParsedChatCompletion, ParsedChatCompletionMessage, ParsedChoice
 from openai.types.chat.parsed_function_tool_call import ParsedFunction, ParsedFunctionToolCall
 from openai.types.completion_usage import CompletionUsage
@@ -1175,6 +1177,90 @@ async def test_r1_reasoning_content_streaming(monkeypatch: pytest.MonkeyPatch) -
     assert isinstance(chunks[4], CreateResult)
     assert chunks[4].content == "This is the main content"
     assert chunks[4].thought == "This is the reasoning content 1This is the reasoning content 2"
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_completion_client_create_stream_logprobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that logprobs carried on streamed content chunks are accumulated into CreateResult.logprobs.
+
+    Regression test: content-bearing chunks used to hit the content fast-path's `continue`
+    before the logprobs collection block, so CreateResult.logprobs was always None for text
+    streams; and the collection block used to overwrite instead of extend across chunks.
+    """
+    stream_tokens = ["Hello", " ", "world"]
+
+    async def _mock_create_stream_logprobs(*args: Any, **kwargs: Any) -> AsyncGenerator[ChatCompletionChunk, None]:
+        for i, token in enumerate(stream_tokens):
+            await asyncio.sleep(0.01)
+            yield ChatCompletionChunk(
+                id="id",
+                choices=[
+                    ChunkChoice(
+                        finish_reason=None,
+                        index=0,
+                        delta=ChoiceDelta(content=token, role="assistant"),
+                        logprobs=ChoiceLogprobs(
+                            content=[
+                                ChatCompletionTokenLogprob(
+                                    token=token,
+                                    logprob=-0.1 * (i + 1),
+                                    bytes=list(token.encode("utf-8")),
+                                    top_logprobs=[
+                                        TopLogprob(
+                                            token=token,
+                                            logprob=-0.1 * (i + 1),
+                                            bytes=list(token.encode("utf-8")),
+                                        )
+                                    ],
+                                )
+                            ]
+                        ),
+                    ),
+                ],
+                created=0,
+                model="gpt-4.1-nano-2025-04-14",
+                object="chat.completion.chunk",
+                usage=None,
+            )
+        yield ChatCompletionChunk(
+            id="id",
+            choices=[
+                ChunkChoice(
+                    finish_reason="stop",
+                    index=0,
+                    delta=ChoiceDelta(content=None, role="assistant"),
+                ),
+            ],
+            created=0,
+            model="gpt-4.1-nano-2025-04-14",
+            object="chat.completion.chunk",
+            usage=CompletionUsage(prompt_tokens=3, completion_tokens=3, total_tokens=6),
+        )
+
+    async def _mock_create_logprobs(*args: Any, **kwargs: Any) -> AsyncGenerator[ChatCompletionChunk, None]:
+        await asyncio.sleep(0.01)
+        return _mock_create_stream_logprobs(*args, **kwargs)
+
+    monkeypatch.setattr(AsyncCompletions, "create", _mock_create_logprobs)
+    client = OpenAIChatCompletionClient(model="gpt-4.1-nano", api_key="api_key")
+    chunks: List[str | CreateResult] = []
+    async for chunk in client.create_stream(
+        messages=[UserMessage(content="Hello", source="user")],
+        extra_create_args={"logprobs": True, "top_logprobs": 1},
+    ):
+        chunks.append(chunk)
+
+    result = chunks[-1]
+    assert isinstance(result, CreateResult)
+    assert result.content == "Hello world"
+    # The streaming result must carry the logprobs of all streamed tokens,
+    # matching what the non-streaming create() path returns for the same response.
+    assert result.logprobs is not None
+    assert [x.token for x in result.logprobs] == stream_tokens
+    assert [x.logprob for x in result.logprobs] == [pytest.approx(-0.1 * (i + 1)) for i in range(len(stream_tokens))]
+    for x in result.logprobs:
+        assert x.top_logprobs is not None
+        assert len(x.top_logprobs) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why are these changes needed?

When streaming with logprobs enabled (`extra_create_args={"logprobs": True, "top_logprobs": N}`), `OpenAIChatCompletionClient.create_stream` returns a `CreateResult` whose `logprobs` is always `None` for text responses, while the non-streaming `create()` path returns full logprobs for the same response.

Two issues in the chunk loop of `create_stream` (`python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py`):

1. **The content fast-path skips logprobs collection.** Any chunk carrying `delta.content` hits `continue` before the `if choice.logprobs and choice.logprobs.content:` block — but content-bearing chunks are exactly the ones that carry the logprobs for those tokens. So for text streams the block never runs and `CreateResult.logprobs` is always `None`.
2. **The collection overwrites instead of accumulating.** Even when the block is reached (tool-call streams), `logprobs = [...]` reassigns the list on every chunk, so only the last chunk's tokens survive.

### Fix

- Move the logprobs collection above the content fast-path so it runs for every non-empty choice.
- Accumulate with `extend` across chunks instead of reassigning.
- Semantics preserved: `logprobs` stays `None` when the stream carried none.

The construction of `ChatCompletionTokenLogprob`/`TopLogprob` entries is unchanged and matches the non-streaming path.

### How it was tested

Added `test_openai_chat_completion_client_create_stream_logprobs` in `python/packages/autogen-ext/tests/models/test_openai_model_client.py`, mirroring the existing mocked-chunk streaming tests: three content chunks each carrying `ChoiceLogprobs` for their delta token plus a finish chunk. The test fails on current `main` (`result.logprobs is None`) and passes with this fix (all three tokens present, in order, with their `top_logprobs`).

`pytest tests/models/test_openai_model_client.py` shows no regressions (failure list identical before/after this change), and `ruff check` / `ruff format --check` (pinned 0.4.8) pass on both touched files.

## Related issue number

None found — searched open/closed issues and PRs for "logprobs", "create_stream logprobs", "logprobs stream"; closest hits (#6192, #1044, #4213) are unrelated.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. (No doc changes needed: bug fix restoring documented `CreateResult.logprobs` behavior; no API change.)
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
