### PR TITLE
fix(autogen-ext): skip LangChain callback-manager (run_manager) when inferring tool args schema

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
@@ -208,15 +208,19 @@ class LangChainToolAdapter(BaseTool[BaseModel, Any]):
                     inspect.Parameter.VAR_KEYWORD,
                 ):
                     continue
-                # LangChain injects a ``run_manager``
-                # (CallbackManagerForToolRun / its async variant) into a tool's
-                # ``_run``/``_arun`` at run time. It is not a user-facing
-                # argument and pydantic cannot build a schema for it, so skip
-                # it. We detect it by annotation when resolvable and, as a
-                # fallback for unresolvable (string) annotations, by the
-                # conventional parameter name.
+                # LangChain injects runtime-only callback arguments into a
+                # tool's ``_run``/``_arun`` that are not user-facing and cannot
+                # be represented in a pydantic schema. LangChain itself excludes
+                # these via ``FILTERED_ARGS = ("run_manager", "callbacks")``:
+                #   * ``run_manager`` (CallbackManagerForToolRun / its async
+                #     variant) — detected by annotation when resolvable, and as
+                #     a fallback for unresolvable (string) annotations, by the
+                #     conventional parameter name.
+                #   * ``callbacks`` (a ``Callbacks`` sequence of handlers) —
+                #     ``_is_callback_manager_annotation`` does not match it, so
+                #     it must be filtered by name.
                 annotation = type_hints.get(k, v.annotation)
-                if _is_callback_manager_annotation(annotation) or k == "run_manager":
+                if _is_callback_manager_annotation(annotation) or k in ("run_manager", "callbacks"):
                     continue
                 fields[k] = (annotation, Field(...))
             args_type = create_model(f"{name}Args", **fields)  # type: ignore

--- a/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
@@ -219,6 +219,13 @@ class LangChainToolAdapter(BaseTool[BaseModel, Any]):
                 #   * ``callbacks`` (a ``Callbacks`` sequence of handlers) —
                 #     ``_is_callback_manager_annotation`` does not match it, so
                 #     it must be filtered by name.
+                # ``get_type_hints`` resolves annotations to real types when it
+                # can, but this module uses ``from __future__ import annotations``,
+                # so annotations arrive as strings and ``get_type_hints`` can fail
+                # (e.g. for a locally-defined tool), leaving a string annotation
+                # that ``_is_callback_manager_annotation``'s ``issubclass`` check
+                # cannot match. The ``run_manager``/``callbacks`` name check is a
+                # deliberate fallback for exactly that case.
                 annotation = type_hints.get(k, v.annotation)
                 if _is_callback_manager_annotation(annotation) or k in ("run_manager", "callbacks"):
                     continue

--- a/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Dict, Type, cast
+import types
+from typing import TYPE_CHECKING, Any, Callable, Dict, Type, Union, cast, get_args, get_origin, get_type_hints
 
 from autogen_core import CancellationToken
 from autogen_core.tools import BaseTool
@@ -10,6 +11,32 @@ from pydantic import BaseModel, Field, create_model
 
 if TYPE_CHECKING:
     from langchain_core.tools import BaseTool as LangChainTool
+
+
+def _is_callback_manager_annotation(annotation: Any) -> bool:
+    """Whether *annotation* is a LangChain callback-manager type.
+
+    LangChain injects a ``run_manager`` (``CallbackManagerForToolRun`` or
+    ``AsyncCallbackManagerForToolRun``) into a tool's ``_run``/``_arun``. It is
+    not a real tool input and pydantic cannot generate a schema for it. Unwrap
+    ``Optional[...]`` / ``Union[...]`` so both the bare type and
+    ``Optional[CallbackManagerForToolRun]`` are detected.
+    """
+    if annotation is None or annotation is inspect.Parameter.empty:
+        return False
+    origin = get_origin(annotation)
+    if origin is Union or (hasattr(types, "UnionType") and origin is types.UnionType):
+        return any(_is_callback_manager_annotation(arg) for arg in get_args(annotation))
+    try:
+        from langchain_core.callbacks.manager import (
+            AsyncCallbackManagerForToolRun,
+            CallbackManagerForToolRun,
+        )
+    except ImportError:
+        return False
+    return isinstance(annotation, type) and issubclass(
+        annotation, (CallbackManagerForToolRun, AsyncCallbackManagerForToolRun)
+    )
 
 
 class LangChainToolAdapter(BaseTool[BaseModel, Any]):
@@ -165,12 +192,33 @@ class LangChainToolAdapter(BaseTool[BaseModel, Any]):
             args_type = self._langchain_tool.args_schema  # pyright: ignore
         else:
             # Infer args_type from the callable's signature
