### PR TITLE
fix(core): keep tool call pairs during token truncation

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/model_context/_token_limited_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_token_limited_chat_completion_context.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from typing_extensions import Self
 
 from .._component_config import Component, ComponentModel
-from ..models import ChatCompletionClient, FunctionExecutionResultMessage, LLMMessage
+from ..models import AssistantMessage, ChatCompletionClient, FunctionExecutionResultMessage, LLMMessage
 from ..tools import ToolSchema
 from ._chat_completion_context import ChatCompletionContext
 
@@ -14,6 +14,27 @@ class TokenLimitedChatCompletionContextConfig(BaseModel):
     token_limit: int | None = None
     tool_schema: List[ToolSchema] | None = None
     initial_messages: List[LLMMessage] | None = None
+
+
+def _is_function_call_message(message: LLMMessage) -> bool:
+    return isinstance(message, AssistantMessage) and isinstance(message.content, list)
+
+
+def _remove_middle_message(messages: List[LLMMessage]) -> None:
+    """Remove the middle message without splitting an adjacent tool call/result pair."""
+    middle_index = len(messages) // 2
+    message = messages[middle_index]
+
+    if _is_function_call_message(message):
+        if middle_index + 1 < len(messages) and isinstance(messages[middle_index + 1], FunctionExecutionResultMessage):
+            del messages[middle_index : middle_index + 2]
+            return
+    elif isinstance(message, FunctionExecutionResultMessage):
+        if middle_index > 0 and _is_function_call_message(messages[middle_index - 1]):
+            del messages[middle_index - 1 : middle_index + 1]
+            return
+
+    messages.pop(middle_index)
 
 
 class TokenLimitedChatCompletionContext(ChatCompletionContext, Component[TokenLimitedChatCompletionContextConfig]):
@@ -61,14 +82,12 @@ class TokenLimitedChatCompletionContext(ChatCompletionContext, Component[TokenLi
         if self._token_limit is None:
             remaining_tokens = self._model_client.remaining_tokens(messages, tools=self._tool_schema)
             while remaining_tokens < 0 and len(messages) > 0:
-                middle_index = len(messages) // 2
-                messages.pop(middle_index)
+                _remove_middle_message(messages)
                 remaining_tokens = self._model_client.remaining_tokens(messages, tools=self._tool_schema)
         else:
             token_count = self._model_client.count_tokens(messages, tools=self._tool_schema)
             while token_count > self._token_limit and len(messages) > 0:
-                middle_index = len(messages) // 2
-                messages.pop(middle_index)
+                _remove_middle_message(messages)
                 token_count = self._model_client.count_tokens(messages, tools=self._tool_schema)
         if messages and isinstance(messages[0], FunctionExecutionResultMessage):
             # Handle the first message is a function call result message.

--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -1,6 +1,8 @@
-from typing import List
+from typing import List, Sequence
+from unittest.mock import MagicMock
 
 import pytest
+from autogen_core import FunctionCall
 from autogen_core.model_context import (
     BufferedChatCompletionContext,
     HeadAndTailChatCompletionContext,
@@ -10,6 +12,7 @@ from autogen_core.model_context import (
 from autogen_core.models import (
     AssistantMessage,
     ChatCompletionClient,
+    FunctionExecutionResult,
     FunctionExecutionResultMessage,
     LLMMessage,
     UserMessage,
@@ -208,3 +211,44 @@ async def test_token_limited_model_context_openai_with_function_result(
     assert type(retrieved[0]) == UserMessage  # Function result should be removed
     assert type(retrieved[1]) == AssistantMessage
     assert type(retrieved[2]) == UserMessage
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pair_start", [2, 3], ids=["result-at-middle", "call-at-middle"])
+@pytest.mark.parametrize("token_limit", [6, None], ids=["count-tokens", "remaining-tokens"])
+async def test_token_limited_model_context_keeps_function_call_result_pairs(
+    pair_start: int, token_limit: int | None
+) -> None:
+    def count_tokens(messages: Sequence[LLMMessage], **_: object) -> int:
+        return len(messages)
+
+    def remaining_tokens(messages: Sequence[LLMMessage], **_: object) -> int:
+        return 6 - len(messages)
+
+    model_client = MagicMock(spec=ChatCompletionClient)
+    model_client.count_tokens.side_effect = count_tokens
+    model_client.remaining_tokens.side_effect = remaining_tokens
+    model_context = TokenLimitedChatCompletionContext(model_client=model_client, token_limit=token_limit)
+
+    function_call = AssistantMessage(
+        content=[FunctionCall(id="call_1", arguments="{}", name="tool")], source="assistant"
+    )
+    function_result = FunctionExecutionResultMessage(
+        content=[FunctionExecutionResult(content="ok", name="tool", call_id="call_1")]
+    )
+    messages: List[LLMMessage] = [
+        UserMessage(content="m0", source="user"),
+        UserMessage(content="m1", source="user"),
+        UserMessage(content="m2", source="user"),
+        UserMessage(content="m3", source="user"),
+        UserMessage(content="m4", source="user"),
+    ]
+    messages[pair_start:pair_start] = [function_call, function_result]
+    for message in messages:
+        await model_context.add_message(message)
+
+    retrieved = await model_context.get_messages()
+
+    assert function_call not in retrieved
+    assert function_result not in retrieved
+    assert len(retrieved) == 5


### PR DESCRIPTION
## Why are these changes needed?

`TokenLimitedChatCompletionContext` removes messages from the middle of the history one at a time. When the midpoint lands on either side of an assistant tool call and its execution result, this can leave an invalid history containing an orphaned result or call.

This change treats adjacent assistant tool-call and execution-result messages as an indivisible pair during token truncation. It applies the same behavior to both explicit `token_limit` counting and model-client `remaining_tokens` counting.

Regression coverage exercises both possible midpoint positions across both token-limit modes.

## Related issue number

Closes #7955

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. No documentation changes are needed for this internal bug fix.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

Local checks:

- `pytest tests -q` (`230 passed`)
- `ruff format --check src tests`
- `ruff check src tests`
- `mypy --config-file ../../pyproject.toml --exclude src/autogen_core/application/protos --exclude tests/protos src tests`
- `pyright --pythonpath ../../.venv/Scripts/python.exe`

---
The follow-up commit on this branch was developed with AI assistance (Claude); the code and tests were reviewed and verified locally before pushing.