### PR TITLE
feat: Add get_thread method to BaseGroupChat (Issue #6085)

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -27,6 +27,7 @@ from ...messages import (
 from ...state import TeamState
 from ._chat_agent_container import ChatAgentContainer
 from ._events import (
+    GroupChatGetThread,
     GroupChatPause,
     GroupChatReset,
     GroupChatResume,
@@ -744,6 +745,37 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
             GroupChatResume(),
             recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
         )
+
+    async def get_thread(self) -> List[BaseAgentEvent | BaseChatMessage]:
+        """Get the message thread of the group chat.
+
+        The team must be initialized before its thread can be retrieved.
+
+        Returns:
+            A list of messages representing the current conversation thread.
+
+        Raises:
+            RuntimeError: If the team has not been initialized.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "The group chat has not been initialized. It must be run before its thread can be retrieved."
+            )
+
+        if self._embedded_runtime:
+            assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+            self._runtime.start()
+
+        try:
+            response = await self._runtime.send_message(
+                GroupChatGetThread(),
+                recipient=AgentId(type=self._group_chat_manager_topic_type, key=self._team_id),
+            )
+            return response.messages  # type: ignore
+        finally:
+            if self._embedded_runtime:
+                assert isinstance(self._runtime, SingleThreadedAgentRuntime)
+                await self._runtime.stop_when_idle()
 
     async def save_state(self) -> Mapping[str, Any]:
         """Save the state of the group chat team.

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -9,6 +9,7 @@ from ...messages import BaseAgentEvent, BaseChatMessage, MessageFactory, SelectS
 from ._events import (
     GroupChatAgentResponse,
     GroupChatError,
+    GroupChatGetThread,
     GroupChatMessage,
     GroupChatPause,
     GroupChatRequestPublish,
@@ -17,6 +18,7 @@ from ._events import (
     GroupChatStart,
     GroupChatTeamResponse,
     GroupChatTermination,
+    GroupChatThreadResponse,
     SerializableException,
 )
 from ._sequential_routed_agent import SequentialRoutedAgent
@@ -56,6 +58,7 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
                 GroupChatTeamResponse,
                 GroupChatMessage,
                 GroupChatReset,
+                GroupChatGetThread,
             ],
         )
         if max_turns is not None and max_turns <= 0:
@@ -284,6 +287,11 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
     async def handle_resume(self, message: GroupChatResume, ctx: MessageContext) -> None:
         """Resume the group chat manager. This is a no-op in the base class."""
         pass
+
+    @rpc
+    async def handle_get_thread(self, message: GroupChatGetThread, ctx: MessageContext) -> GroupChatThreadResponse:
+        """Handle a request to get the message thread."""
+        return GroupChatThreadResponse(messages=list(self._message_thread))
 
     @abstractmethod
     async def validate_group_state(self, messages: List[BaseChatMessage] | None) -> None:

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_events.py
@@ -106,6 +106,19 @@ class GroupChatResume(BaseModel):
     ...
 
 
+class GroupChatGetThread(BaseModel):
+    """A request to get the message thread from the group chat."""
+
+    ...
+
+
+class GroupChatThreadResponse(BaseModel):
+    """A response containing the message thread from the group chat."""
+
+    messages: List[SerializeAsAny[BaseAgentEvent | BaseChatMessage]]
+    """The messages in the thread."""
+
+
 class GroupChatError(BaseModel):
     """A message indicating that an error occurred in the group chat."""
 

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -1944,3 +1944,25 @@ async def test_selector_group_chat_streaming(runtime: AgentRuntime | None) -> No
 
     # Content-based verification instead of index-based
     # Note: The streaming test verifies the streaming behavior, not the final result content
+
+
+@pytest.mark.asyncio
+async def test_round_robin_group_chat_get_thread(runtime: AgentRuntime | None) -> None:
+    agent_1 = _EchoAgent("agent_1", description="echo agent 1")
+    agent_2 = _EchoAgent("agent_2", description="echo agent 2")
+    termination = MaxMessageTermination(2)
+    team = RoundRobinGroupChat(participants=[agent_1, agent_2], termination_condition=termination, runtime=runtime)
+
+    # Test error before init
+    team2 = RoundRobinGroupChat(participants=[agent_1, agent_2], termination_condition=termination, runtime=runtime)
+    with pytest.raises(RuntimeError, match="The group chat has not been initialized."):
+        await team2.get_thread()
+
+    await team.run(
+        task="Write a program that prints 'Hello, world!'",
+    )
+
+    thread = await team.get_thread()
+    assert len(thread) == 2
+    assert getattr(thread[0], "source", None) == "user"
+    assert getattr(thread[1], "source", None) == "agent_1"


### PR DESCRIPTION
### Description
Fixes #6085

This PR implements the `get_thread` method for `BaseGroupChat` as requested in #6085.

#### Changes:
1. **Events**: Added `GroupChatGetThread` request event and `GroupChatThreadResponse` to properly encapsulate the message list as a serializable Pydantic model. This resolves type-checking issues where `autogen_core`'s `@rpc` validator natively rejects raw `List` return signatures.
2. **Manager**: Added `handle_get_thread` RPC handler to `BaseGroupChatManager`.
3. **Group Chat**: Added `get_thread` to `BaseGroupChat`. Included startup and shutdown lifecycle management of the embedded runtime to ensure the event loop is active when the method intercepts the request.
4. **Tests**: Added `test_round_robin_group_chat_get_thread` and verified both `single_threaded` and `embedded` configurations.