### PR TITLE
fix(grpc): isolate host response correlation IDs

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host_servicer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host_servicer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from abc import ABC, abstractmethod
 from asyncio import Future, Task
 from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Generic, Sequence, Set, Tuple, TypeVar
@@ -106,7 +107,7 @@ class GrpcWorkerAgentRuntimeHostServicer(agent_worker_pb2_grpc.AgentRpcServicer)
         ] = {}
         self._agent_type_to_client_id_lock = asyncio.Lock()
         self._agent_type_to_client_id: Dict[str, ClientConnectionId] = {}
-        self._pending_responses: Dict[ClientConnectionId, Dict[str, Future[Any]]] = {}
+        self._pending_responses: Dict[ClientConnectionId, Dict[str, Tuple[Future[Any], str]]] = {}
         self._background_tasks: Set[Task[Any]] = set()
         self._subscription_manager = SubscriptionManager()
         self._client_id_to_subscription_id_mapping: Dict[ClientConnectionId, set[str]] = {}
@@ -134,7 +135,7 @@ class GrpcWorkerAgentRuntimeHostServicer(agent_worker_pb2_grpc.AgentRpcServicer)
             # Clean up the client connection.
             del self._data_connections[client_id]
             # Cancel pending requests sent to this client.
-            for future in self._pending_responses.pop(client_id, {}).values():
+            for future, _ in self._pending_responses.pop(client_id, {}).values():
                 future.cancel()
             # Remove the client id from the agent type to client id mapping.
             await self._on_client_disconnect(client_id)
@@ -240,11 +241,27 @@ class GrpcWorkerAgentRuntimeHostServicer(agent_worker_pb2_grpc.AgentRpcServicer)
         if target_send_queue is None:
             logger.error(f"Client {target_client_id} not found, failed to deliver message.")
             return
-        await target_send_queue.send(agent_worker_pb2.Message(request=request))
+        # request_id is only unique within a worker runtime. Replace it while the
+        # request is routed through the host so requests from different workers
+        # cannot overwrite each other in _pending_responses.
+        host_request_id = str(uuid.uuid4())
+        forwarded_request = agent_worker_pb2.RpcRequest()
+        forwarded_request.CopyFrom(request)
+        forwarded_request.request_id = host_request_id
 
-        # Create a future to wait for the response from the target.
-        future = asyncio.get_event_loop().create_future()
-        self._pending_responses.setdefault(target_client_id, {})[request.request_id] = future
+        # Register the response future before forwarding the request. A fast target
+        # may otherwise respond before the host has recorded how to route the reply.
+        future: Future[agent_worker_pb2.RpcResponse] = asyncio.get_running_loop().create_future()
+        pending_responses = self._pending_responses.setdefault(target_client_id, {})
+        pending_responses[host_request_id] = (future, request.request_id)
+        try:
+            await target_send_queue.send(agent_worker_pb2.Message(request=forwarded_request))
+        except BaseException:
+            pending_responses.pop(host_request_id, None)
+            if not pending_responses:
+                self._pending_responses.pop(target_client_id, None)
+            future.cancel()
+            raise
 
         # Create a task to wait for the response and send it back to the client.
         send_response_task = asyncio.create_task(self._wait_and_send_response(future, client_id))
@@ -265,8 +282,23 @@ class GrpcWorkerAgentRuntimeHostServicer(agent_worker_pb2_grpc.AgentRpcServicer)
 
     async def _process_response(self, response: agent_worker_pb2.RpcResponse, client_id: ClientConnectionId) -> None:
         # Setting the result of the future will send the response back to the original sender.
-        future = self._pending_responses[client_id].pop(response.request_id)
-        future.set_result(response)
+        pending_responses = self._pending_responses.get(client_id)
+        if pending_responses is None:
+            logger.warning(f"Received response from client {client_id} with no pending requests.")
+            return
+
+        pending_response = pending_responses.pop(response.request_id, None)
+        if not pending_responses:
+            self._pending_responses.pop(client_id, None)
+        if pending_response is None:
+            logger.warning(f"Received response from client {client_id} with unknown request_id {response.request_id}.")
+            return
+
+        future, original_request_id = pending_response
+        restored_response = agent_worker_pb2.RpcResponse()
+        restored_response.CopyFrom(response)
+        restored_response.request_id = original_request_id
+        future.set_result(restored_response)
 
     async def _process_event(self, event: cloudevent_pb2.CloudEvent) -> None:
         topic_id = TopicId(type=event.type, source=event.source)

--- a/python/packages/autogen-ext/tests/test_worker_runtime.py
+++ b/python/packages/autogen-ext/tests/test_worker_runtime.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any, List
 
 import pytest