-            sig = inspect.signature(cast(Callable[..., Any], self._callable))  # type: ignore
-            fields = {
-                k: (v.annotation, Field(...))
-                for k, v in sig.parameters.items()
-                if k != "self" and v.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
-            }
+            callable_ = cast(Callable[..., Any], self._callable)  # type: ignore
+            sig = inspect.signature(callable_)
+            # Resolve annotations (they may be strings under
+            # ``from __future__ import annotations``) so we can recognize
+            # callback-manager-typed parameters.
+            try:
+                type_hints = get_type_hints(callable_)
+            except Exception:
+                type_hints = {}
+            fields = {}
+            for k, v in sig.parameters.items():
+                if k == "self" or v.kind in (
+                    inspect.Parameter.VAR_POSITIONAL,
+                    inspect.Parameter.VAR_KEYWORD,
+                ):
+                    continue
+                # LangChain injects a ``run_manager``
+                # (CallbackManagerForToolRun / its async variant) into a tool's
+                # ``_run``/``_arun`` at run time. It is not a user-facing
+                # argument and pydantic cannot build a schema for it, so skip
+                # it. We detect it by annotation when resolvable and, as a
+                # fallback for unresolvable (string) annotations, by the
+                # conventional parameter name.
+                annotation = type_hints.get(k, v.annotation)
+                if _is_callback_manager_annotation(annotation) or k == "run_manager":
+                    continue
+                fields[k] = (annotation, Field(...))
             args_type = create_model(f"{name}Args", **fields)  # type: ignore
             # Note: type ignore is used due to a LangChain typing limitation
 

--- a/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
@@ -5,6 +5,7 @@ import pytest
 from autogen_core import CancellationToken
 from autogen_core.tools import Tool
 from autogen_ext.tools.langchain import LangChainToolAdapter  # type: ignore
+from langchain_core.callbacks import Callbacks
 from langchain_core.callbacks.manager import AsyncCallbackManagerForToolRun, CallbackManagerForToolRun
 from langchain_core.tools import BaseTool as LangChainTool
 from langchain_core.tools import tool  # pyright: ignore
@@ -129,8 +130,45 @@ async def test_langchain_tool_adapter_skips_run_manager() -> None:
 
     schema = adapter.schema
     assert schema["name"] == "NoSchema"
+    assert "parameters" in schema
+    assert "properties" in schema["parameters"]
     props = schema["parameters"]["properties"]
     assert set(props.keys()) == {"a", "b"}
+    assert "required" in schema["parameters"]
+    assert set(schema["parameters"]["required"]) == {"a", "b"}
+
+    result = await adapter.run_json({"a": 2, "b": 3}, CancellationToken())
+    assert result == 5
+
+
+class NoSchemaCallbacksTool(LangChainTool):
+    name: str = "NoSchemaCallbacks"
+    description: str = "a tool without an explicit args schema that also accepts callbacks"
+
+    def _run(self, a: int, b: int, callbacks: Callbacks = None) -> int:
+        return a + b
+
+    async def _arun(self, a: int, b: int, callbacks: Callbacks = None) -> int:
+        return a + b
+
+
+@pytest.mark.asyncio
+async def test_langchain_tool_adapter_skips_callbacks() -> None:
+    # In addition to ``run_manager``, LangChain also reserves ``callbacks`` (a
+    # ``Callbacks`` sequence of handlers) as a runtime-only argument -- it is in
+    # LangChain's ``FILTERED_ARGS``. Its annotation is not matched by
+    # ``_is_callback_manager_annotation``, so the adapter must skip it by name;
+    # otherwise inferring the args schema raises PydanticSchemaGenerationError.
+    tool = NoSchemaCallbacksTool()
+    adapter = LangChainToolAdapter(tool)  # type: ignore
+
+    schema = adapter.schema
+    assert schema["name"] == "NoSchemaCallbacks"
+    assert "parameters" in schema
+    assert "properties" in schema["parameters"]
+    props = schema["parameters"]["properties"]
+    assert set(props.keys()) == {"a", "b"}
+    assert "required" in schema["parameters"]
     assert set(schema["parameters"]["required"]) == {"a", "b"}
 
     result = await adapter.run_json({"a": 2, "b": 3}, CancellationToken())

--- a/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
@@ -100,3 +100,38 @@ async def test_langchain_tool_adapter(caplog: pytest.LogCaptureFixture) -> None:
     # Test run method for CustomCalculatorTool
     custom_result = await custom_adapter.run_json({"a": 3, "b": 4}, CancellationToken())
     assert custom_result == 12
