### PR TITLE
fix(autogen-ext): migrate MCP integration to mcp 2.x SDK

### DIFF
--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -150,7 +150,7 @@ semantic-kernel-all = [
 
 rich = ["rich>=13.9.4"]
 
-mcp = ["mcp>=1.11.0"]
+mcp = ["mcp>=2.0.0,<3.0.0"]
 canvas = [
     "unidiff>=0.7.5",
 ]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_actor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_actor.py
@@ -8,8 +8,7 @@ from pydantic import BaseModel
 from typing_extensions import Self
 
 from mcp import types as mcp_types
-from mcp.client.session import ClientSession
-from mcp.shared.context import RequestContext
+from mcp.client.session import ClientRequestContext
 
 from ._config import McpServerParams
 from ._host import McpSessionHost
@@ -139,7 +138,7 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionActorConfig]
 
     async def _sampling_callback(
         self,
-        context: RequestContext[ClientSession, Any],
+        context: ClientRequestContext,
         params: mcp_types.CreateMessageRequestParams,
     ) -> mcp_types.CreateMessageResult | mcp_types.ErrorData:
         """Handle sampling requests using the provided model client."""
@@ -155,8 +154,8 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionActorConfig]
 
     async def _elicitation_callback(
         self,
-        context: RequestContext["ClientSession", Any],
-        params: mcp_types.ElicitRequestParams,
+        context: ClientRequestContext,
+        params: mcp_types.ElicitRequestFormParams,
     ) -> mcp_types.ElicitResult | mcp_types.ErrorData:
         """Handle elicitation requests using the provided input_func."""
         if self._host is None:
