### PR TITLE
Add OpenEval adapter for AutoGen evals

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/eval/__init__.py
+++ b/python/packages/autogen-studio/autogenstudio/eval/__init__.py
@@ -1,0 +1,1 @@
+from .openeval import from_openeval, to_openeval

--- a/python/packages/autogen-studio/autogenstudio/eval/openeval.py
+++ b/python/packages/autogen-studio/autogenstudio/eval/openeval.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from autogenstudio.datamodel.eval import EvalTask
+
+try:
+    from openeval.types import OPENEVAL_VERSION
+except ImportError:  # pragma: no cover - exercised when SDK is unavailable locally.
+    OPENEVAL_VERSION = "unknown"
+
+
+def _get_attr_or_item(source: Any, name: str, default: Any = None) -> Any:
+    if isinstance(source, Mapping):
+        return source.get(name, default)
+    return getattr(source, name, default)
+
+
+def _task_payload(task: Any) -> dict[str, Any]:
+    task_id = _get_attr_or_item(task, "task_id")
+    input_data = _get_attr_or_item(task, "input")
+    expected_outputs = _get_attr_or_item(task, "expected_outputs") or []
+    metadata = _get_attr_or_item(task, "metadata") or {}
+    name = _get_attr_or_item(task, "name", "")
+    description = _get_attr_or_item(task, "description", "")
+
+    return {
+        "id": str(task_id),
+        "input": input_data,
+        "expected_output": expected_outputs[0] if expected_outputs else None,
+        "expected_outputs": expected_outputs,
+        "graders": ["gr_output_match"],
+        "expected_tools": metadata.get("expected_tools", []),
+        "name": name,
+        "description": description,
+    }
+
+
+def to_openeval(eval_suite: Any) -> dict[str, Any]:
+    """Convert an AutoGen eval suite into an OpenEval-compatible payload."""
+    tasks = _get_attr_or_item(eval_suite, "tasks", [])
+    if not isinstance(tasks, Sequence) or isinstance(tasks, (str, bytes)):
+        tasks = [tasks]
+
+    suite_id = _get_attr_or_item(eval_suite, "run_id", None) or _get_attr_or_item(eval_suite, "id", None) or "autogen_eval"
+    return {
+        "version": OPENEVAL_VERSION,
+        "id": f"autogen_eval_{suite_id}",
+        "test_cases": [_task_payload(task) for task in tasks if task is not None],
+        "graders": [
+            {
+                "id": "gr_output_match",
+                "type": "exact_match",
+                "params": {"ignore_case": True},
+            }
+        ],
+    }
+
+
+def from_openeval(suite: Mapping[str, Any]) -> list[EvalTask]:
+    """Convert an OpenEval suite into AutoGen eval tasks."""
+    tasks = []
+    for test_case in suite.get("test_cases", []):
+        task = EvalTask(
+            task_id=test_case["id"],
+            input=test_case["input"],
+            name=test_case.get("name", ""),
+            description=test_case.get("description", ""),
+            expected_outputs=[test_case.get("expected_output")] if test_case.get("expected_output") is not None else [],
+            metadata={"expected_tools": test_case.get("expected_tools", [])},
+        )
+        tasks.append(task)
+    return tasks

--- a/python/packages/autogen-studio/pyproject.toml
+++ b/python/packages/autogen-studio/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "loguru",
     "pyyaml",
     "html2text",
+    "openeval-sdk",
     "autogen-core>=0.4.9.2,<0.7",
     "autogen-agentchat>=0.4.9.2,<0.7",
     "autogen-ext[magentic-one, openai, azure, mcp]>=0.4.2,<0.7",

--- a/python/packages/autogen-studio/pyproject.toml
+++ b/python/packages/autogen-studio/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "loguru",
     "pyyaml",
     "html2text",
-    "openeval-sdk",
+    "evalport-sdk",
     "autogen-core>=0.4.9.2,<0.7",
     "autogen-agentchat>=0.4.9.2,<0.7",
     "autogen-ext[magentic-one, openai, azure, mcp]>=0.4.2,<0.7",

