### PR TITLE
Use UTF-8 for gallery YAML files

### DIFF
--- a/python/docs/src/_extension/gallery_directive.py
+++ b/python/docs/src/_extension/gallery_directive.py
@@ -79,7 +79,7 @@ class GalleryGridDirective(SphinxDirective):
                 logger.info(f"Could not find grid data at {path_data}.")
                 nodes.text("No grid data found at {path_data}.")
                 return
-            yaml_string = path_data.read_text()
+            yaml_string = path_data.read_text(encoding="utf-8")
         else:
             yaml_string = "\n".join(self.content)
 


### PR DESCRIPTION
## Summary
- Read gallery directive YAML data files with `encoding="utf-8"`.

## Problem
The docs gallery directive can load YAML from a file passed to the directive, but `Path.read_text()` currently uses the platform default encoding. Gallery metadata is repo documentation content, so decoding it explicitly as UTF-8 avoids locale-dependent docs builds on Windows or other non-UTF-8 environments.

## Before / After
Before: gallery YAML file decoding depended on the local platform default encoding.

After: gallery YAML files are decoded as UTF-8.

## Verification
- `python -m py_compile python/docs/src/_extension/gallery_directive.py`