+
+
+class NoSchemaTool(LangChainTool):
+    name: str = "NoSchema"
+    description: str = "a tool without an explicit args schema"
+
+    def _run(self, a: int, b: int, run_manager: Optional[CallbackManagerForToolRun] = None) -> int:
+        return a + b
+
+    async def _arun(
+        self,
+        a: int,
+        b: int,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> int:
+        return a + b
+
+
+@pytest.mark.asyncio
+async def test_langchain_tool_adapter_skips_run_manager() -> None:
+    # Tools without an explicit args_schema get their args inferred from the
+    # callable's signature. LangChain injects a ``run_manager`` into ``_run``
+    # which is not a user-facing input and cannot be turned into a pydantic
+    # schema; the adapter must skip it (see #6385).
+    tool = NoSchemaTool()
+    adapter = LangChainToolAdapter(tool)  # type: ignore
+
+    schema = adapter.schema
+    assert schema["name"] == "NoSchema"
+    props = schema["parameters"]["properties"]
+    assert set(props.keys()) == {"a", "b"}
+    assert set(schema["parameters"]["required"]) == {"a", "b"}
+
+    result = await adapter.run_json({"a": 2, "b": 3}, CancellationToken())
+    assert result == 5

--- a/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
@@ -133,6 +133,7 @@ async def test_langchain_tool_adapter_skips_run_manager() -> None:
     assert "parameters" in schema
     assert "properties" in schema["parameters"]
     props = schema["parameters"]["properties"]
+    assert "run_manager" not in props
     assert set(props.keys()) == {"a", "b"}
     assert "required" in schema["parameters"]
     assert set(schema["parameters"]["required"]) == {"a", "b"}
@@ -167,6 +168,46 @@ async def test_langchain_tool_adapter_skips_callbacks() -> None:
     assert "parameters" in schema
     assert "properties" in schema["parameters"]
     props = schema["parameters"]["properties"]
+    assert "callbacks" not in props
+    assert set(props.keys()) == {"a", "b"}
+    assert "required" in schema["parameters"]
+    assert set(schema["parameters"]["required"]) == {"a", "b"}
+
+    result = await adapter.run_json({"a": 2, "b": 3}, CancellationToken())
+    assert result == 5
+
+
+class NoSchemaAsyncManagerTool(LangChainTool):
+    name: str = "NoSchemaAsyncManager"
+    description: str = "a tool whose sync _run is annotated with the async callback manager type"
+
+    def _run(
+        self, a: int, b: int, run_manager: Optional[AsyncCallbackManagerForToolRun] = None
+    ) -> int:
+        return a + b
+
+    async def _arun(
+        self, a: int, b: int, run_manager: Optional[AsyncCallbackManagerForToolRun] = None
+    ) -> int:
+        return a + b
+
+
+@pytest.mark.asyncio
+async def test_langchain_tool_adapter_skips_async_run_manager() -> None:
+    # The detection must cover the *async* callback-manager type
+    # (``AsyncCallbackManagerForToolRun``), not only the sync
+    # ``CallbackManagerForToolRun``. ``_is_callback_manager_annotation`` unwraps
+    # ``Optional[...]`` and matches both via ``issubclass``, so a tool that
+    # annotates its signature with the async variant is still filtered out.
+    tool = NoSchemaAsyncManagerTool()
+    adapter = LangChainToolAdapter(tool)  # type: ignore
+
+    schema = adapter.schema
+    assert schema["name"] == "NoSchemaAsyncManager"
+    assert "parameters" in schema
+    assert "properties" in schema["parameters"]
+    props = schema["parameters"]["properties"]
+    assert "run_manager" not in props
     assert set(props.keys()) == {"a", "b"}
     assert "required" in schema["parameters"]
     assert set(schema["parameters"]["required"]) == {"a", "b"}

--- a/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
@@ -181,14 +181,10 @@ class NoSchemaAsyncManagerTool(LangChainTool):
     name: str = "NoSchemaAsyncManager"
     description: str = "a tool whose sync _run is annotated with the async callback manager type"
 
-    def _run(
-        self, a: int, b: int, run_manager: Optional[AsyncCallbackManagerForToolRun] = None
-    ) -> int:
+    def _run(self, a: int, b: int, run_manager: Optional[AsyncCallbackManagerForToolRun] = None) -> int:
         return a + b
 
-    async def _arun(
-        self, a: int, b: int, run_manager: Optional[AsyncCallbackManagerForToolRun] = None
-    ) -> int:
+    async def _arun(self, a: int, b: int, run_manager: Optional[AsyncCallbackManagerForToolRun] = None) -> int:
         return a + b
 
 


### PR DESCRIPTION
## Summary
Fixes #6385.

`LangChainToolAdapter` inferred a pydantic args model from the callable's signature when a tool provided no `args_schema`. LangChain injects a `run_manager` (`CallbackManagerForToolRun` / its async variant) into a tool's `_run`/`_arun`, and pydantic cannot generate a schema for that type, so constructing the adapter raised `Unable to generate pydantic-core schema for ...CallbackManagerForToolRun` (e.g. `GoogleDriveSearchTool`).

- In `_langchain_adapter.py`, when inferring fields, skip parameters whose annotation resolves to a LangChain callback-manager type. Detection unwraps `Optional[...]`/`Union[...]` and also falls back to the conventional `run_manager` parameter name for unresolvable (string) annotations (the module uses `from __future__ import annotations`).
- The adapter never passed a callback manager to the underlying tool, so omitting `run_manager` from the schema is correct — the tool still runs without it (it defaults to `None`).
- Adds a regression test (`test_langchain_tool_adapter_skips_run_manager`) using a tool without an explicit `args_schema`.

## Test plan
- `pytest python/packages/autogen-ext/tests/tools/test_langchain_tools.py` — passes (2 tests).