### PR TITLE
fix(agentchat): preserve chronological order in MessageFilterAgent._apply_filter

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
@@ -152,19 +152,20 @@ class MessageFilterAgent(BaseChatAgent, Component[MessageFilterAgentConfig]):
         return self._wrapped_agent.produced_message_types
 
     def _apply_filter(self, messages: Sequence[BaseChatMessage]) -> Sequence[BaseChatMessage]:
-        result: List[BaseChatMessage] = []
+        selected: set[int] = set()
 
         for source_filter in self._filter.per_source:
-            msgs = [m for m in messages if m.source == source_filter.source]
+            indexed = [(i, m) for i, m in enumerate(messages) if m.source == source_filter.source]
 
             if source_filter.position == "first" and source_filter.count:
-                msgs = msgs[: source_filter.count]
+                indexed = indexed[: source_filter.count]
             elif source_filter.position == "last" and source_filter.count:
-                msgs = msgs[-source_filter.count :]
+                indexed = indexed[-source_filter.count :]
 
-            result.extend(msgs)
+            for i, _ in indexed:
+                selected.add(i)
 
-        return result
+        return [m for i, m in enumerate(messages) if i in selected]
 
     async def on_messages(
         self,

--- a/python/packages/autogen-agentchat/tests/test_group_chat_graph.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat_graph.py
@@ -1143,6 +1143,37 @@ async def test_message_filter_agent_with_position_none_gets_all() -> None:
 
 
 @pytest.mark.asyncio
+async def test_message_filter_agent_preserves_chronological_order() -> None:
+    """Regression #7971: filtered messages must arrive in original chronological order.
+
+    When per_source lists 'A' before 'user', the result must still be ordered by
+    each message's position in the original conversation, not by filter-config order.
+    """
+    inner_agent = _TestMessageFilterAgent("inner")
+    wrapper = MessageFilterAgent(
+        name="wrapper",
+        wrapped_agent=inner_agent,
+        filter=MessageFilterConfig(
+            per_source=[
+                PerSourceFilter(source="A", position="last", count=1),
+                PerSourceFilter(source="user", position="first", count=1),
+            ]
+        ),
+    )
+    messages = [
+        TextMessage(source="user", content="user-first"),
+        TextMessage(source="A", content="A-first"),
+        TextMessage(source="A", content="A-second"),
+    ]
+    await wrapper.on_messages(messages, CancellationToken())
+    received = inner_agent.received_messages
+    assert len(received) == 2
+    # user message came first in the original list, so it must arrive first
+    assert received[0].content == "user-first"  # type: ignore[attr-defined]
+    assert received[1].content == "A-second"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_digraph_group_chat() -> None:
     inner_agent = _TestMessageFilterAgent("agent")
     wrapper = MessageFilterAgent(


### PR DESCRIPTION
**Issue:** #7971

## Problem

`MessageFilterAgent._apply_filter` built its result by iterating `per_source` filters and appending matching messages in filter-config order. When multiple sources were configured, messages from a later-listed source that chronologically preceded messages from an earlier-listed source were emitted out of order, breaking the LLM agent's conversation timeline.

For example, given messages `[user, A(old), B, A(new)]` and a filter listing A before user:
- **Before fix:** `[A(old), A(new), user]` — config order, not chronological
- **After fix:** `[user, A(old), A(new)]` — original conversation order preserved (with position="last", count=1 → `[user, A(new)]`)

## Change

Track the original message index for each selected message and emit in original conversation order. The per-source count/position filtering logic is unchanged.

```python
# Before
result: List[BaseChatMessage] = []
for source_filter in self._filter.per_source:
    msgs = [m for m in messages if m.source == source_filter.source]
    # ... slice by position/count ...
    result.extend(msgs)  # order follows filter-config, not timeline
return result

# After
selected: set[int] = set()
for source_filter in self._filter.per_source:
    indexed = [(i, m) for i, m in enumerate(messages) if m.source == source_filter.source]
    # ... slice by position/count ...
    for i, _ in indexed:
        selected.add(i)
return [m for i, m in enumerate(messages) if i in selected]  # original order
```

## Tests

New regression test `test_message_filter_agent_preserves_chronological_order` in `tests/test_group_chat_graph.py`:
- Sets up `per_source=[A-last(1), user-first(1)]` (A listed before user)
- Messages arrive in order: user, A(first), A(second)
- Asserts the wrapped agent receives `[user, A(second)]` — original order — not `[A(second), user]` — config order

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.