### PR TITLE
fix(grpc): surface worker runtime exceptions

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py
@@ -219,6 +219,16 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
 
     Cross-language agents will additionally require all agents use shared protobuf schemas for any message types that are sent between agents.
 
+    Args:
+        host_address: The address of the gRPC runtime host.
+        tracer_provider: The tracer provider to use for tracing.
+        extra_grpc_config: Additional gRPC channel configuration.
+        payload_serialization_format: The serialization format for message payloads.
+        ignore_unhandled_exceptions: Whether to log and ignore unhandled exceptions from
+            background tasks and the read loop. When ``False``, the first exception is
+            raised from :meth:`stop` after the runtime has finished cleanup. Defaults to
+            ``True``.
+
     .. _agent_worker.proto: https://github.com/microsoft/autogen/blob/main/protos/agent_worker.proto
 
     .. _cloudevent.proto: https://github.com/microsoft/autogen/blob/main/protos/cloudevent.proto
@@ -232,6 +242,7 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
         tracer_provider: TracerProvider | None = None,
         extra_grpc_config: ChannelArgumentType | None = None,
         payload_serialization_format: str = JSON_DATA_CONTENT_TYPE,
+        ignore_unhandled_exceptions: bool = True,
     ) -> None:
         self._host_address = host_address
         self._trace_helper = TraceHelper(tracer_provider, MessageRuntimeTracingConfig("Worker Runtime"))
@@ -252,6 +263,8 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
         self._serialization_registry = SerializationRegistry()
         self._extra_grpc_config = extra_grpc_config or []
         self._agent_instance_types: Dict[str, Type[Agent]] = {}
+        self._ignore_unhandled_exceptions = ignore_unhandled_exceptions
+        self._background_exception: BaseException | None = None
 
         if payload_serialization_format not in {JSON_DATA_CONTENT_TYPE, PROTOBUF_DATA_CONTENT_TYPE}:
             raise ValueError(f"Unsupported payload serialization format: {payload_serialization_format}")
@@ -271,10 +284,17 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
             self._read_task = asyncio.create_task(self._run_read_loop())
         self._running = True
 
-    def _raise_on_exception(self, task: Task[Any]) -> None:
+    def _handle_background_task_result(self, task: Task[Any]) -> None:
+        if task.cancelled():
+            return
         exception = task.exception()
         if exception is not None:
-            raise exception
+            self._handle_unhandled_exception(exception, "Error in background task")
+
+    def _handle_unhandled_exception(self, exception: BaseException, message: str) -> None:
+        logger.error(message, exc_info=exception)
+        if not self._ignore_unhandled_exceptions and self._background_exception is None:
+            self._background_exception = exception
 
     async def _run_read_loop(self) -> None:
         logger.info("Starting read loop")
@@ -288,22 +308,24 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
                     case "request":
                         task = asyncio.create_task(self._process_request(message.request))
                         self._background_tasks.add(task)
-                        task.add_done_callback(self._raise_on_exception)
+                        task.add_done_callback(self._handle_background_task_result)
                         task.add_done_callback(self._background_tasks.discard)
                     case "response":
                         task = asyncio.create_task(self._process_response(message.response))
                         self._background_tasks.add(task)
-                        task.add_done_callback(self._raise_on_exception)
+                        task.add_done_callback(self._handle_background_task_result)
                         task.add_done_callback(self._background_tasks.discard)
                     case "cloudEvent":
                         task = asyncio.create_task(self._process_event(message.cloudEvent))
                         self._background_tasks.add(task)
-                        task.add_done_callback(self._raise_on_exception)
+                        task.add_done_callback(self._handle_background_task_result)
                         task.add_done_callback(self._background_tasks.discard)
                     case None:
                         logger.warning("No message")
             except Exception as e:
-                logger.error("Error in read loop", exc_info=e)
+                self._handle_unhandled_exception(e, "Error in read loop")
+                if not self._ignore_unhandled_exceptions:
+                    break
 
     async def stop(self) -> None:
         """Stop the runtime immediately."""
@@ -311,16 +333,14 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
             raise RuntimeError("Runtime is not running.")
         self._running = False
         # Wait for all background tasks to finish.
-        final_tasks_results = await asyncio.gather(*self._background_tasks, return_exceptions=True)
-        for task_result in final_tasks_results:
-            if isinstance(task_result, Exception):
-                logger.error("Error in background task", exc_info=task_result)
+        await asyncio.gather(*self._background_tasks, return_exceptions=True)
         # Close the host connection.
         if self._host_connection is not None:
             try:
                 await self._host_connection.close()
             except asyncio.CancelledError:
                 pass
