### PR TITLE
Include tool_choice in ChatCompletionCache's cache key

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
@@ -179,6 +179,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         tools: Sequence[Tool | ToolSchema],
         json_output: Optional[bool | type[BaseModel]],
         extra_create_args: Mapping[str, Any],
+        tool_choice: Tool | Literal["auto", "required", "none"] = "auto",
     ) -> tuple[Optional[Union[CreateResult, List[Union[str, CreateResult]]]], str]:
         """
         Helper function to check the cache for a result.
@@ -192,11 +193,17 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         elif isinstance(json_output, bool):
             json_output_data = json_output
 
+        # tool_choice changes what the underlying client is asked to do (let the model decide,
+        # force a tool call, forbid tool calls, or force one specific tool) and materially
+        # changes the shape of the response, so it must be part of the cache key too.
+        tool_choice_data = tool_choice.schema if isinstance(tool_choice, Tool) else tool_choice
+
         data = {
             "messages": [message.model_dump() for message in messages],
             "tools": [(tool.schema if isinstance(tool, Tool) else tool) for tool in tools],
             "json_output": json_output_data,
             "extra_create_args": extra_create_args,
+            "tool_choice": tool_choice_data,
         }
         serialized_data = json.dumps(data, sort_keys=True)
         cache_key = hashlib.sha256(serialized_data.encode()).hexdigest()
@@ -270,7 +277,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
 
         NOTE: cancellation_token is ignored for cached results.
         """
-        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args)
+        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args, tool_choice)
         if cached_result is not None:
             if isinstance(cached_result, CreateResult):
                 # Cache hit from previous non-streaming call
@@ -319,6 +326,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
                 tools,
                 json_output,
                 extra_create_args,
+                tool_choice,
             )
             if cached_result is not None:
                 if isinstance(cached_result, list):

--- a/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
+++ b/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
@@ -84,6 +84,59 @@ async def test_cache_miss_on_tool_choice_change() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cache_hit_omitted_tool_choice_matches_explicit_auto() -> None:
+    """Regression test: omitting tool_choice entirely must hash identically to passing
+    tool_choice="auto" explicitly, since that is create()'s own default. If a future change
+    let these two forms diverge (e.g. by defaulting _check_cache's tool_choice to something
+    that doesn't match create()'s default), every caller that omits tool_choice would silently
+    stop sharing a cache with callers who pass "auto" explicitly, and vice versa."""
+    responses, prompts, system_prompt, _, cached_client = get_test_data()
+
+    message = [system_prompt, UserMessage(content=prompts[0], source="user")]
+
+    response0 = await cached_client.create(message)  # tool_choice omitted
+    assert not response0.cached
+    assert response0.content == responses[0]
+
+    response0_explicit_auto = await cached_client.create(message, tool_choice="auto")
+    assert response0_explicit_auto.cached
+    assert response0_explicit_auto.content == responses[0]
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_on_forced_tool_choice_then_none() -> None:
+    """Regression test covering the specific transition raised in review on #7968: an
+    agent step that forces a specific tool call followed by a step that forbids tool calls
+    entirely. These represent different authority boundaries for the model (forced to call
+    a tool vs. not allowed to), so serving step two a cached response generated under step
+    one's tool_choice would let the caller act on a result produced under the wrong policy."""
+    responses, prompts, system_prompt, _, cached_client = get_test_data()
+    from autogen_core.tools import FunctionTool
+
+    def _add_numbers(a: int, b: int) -> int:
+        return a + b
+
+    add_tool = FunctionTool(_add_numbers, description="Add two numbers together", name="add_numbers")
+    message = [system_prompt, UserMessage(content=prompts[0], source="user")]
+
+    response0 = await cached_client.create(message, tools=[add_tool], tool_choice=add_tool)
+    assert not response0.cached
+    assert response0.content == responses[0]
+
+    # Same messages and tools, but tool_choice="none" instead of forcing add_tool: must not
+    # replay response0, that response was generated under a "you must call add_numbers"
+    # instruction, not a "you may not call any tool" one.
+    response1 = await cached_client.create(message, tools=[add_tool], tool_choice="none")
+    assert not response1.cached
+    assert response1.content == responses[1]
+
+    # The original forced-tool call is still a cache hit against itself.
+    response0_cached = await cached_client.create(message, tools=[add_tool], tool_choice=add_tool)
+    assert response0_cached.cached
+    assert response0_cached.content == responses[0]
+
+
+@pytest.mark.asyncio
 async def test_cache_structured_output_with_args() -> None:
     responses, prompts, system_prompt, _, cached_client = get_test_data(num_messages=4)
 

