### PR TITLE
fix(mcp): prevent tool override name collisions

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
@@ -258,6 +258,7 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
                         f"'{existing_original}' and '{original_name}'. Override names must be unique."
                     )
                 self._override_name_to_original[override_name] = original_name
+        self._tool_override_names_validated = not self._override_name_to_original
 
         self._host = host
 
@@ -284,6 +285,8 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
             list_tool_result, ListToolsResult
         ), f"list_tools must return a CallToolResult, instead of : {str(type(list_tool_result))}"
         schema: List[ToolSchema] = []
+        exposed_name_to_original: Dict[str, str] = {}
+        resolved_override_name_to_original: Dict[str, str] = {}
         for tool in list_tool_result.tools:
             original_name = tool.name
             name = original_name
@@ -294,8 +297,19 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
                 override = self._tool_overrides[original_name]
                 if override.name is not None:
                     name = override.name
+                    if name != original_name:
+                        resolved_override_name_to_original[name] = original_name
                 if override.description is not None:
                     description = override.description
+
+            existing_original = exposed_name_to_original.get(name)
+            if existing_original is not None and existing_original != original_name:
+                raise ValueError(
+                    f"Duplicate exposed tool name '{name}' for MCP tools "
+                    f"'{existing_original}' and '{original_name}'. Tool override names must not conflict "
+                    "with server tool names."
+                )
+            exposed_name_to_original[name] = original_name
 
             parameters = ParametersSchema(
                 type="object",
@@ -309,6 +323,8 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
                 parameters=parameters,
             )
             schema.append(tool_schema)
+        self._override_name_to_original = resolved_override_name_to_original
+        self._tool_override_names_validated = True
         return schema
 
     async def call_tool(
@@ -328,6 +344,9 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
             cancellation_token = CancellationToken()
         if not arguments:
             arguments = {}
+
+        if not self._tool_override_names_validated:
+            await self.list_tools()
 
         # Check if the name is an override name and map it back to the original
         original_name = self._override_name_to_original.get(name, name)

--- a/python/packages/autogen-ext/tests/tools/test_mcp_workbench_overrides.py
+++ b/python/packages/autogen-ext/tests/tools/test_mcp_workbench_overrides.py
@@ -296,3 +296,91 @@ def test_mcp_workbench_conflict_detection() -> None:
     }
     with pytest.raises(ValueError):
         McpWorkbench(server_params=server_params, tool_overrides=overrides_duplicate)
+
+
+@pytest.mark.asyncio
+async def test_mcp_workbench_rejects_override_name_colliding_with_server_tool(
+    sample_mcp_tools: list[Tool], mock_mcp_actor: AsyncMock, sample_server_params: StdioServerParams
+) -> None:
+    """An override must not shadow another tool returned by the MCP server."""
+
+    workbench = McpWorkbench(
+        server_params=sample_server_params,
+        tool_overrides={"fetch": ToolOverride(name="search")},
+    )
+    workbench._actor = mock_mcp_actor  # type: ignore[reportPrivateUsage]
+
+    future_result: asyncio.Future[ListToolsResult] = asyncio.Future()
+    future_result.set_result(ListToolsResult(tools=sample_mcp_tools))
+    mock_mcp_actor.call.return_value = future_result
+
+    try:
+        with pytest.raises(
+            ValueError,
+            match="Duplicate exposed tool name 'search' for MCP tools 'fetch' and 'search'",
+        ):
+            await workbench.list_tools()
+    finally:
+        workbench._actor = None  # type: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_mcp_workbench_validates_override_names_before_direct_call(
+    sample_mcp_tools: list[Tool], mock_mcp_actor: AsyncMock, sample_server_params: StdioServerParams
+) -> None:
+    """Direct calls must not bypass override-name collision validation."""
+
+    workbench = McpWorkbench(
+        server_params=sample_server_params,
+        tool_overrides={"fetch": ToolOverride(name="search")},
+    )
+    workbench._actor = mock_mcp_actor  # type: ignore[reportPrivateUsage]
+
+    future_result: asyncio.Future[ListToolsResult] = asyncio.Future()
+    future_result.set_result(ListToolsResult(tools=sample_mcp_tools))
+    mock_mcp_actor.call.return_value = future_result
+
+    try:
+        with pytest.raises(ValueError, match="Duplicate exposed tool name 'search'"):
+            await workbench.call_tool("search", {"query": "example"})
+        mock_mcp_actor.call.assert_awaited_once_with("list_tools", None)
+    finally:
+        workbench._actor = None  # type: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_mcp_workbench_does_not_route_through_override_for_missing_original(
+    sample_mcp_tools: list[Tool], mock_mcp_actor: AsyncMock, sample_server_params: StdioServerParams
+) -> None:
+    """Overrides for absent tools must not shadow tools that the server still exposes."""
+
+    workbench = McpWorkbench(
+        server_params=sample_server_params,
+        tool_overrides={"missing": ToolOverride(name="search")},
+    )
+    workbench._actor = mock_mcp_actor  # type: ignore[reportPrivateUsage]
+
+    from mcp.types import CallToolResult, TextContent
+
+    mock_result = CallToolResult(content=[TextContent(text="found", type="text")], isError=False)
+
+    def mock_call_side_effect(
+        method: str, args: dict[str, Any] | None = None
+    ) -> asyncio.Future[ListToolsResult | CallToolResult]:
+        future_result: asyncio.Future[ListToolsResult | CallToolResult] = asyncio.Future()
+        if method == "list_tools":
+            future_result.set_result(ListToolsResult(tools=sample_mcp_tools[1:]))
+        elif method == "call_tool":
+            future_result.set_result(mock_result)
+        else:
+            future_result.set_exception(ValueError(f"Unexpected method: {method}"))
+        return future_result
+
+    mock_mcp_actor.call.side_effect = mock_call_side_effect
+
+    try:
+        result = await workbench.call_tool("search", {"query": "example"})
+        assert result.is_error is False
+        assert mock_mcp_actor.call.call_args_list[-1].args[1]["name"] == "search"
+    finally:
+        workbench._actor = None  # type: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Why are these changes needed?

McpWorkbench.tool_overrides validates renamed tools only against other configured overrides. It does not validate the final exposed names against the tools actually returned by the MCP server.

As a result, renaming fetch to an existing server tool name such as search can expose two schemas named search and route a real search call to fetch. A stale override for an original tool that is no longer present can cause the same wrong-route class by retaining a reverse mapping that shadows a present server tool.

This patch:

- validates exposed names against the actual list_tools result
- performs the validation before a direct call_tool can use renamed routing
- rebuilds reverse routing only from original tools currently present on the server
- adds regressions for real-name collisions, direct-call validation, and stale overrides

No public API or persistence format changes.

## Related issue number

No existing issue covers this root cause. I also checked current open PRs before publication; #7594 changes schema handling and is unrelated.

## Checks

- [x] Documentation changes are not needed; this is an internal routing correctness fix.
- [x] I've added tests corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

### Verification

RED before the production change:

- the real-server-name collision regression failed because no ValueError was raised

GREEN after the change:

- related MCP workbench suites: 39 passed
- Ruff lint and format: passed
- Pyright: passed
- mypy: passed
- git diff --check: passed

The broader test_mcp_tools.py run reached 22 passed, 1 skipped with five external mcp-server-fetch / mcp-server-git failures. Those exact five failures reproduce on untouched main, so they are baseline environment noise rather than regressions from this patch.

### AI assistance

This patch was prepared with Codex under the contributor's direction. Codex was used for issue/PR race checking, RED/GREEN implementation, current-main verification, and preparing this draft description.