### PR TITLE
Preserve chronological order in MessageFilterAgent._apply_filter

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
@@ -152,19 +152,23 @@ class MessageFilterAgent(BaseChatAgent, Component[MessageFilterAgentConfig]):
         return self._wrapped_agent.produced_message_types
 
     def _apply_filter(self, messages: Sequence[BaseChatMessage]) -> Sequence[BaseChatMessage]:
-        result: List[BaseChatMessage] = []
+        # Track each kept message by its original index so the result below can be
+        # restored to chronological order, instead of the order per_source happens
+        # to list its sources in.
+        kept: dict[int, BaseChatMessage] = {}
 
         for source_filter in self._filter.per_source:
-            msgs = [m for m in messages if m.source == source_filter.source]
+            indexed_msgs = [(i, m) for i, m in enumerate(messages) if m.source == source_filter.source]
 
             if source_filter.position == "first" and source_filter.count:
-                msgs = msgs[: source_filter.count]
+                indexed_msgs = indexed_msgs[: source_filter.count]
             elif source_filter.position == "last" and source_filter.count:
-                msgs = msgs[-source_filter.count :]
+                indexed_msgs = indexed_msgs[-source_filter.count :]
 
-            result.extend(msgs)
+            for i, m in indexed_msgs:
+                kept[i] = m
 
-        return result
+        return [kept[i] for i in sorted(kept)]
 
     async def on_messages(
         self,

--- a/python/packages/autogen-agentchat/tests/test_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_message_filter_agent.py
@@ -1,0 +1,95 @@
+from typing import Sequence
+
+import pytest
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.agents._message_filter_agent import (
+    MessageFilterAgent,
+    MessageFilterConfig,
+    PerSourceFilter,
+)
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import BaseChatMessage, TextMessage
+from autogen_core import CancellationToken
+
+
+class _RecordingAgent(BaseChatAgent):
+    """Records the exact sequence of messages it receives, for assertions."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name=name, description="records message order")
+        self.received: list[BaseChatMessage] = []
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        self.received = list(messages)
+        return Response(chat_message=TextMessage(content="ack", source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        self.received = []
+
+
+@pytest.mark.asyncio
+async def test_message_filter_agent_preserves_chronological_order() -> None:
+    """Regression test: filtered messages from multiple sources must come out in their
+    original chronological order, not in the order per_source lists its sources."""
+    transcript = [
+        TextMessage(content="please solve X", source="user"),
+        TextMessage(content="A's first attempt", source="A"),
+        TextMessage(content="B's first review", source="B"),
+        TextMessage(content="A's second attempt", source="A"),
+    ]
+
+    inner = _RecordingAgent("inner")
+    agent = MessageFilterAgent(
+        name="B",
+        wrapped_agent=inner,
+        filter=MessageFilterConfig(
+            per_source=[
+                # Deliberately listed out of chronological order: "A" is listed before
+                # "B" here, even though B's kept message (t2) predates A's kept message (t3).
+                PerSourceFilter(source="user", position="first", count=1),
+                PerSourceFilter(source="A", position="last", count=1),
+                PerSourceFilter(source="B", position="last", count=10),
+            ]
+        ),
+    )
+
+    await agent.on_messages(transcript, CancellationToken())
+
+    assert [m.source for m in inner.received] == ["user", "B", "A"]
+    assert [m.content for m in inner.received] == [
+        "please solve X",
+        "B's first review",
+        "A's second attempt",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_message_filter_agent_first_and_last_counts_per_source() -> None:
+    """Sanity check that first-N/last-N selection within a single source is unaffected
+    by the chronological-ordering fix."""
+    transcript = [
+        TextMessage(content="user msg", source="user"),
+        TextMessage(content="A msg 1", source="A"),
+        TextMessage(content="A msg 2", source="A"),
+        TextMessage(content="A msg 3", source="A"),
+    ]
+
+    inner = _RecordingAgent("inner")
+    agent = MessageFilterAgent(
+        name="wrapper",
+        wrapped_agent=inner,
+        filter=MessageFilterConfig(
+            per_source=[
+                PerSourceFilter(source="user", position="first", count=1),
+                PerSourceFilter(source="A", position="last", count=2),
+            ]
+        ),
+    )
+
+    await agent.on_messages(transcript, CancellationToken())
+
+    assert [m.content for m in inner.received] == ["user msg", "A msg 2", "A msg 3"]


### PR DESCRIPTION
Fixes #7971.

## What's broken

`MessageFilterAgent._apply_filter` built its result by iterating `MessageFilterConfig.per_source` and extending the output with each source's matches in turn, so the emitted sequence's order reflected the order sources are listed in the filter config, not each message's actual chronological position.

This breaks the class's own documented example: a looping graph `A → B → A → B → C` where B is configured with `per_source=[user-first(1), A-last(1), B-last(N)]` specifically "to see the user message, last message from A, and its own prior responses (for reflection)". If A has spoken twice by the time B runs again, the real timeline is `user → A(older) → B(own) → A(newer)`, but the old code emitted `[user, A(newer), B(own)]`, placing A's newer message before B's own prior response that actually happened earlier. The wrapped agent silently receives a scrambled timeline, no error or warning.

## Fix

Track each kept message by its original index while applying the per-source first-N/last-N selection (that part is unchanged), then return messages sorted by original index, so the emitted subsequence always preserves chronological order regardless of `per_source`'s list order.

## Testing

There was no dedicated test file for `MessageFilterAgent` before this, added `tests/test_message_filter_agent.py` with two tests:
- `test_message_filter_agent_preserves_chronological_order`: reproduces the exact scenario above (sources listed out of chronological order in the filter config) and asserts the wrapped agent receives messages in original timeline order.
- `test_message_filter_agent_first_and_last_counts_per_source`: sanity check that first-N/last-N selection within a single source still works correctly, unaffected by the ordering fix.

Verified both directions locally:
```
# against the unfixed _apply_filter (git stash)
FAILED tests/test_message_filter_agent.py::test_message_filter_agent_preserves_chronological_order
AssertionError: assert ['user', 'A', 'B'] == ['user', 'B', 'A']
tests/test_message_filter_agent.py::test_message_filter_agent_first_and_last_counts_per_source PASSED
(the count-selection logic itself was never broken, only cross-source ordering)

# against the fix
tests/test_message_filter_agent.py::test_message_filter_agent_preserves_chronological_order PASSED
tests/test_message_filter_agent.py::test_message_filter_agent_first_and_last_counts_per_source PASSED
```
