### PR TITLE
fix: stream from any StreamWorkbench, not just StaticStreamWorkbench

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -35,7 +35,7 @@ from autogen_core.models import (
     LLMMessage,
     SystemMessage,
 )
-from autogen_core.tools import BaseTool, FunctionTool, StaticStreamWorkbench, ToolResult, Workbench
+from autogen_core.tools import BaseTool, FunctionTool, StaticStreamWorkbench, StreamWorkbench, ToolResult, Workbench
 from pydantic import BaseModel, Field
 from typing_extensions import Self
 
@@ -1577,7 +1577,7 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         for wb in workbench:
             tools = await wb.list_tools()
             if any(t["name"] == tool_call.name for t in tools):
-                if isinstance(wb, StaticStreamWorkbench):
+                if isinstance(wb, StreamWorkbench):
                     tool_result: ToolResult | None = None
                     async for event in wb.call_tool_stream(
                         name=tool_call.name,

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -4,7 +4,7 @@
 import asyncio
 import json
 import os
-from typing import Any, List, Optional, Union, cast
+from typing import Any, AsyncGenerator, List, Mapping, Optional, Union, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-party imports
@@ -40,6 +40,7 @@ from autogen_core.models import (
     SystemMessage,
     UserMessage,
 )
+from autogen_core.tools import StreamWorkbench, TextResultContent, ToolResult, ToolSchema
 from autogen_ext.models.anthropic import AnthropicChatCompletionClient
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from autogen_ext.models.replay import ReplayChatCompletionClient
@@ -3167,6 +3168,80 @@ class TestAssistantAgentWorkbenchIntegration:
         content = result.messages[-1].content
         assert "Result from concurrent_tool1" in content
         assert "Result from concurrent_tool2" in content
+
+    @pytest.mark.asyncio
+    async def test_custom_stream_workbench_uses_streaming_path(self) -> None:
+        """Test that any StreamWorkbench, not just StaticStreamWorkbench, is streamed from."""
+
+        class CustomStreamWorkbench(StreamWorkbench):
+            async def list_tools(self) -> List[ToolSchema]:
+                return [ToolSchema(name="stream_tool", description="A streaming tool")]
+
+            async def call_tool(
+                self,
+                name: str,
+                arguments: Mapping[str, Any] | None = None,
+                cancellation_token: CancellationToken | None = None,
+                call_id: str | None = None,
+            ) -> ToolResult:
+                return ToolResult(name=name, result=[TextResultContent(content="final result")])
+
+            async def call_tool_stream(
+                self,
+                name: str,
+                arguments: Mapping[str, Any] | None = None,
+                cancellation_token: CancellationToken | None = None,
+                call_id: str | None = None,
+            ) -> AsyncGenerator[Any | ToolResult, None]:
+                yield ModelClientStreamingChunkEvent(content="progress", source="stream_tool")
+                yield ToolResult(name=name, result=[TextResultContent(content="final result")])
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def reset(self) -> None:
+                pass
+
+            async def save_state(self) -> Mapping[str, Any]:
+                return {}
+
+            async def load_state(self, state: Mapping[str, Any]) -> None:
+                pass
+
+        model_client = ReplayChatCompletionClient(
+            [
+                CreateResult(
+                    finish_reason="function_calls",
+                    content=[FunctionCall(id="1", arguments=json.dumps({}), name="stream_tool")],
+                    usage=RequestUsage(prompt_tokens=10, completion_tokens=5),
+                    cached=False,
+                ),
+            ],
+            model_info={
+                "function_calling": True,
+                "vision": False,
+                "json_output": False,
+                "family": ModelFamily.GPT_4O,
+                "structured_output": False,
+            },
+        )
+
+        agent = AssistantAgent(
+            name="test_agent",
+            model_client=model_client,
+            workbench=CustomStreamWorkbench(),
+        )
+
+        messages = [message async for message in agent.run_stream(task="Test streaming workbench")]
+
+        chunks = [m for m in messages if isinstance(m, ModelClientStreamingChunkEvent)]
+        assert [chunk.content for chunk in chunks] == ["progress"]
+        assert isinstance(messages[-1], TaskResult)
+        assert isinstance(messages[-1].messages[-1], ToolCallSummaryMessage)
+        assert messages[-1].messages[-1].content == "final result"
 
 
 class TestAssistantAgentComplexIntegration:

--- a/python/packages/autogen-core/src/autogen_core/tools/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/__init__.py
@@ -10,7 +10,7 @@ from ._base import (
 )
 from ._function_tool import FunctionTool
 from ._static_workbench import StaticStreamWorkbench, StaticWorkbench
-from ._workbench import ImageResultContent, TextResultContent, ToolResult, Workbench
+from ._workbench import ImageResultContent, StreamWorkbench, TextResultContent, ToolResult, Workbench
 
 __all__ = [
     "Tool",
@@ -22,6 +22,7 @@ __all__ = [
     "BaseStreamTool",
     "FunctionTool",
     "Workbench",
+    "StreamWorkbench",
     "ToolResult",
     "TextResultContent",
     "ImageResultContent",


### PR DESCRIPTION
Fixes #8008

`AssistantAgent._execute_tool_call` picked the streaming path with `isinstance(wb, StaticStreamWorkbench)`, narrowing on one concrete class instead of `StreamWorkbench`, the ABC that declares `call_tool_stream`. Any other `StreamWorkbench` fell through to the plain `call_tool()` branch and its intermediate events never reached the agent's stream. `StreamWorkbench` also was not exported from `autogen_core.tools`, so the interface was not publicly importable in the first place.

Changes:

- `_assistant_agent.py`: check `isinstance(wb, StreamWorkbench)`. `StaticStreamWorkbench` subclasses it, so existing behavior is unchanged.
- `autogen_core/tools/__init__.py`: export `StreamWorkbench`.
- New test `TestAssistantAgentWorkbenchIntegration::test_custom_stream_workbench_uses_streaming_path`, which drives an `AssistantAgent` with a `StreamWorkbench` that is not a `StaticStreamWorkbench` and asserts the intermediate event surfaces. It fails on main with `assert [] == ['progress']`.

`McpWorkbench` is a plain `Workbench`, so it is unaffected either way.

Verified on Linux x86_64, CPU only, Python 3.12. Full `autogen-agentchat` suite (290 passed, 5 skipped) and `autogen-core` suite plus `test_group_chat.py` (238 passed) are green. `ruff check`, `ruff format --check`, `mypy` on `autogen-agentchat`, and `pyright` on both packages are clean.

Not verified: no live model provider or real streaming workbench, all model calls go through `ReplayChatCompletionClient`. `mypy` on `autogen-core` does not complete on a clean tree in my sandbox (preexisting duplicate-module error on `tests/protos/serialization_test_pb2.pyi`), so it gives no signal on the `__init__.py` edit. `packages/autogen-core/tests/test_json_to_pydantic.py` was skipped, it fails at collection on a clean tree here for a missing `email-validator`.

Reported by @babyblueviper1, who traced the `isinstance` narrowing while building a workbench-level approval gate and named it precisely in the issue.