--- a/python/packages/autogen-studio/tests/test_openeval.py
+++ b/python/packages/autogen-studio/tests/test_openeval.py
@@ -1,0 +1,38 @@
+from autogenstudio.datamodel.eval import EvalTask
+from autogenstudio.eval import from_openeval, to_openeval
+
+
+def test_to_openeval_round_trip():
+    tasks = [
+        EvalTask(
+            task_id="task-1",
+            input="question-1",
+            name="Task 1",
+            description="desc-1",
+            expected_outputs=["answer-1"],
+            metadata={"expected_tools": ["tool-a"]},
+        ),
+        EvalTask(
+            task_id="task-2",
+            input=["prompt", "image"],
+            expected_outputs=[],
+            metadata={},
+        ),
+    ]
+
+    suite = to_openeval({"run_id": "run-42", "tasks": tasks})
+
+    assert suite["version"]
+    assert suite["id"] == "autogen_eval_run-42"
+    assert suite["graders"][0]["id"] == "gr_output_match"
+    assert suite["test_cases"][0]["id"] == "task-1"
+    assert suite["test_cases"][0]["expected_output"] == "answer-1"
+    assert suite["test_cases"][0]["expected_tools"] == ["tool-a"]
+    assert suite["test_cases"][1]["expected_output"] is None
+
+    imported = from_openeval(suite)
+    assert imported[0].task_id == "task-1"
+    assert imported[0].input == "question-1"
+    assert imported[0].expected_outputs == ["answer-1"]
+    assert imported[1].task_id == "task-2"
+    assert imported[1].metadata == {"expected_tools": []}

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12.4' and sys_platform == 'darwin'",
@@ -842,6 +842,7 @@ dependencies = [
     { name = "autogen-agentchat" },
     { name = "autogen-core" },
     { name = "autogen-ext", extra = ["azure", "magentic-one", "mcp", "openai"] },
+    { name = "evalport-sdk" },
     { name = "fastapi", extra = ["standard"] },
     { name = "html2text" },
     { name = "loguru" },
@@ -873,6 +874,7 @@ requires-dist = [
     { name = "autogen-agentchat", editable = "packages/autogen-agentchat" },
     { name = "autogen-core", editable = "packages/autogen-core" },
     { name = "autogen-ext", extras = ["azure", "magentic-one", "mcp", "openai"], editable = "packages/autogen-ext" },
+    { name = "evalport-sdk" },
     { name = "fastapi", marker = "extra == 'web'" },
     { name = "fastapi", extras = ["standard"] },
     { name = "html2text" },
@@ -2035,6 +2037,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/ea/8b0ac4469d4c347c6a385ff09dc3c048c2d021696664e26c7ee6791631b5/eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1", size = 9079, upload-time = "2024-12-21T20:09:46.005Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/31/55cd413eaccd39125368be33c46de24a1f639f2e12349b0361b4678f3915/eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a", size = 5830, upload-time = "2024-12-21T20:09:44.175Z" },
+]
+
+[[package]]
+name = "evalport-sdk"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9b/42b0152cca5e85407b11903a553d8239094dda0cdc1e34cf3ddf06776b27/evalport_sdk-1.0.0.tar.gz", hash = "sha256:10ecd1b35b31c11d508091f0dd7f1de7d018384bb9a4e033ebd8435b6926fced", size = 7124, upload-time = "2026-08-02T18:14:00.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/b7/9adb560ccaa9a645181b702712ebc95b8b012d5415798e73f835aa937982/evalport_sdk-1.0.0-py3-none-any.whl", hash = "sha256:81fb2fb1e6507cec5a08439db9fd96cc21cae33930c65472e7e41efc07b34829", size = 9415, upload-time = "2026-08-02T18:13:59.589Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a small OpenEval adapter in `autogenstudio/eval` so AutoGen eval data can be exported to and imported from the OpenEval format.

## Why

Issue #8005 proposed native import/export support. The maintainer guidance pointed to a new module boundary and a minimal `to_openeval()` / `from_openeval()` surface, so this keeps the integration narrow and localized.

## What changed

- Added `autogenstudio.eval.openeval` with `to_openeval()` and `from_openeval()` helpers.
- Re-exported the adapter from `autogenstudio.eval`.
- Added the renamed `evalport-sdk` distribution as a runtime dependency while retaining the backward-compatible `openeval` Python imports.
- Updated the workspace lockfile for `evalport-sdk` 1.0.0.
- Added a regression test covering a round-trip between AutoGen tasks and OpenEval payloads.

## Validation

- `uv lock --check`.
- Verified `evalport-sdk==1.0.0` provides `openeval.types` and `openeval.validate`.
- `python3 -m py_compile` on the new module and test file.
- Dependency-free smoke test that loaded the module with stubs and verified the conversion behavior.

## References

Fixes #8005.
