### PR TITLE
fix: cap mcp dependency to <2 to prevent breaking API changes

### DIFF
--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -150,7 +150,7 @@ semantic-kernel-all = [
 
 rich = ["rich>=13.9.4"]
 
-mcp = ["mcp>=1.11.0"]
+mcp = ["mcp>=1.11.0,<2"]
 canvas = [
     "unidiff>=0.7.5",
 ]


### PR DESCRIPTION
## Problem

Fixes #8014

The `mcp` Python SDK released version 2.0.0 with breaking API changes:
- `streamablehttp_client` renamed to `streamable_http_client`
- Return tuple changed from 3-tuple to 2-tuple
- `read_timeout_seconds` changed from `timedelta` to `float`
- camelCase attributes renamed to snake_case (`inputSchema` -> `input_schema`, `isError` -> `is_error`)

Since `autogen-ext` declares `mcp>=1.11.0` with no upper bound, fresh installs resolve to `mcp==2.0.0` and immediately break.

## Solution

Cap the dependency at `mcp>=1.11.0,<2` in `pyproject.toml` to prevent automatic upgrade to the incompatible 2.x line.

This is the minimal short-term fix. A full MCP 2.0 migration can be done as a follow-up.

## Changes

- `python/packages/autogen-ext/pyproject.toml`: Changed `mcp>=1.11.0` to `mcp>=1.11.0,<2`
