### PR TITLE
docs: fix broken .NET sample links in website articles

### DIFF
--- a/dotnet/website/articles/AutoGen.Gemini/Chat-with-google-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Chat-with-google-gemini.md
@@ -3,7 +3,7 @@ This example shows how to use @AutoGen.Gemini.GeminiChatAgent to connect to Goog
 To run this example, you need to have a Google AI Gemini API key. For how to get a Google Gemini API key, please refer to [Google Gemini](https://gemini.google.com/).
 
 > [!NOTE]
-> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs)
+> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs)
 
 > [!NOTE]
 > What's the difference between Google AI Gemini and Vertex AI Gemini?

--- a/dotnet/website/articles/AutoGen.Gemini/Chat-with-vertex-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Chat-with-vertex-gemini.md
@@ -3,7 +3,7 @@ This example shows how to use @AutoGen.Gemini.GeminiChatAgent to connect to Vert
 To run this example, you need to have a project on Google Cloud with access to Vertex AI API. For more information please refer to [Google Vertex AI](https://cloud.google.com/vertex-ai/docs).
 
 > [!NOTE]
-> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.Gemini.Sample/Chat_With_Vertex_Gemini.cs)
+> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Vertex_Gemini.cs)
 
 > [!NOTE]
 > What's the difference between Google AI Gemini and Vertex AI Gemini?

--- a/dotnet/website/articles/AutoGen.Gemini/Function-call-with-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Function-call-with-gemini.md
@@ -4,7 +4,7 @@ To run this example, you need to have a project on Google Cloud with access to V
 
 
 > [!NOTE]
-> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs)
+> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs)
 
 ### Step 1: Install AutoGen.Gemini and AutoGen.SourceGenerator
 

--- a/dotnet/website/articles/AutoGen.Gemini/Image-chat-with-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Image-chat-with-gemini.md
@@ -4,7 +4,7 @@ To run this example, you need to have a project on Google Cloud with access to V
 
 
 > [!NOTE]
-> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.Gemini.Sample/Image_Chat_With_Vertex_Gemini.cs)
+> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Gemini.Sample/Image_Chat_With_Vertex_Gemini.cs)
 
 ### Step 1: Install AutoGen.Gemini
 

--- a/dotnet/website/articles/AutoGen.Gemini/Overview.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Overview.md
@@ -9,4 +9,4 @@ AutoGen.Gemini also provides the following middleware:
 
 ## Examples
 
-You can find more examples under the [gemini sample project](https://github.com/microsoft/autogen/tree/main/dotnet/samples/AutoGen.Gemini.Sample)
+You can find more examples under the [gemini sample project](https://github.com/microsoft/autogen/tree/main/dotnet/samples/AgentChat/AutoGen.Gemini.Sample)

--- a/dotnet/website/articles/AutoGen.Ollama/Chat-with-llama.md
+++ b/dotnet/website/articles/AutoGen.Ollama/Chat-with-llama.md
@@ -3,7 +3,7 @@ This example shows how to use @AutoGen.Ollama.OllamaAgent to connect to Ollama s
 To run this example, you need to have an Ollama server running aside and have `llama3:latest` model installed. For how to setup an Ollama server, please refer to [Ollama](https://ollama.com/).
 
 > [!NOTE]
-> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.Ollama.Sample/Chat_With_LLaMA.cs)
+> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaMA.cs)
 
 ### Step 1: Install AutoGen.Ollama
 

--- a/dotnet/website/articles/AutoGen.Ollama/Chat-with-llava.md
+++ b/dotnet/website/articles/AutoGen.Ollama/Chat-with-llava.md
@@ -3,7 +3,7 @@ This sample shows how to use @AutoGen.Ollama.OllamaAgent to chat with LLaVA mode
 To run this example, you need to have an Ollama server running aside and have `llava:latest` model installed. For how to setup an Ollama server, please refer to [Ollama](https://ollama.com/).
 
 > [!NOTE]
-> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs)
+> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs)
 
 ### Step 1: Install AutoGen.Ollama
 

--- a/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelChatAgent-simple-chat.md
+++ b/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelChatAgent-simple-chat.md
@@ -3,7 +3,7 @@
 The following step-by-step example shows how to create an @AutoGen.SemanticKernel.SemanticKernelChatCompletionAgent and chat with it:
 
 > [!NOTE]
-> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs).
+> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs).
 
 ### Step 1: add using statement
 [!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Using)]

