### PR TITLE
docs: fix broken Workbench :meth: cross-references in workbench docstrings

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/tools/_workbench.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_workbench.py
@@ -175,7 +175,7 @@ class Workbench(ABC, ComponentBase[BaseModel]):
         Enter the workbench context manager.
 
         This method is called when the workbench is used in a `with` statement.
-        It calls the :meth:`~autogen_core.tools.WorkBench.start` method to start the workbench.
+        It calls the :meth:`~autogen_core.tools.Workbench.start` method to start the workbench.
         """
         await self.start()
         return self
@@ -186,7 +186,7 @@ class Workbench(ABC, ComponentBase[BaseModel]):
         """
         Exit the workbench context manager.
         This method is called when the workbench is used in a `with` statement.
-        It calls the :meth:`~autogen_core.tools.WorkBench.stop` method to stop the workbench.
+        It calls the :meth:`~autogen_core.tools.Workbench.stop` method to stop the workbench.
         """
         await self.stop()
 


### PR DESCRIPTION
## Why

The `Workbench` async context manager docstrings reference a class named `WorkBench` (capital `B`), which does not exist. The actual class is `Workbench`, and the class-level docstring in the same file already uses the correct references. As a result, the Sphinx `:meth:` cross-references in `__aenter__` and `__aexit__` fail to resolve.

## What

Fix the two broken cross-references in `python/packages/autogen-core/src/autogen_core/tools/_workbench.py`:

```
- :meth:`~autogen_core.tools.WorkBench.start`  ->  :meth:`~autogen_core.tools.Workbench.start`
- :meth:`~autogen_core.tools.WorkBench.stop`   ->  :meth:`~autogen_core.tools.Workbench.stop`
```

Docstring-only change; no behavior or API changes. Now consistent with the existing correct references in the `Workbench` class docstring.