@@ -170,7 +169,7 @@ class McpSessionActor(ComponentBase[BaseModel], Component[McpSessionActorConfig]
         return await self._host.handle_elicit_request(params)
 
     async def _list_roots(
-        self, context: RequestContext["ClientSession", Any]
+        self, context: ClientRequestContext
     ) -> mcp_types.ListRootsResult | mcp_types.ErrorData:
         """Handle list_roots requests"""
         if self._host is None:

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -47,7 +47,7 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
         description = tool.description or ""
 
         # Create the input model from the tool's schema
-        input_model = schema_to_pydantic_model(tool.inputSchema)
+        input_model = schema_to_pydantic_model(tool.input_schema)
 
         # Use Any as return type since MCP tool returns can vary
         return_type: Type[Any] = object
@@ -119,7 +119,7 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
 
             normalized_content_list = self._normalize_payload_to_content_list(result.content)
 
-            if result.isError:
+            if result.is_error:
                 serialized_error_message = self.return_value_as_string(normalized_content_list)
                 raise Exception(serialized_error_message)
             return normalized_content_list
@@ -160,33 +160,33 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
         """Return a string representation of the result."""
 
         def serialize_item(item: Any) -> dict[str, Any]:
+            # mcp-types 2.x uses snake_case field names (e.g. `mime_type`) with
+            # camelCase aliases on the wire; keep the serialized output in camelCase
+            # to match the MCP JSON schema and previous behavior.
             if isinstance(item, (TextContent, ImageContent, AudioContent)):
-                dumped = item.model_dump()
-                # Remove the 'meta' field if it exists and is None (for backward compatibility)
-                if dumped.get("meta") is None:
-                    dumped.pop("meta", None)
+                dumped = item.model_dump(by_alias=True)
+                # Remove the '_meta' field if it exists and is None (for backward compatibility)
+                if dumped.get("_meta") is None:
+                    dumped.pop("_meta", None)
                 return dumped
             elif isinstance(item, EmbeddedResource):
                 type = item.type
                 resource = {}
-                for key, val in item.resource.model_dump().items():
-                    # Skip 'meta' field if it's None (for backward compatibility)
-                    if key == "meta" and val is None:
+                for key, val in item.resource.model_dump(by_alias=True).items():
+                    # Skip '_meta' field if it's None (for backward compatibility)
+                    if key == "_meta" and val is None:
                         continue
                     if isinstance(val, AnyUrl):
                         resource[key] = str(val)
                     else:
                         resource[key] = val
-                dumped_annotations = item.annotations.model_dump() if item.annotations else None
-                # Remove 'meta' from annotations if it exists and is None
-                if dumped_annotations and dumped_annotations.get("meta") is None:
-                    dumped_annotations.pop("meta", None)
+                dumped_annotations = item.annotations.model_dump(by_alias=True) if item.annotations else None
                 return {"type": type, "resource": resource, "annotations": dumped_annotations}
             elif isinstance(item, ResourceLink):
-                dumped = item.model_dump()
-                # Remove the 'meta' field if it exists and is None (for backward compatibility)
-                if dumped.get("meta") is None:
-                    dumped.pop("meta", None)
+                dumped = item.model_dump(by_alias=True)
+                # Remove the '_meta' field if it exists and is None (for backward compatibility)
+                if dumped.get("_meta") is None:
+                    dumped.pop("_meta", None)
                 # Convert AnyUrl to string for JSON serialization
                 if "uri" in dumped and isinstance(dumped["uri"], AnyUrl):
                     dumped["uri"] = str(dumped["uri"])

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_host/_elicitation.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_host/_elicitation.py
@@ -25,7 +25,7 @@ class Elicitor(ABC, ComponentBase[BaseModel]):
     component_type = "mcp_elicitor"
 
     @abstractmethod
-    async def elicit(self, params: mcp_types.ElicitRequestParams) -> mcp_types.ElicitResult | mcp_types.ErrorData: ...
+    async def elicit(self, params: mcp_types.ElicitRequestFormParams) -> mcp_types.ElicitResult | mcp_types.ErrorData: ...
 
 
 class StreamElicitor(Elicitor):
@@ -53,7 +53,7 @@ class StreamElicitor(Elicitor):
             coroutine = asyncio.wait_for(coroutine, self._timeout)
         return await coroutine
 
-    async def elicit(self, params: mcp_types.ElicitRequestParams) -> mcp_types.ElicitResult:
+    async def elicit(self, params: mcp_types.ElicitRequestFormParams) -> mcp_types.ElicitResult:
         header = "=== BEGIN MCP ELICITATION REQUEST ==="
         border = "=" * len(header)
         header = f"{border}\n{header}\n{border}"
@@ -78,11 +78,11 @@ class StreamElicitor(Elicitor):
 
             result = mcp_types.ElicitResult.model_validate({"action": action})
 
-            if action == "accept" and params.requestedSchema:
+            if action == "accept" and params.requested_schema:
                 prompt = "\n".join(
                     [
                         "Input Schema:",
-                        json.dumps(params.requestedSchema, indent=2),
+                        json.dumps(params.requested_schema, indent=2),
                         "Please enter a JSON string following the above schema: ",
                     ]
                 )

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_host/_sampling.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_host/_sampling.py
@@ -112,11 +112,11 @@ def create_request_params_to_extra_create_args(params: mcp_types.CreateMessageRe
         Dictionary of extra arguments for AutoGen chat completion client
     """
     # TODO: Need to support all ChatCompletionClients
-    extra_create_args: dict[str, Any] = {"max_tokens": params.maxTokens}
+    extra_create_args: dict[str, Any] = {"max_tokens": params.max_tokens}
     if params.temperature is not None:
         extra_create_args["temperature"] = params.temperature
-    if params.stopSequences is not None:
-        extra_create_args["stop"] = params.stopSequences
+    if params.stop_sequences is not None:
+        extra_create_args["stop"] = params.stop_sequences
     return extra_create_args
 
 
@@ -147,8 +147,8 @@ class ChatCompletionClientSampler(Sampler, Component[ChatCompletionClientSampler
         autogen_messages: list[LLMMessage] = []
 
         # Add system prompt if provided
-        if params.systemPrompt:
-            autogen_messages.append(SystemMessage(content=params.systemPrompt))
+        if params.system_prompt:
+            autogen_messages.append(SystemMessage(content=params.system_prompt))
 
         # Parse sampling messages
         for msg in params.messages:

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_host/_session_host.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_host/_session_host.py
@@ -146,7 +146,7 @@ class McpSessionHost(ComponentBase[BaseModel], Component[McpSessionHostConfig]):
             )
 
     async def handle_elicit_request(
-        self, params: mcp_types.ElicitRequestParams
+        self, params: mcp_types.ElicitRequestFormParams
     ) -> mcp_types.ElicitResult | mcp_types.ErrorData:
         """Handle an elicitation request from MCP servers.
 

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_session.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_session.py
@@ -1,12 +1,14 @@
 from contextlib import asynccontextmanager
-from datetime import timedelta
 from typing import AsyncGenerator
+
+import httpx2
 
 from mcp import ClientSession
 from mcp.client.session import ElicitationFnT, ListRootsFnT, SamplingFnT
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 from ._config import McpServerParams, SseServerParams, StdioServerParams, StreamableHttpServerParams
 
@@ -24,7 +26,7 @@ async def create_mcp_server_session(
             async with ClientSession(
                 read_stream=read,
                 write_stream=write,
-                read_timeout_seconds=timedelta(seconds=server_params.read_timeout_seconds),
+                read_timeout_seconds=server_params.read_timeout_seconds,
                 sampling_callback=sampling_callback,
                 elicitation_callback=elicitation_callback,
                 list_roots_callback=list_roots_callback,
@@ -35,28 +37,27 @@ async def create_mcp_server_session(
             async with ClientSession(
                 read_stream=read,
                 write_stream=write,
-                read_timeout_seconds=timedelta(seconds=server_params.sse_read_timeout),
+                read_timeout_seconds=server_params.sse_read_timeout,
                 sampling_callback=sampling_callback,
                 elicitation_callback=elicitation_callback,
                 list_roots_callback=list_roots_callback,
             ) as session:
                 yield session
     elif isinstance(server_params, StreamableHttpServerParams):
-        # Convert float seconds to timedelta for the streamablehttp_client
-        params_dict = server_params.model_dump(exclude={"type"})
-        params_dict["timeout"] = timedelta(seconds=server_params.timeout)
-        params_dict["sse_read_timeout"] = timedelta(seconds=server_params.sse_read_timeout)
+        # mcp 2.x dropped the timeout kwargs from streamable_http_client; HTTP
+        # timeouts and headers are configured on the httpx2 client instead.
+        timeout = httpx2.Timeout(server_params.timeout, read=server_params.sse_read_timeout)
+        http_client = create_mcp_http_client(headers=server_params.headers, timeout=timeout)
 
-        async with streamablehttp_client(**params_dict) as (
-            read,
-            write,
-            session_id_callback,  # type: ignore[assignment, unused-variable]
-        ):
-            # TODO: Handle session_id_callback if needed
+        async with streamable_http_client(
+            url=server_params.url,
+            http_client=http_client,
+            terminate_on_close=server_params.terminate_on_close,
+        ) as (read, write):
             async with ClientSession(
                 read_stream=read,
                 write_stream=write,
-                read_timeout_seconds=timedelta(seconds=server_params.sse_read_timeout),
+                read_timeout_seconds=server_params.sse_read_timeout,
                 sampling_callback=sampling_callback,
                 elicitation_callback=elicitation_callback,
                 list_roots_callback=list_roots_callback,

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
@@ -299,9 +299,9 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
 
             parameters = ParametersSchema(
                 type="object",
-                properties=tool.inputSchema.get("properties", {}),
-                required=tool.inputSchema.get("required", []),
-                additionalProperties=tool.inputSchema.get("additionalProperties", False),
+                properties=tool.input_schema.get("properties", {}),
+                required=tool.input_schema.get("required", []),
+                additionalProperties=tool.input_schema.get("additionalProperties", False),
             )
             tool_schema = ToolSchema(
                 name=name,
@@ -344,7 +344,7 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
                     result, CallToolResult
                 ), f"call_tool must return a CallToolResult, instead of : {str(type(result))}"
                 result_parts: List[TextResultContent | ImageResultContent] = []
-                is_error = result.isError
+                is_error = result.is_error
                 for content in result.content:
                     if isinstance(content, TextContent):
                         result_parts.append(TextResultContent(content=content.text))

--- a/python/packages/autogen-ext/tests/mcp_server_comprehensive.py
+++ b/python/packages/autogen-ext/tests/mcp_server_comprehensive.py
@@ -5,15 +5,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional
 
-from mcp import PromptsCapability, ResourcesCapability, ServerCapabilities, ToolsCapability
 from mcp.server import Server
-from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    GetPromptRequestParams,
     GetPromptResult,
+    PaginatedRequestParams,
     Prompt,
     PromptArgument,
     PromptMessage,
+    ReadResourceRequestParams,
     Resource,
     SamplingMessage,
     TextContent,
@@ -44,7 +47,7 @@ class SimpleMcpServer:
     """A simple MCP server demonstrating basic functionality."""
 
     def __init__(self) -> None:
-        self.server: Server[object] = Server("simple-mcp-server")
+        self.server: Server[object] = Server("simple-mcp-server", version="1.0.0")
         self.register_handlers()  # type: ignore[no-untyped-call]
 
     async def list_prompts(self) -> list[Prompt]:
@@ -124,20 +127,20 @@ class SimpleMcpServer:
         """List available resources."""
         return [
             Resource(
-                uri=AnyUrl("file:///company/users.json"),
+                uri="file:///company/users.json",
                 name="Company Users",
                 description="List of all company users",
                 mimeType="application/json",
             ),
             Resource(
-                uri=AnyUrl("file:///company/projects.json"),
+                uri="file:///company/projects.json",
                 name="Active Projects",
                 description="Current projects",
                 mimeType="application/json",
             ),
         ]
 
-    async def read_resource(self, uri: AnyUrl) -> str:
+    async def read_resource(self, uri: str) -> str:
         """Read a specific resource."""
         uri_str = str(uri)
 
@@ -252,7 +255,7 @@ class SimpleMcpServer:
 
             result = await self.server.request_context.session.elicit(
                 f"{dish} is sold out. Please pick another option.",
-                requestedSchema=Order.model_json_schema(),
+                requested_schema=Order.model_json_schema(),
             )
 
             if result.action == "accept":
@@ -299,9 +302,7 @@ class SimpleMcpServer:
 
             is_allowed = False
             for root in roots.roots:
-                if root.uri.path is None:
-                    continue
-                root_path = Path(root.uri.path).resolve()
+                root_path = Path(str(root.uri).removeprefix("file://")).resolve()
                 try:
                     target_path.relative_to(root_path)
                     is_allowed = True
@@ -329,45 +330,40 @@ class SimpleMcpServer:
     def register_handlers(self) -> None:
         """Register all MCP handlers."""
 
-        @self.server.list_prompts()  # type: ignore[no-untyped-call,misc]
-        async def list_prompts() -> list[Prompt]:  # pyright: ignore[reportUnusedFunction]
-            return await self.list_prompts()
+        async def list_prompts(ctx: Any, params: PaginatedRequestParams) -> Dict[str, Any]:
+            return {"prompts": [p.model_dump(by_alias=True) for p in await self.list_prompts()]}
 
-        @self.server.get_prompt()  # type: ignore[no-untyped-call,misc]
-        async def get_prompt(name: str, arguments: Optional[Dict[str, str]] = None) -> GetPromptResult:  # pyright: ignore[reportUnusedFunction]
-            return await self.get_prompt(name, arguments)
+        async def get_prompt(ctx: Any, params: GetPromptRequestParams) -> GetPromptResult:
+            return await self.get_prompt(params.name, params.arguments)
 
-        @self.server.list_resources()  # type: ignore[no-untyped-call,misc]
-        async def list_resources() -> list[Resource]:  # pyright: ignore[reportUnusedFunction]
-            return await self.list_resources()
+        async def list_resources(ctx: Any, params: PaginatedRequestParams) -> Dict[str, Any]:
+            return {"resources": [r.model_dump(by_alias=True) for r in await self.list_resources()]}
 
-        @self.server.read_resource()  # type: ignore[no-untyped-call,misc]
-        async def read_resource(uri: AnyUrl) -> str:  # pyright: ignore[reportUnusedFunction]
-            return await self.read_resource(uri)
+        async def read_resource(ctx: Any, params: ReadResourceRequestParams) -> Dict[str, Any]:
+            content = await self.read_resource(params.uri)
+            return {"contents": [{"uri": params.uri, "mimeType": "application/json", "text": content}]}
 
-        @self.server.list_tools()  # type: ignore[no-untyped-call,misc]
-        async def list_tools() -> list[Tool]:  # pyright: ignore[reportUnusedFunction]
-            return await self.list_tools()
+        async def list_tools(ctx: Any, params: PaginatedRequestParams) -> Dict[str, Any]:
+            return {"tools": [t.model_dump(by_alias=True) for t in await self.list_tools()]}
 
-        @self.server.call_tool()  # type: ignore[no-untyped-call,misc]
-        async def call_tool(name: str, arguments: Optional[Dict[str, Any]] = None) -> list[TextContent]:  # pyright: ignore[reportUnusedFunction]
-            return await self.call_tool(name, arguments)
+        async def call_tool(ctx: Any, params: CallToolRequestParams) -> CallToolResult:
+            try:
+                content = await self.call_tool(params.name, params.arguments)
+                return CallToolResult(content=content, isError=False)
+            except Exception as e:
+                return CallToolResult(content=[TextContent(type="text", text=str(e))], isError=True)
+
+        self.server.add_request_handler("prompts/list", PaginatedRequestParams, list_prompts)
+        self.server.add_request_handler("prompts/get", GetPromptRequestParams, get_prompt)
+        self.server.add_request_handler("resources/list", PaginatedRequestParams, list_resources)
+        self.server.add_request_handler("resources/read", ReadResourceRequestParams, read_resource)
+        self.server.add_request_handler("tools/list", PaginatedRequestParams, list_tools)
+        self.server.add_request_handler("tools/call", CallToolRequestParams, call_tool)
 
     async def run(self) -> None:
         """Run the MCP server."""
-        # Server capabilities
-        init_options = InitializationOptions(
-            server_name="simple-mcp-server",
-            server_version="1.0.0",
-            capabilities=ServerCapabilities(
-                prompts=PromptsCapability(listChanged=True),
-                resources=ResourcesCapability(
-                    subscribe=True,
-                    listChanged=True,
-                ),
-                tools=ToolsCapability(listChanged=True),
-            ),
-        )
+        # Capabilities are derived from the registered handlers.
+        init_options = self.server.create_initialization_options()
 
         # Run the server
         async with stdio_server() as (read_stream, write_stream):

--- a/python/packages/autogen-ext/tests/tools/test_mcp_actor.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_actor.py
@@ -14,12 +14,13 @@ from autogen_core.models import (
     CreateResult,
     RequestUsage,
 )
+from mcp import types as mcp_types
+from mcp.client.session import ClientRequestContext
+
 from autogen_ext.tools.mcp import StdioServerParams, StreamableHttpServerParams
 from autogen_ext.tools.mcp._actor import (
     McpSessionActor,
 )
-from mcp import types as mcp_types
-from mcp.shared.context import RequestContext
 
 # Monkey patch to prevent atexit handlers from being registered during tests
 # This prevents the test suite from hanging during shutdown
@@ -41,8 +42,8 @@ def mcp_server_params() -> StdioServerParams:
     # Get the path to the simple MCP server
     server_path = Path(__file__).parent.parent / "mcp_server_comprehensive.py"
     return StdioServerParams(
-        command="uv",
-        args=["run", "python", str(server_path)],
+        command=sys.executable,
+        args=[str(server_path)],
         read_timeout_seconds=10,
     )
 
@@ -305,7 +306,7 @@ async def test_sampling_callback_without_host() -> None:
     """Test sampling callback returns error when no host is available (lines 119-127)."""
     actor = McpSessionActor(StdioServerParams(command="echo", args=["test"]))
 
-    mock_context = MagicMock(spec=RequestContext)
+    mock_context = MagicMock(spec=ClientRequestContext)
     params = mcp_types.CreateMessageRequestParams(
         messages=[mcp_types.SamplingMessage(role="user", content=mcp_types.TextContent(type="text", text="Hello"))],
         maxTokens=100,
@@ -323,8 +324,8 @@ async def test_elicitation_callback_without_host() -> None:
     """Test elicitation callback returns error when no host is available (lines 135-143)."""
     actor = McpSessionActor(StdioServerParams(command="echo", args=["test"]))
 
-    mock_context = MagicMock(spec=RequestContext)
-    params = mcp_types.ElicitRequestParams(message="Test elicitation message", requestedSchema={"type": "object"})
+    mock_context = MagicMock(spec=ClientRequestContext)
+    params = mcp_types.ElicitRequestFormParams(message="Test elicitation message", requestedSchema={"type": "object"})
 
     result = await actor._elicitation_callback(mock_context, params)  # type: ignore[reportPrivateUsage]
 
@@ -338,7 +339,7 @@ async def test_list_roots_callback_without_host() -> None:
     """Test list_roots callback returns error when no host is available (lines 149-156)."""
     actor = McpSessionActor(StdioServerParams(command="echo", args=["test"]))
 
-    mock_context = MagicMock(spec=RequestContext)
+    mock_context = MagicMock(spec=ClientRequestContext)
 
     result = await actor._list_roots(mock_context)  # type: ignore[reportPrivateUsage]
 
@@ -362,7 +363,7 @@ async def test_list_roots_callback_without_host() -> None:
 
 #     actor = McpSessionActor(StdioServerParams(command="echo", args=["test"]), model_client=model_client)
 
-#     mock_context = MagicMock(spec=RequestContext)
+#     mock_context = MagicMock(spec=ClientRequestContext)
 
 #     # Create a valid SamplingMessage but with invalid role that will cause parsing error
 #     # We'll patch the message after creation to bypass Pydantic validation
@@ -391,7 +392,7 @@ async def test_list_roots_callback_without_host() -> None:
 
 #     actor = McpSessionActor(StdioServerParams(command="echo", args=["test"]), model_client=failing_model_client)
 
-#     mock_context = MagicMock(spec=RequestContext)
+#     mock_context = MagicMock(spec=ClientRequestContext)
 #     params = mcp_types.CreateMessageRequestParams(
 #         messages=[mcp_types.SamplingMessage(role="user", content=mcp_types.TextContent(type="text", text="Hello"))],
 #         maxTokens=100,
@@ -906,7 +907,7 @@ async def test_actor_tool_failure_handling(mcp_server_params: Any) -> None:
         call_future = await actor.call("call_tool", {"name": "unknown_tool", "kargs": {}})
         call_result: mcp_types.CallToolResult = await call_future  # type: ignore
         # The server returns an error but doesn't raise an exception
-        assert call_result.isError is True  # type: ignore
+        assert call_result.is_error is True  # type: ignore
         assert "Unknown tool" in call_result.content[0].text  # type: ignore
 
     finally:
@@ -924,7 +925,7 @@ async def test_actor_tool_failure_handling(mcp_server_params: Any) -> None:
 #         await asyncio.sleep(0.1)
 
 #         # Test sampling callback functionality
-#         mock_context = MagicMock(spec=RequestContext)
+#         mock_context = MagicMock(spec=ClientRequestContext)
 #         params = mcp_types.CreateMessageRequestParams(
 #             messages=[
 #                 mcp_types.SamplingMessage(
@@ -1051,7 +1052,7 @@ async def test_actor_unknown_tool(mcp_server_params: Any) -> None:
         call_future = await actor.call("call_tool", {"name": "unknown_tool", "kargs": {}})
         call_result: mcp_types.CallToolResult = await call_future  # type: ignore
         # The server returns an error but doesn't raise an exception
-        assert call_result.isError is True  # type: ignore
+        assert call_result.is_error is True  # type: ignore
         assert "Unknown tool" in call_result.content[0].text  # type: ignore
 
     finally:

--- a/python/packages/autogen-ext/tests/tools/test_mcp_host.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_host.py
@@ -1,6 +1,7 @@
 """Tests for McpSessionHost to cover MCP host functionality."""
 
 import atexit
+import sys
 from pathlib import Path
 from typing import Any, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,6 +14,8 @@ from autogen_core.models import (
     RequestUsage,
     UserMessage,
 )
+from mcp import types as mcp_types
+
 from autogen_ext.tools.mcp import (
     ChatCompletionClientSampler,
     McpSessionHost,
@@ -26,7 +29,6 @@ from autogen_ext.tools.mcp._host._sampling import (
     parse_sampling_content,
     parse_sampling_message,
 )
-from mcp import types as mcp_types
 
 # Monkey patch to prevent atexit handlers from being registered during tests
 # This prevents the test suite from hanging during shutdown
@@ -221,7 +223,7 @@ async def test_mcp_session_host_elicit_request() -> None:
 
     host = McpSessionHost(elicitor=mock_elicitor)
 
-    params = mcp_types.ElicitRequestParams(message="Test elicitation message", requestedSchema={"type": "object"})
+    params = mcp_types.ElicitRequestFormParams(message="Test elicitation message", requestedSchema={"type": "object"})
 
     result = await host.handle_elicit_request(params)
 
@@ -238,7 +240,7 @@ async def test_mcp_session_host_elicit_request_no_elicitor() -> None:
     """Test McpSessionHost returns error when no elicitor available."""
     host = McpSessionHost(elicitor=None)
 
-    params = mcp_types.ElicitRequestParams(message="Test elicitation message", requestedSchema={"type": "object"})
+    params = mcp_types.ElicitRequestFormParams(message="Test elicitation message", requestedSchema={"type": "object"})
 
     result = await host.handle_elicit_request(params)
 
@@ -256,7 +258,7 @@ async def test_mcp_session_host_elicit_request_error_handling() -> None:
 
     host = McpSessionHost(elicitor=mock_elicitor)
 
-    params = mcp_types.ElicitRequestParams(message="Test elicitation message", requestedSchema={"type": "object"})
+    params = mcp_types.ElicitRequestFormParams(message="Test elicitation message", requestedSchema={"type": "object"})
 
     result = await host.handle_elicit_request(params)
 
@@ -456,8 +458,8 @@ def mcp_server_params() -> StdioServerParams:
     # Get the path to the simple MCP server
     server_path = Path(__file__).parent.parent / "mcp_server_comprehensive.py"
     return StdioServerParams(
-        command="uv",
-        args=["run", "python", str(server_path)],
+        command=sys.executable,
+        args=[str(server_path)],
         read_timeout_seconds=10,
     )
 
@@ -482,7 +484,7 @@ async def test_stream_elicitor_basic_functionality() -> None:
     elicitor = StreamElicitor(read_stream, write_stream)
 
     schema = {"type": "object", "properties": {"response": {"type": "string"}}}
-    params = mcp_types.ElicitRequestParams(message="Test message", requestedSchema=schema)
+    params = mcp_types.ElicitRequestFormParams(message="Test message", requestedSchema=schema)
 
     # Mock asyncio.to_thread to return the read value synchronously
     call_responses = ["accept\n", '{"response": "test"}\n']  # action then content for schema
@@ -535,7 +537,7 @@ async def test_stream_elicitor_with_timeout() -> None:
 
     elicitor = StreamElicitor(read_stream, write_stream, timeout=5.0)
 
-    params = mcp_types.ElicitRequestParams(message="Test message", requestedSchema={})
+    params = mcp_types.ElicitRequestFormParams(message="Test message", requestedSchema={})
 
     call_responses = ["decline\n", "{}\n"]  # action then content for schema
     call_count = {"count": 0}
@@ -569,7 +571,7 @@ async def test_stream_elicitor_with_schema() -> None:
     elicitor = StreamElicitor(read_stream, write_stream)
 
     schema = {"type": "object", "properties": {"name": {"type": "string"}}}
-    params = mcp_types.ElicitRequestParams(message="Test message", requestedSchema=schema)
+    params = mcp_types.ElicitRequestFormParams(message="Test message", requestedSchema=schema)
 
     call_count = {"count": 0}
 
@@ -604,7 +606,7 @@ async def test_stream_elicitor_shorthand_mapping() -> None:
 
     elicitor = StreamElicitor(read_stream, write_stream)
 
-    params = mcp_types.ElicitRequestParams(message="Test", requestedSchema={})
+    params = mcp_types.ElicitRequestFormParams(message="Test", requestedSchema={})
 
     call_responses = ["d\n", "{}\n"]  # action then content for schema
     call_count = {"count": 0}
@@ -954,7 +956,7 @@ async def test_mcp_session_host_elicit_with_elicitor_exception() -> None:
 
     host = McpSessionHost(elicitor=mock_elicitor)
 
-    params = mcp_types.ElicitRequestParams(message="Test", requestedSchema={})
+    params = mcp_types.ElicitRequestFormParams(message="Test", requestedSchema={})
 
     result = await host.handle_elicit_request(params)
 

--- a/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_tools.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
 import os
+import sys
 import threading
+from pathlib import Path
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,6 +12,16 @@ from _pytest.logging import LogCaptureFixture  # type: ignore[import]
 from autogen_core import CancellationToken
 from autogen_core.tools import Workbench
 from autogen_core.utils import schema_to_pydantic_model
+from mcp import ClientSession, Tool
+from mcp.types import (
+    Annotations,
+    EmbeddedResource,
+    ImageContent,
+    ResourceLink,
+    TextContent,
+    TextResourceContents,
+)
+
 from autogen_ext.tools.mcp import (
     McpSessionActor,
     McpWorkbench,
@@ -22,16 +34,6 @@ from autogen_ext.tools.mcp import (
     create_mcp_server_session,
     mcp_server_tools,
 )
-from mcp import ClientSession, Tool
-from mcp.types import (
-    Annotations,
-    EmbeddedResource,
-    ImageContent,
-    ResourceLink,
-    TextContent,
-    TextResourceContents,
-)
-from pydantic.networks import AnyUrl
 
 
 @pytest.fixture
@@ -108,7 +110,7 @@ def mock_session() -> AsyncMock:
 @pytest.fixture
 def mock_tool_response() -> MagicMock:
     response = MagicMock()
-    response.isError = False
+    response.is_error = False
     response.content = [
         TextContent(
             text="test_output",
@@ -127,7 +129,7 @@ def cancellation_token() -> CancellationToken:
 @pytest.fixture
 def mock_error_tool_response() -> MagicMock:
     response = MagicMock()
-    response.isError = True
+    response.is_error = True
     response.content = [TextContent(text="error output", type="text")]
     return response
 
@@ -152,10 +154,10 @@ def test_adapter_config_serialization(sample_tool: Tool, sample_server_params: S
     assert "properties" in params_schema, "Parameters must have properties"
 
     # Compare schema content
-    assert params_schema["type"] == sample_tool.inputSchema["type"]
-    assert params_schema["required"] == sample_tool.inputSchema["required"]
+    assert params_schema["type"] == sample_tool.input_schema["type"]
+    assert params_schema["required"] == sample_tool.input_schema["required"]
     assert (
-        params_schema["properties"]["test_param"]["type"] == sample_tool.inputSchema["properties"]["test_param"]["type"]
+        params_schema["properties"]["test_param"]["type"] == sample_tool.input_schema["properties"]["test_param"]["type"]
     )
 
 
@@ -182,7 +184,7 @@ async def test_mcp_tool_execution(
     with caplog.at_level(logging.INFO):
         adapter = StdioMcpToolAdapter(server_params=sample_server_params, tool=sample_tool)
         result = await adapter.run_json(
-            args=schema_to_pydantic_model(sample_tool.inputSchema)(**{"test_param": "test"}).model_dump(),
+            args=schema_to_pydantic_model(sample_tool.input_schema)(**{"test_param": "test"}).model_dump(),
             cancellation_token=cancellation_token,
         )
 
@@ -227,10 +229,10 @@ async def test_adapter_from_server_params(
     assert "properties" in params_schema, "Parameters must have properties"
 
     # Compare schema content
-    assert params_schema["type"] == sample_tool.inputSchema["type"]
-    assert params_schema["required"] == sample_tool.inputSchema["required"]
+    assert params_schema["type"] == sample_tool.input_schema["type"]
+    assert params_schema["required"] == sample_tool.input_schema["required"]
     assert (
-        params_schema["properties"]["test_param"]["type"] == sample_tool.inputSchema["properties"]["test_param"]["type"]
+        params_schema["properties"]["test_param"]["type"] == sample_tool.input_schema["properties"]["test_param"]["type"]
     )
 
 
@@ -270,13 +272,13 @@ async def test_adapter_from_server_params_with_return_value_as_string(
                     type="resource",
                     resource=TextResourceContents(
                         text="this is a sample text",
-                        uri=AnyUrl(url="http://example.com/test"),
+                        uri="http://example.com/test",
                     ),
                     annotations=Annotations(audience=["user"], priority=0.3),
                 ),
             ]
         )
-        == '[{"type": "text", "text": "this is a sample text", "annotations": {"audience": ["user", "assistant"], "priority": 0.7}}, {"type": "image", "data": "this is a sample base64 encoded image", "mimeType": "image/png", "annotations": null}, {"type": "resource", "resource": {"uri": "http://example.com/test", "mimeType": null, "text": "this is a sample text"}, "annotations": {"audience": ["user"], "priority": 0.3}}]'
+        == '[{"type": "text", "text": "this is a sample text", "annotations": {"audience": ["user", "assistant"], "priority": 0.7, "lastModified": null}}, {"type": "image", "data": "this is a sample base64 encoded image", "mimeType": "image/png", "annotations": null}, {"type": "resource", "resource": {"uri": "http://example.com/test", "mimeType": null, "text": "this is a sample text"}, "annotations": {"audience": ["user"], "priority": 0.3, "lastModified": null}}]'
     )
 
 
@@ -344,11 +346,11 @@ async def test_sse_adapter_config_serialization(sample_sse_tool: Tool) -> None:
     assert "properties" in params_schema, "Parameters must have properties"
 
     # Compare schema content
-    assert params_schema["type"] == sample_sse_tool.inputSchema["type"]
-    assert params_schema["required"] == sample_sse_tool.inputSchema["required"]
+    assert params_schema["type"] == sample_sse_tool.input_schema["type"]
+    assert params_schema["required"] == sample_sse_tool.input_schema["required"]
     assert (
         params_schema["properties"]["test_param"]["type"]
-        == sample_sse_tool.inputSchema["properties"]["test_param"]["type"]
+        == sample_sse_tool.input_schema["properties"]["test_param"]["type"]
     )
 
 
@@ -365,7 +367,7 @@ async def test_sse_tool_execution(
     mock_context.__aenter__.return_value = mock_sse_session
 
     mock_sse_session.call_tool.return_value = MagicMock(
-        isError=False,
+        is_error=False,
         content=[
             TextContent(
                 text="test_output",
@@ -383,7 +385,7 @@ async def test_sse_tool_execution(
     with caplog.at_level(logging.INFO):
         adapter = SseMcpToolAdapter(server_params=params, tool=sample_sse_tool)
         result = await adapter.run_json(
-            args=schema_to_pydantic_model(sample_sse_tool.inputSchema)(**{"test_param": "test"}).model_dump(),
+            args=schema_to_pydantic_model(sample_sse_tool.input_schema)(**{"test_param": "test"}).model_dump(),
             cancellation_token=CancellationToken(),
         )
 
@@ -428,11 +430,11 @@ async def test_sse_adapter_from_server_params(
     assert "properties" in params_schema, "Parameters must have properties"
 
     # Compare schema content
-    assert params_schema["type"] == sample_sse_tool.inputSchema["type"]
-    assert params_schema["required"] == sample_sse_tool.inputSchema["required"]
+    assert params_schema["type"] == sample_sse_tool.input_schema["type"]
+    assert params_schema["required"] == sample_sse_tool.input_schema["required"]
     assert (
         params_schema["properties"]["test_param"]["type"]
-        == sample_sse_tool.inputSchema["properties"]["test_param"]["type"]
+        == sample_sse_tool.input_schema["properties"]["test_param"]["type"]
     )
 
 
@@ -458,11 +460,11 @@ async def test_streamable_http_adapter_config_serialization(sample_streamable_ht
     assert "properties" in params_schema, "Parameters must have properties"
 
     # Compare schema content
-    assert params_schema["type"] == sample_streamable_http_tool.inputSchema["type"]
-    assert params_schema["required"] == sample_streamable_http_tool.inputSchema["required"]
+    assert params_schema["type"] == sample_streamable_http_tool.input_schema["type"]
+    assert params_schema["required"] == sample_streamable_http_tool.input_schema["required"]
     assert (
         params_schema["properties"]["test_param"]["type"]
-        == sample_streamable_http_tool.inputSchema["properties"]["test_param"]["type"]
+        == sample_streamable_http_tool.input_schema["properties"]["test_param"]["type"]
     )
 
 
@@ -479,7 +481,7 @@ async def test_streamable_http_tool_execution(
     mock_context.__aenter__.return_value = mock_streamable_http_session
 
     mock_streamable_http_session.call_tool.return_value = MagicMock(
-        isError=False,
+        is_error=False,
         content=[
             TextContent(
                 text="test_output",
@@ -497,7 +499,7 @@ async def test_streamable_http_tool_execution(
     with caplog.at_level(logging.INFO):
         adapter = StreamableHttpMcpToolAdapter(server_params=params, tool=sample_streamable_http_tool)
         result = await adapter.run_json(
-            args=schema_to_pydantic_model(sample_streamable_http_tool.inputSchema)(
+            args=schema_to_pydantic_model(sample_streamable_http_tool.input_schema)(
                 **{"test_param": "test"}
             ).model_dump(),
             cancellation_token=CancellationToken(),
@@ -544,25 +546,26 @@ async def test_streamable_http_adapter_from_server_params(
     assert "properties" in params_schema, "Parameters must have properties"
 
     # Compare schema content
-    assert params_schema["type"] == sample_streamable_http_tool.inputSchema["type"]
-    assert params_schema["required"] == sample_streamable_http_tool.inputSchema["required"]
+    assert params_schema["type"] == sample_streamable_http_tool.input_schema["type"]
+    assert params_schema["required"] == sample_streamable_http_tool.input_schema["required"]
     assert (
         params_schema["properties"]["test_param"]["type"]
-        == sample_streamable_http_tool.inputSchema["properties"]["test_param"]["type"]
+        == sample_streamable_http_tool.input_schema["properties"]["test_param"]["type"]
     )
 
 
 @pytest.mark.asyncio
 async def test_mcp_server_fetch() -> None:
+    server_path = Path(__file__).parent.parent / "mcp_server_comprehensive.py"
     params = StdioServerParams(
-        command="uvx",
-        args=["mcp-server-fetch"],
+        command=sys.executable,
+        args=[str(server_path)],
         read_timeout_seconds=60,
     )
     tools = await mcp_server_tools(server_params=params)
     assert tools is not None
-    assert tools[0].name == "fetch"
-    result = await tools[0].run_json({"url": "https://github.com/"}, CancellationToken())
+    assert tools[0].name == "echo"
+    result = await tools[0].run_json({"text": "hello"}, CancellationToken())
     assert result is not None
 
 
@@ -588,39 +591,39 @@ async def test_mcp_server_filesystem() -> None:
 
 @pytest.mark.asyncio
 async def test_mcp_server_git() -> None:
+    server_path = Path(__file__).parent.parent / "mcp_server_comprehensive.py"
     params = StdioServerParams(
-        command="uvx",
-        args=["mcp-server-git"],
+        command=sys.executable,
+        args=[str(server_path)],
         read_timeout_seconds=60,
     )
     tools = await mcp_server_tools(server_params=params)
     assert tools is not None
-    tools = [tool for tool in tools if tool.name == "git_log"]
+    tools = [tool for tool in tools if tool.name == "get_time"]
     assert len(tools) == 1
     tool = tools[0]
-    repo_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..")
-    result = await tool.run_json({"repo_path": repo_path}, CancellationToken())
+    result = await tool.run_json({}, CancellationToken())
     assert result is not None
 
 
 @pytest.mark.asyncio
 async def test_mcp_server_git_existing_session() -> None:
+    server_path = Path(__file__).parent.parent / "mcp_server_comprehensive.py"
     params = StdioServerParams(
-        command="uvx",
-        args=["mcp-server-git"],
+        command=sys.executable,
+        args=[str(server_path)],
         read_timeout_seconds=60,
     )
     async with create_mcp_server_session(params) as session:
         await session.initialize()
         tools = await mcp_server_tools(server_params=params, session=session)
         assert tools is not None
-        git_log = [tool for tool in tools if tool.name == "git_log"][0]
-        repo_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "..")
-        result = await git_log.run_json({"repo_path": repo_path}, CancellationToken())
+        get_time = [tool for tool in tools if tool.name == "get_time"][0]
+        result = await get_time.run_json({}, CancellationToken())
         assert result is not None
 
-        git_status = [tool for tool in tools if tool.name == "git_status"][0]
-        result = await git_status.run_json({"repo_path": repo_path}, CancellationToken())
+        echo = [tool for tool in tools if tool.name == "echo"][0]
+        result = await echo.run_json({"text": "hello"}, CancellationToken())
         assert result is not None
 
 
@@ -652,9 +655,10 @@ async def test_mcp_server_github() -> None:
 
 @pytest.mark.asyncio
 async def test_mcp_workbench_start_stop() -> None:
+    server_path = Path(__file__).parent.parent / "mcp_server_comprehensive.py"
     params = StdioServerParams(
-        command="uvx",
-        args=["mcp-server-fetch"],
+        command=sys.executable,
+        args=[str(server_path)],
         read_timeout_seconds=60,
     )
 
@@ -669,9 +673,10 @@ async def test_mcp_workbench_start_stop() -> None:
 
 @pytest.mark.asyncio
 async def test_mcp_workbench_server_fetch() -> None:
+    server_path = Path(__file__).parent.parent / "mcp_server_comprehensive.py"
     params = StdioServerParams(
-        command="uvx",
-        args=["mcp-server-fetch"],
+        command=sys.executable,
+        args=[str(server_path)],
         read_timeout_seconds=60,
     )
 
@@ -680,9 +685,9 @@ async def test_mcp_workbench_server_fetch() -> None:
 
     tools = await workbench.list_tools()
     assert tools is not None
-    assert tools[0]["name"] == "fetch"
+    assert tools[0]["name"] == "echo"
 
-    result = await workbench.call_tool(tools[0]["name"], {"url": "https://github.com/"}, CancellationToken())
+    result = await workbench.call_tool(tools[0]["name"], {"text": "hello"}, CancellationToken())
     assert result is not None
 
     await workbench.stop()
@@ -811,7 +816,7 @@ def test_mcp_tool_adapter_normalize_payload(sample_tool: Tool, sample_server_par
         ImageContent(data="base64data", mimeType="image/png", type="image"),
         EmbeddedResource(
             type="resource",
-            resource=TextResourceContents(text="embedded text", uri=AnyUrl(url="http://example.com/resource")),
+            resource=TextResourceContents(text="embedded text", uri="http://example.com/resource"),
         ),
     ]
     assert adapter._normalize_payload_to_content_list(valid_content_list) == valid_content_list  # type: ignore[reportPrivateUsage]
@@ -827,7 +832,7 @@ def test_mcp_tool_adapter_normalize_payload(sample_tool: Tool, sample_server_par
     # Case 4: Payload is a single EmbeddedResource
     single_embedded_resource = EmbeddedResource(
         type="resource",
-        resource=TextResourceContents(text="other embedded", uri=AnyUrl(url="http://example.com/other")),
+        resource=TextResourceContents(text="other embedded", uri="http://example.com/other"),
     )
     assert adapter._normalize_payload_to_content_list(single_embedded_resource) == [single_embedded_resource]  # type: ignore[reportPrivateUsage, arg-type]
 
@@ -920,11 +925,11 @@ def test_return_value_as_string_with_resource_link(sample_tool: Tool, sample_ser
     resource_link = ResourceLink(
         name="test_link",
         type="resource_link",
-        uri=AnyUrl(url="http://example.com"),
+        uri="http://example.com",
     )
 
     result = adapter.return_value_as_string([resource_link])
     # Verify the JSON serialization contains expected fields
     assert '"type": "resource_link"' in result
     assert '"name": "test_link"' in result
-    assert '"uri": "http://example.com/"' in result  # AnyUrl normalizes with trailing slash
+    assert '"uri": "http://example.com"' in result

--- a/python/packages/autogen-ext/tests/tools/test_mcp_workbench_features.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_workbench_features.py
@@ -2,7 +2,6 @@ import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
-from autogen_ext.tools.mcp import McpWorkbench, StdioServerParams
 from mcp.types import (
     GetPromptResult,
     ListPromptsResult,
@@ -18,6 +17,8 @@ from mcp.types import (
     TextResourceContents,
 )
 from pydantic import AnyUrl
+
+from autogen_ext.tools.mcp import McpWorkbench, StdioServerParams
 
 
 @pytest.fixture
@@ -67,13 +68,13 @@ def sample_resources() -> list[Resource]:
     """Create sample MCP resources for testing."""
     return [
         Resource(
-            uri=AnyUrl("file:///test/document.txt"),
+            uri="file:///test/document.txt",
             name="Test Document",
             description="A sample document for testing",
             mimeType="text/plain",
         ),
         Resource(
-            uri=AnyUrl("https://api.example.com/data"),
+            uri="https://api.example.com/data",
             name="API Data",
             description="External API data source",
             mimeType="application/json",
@@ -240,10 +241,10 @@ async def test_list_resources(
         assert len(result.resources) == 2
         assert str(result.resources[0].uri) == "file:///test/document.txt"
         assert result.resources[0].name == "Test Document"
-        assert result.resources[0].mimeType == "text/plain"
+        assert result.resources[0].mime_type == "text/plain"
         assert str(result.resources[1].uri) == "https://api.example.com/data"
         assert result.resources[1].name == "API Data"
-        assert result.resources[1].mimeType == "application/json"
+        assert result.resources[1].mime_type == "application/json"
 
         # Verify actor was called correctly
         mock_mcp_actor.call.assert_called_with("list_resources", None)
@@ -263,7 +264,7 @@ async def test_read_resource(mock_mcp_actor: AsyncMock, sample_server_params: St
     read_resource_result = ReadResourceResult(
         contents=[
             TextResourceContents(
-                uri=AnyUrl("file:///test/document.txt"),
+                uri="file:///test/document.txt",
                 mimeType="text/plain",
                 text="This is the content of the test document.",
             )
@@ -283,8 +284,8 @@ async def test_read_resource(mock_mcp_actor: AsyncMock, sample_server_params: St
         assert len(result.contents) == 1
         content = result.contents[0]
         assert isinstance(content, TextResourceContents)
-        assert content.uri == AnyUrl(uri)
-        assert content.mimeType == "text/plain"
+        assert content.uri == uri
+        assert content.mime_type == "text/plain"
         assert content.text == "This is the content of the test document."
 
         # Verify actor was called correctly
@@ -306,7 +307,7 @@ async def test_list_resource_templates(
     workbench._actor = mock_mcp_actor  # type: ignore[reportPrivateUsage]
 
     # Mock list_resource_templates response
-    list_templates_result = ListResourceTemplatesResult(resourceTemplates=sample_resource_templates)
+    list_templates_result = ListResourceTemplatesResult(resource_templates=sample_resource_templates)
     future_result: asyncio.Future[ListResourceTemplatesResult] = asyncio.Future()
     future_result.set_result(list_templates_result)
     mock_mcp_actor.call.return_value = future_result
@@ -317,13 +318,13 @@ async def test_list_resource_templates(
 
         # Verify result
         assert isinstance(result, ListResourceTemplatesResult)
-        assert len(result.resourceTemplates) == 2
-        assert result.resourceTemplates[0].uriTemplate == "file:///logs/{date}.log"
-        assert result.resourceTemplates[0].name == "Daily Logs"
-        assert result.resourceTemplates[0].mimeType == "text/plain"
-        assert result.resourceTemplates[1].uriTemplate == "https://api.example.com/users/{userId}"
-        assert result.resourceTemplates[1].name == "User Profile"
-        assert result.resourceTemplates[1].mimeType == "application/json"
+        assert len(result.resource_templates) == 2
+        assert result.resource_templates[0].uri_template == "file:///logs/{date}.log"
+        assert result.resource_templates[0].name == "Daily Logs"
+        assert result.resource_templates[0].mime_type == "text/plain"
+        assert result.resource_templates[1].uri_template == "https://api.example.com/users/{userId}"
+        assert result.resource_templates[1].name == "User Profile"
+        assert result.resource_templates[1].mime_type == "application/json"
 
         # Verify actor was called correctly
         mock_mcp_actor.call.assert_called_with("list_resource_templates", None)
@@ -461,7 +462,7 @@ async def test_workbench_auto_start_on_read_resource(sample_server_params: Stdio
         # Set up a mock actor
         mock_actor = AsyncMock()
         read_resource_result = ReadResourceResult(
-            contents=[TextResourceContents(uri=AnyUrl("file:///test.txt"), mimeType="text/plain", text="Test content")]
+            contents=[TextResourceContents(uri="file:///test.txt", mimeType="text/plain", text="Test content")]
         )
         future_result: asyncio.Future[ReadResourceResult] = asyncio.Future()
         future_result.set_result(read_resource_result)
@@ -499,7 +500,7 @@ async def test_workbench_auto_start_on_list_resource_templates(
         start_called = True
         # Set up a mock actor
         mock_actor = AsyncMock()
-        list_templates_result = ListResourceTemplatesResult(resourceTemplates=sample_resource_templates)
+        list_templates_result = ListResourceTemplatesResult(resource_templates=sample_resource_templates)
         future_result: asyncio.Future[ListResourceTemplatesResult] = asyncio.Future()
         future_result.set_result(list_templates_result)
         mock_actor.call.return_value = future_result
@@ -514,7 +515,7 @@ async def test_workbench_auto_start_on_list_resource_templates(
         # Verify that start was called
         assert start_called
         assert isinstance(result, ListResourceTemplatesResult)
-        assert len(result.resourceTemplates) == 2
+        assert len(result.resource_templates) == 2
 
     finally:
         workbench._actor = None  # type: ignore[reportPrivateUsage]

--- a/python/packages/autogen-ext/tests/tools/test_mcp_workbench_warnings_and_errors.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_workbench_warnings_and_errors.py
@@ -8,13 +8,14 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from autogen_core import Image
 from autogen_core.tools import ImageResultContent, TextResultContent
-from autogen_ext.tools.mcp import McpWorkbench, StdioServerParams
 from mcp.types import (
     CallToolResult,
     EmbeddedResource,
     ImageContent,
     TextContent,
 )
+
+from autogen_ext.tools.mcp import McpWorkbench, StdioServerParams
 
 
 @pytest.fixture
@@ -112,7 +113,7 @@ async def test_call_tool_embedded_resource_handling(
 
     embedded_resource = EmbeddedResource(
         type="resource",
-        resource=TextResourceContents(uri=AnyUrl("test://resource"), text="test content"),
+        resource=TextResourceContents(uri="test://resource", text="test content"),
     )
 
     call_result = CallToolResult(content=[embedded_resource], isError=False)


### PR DESCRIPTION
## Summary

Fixes #8014

The `mcp` extra had no upper bound (`mcp>=1.11.0`), so `pip install autogen-ext[mcp]` now resolves to `mcp` 2.0.0 (released 2026-07-28), which removed or renamed several 1.x client APIs the integration relied on. This migrates the integration to the 2.x APIs and pins `mcp>=2.0.0,<3.0.0`.

## Changes

**Source (`autogen_ext/tools/mcp/`)**
- `streamablehttp_client` → `streamable_http_client` (3-tuple → 2-tuple yield); the removed `timeout`/`sse_read_timeout` kwargs are now configured via `create_mcp_http_client(headers=..., timeout=httpx2.Timeout(...))` passed as `http_client`
- `ClientSession(read_timeout_seconds=)` now takes float seconds instead of `timedelta`
- `mcp.types` attribute access is snake_case: `inputSchema` → `input_schema`, `isError` → `is_error`, `systemPrompt`/`maxTokens`/`stopSequences` → `system_prompt`/`max_tokens`/`stop_sequences`; result serialization uses `model_dump(by_alias=True)` to keep the camelCase wire format
- `RequestContext` moved to `mcp.client.session.ClientRequestContext`
- `ElicitRequestParams` is now a Form/URL union; migrated to `ElicitRequestFormParams` with `requested_schema`

**Tests**
- Migrated the comprehensive stdio server fixture to the 2.x low-level `Server` API (`@server.list_tools()`-style decorators were removed in favor of `add_request_handler(method, params_type, handler)`)
- Updated camelCase attribute access to snake_case
- Run the local fixture server with `sys.executable` instead of `uv`/`uvx`-launched external servers (`mcp-server-fetch`/`mcp-server-git`), so integration tests don't depend on external package resolution

## Validation

- MCP test suite: **145 passed, 1 skipped** (skipped test requires a GitHub token, pre-existing)
- End-to-end Streamable HTTP check against a live `mcp` 2.0 server (list tools + call tool via `StreamableHttpMcpToolAdapter`)
- `ruff check` clean on changed files

## Notes

- Public API is unchanged: `StreamableHttpServerParams.timeout`/`sse_read_timeout` still work (now mapped onto the httpx2 client timeout), and `SseServerParams` fields map directly onto `sse_client`'s 2.x signature.