--- a/dotnet/website/articles/AutoGen.SemanticKernel/Use-kernel-plugin-in-other-agents.md
+++ b/dotnet/website/articles/AutoGen.SemanticKernel/Use-kernel-plugin-in-other-agents.md
@@ -3,7 +3,7 @@ In semantic kernel, a kernel plugin is a collection of kernel functions that can
 `AutoGen.SemanticKernel` provides a middleware called @AutoGen.SemanticKernel.KernelPluginMiddleware that allows you to use semantic kernel plugins in other AutoGen agents like @AutoGen.OpenAI.OpenAIChatAgent. The following example shows how to define a simple plugin with a single `GetWeather` function and use it in @AutoGen.OpenAI.OpenAIChatAgent.
 
 > [!NOTE]
-> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs)
+> You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs)
 
 ### Step 1: add using statement
 [!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Using)]

--- a/dotnet/website/articles/Function-call-with-ollama-and-litellm.md
+++ b/dotnet/website/articles/Function-call-with-ollama-and-litellm.md
@@ -1,6 +1,6 @@
 This example shows how to use function call with local LLM models where [Ollama](https://ollama.com/) as local model provider and [LiteLLM](https://docs.litellm.ai/docs/) proxy server which provides an openai-api compatible interface.
 
-[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.OpenAI.Sample/Tool_Call_With_Ollama_And_LiteLLM.cs)
+[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.OpenAI.Sample/Tool_Call_With_Ollama_And_LiteLLM.cs)
 
 To run this example, the following prerequisites are required:
 - Install [Ollama](https://ollama.com/) and [LiteLLM](https://docs.litellm.ai/docs/) on your local machine.

--- a/dotnet/website/articles/OpenAIChatAgent-connect-to-third-party-api.md
+++ b/dotnet/website/articles/OpenAIChatAgent-connect-to-third-party-api.md
@@ -1,6 +1,6 @@
 The following example shows how to connect to third-party OpenAI API using @AutoGen.OpenAI.OpenAIChatAgent.
 
-[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs)
+[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs)
 
 ## Overview
 A lot of LLM applications/platforms support spinning up a chat server that is compatible with OpenAI API, such as LM Studio, Ollama, Mistral etc. This means that you can connect to these servers using the @AutoGen.OpenAI.OpenAIChatAgent.

--- a/dotnet/website/articles/OpenAIChatAgent-use-json-mode.md
+++ b/dotnet/website/articles/OpenAIChatAgent-use-json-mode.md
@@ -1,6 +1,6 @@
 The following example shows how to enable JSON mode in @AutoGen.OpenAI.OpenAIChatAgent.
 
-[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.OpenAI.Sample/Use_Json_Mode.cs)
+[![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.OpenAI.Sample/Use_Json_Mode.cs)
 
 ## What is JSON mode?
 JSON mode is a new feature in OpenAI which allows you to instruct model to always respond with a valid JSON object. This is useful when you want to constrain the model output to JSON format only.

--- a/dotnet/website/articles/Run-dotnet-code.md
+++ b/dotnet/website/articles/Run-dotnet-code.md
@@ -57,5 +57,5 @@ Then you can add the python kernel to the dotnet-interactive composite kernel by
 
 ## Further reading
 You can refer to the following examples for running code snippet in agentic workflow:
-- Dynamic_GroupChat_Coding_Task:  [![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.Basic.Sample/Example04_Dynamic_GroupChat_Coding_Task.cs)
-- Dynamic_GroupChat_Calculate_Fibonacci: [![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs)
+- Dynamic_GroupChat_Coding_Task:  [![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Basic.Sample/Example04_Dynamic_GroupChat_Coding_Task.cs)
+- Dynamic_GroupChat_Calculate_Fibonacci: [![](https://img.shields.io/badge/Open%20on%20Github-grey?logo=github)](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs)


### PR DESCRIPTION
## Why

The AutoGen .NET sample projects were moved from `dotnet/samples/AutoGen.*.Sample/` into `dotnet/samples/AgentChat/AutoGen.*.Sample/`. The tutorial articles under `dotnet/website/articles/` still link to the old locations, so their **complete sample code** / **Open on GitHub** links currently return 404.

## What

Updates the 14 affected links across 13 article pages to insert `AgentChat/` into the path. For example:

```
- .../blob/main/dotnet/samples/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs
+ .../blob/main/dotnet/samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs
```

Each updated target was verified to exist on `main`. Docs-only change; no code or release notes touched.