### PR TITLE
fix: include tool_choice in ChatCompletionCache cache key (issue #7968)

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
@@ -179,6 +179,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         tools: Sequence[Tool | ToolSchema],
         json_output: Optional[bool | type[BaseModel]],
         extra_create_args: Mapping[str, Any],
+        tool_choice: "Tool | Literal['auto', 'required', 'none']" = "auto",
     ) -> tuple[Optional[Union[CreateResult, List[Union[str, CreateResult]]]], str]:
         """
         Helper function to check the cache for a result.
@@ -192,10 +193,20 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         elif isinstance(json_output, bool):
             json_output_data = json_output
 
+        # Normalize tool_choice so it contributes to the cache key. A previous
+        # request with a different tool_choice must not be served from cache
+        # (see issue #7968: cache key ignored tool_choice and returned stale
+        # responses when only tool_choice differed).
+        if isinstance(tool_choice, Tool):
+            tool_choice_data: Any = tool_choice.schema
+        else:
+            tool_choice_data = tool_choice
+
         data = {
             "messages": [message.model_dump() for message in messages],
             "tools": [(tool.schema if isinstance(tool, Tool) else tool) for tool in tools],
             "json_output": json_output_data,
+            "tool_choice": tool_choice_data,
             "extra_create_args": extra_create_args,
         }
         serialized_data = json.dumps(data, sort_keys=True)
@@ -270,7 +281,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
 
         NOTE: cancellation_token is ignored for cached results.
         """
-        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args)
+        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args, tool_choice)
         if cached_result is not None:
             if isinstance(cached_result, CreateResult):
                 # Cache hit from previous non-streaming call
@@ -319,6 +330,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
                 tools,
                 json_output,
                 extra_create_args,
+                tool_choice,
             )
             if cached_result is not None:
                 if isinstance(cached_result, list):

--- a/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
+++ b/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
@@ -956,3 +956,27 @@ async def test_create_stream_with_cached_non_streaming_result_non_string_content
     assert stream_results[0].content == [expected_function_call]
     assert stream_results[0].finish_reason == "function_calls"
     assert stream_results[0].cached is True
+
+
+async def test_cache_key_includes_tool_choice() -> None:
+    """Different tool_choice values on otherwise identical requests must produce
+    different cache keys (regression for issue #7968)."""
+    _, _, _, replay_client, _ = get_test_data()
+    messages = [
+        SystemMessage(content="You are helpful.", source="system"),
+        UserMessage(content="Hello", source="user"),
+    ]
+
+    cache_store = MockCacheStore(return_value=None)
+    client = ChatCompletionCache(replay_client, cache_store)
+
+    _, key_auto = client._check_cache(messages, [], None, {}, "auto")  # type: ignore
+    _, key_required = client._check_cache(messages, [], None, {}, "required")  # type: ignore
+    _, key_none = client._check_cache(messages, [], None, {}, "none")  # type: ignore
+    _, key_auto_again = client._check_cache(messages, [], None, {}, "auto")  # type: ignore
+
+    print("KEYS:", key_auto[:16], key_required[:16], key_none[:16])
+    assert key_auto != key_required
+    assert key_auto != key_none
+    assert key_required != key_none
+    assert key_auto == key_auto_again


### PR DESCRIPTION
## Summary
Fixes #7968.

`ChatCompletionCache._check_cache` computed the cache key from `messages`, `tools`, `json_output`, and `extra_create_args` — but **ignored `tool_choice`**. Two requests that differed only in `tool_choice` (`"auto"` vs `"required"` vs `"none"`) therefore collided on the same cache key, and a stale cached response was served for the wrong `tool_choice`.

### Before
```python
r1 = await client.create(msgs, tool_choice="auto")      # cached (call #1)
r2 = await client.create(msgs, tool_choice="required")  # served r1 from cache — WRONG
```

### After
- `tool_choice` is now passed into `_check_cache` and included in the serialized cache-key payload (normalized: `Tool` → `.schema`, otherwise the literal string).
- Keys for different `tool_choice` values are distinct; identical requests still dedupe.

## Changes
- `python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py`: thread `tool_choice` through `_check_cache` and into the cache-key data dict.
- `tests/models/test_chat_completion_cache.py`: add `test_cache_key_includes_tool_choice` (verifies `auto`/`required`/`none` produce distinct keys, and that identical `tool_choice` is stable).

## Test plan
- [x] `pytest tests/models/test_chat_completion_cache.py` → 26 passed, 1 skipped
- Non-breaking: only widens the cache key; previously-cached entries simply miss and re-fetch.

Happy to adjust the normalization if maintainers prefer a different scheme.