@@ -17,6 +18,7 @@ from autogen_core import (
     TypeSubscription,
     default_subscription,
     event,
+    message_handler,
     try_get_known_serializers_for_type,
     type_subscription,
 )
@@ -709,6 +711,67 @@ async def test_instance_factory_messaging() -> None:
 
 #     await worker.stop()
 #     await host.stop()
+
+
+@pytest.mark.grpc
+@pytest.mark.asyncio
+async def test_cross_runtime_rpc_request_ids_do_not_collide() -> None:
+    """Requests from different workers must not share host correlation IDs."""
+    host_address = "localhost:50062"
+
+    @dataclass
+    class PingMessage:
+        content: str
+
+    class InnerAgent(RoutedAgent):
+        def __init__(self) -> None:
+            super().__init__("Inner echo agent")
+
+        @message_handler
+        async def on_ping(self, message: PingMessage, ctx: MessageContext) -> PingMessage:
+            return PingMessage(content=f"inner:{message.content}")
+
+    class RelayAgent(RoutedAgent):
+        def __init__(self) -> None:
+            super().__init__("Relay agent")
+
+        @message_handler
+        async def on_ping(self, message: PingMessage, ctx: MessageContext) -> PingMessage:
+            inner_response = await self.send_message(
+                PingMessage(content=message.content), AgentId("inner_agent", "default")
+            )
+            assert isinstance(inner_response, PingMessage)
+            return PingMessage(content=f"relay:{inner_response.content}")
+
+    host = GrpcWorkerAgentRuntimeHost(address=host_address)
+    host.start()
+    agent_runtime = GrpcWorkerAgentRuntime(host_address=host_address)
+    sender_runtime = GrpcWorkerAgentRuntime(host_address=host_address)
+
+    try:
+        agent_runtime.add_message_serializer(try_get_known_serializers_for_type(PingMessage))
+        await agent_runtime.start()
+        await RelayAgent.register(agent_runtime, "relay_agent", lambda: RelayAgent())
+        await InnerAgent.register(agent_runtime, "inner_agent", lambda: InnerAgent())
+
+        sender_runtime.add_message_serializer(try_get_known_serializers_for_type(PingMessage))
+        await sender_runtime.start()
+
+        # Both runtimes issue their first request to agent_runtime. Before the fix,
+        # both were stored as (agent_runtime_client_id, "1"), so the nested call
+        # overwrote the outer call's Future and the second response raised KeyError.
+        result = await asyncio.wait_for(
+            sender_runtime.send_message(PingMessage(content="hello"), AgentId("relay_agent", "default")),
+            timeout=10,
+        )
+
+        assert result == PingMessage(content="relay:inner:hello")
+        assert host._servicer._pending_responses == {}  # type: ignore[reportPrivateUsage]
+    finally:
+        await sender_runtime.stop()
+        await agent_runtime.stop()
+        await host.stop()
+
 
 if __name__ == "__main__":
     os.environ["GRPC_VERBOSITY"] = "DEBUG"


### PR DESCRIPTION
## Summary

Fixes #7016.

`GrpcWorkerAgentRuntime` request IDs are local counters, so different workers can both send request `"1"` to agents hosted by the same target runtime. The host previously keyed pending responses by `(target_client_id, request_id)`, allowing the second request to overwrite the first Future and causing a later response to raise `KeyError`.

This change:

- replaces each forwarded worker-local request ID with a host-generated UUID;
- stores the original sender request ID and restores it on the response;
- registers the pending Future before forwarding, so a fast response cannot race ahead of host bookkeeping;
- removes pending state if forwarding fails and safely ignores unknown or duplicate responses;
- removes empty per-client pending-response maps after completion;
- adds an end-to-end regression test for the cross-runtime nested-RPC topology from #7016.

## Impact

Concurrent or nested RPCs from different worker runtimes can target the same runtime without corrupting response routing. The wire schema is unchanged: only the request ID used between the host and target worker is replaced temporarily, then restored before the response reaches the original sender.

## Relationship to #7637

PR #7637 addresses the same collision with host-generated UUIDs. This version also registers correlation state before forwarding and covers failure cleanup, unknown responses, and removal of empty pending maps, avoiding a response-registration race and stale host state.

## Validation

- `python -m pytest python/packages/autogen-ext/tests/test_worker_runtime.py::test_cross_runtime_rpc_request_ids_do_not_collide -q --grpc` — 1 passed
- `ruff check` on the implementation and test — passed
- `ruff format --check` on the implementation and test — passed
- targeted `mypy` on the implementation and test — passed

An additional run of the complete `test_worker_runtime.py` reached 100% (`15 passed`, `3 skipped` by marker output), but the Windows pytest process remained alive after suite teardown and was terminated at the 300-second command timeout. The new targeted regression test exits cleanly.