--- a/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
+++ b/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
@@ -59,6 +59,31 @@ async def test_cache_basic_with_args() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cache_miss_on_tool_choice_change() -> None:
+    """Regression test: tool_choice must be part of the cache key, since it changes what the
+    underlying client is asked to do (let the model decide, force/forbid a tool call) and can
+    materially change the shape of the response. A call that only differs by tool_choice must
+    not be served a cached result from a call made with a different tool_choice."""
+    responses, prompts, system_prompt, _, cached_client = get_test_data()
+
+    message = [system_prompt, UserMessage(content=prompts[0], source="user")]
+
+    response0 = await cached_client.create(message, tool_choice="auto")
+    assert not response0.cached
+    assert response0.content == responses[0]
+
+    # Same messages, different tool_choice: must be a cache miss, not a replay of response0.
+    response1 = await cached_client.create(message, tool_choice="none")
+    assert not response1.cached
+    assert response1.content == responses[1]
+
+    # Now this exact (messages, tool_choice="auto") combination should be a cache hit.
+    response0_cached = await cached_client.create(message, tool_choice="auto")
+    assert response0_cached.cached
+    assert response0_cached.content == responses[0]
+
+
+@pytest.mark.asyncio
 async def test_cache_structured_output_with_args() -> None:
     responses, prompts, system_prompt, _, cached_client = get_test_data(num_messages=4)
 


### PR DESCRIPTION
Fixes #7968.

## What's wrong

`ChatCompletionCache._check_cache` builds its cache key from `messages`, `tools`, `json_output`, and `extra_create_args` only, `tool_choice` was never included, even though it's an explicit parameter of `create()`/`create_stream()` that changes what the underlying client is asked to do (let the model decide, force a tool call, forbid tool calls, or force one specific tool) and materially changes the shape of the response. Two calls with identical messages/tools but different `tool_choice` collided on the same cache key, so the second call was silently served the first call's cached response.

This is exactly the scenario the codebase itself exercises: `AssistantAgent._reflect_on_tool_use_flow` passes `tool_choice="none"` to force a plain-text reflection after tool execution, while the normal tool-call path uses `tool_choice="auto"`. Reusing one `ChatCompletionCache`-wrapped client across both would be affected.

## Fix

Thread `tool_choice` through to `_check_cache` from both `create()` and `create_stream()`, and include it in the hashed data (serializing a forced `Tool`'s `.schema`, the same way `tools` is already serialized, or the literal string otherwise).

## Testing

Added `test_cache_miss_on_tool_choice_change` to `tests/models/test_chat_completion_cache.py`, next to the existing `test_cache_basic_with_args` which already tests "cache miss if args change" for `json_output`.

Verified red against the original code:
```
AssertionError: assert not True
 +  where True = CreateResult(..., cached=True).cached
```
(the second call, same messages but `tool_choice="none"`, incorrectly reported `cached=True`)

Verified green with the fix, and ran the full suite:
```
tests/models/test_chat_completion_cache.py: 27 passed
```
No regressions in any of the existing 26 tests.

I also reproduced the original bug with a small fake `ChatCompletionClient` whose response actually depends on `tool_choice` (to mirror what a real provider does, since `ReplayChatCompletionClient` alone can't distinguish "wrong response shape", only "which response index"), confirming the underlying client was only ever invoked once across both calls before the fix, and correctly invoked twice after.
