### PR TITLE
fix(autogen-ext): include tool_choice in ChatCompletionCache cache key (#7968)

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
@@ -177,8 +177,9 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         self,
         messages: Sequence[LLMMessage],
         tools: Sequence[Tool | ToolSchema],
-        json_output: Optional[bool | type[BaseModel]],
-        extra_create_args: Mapping[str, Any],
+        json_output: Optional[bool | type[BaseModel]] = None,
+        extra_create_args: Mapping[str, Any] = {},
+        tool_choice: Tool | Literal["auto", "required", "none"] | None = "auto",
     ) -> tuple[Optional[Union[CreateResult, List[Union[str, CreateResult]]]], str]:
         """
         Helper function to check the cache for a result.
@@ -192,9 +193,12 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         elif isinstance(json_output, bool):
             json_output_data = json_output
 
+        tool_choice_data: Any = tool_choice.schema if isinstance(tool_choice, Tool) else tool_choice
+
         data = {
             "messages": [message.model_dump() for message in messages],
             "tools": [(tool.schema if isinstance(tool, Tool) else tool) for tool in tools],
+            "tool_choice": tool_choice_data,
             "json_output": json_output_data,
             "extra_create_args": extra_create_args,
         }
@@ -270,7 +274,9 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
 
         NOTE: cancellation_token is ignored for cached results.
         """
-        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args)
+        cached_result, cache_key = self._check_cache(
+            messages, tools, json_output=json_output, extra_create_args=extra_create_args, tool_choice=tool_choice
+        )
         if cached_result is not None:
             if isinstance(cached_result, CreateResult):
                 # Cache hit from previous non-streaming call
@@ -317,8 +323,9 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
             cached_result, cache_key = self._check_cache(
                 messages,
                 tools,
-                json_output,
-                extra_create_args,
+                json_output=json_output,
+                extra_create_args=extra_create_args,
+                tool_choice=tool_choice,
             )
             if cached_result is not None:
                 if isinstance(cached_result, list):

--- a/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
+++ b/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
@@ -956,3 +956,31 @@ async def test_create_stream_with_cached_non_streaming_result_non_string_content
     assert stream_results[0].content == [expected_function_call]
     assert stream_results[0].finish_reason == "function_calls"
     assert stream_results[0].cached is True
+
+
+@pytest.mark.asyncio
+async def test_cache_key_includes_tool_choice() -> None:
+    """Test that calls with different tool_choice produce different cache keys and cache misses."""
+    _, prompts, system_prompt, _, _ = get_test_data()
+    responses = ["response for auto", "response for none"]
+    replay_client = ReplayChatCompletionClient(responses)
+    replay_client.set_cached_bool_value(False)
+    cached_client = ChatCompletionCache(replay_client)
+
+    messages = [system_prompt, UserMessage(content=prompts[0], source="user")]
+
+    # First call with tool_choice="auto"
+    res1 = await cached_client.create(messages, tool_choice="auto")
+    assert res1.cached is False
+    assert res1.content == "response for auto"
+
+    # Second call with same message but tool_choice="none" -> should be a cache miss
+    res2 = await cached_client.create(messages, tool_choice="none")
+    assert res2.cached is False
+    assert res2.content == "response for none"
+
+    # Third call with tool_choice="auto" again -> should be a cache hit
+    res3 = await cached_client.create(messages, tool_choice="auto")
+    assert res3.cached is True
+    assert res3.content == "response for auto"
+


### PR DESCRIPTION
Fixes #7968

## Problem

`ChatCompletionCache._check_cache()` computed the SHA-256 cache key from messages and tools only. Calls with identical messages/tools but different `tool_choice` values (e.g., `auto` vs `none`) incorrectly returned stale cached results.

## Fix

Include `tool_choice` in the cache key computation.

## Changes

- `python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py`: include `tool_choice` in key
- `python/packages/autogen-ext/tests/models/test_chat_completion_cache.py`: add `test_cache_key_includes_tool_choice`

## Verification

Cache miss now correctly occurs when `tool_choice` changes.