+
         # Cancel the read task.
         if self._read_task is not None:
             self._read_task.cancel()
@@ -328,6 +348,11 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
                 await self._read_task
             except asyncio.CancelledError:
                 pass
+
+        if self._background_exception is not None:
+            exception = self._background_exception
+            self._background_exception = None
+            raise exception
 
     async def stop_when_signal(self, signals: Sequence[signal.Signals] = (signal.SIGTERM, signal.SIGINT)) -> None:
         """Stop the runtime when a signal is received."""
@@ -406,7 +431,7 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
             # TODO: Find a way to handle timeouts/errors
             task = asyncio.create_task(self._send_message(runtime_message, "send", recipient, telemetry_metadata))
             self._background_tasks.add(task)
-            task.add_done_callback(self._raise_on_exception)
+            task.add_done_callback(self._handle_background_task_result)
             task.add_done_callback(self._background_tasks.discard)
             return await future
 
@@ -486,7 +511,7 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
             telemetry_metadata = get_telemetry_grpc_metadata()
             task = asyncio.create_task(self._send_message(runtime_message, "publish", topic_id, telemetry_metadata))
             self._background_tasks.add(task)
-            task.add_done_callback(self._raise_on_exception)
+            task.add_done_callback(self._handle_background_task_result)
             task.add_done_callback(self._background_tasks.discard)
 
     async def save_state(self) -> Mapping[str, Any]:
@@ -700,7 +725,7 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
         try:
             await asyncio.gather(*responses)
         except BaseException as e:
-            logger.error("Error handling event", exc_info=e)
+            self._handle_unhandled_exception(e, "Error handling event")
 
     async def _register_agent_type(self, agent_type: str) -> None:
         if self._host_connection is None:

