### PR TITLE
fix(ext): write Jupyter HTML output as UTF-8

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py
@@ -275,7 +275,7 @@ class DockerJupyterCodeExecutor(CodeExecutor, Component[DockerJupyterCodeExecuto
         """Save html data to a file."""
         filename = f"{uuid.uuid4().hex}.html"
         path = os.path.join(str(self._output_dir), filename)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(html_data)
         return os.path.abspath(path)
 

--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/jupyter/_jupyter_code_executor.py
@@ -262,7 +262,7 @@ class JupyterCodeExecutor(CodeExecutor, Component[JupyterCodeExecutorConfig]):
     def _save_html(self, html_data: str) -> Path:
         """Save HTML data to a file."""
         path = self._output_dir / f"{uuid.uuid4().hex}.html"
-        path.write_text(html_data)
+        path.write_text(html_data, encoding="utf-8")
         return path.absolute()
 
     async def restart(self) -> None:

--- a/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_jupyter_code_executor.py
@@ -194,6 +194,36 @@ async def test_execute_code_with_html_output(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_code_with_non_ascii_html_output(tmp_path: Path) -> None:
+    async with JupyterCodeExecutor(output_dir=tmp_path) as executor:
+        await executor.start()
+        code_blocks = [
+            CodeBlock(
+                code=inspect.cleandoc("""
+                    from IPython.core.display import HTML
+                    HTML("<div>Unicode: 你好 🎉 Ñoño</div>")
+                """),
+                language="python",
+            )
+        ]
+
+        code_result = await executor.execute_code_blocks(code_blocks, CancellationToken())
+
+        assert len(code_result.output_files) == 1
+        assert code_result.exit_code == 0
+        assert code_result.output == "<IPython.core.display.HTML object>"
+
+        # Verify UTF-8 encoding by reading the HTML file
+        html_file = code_result.output_files[0]
+        html_content = html_file.read_text(encoding="utf-8")
+        assert "你好" in html_content
+        assert "🎉" in html_content
+        assert "Ñoño" in html_content
+
+        await executor.stop()
+
+
+@pytest.mark.asyncio
 async def test_jupyter_code_executor_serialization(tmp_path: Path) -> None:
     executor = JupyterCodeExecutor(output_dir=tmp_path)
     await executor.start()


### PR DESCRIPTION
## Problem

The `_save_html` methods in both Jupyter code executors write HTML cell output using Python's platform-default text encoding:

- `autogen_ext/code_executors/jupyter/_jupyter_code_executor.py` — `path.write_text(html_data)`
- `autogen_ext/code_executors/docker_jupyter/_docker_jupyter.py` — `open(path, "w")`

On Windows the default encoding is the locale codepage (typically cp1252), so saving cell output that contains non-ASCII characters — pandas DataFrame HTML, matplotlib labels, emojis, or any non-Latin text — raises `UnicodeEncodeError` and aborts execution. On POSIX systems with a non-UTF-8 locale the same failure can occur.

## Fix

Pass `encoding="utf-8"` explicitly on both write paths. HTML is conventionally UTF-8, and this matches the existing convention in the sibling executors (`local` and `docker` both already use `encoding="utf-8"` when writing code files).

## How verified

- Confirmed both call sites previously omitted an encoding argument and would fall back to `locale.getpreferredencoding()`.
- Reproduced the class of failure: writing HTML containing non-ASCII with the cp1252 default raises `UnicodeEncodeError`; with `encoding="utf-8"` it succeeds.
- Syntax-checked both modified files. Two-line diff, no behavior change on systems already defaulting to UTF-8.