### PR TITLE
fix(ext): cap MCP SDK before breaking 2.0 APIs

### DIFF
--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -150,7 +150,7 @@ semantic-kernel-all = [
 
 rich = ["rich>=13.9.4"]
 
-mcp = ["mcp>=1.11.0"]
+mcp = ["mcp>=1.11.0,<2.0.0"]
 canvas = [
     "unidiff>=0.7.5",
 ]


### PR DESCRIPTION
Fixes #8014

---

The MCP integration currently allows mcp 2.x even though it imports and calls APIs removed or changed in that release. Cap the optional dependency at the last compatible major version so fresh installs remain functional until the migration is completed.

Tests: parsed python/packages/autogen-ext/pyproject.toml with Python's TOML parser.