--- a/python/packages/autogen-ext/tests/test_worker_runtime.py
+++ b/python/packages/autogen-ext/tests/test_worker_runtime.py
@@ -5,6 +5,7 @@ from typing import Any, List
 
 import pytest
 from autogen_core import (
+    JSON_DATA_CONTENT_TYPE,
     PROTOBUF_DATA_CONTENT_TYPE,
     AgentId,
     AgentType,
@@ -20,7 +21,8 @@ from autogen_core import (
     try_get_known_serializers_for_type,
     type_subscription,
 )
-from autogen_ext.runtimes.grpc import GrpcWorkerAgentRuntime, GrpcWorkerAgentRuntimeHost
+from autogen_ext.runtimes.grpc import GrpcWorkerAgentRuntime, GrpcWorkerAgentRuntimeHost, _constants
+from autogen_ext.runtimes.grpc.protos import cloudevent_pb2
 from autogen_test_utils import (
     CascadingAgent,
     CascadingMessageType,
@@ -32,6 +34,130 @@ from autogen_test_utils import (
 )
 
 from .protos.serialization_test_pb2 import ProtoMessage
+
+
+@pytest.mark.asyncio
+async def test_background_task_exception_is_logged_by_default(caplog: pytest.LogCaptureFixture) -> None:
+    worker = GrpcWorkerAgentRuntime(host_address="unused")
+
+    async def fail() -> None:
+        raise ValueError("background failure")
+
+    task = asyncio.create_task(fail())
+    task.add_done_callback(worker._handle_background_task_result)  # type: ignore[reportPrivateUsage]
+
+    with caplog.at_level(logging.ERROR, logger="autogen_core"):
+        with pytest.raises(ValueError, match="background failure"):
+            await task
+        await asyncio.sleep(0)
+
+    assert worker._background_exception is None  # type: ignore[reportPrivateUsage]
+    assert any("Error in background task" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_background_task_exception_is_raised_from_stop() -> None:
+    worker = GrpcWorkerAgentRuntime(host_address="unused", ignore_unhandled_exceptions=False)
+
+    async def fail() -> None:
+        raise ValueError("background failure")
+
+    task = asyncio.create_task(fail())
+    worker._background_tasks.add(task)  # type: ignore[reportPrivateUsage]
+    task.add_done_callback(worker._handle_background_task_result)  # type: ignore[reportPrivateUsage]
+    task.add_done_callback(worker._background_tasks.discard)  # type: ignore[reportPrivateUsage]
+    worker._running = True  # type: ignore[reportPrivateUsage]
+
+    with pytest.raises(ValueError, match="background failure"):
+        await worker.stop()
+
+    assert worker._background_exception is None  # type: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_read_loop_exception_is_raised_from_stop() -> None:
+    class FailingHostConnection:
+        async def recv(self) -> Any:
+            raise RuntimeError("read failure")
+
+        async def close(self) -> None:
+            pass
+
+    worker = GrpcWorkerAgentRuntime(host_address="unused", ignore_unhandled_exceptions=False)
+    worker._host_connection = FailingHostConnection()  # type: ignore[reportPrivateUsage,assignment]
+    worker._running = True  # type: ignore[reportPrivateUsage]
+    worker._read_task = asyncio.create_task(worker._run_read_loop())  # type: ignore[reportPrivateUsage]
+
+    await worker._read_task  # type: ignore[reportPrivateUsage]
+
+    with pytest.raises(RuntimeError, match="read failure"):
+        await worker.stop()
+
+
+@pytest.mark.asyncio
+async def test_first_background_exception_is_preserved() -> None:
+    worker = GrpcWorkerAgentRuntime(host_address="unused", ignore_unhandled_exceptions=False)
+
+    async def fail(message: str) -> None:
+        raise ValueError(message)
+
+    first = asyncio.create_task(fail("first failure"))
+    second = asyncio.create_task(fail("second failure"))
+    first.add_done_callback(worker._handle_background_task_result)  # type: ignore[reportPrivateUsage]
+    second.add_done_callback(worker._handle_background_task_result)  # type: ignore[reportPrivateUsage]
+
+    for task in (first, second):
+        with pytest.raises(ValueError):
+            await task
+        await asyncio.sleep(0)
+
+    assert isinstance(worker._background_exception, ValueError)  # type: ignore[reportPrivateUsage]
+    assert str(worker._background_exception) == "first failure"  # type: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_event_handler_exception_is_raised_from_stop() -> None:
+    @default_subscription
+    class FailingAgent(RoutedAgent):
+        def __init__(self) -> None:
+            super().__init__("A failing agent.")
+
+        @event
+        async def on_new_message(self, message: MessageType, ctx: MessageContext) -> None:
+            raise ValueError("event failure")
+
+    worker = GrpcWorkerAgentRuntime(host_address="unused", ignore_unhandled_exceptions=False)
+    worker.add_message_serializer(try_get_known_serializers_for_type(MessageType))
+    agent = FailingAgent()
+    agent_id = AgentId("failing", "default")
+    await agent.bind_id_and_runtime(id=agent_id, runtime=worker)
+    worker._instantiated_agents[agent_id] = agent  # type: ignore[reportPrivateUsage]
+    await worker._subscription_manager.add_subscription(DefaultSubscription(agent_type="failing"))  # type: ignore[reportPrivateUsage]
+    event_message = cloudevent_pb2.CloudEvent(
+        id="event-1",
+        spec_version="1.0",
+        type="default",
+        source="default",
+        attributes={
+            _constants.DATA_CONTENT_TYPE_ATTR: cloudevent_pb2.CloudEvent.CloudEventAttributeValue(
+                ce_string=JSON_DATA_CONTENT_TYPE
+            ),
+            _constants.DATA_SCHEMA_ATTR: cloudevent_pb2.CloudEvent.CloudEventAttributeValue(
+                ce_string=worker._serialization_registry.type_name(MessageType())  # type: ignore[reportPrivateUsage]
+            ),
+        },
+        binary_data=worker._serialization_registry.serialize(  # type: ignore[reportPrivateUsage]
+            MessageType(),
+            type_name=worker._serialization_registry.type_name(MessageType()),  # type: ignore[reportPrivateUsage]
+            data_content_type=JSON_DATA_CONTENT_TYPE,
+        ),
+    )
+
+    await worker._process_event(event_message)  # type: ignore[reportPrivateUsage]
+    worker._running = True  # type: ignore[reportPrivateUsage]
+
+    with pytest.raises(ValueError, match="event failure"):
+        await worker.stop()
 
 
 @pytest.mark.grpc


### PR DESCRIPTION
## Summary

- add an `ignore_unhandled_exceptions` option to `GrpcWorkerAgentRuntime`, matching the existing single-threaded runtime default
- retain the first unhandled event, read-loop, or background-task exception and raise it from `stop()` after cleanup when propagation is enabled
- replace done-callback re-raises with deterministic logging and lifecycle-based propagation
- add offline regression coverage for default logging, event-handler failures, read-loop failures, background-task failures, and first-exception preservation

Fixes #6140

## Validation

- `python -m pytest packages/autogen-ext/tests/test_worker_runtime.py --grpc -q` (`14 passed, 8 skipped`)
- `ruff check` and `ruff format --check` for both changed files
- `mypy` for both changed files (`Success: no issues found`)
- `git diff --check`