### PR TITLE
Fix Gemini function call documentation sample paths

### DIFF
--- a/dotnet/website/articles/AutoGen.Gemini/Function-call-with-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Function-call-with-gemini.md
@@ -18,21 +18,21 @@ dotnet add package AutoGen.SourceGenerator
 The AutoGen.SourceGenerator package is required to generate the @AutoGen.Core.FunctionContract. For more information, please refer to [Create-type-safe-function-call](../Create-type-safe-function-call.md)
 
 ### Step 2: Add using statement
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=Using)]
 
 ### Step 3: Create `MovieFunction`
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=MovieFunction)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=MovieFunction)]
 
 ### Step 4: Create a Gemini agent
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=Create_Gemini_Agent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=Create_Gemini_Agent)]
 
 ### Step 5: Single turn function call
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=Single_turn)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=Single_turn)]
 
 ### Step 6: Multi-turn function call
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=Multi_turn)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=Multi_turn)]
 


### PR DESCRIPTION
## Why are these changes needed?

The Gemini function-call documentation references an outdated sample file path. This causes the embedded C# code samples to fail to load from the current sample location.

This change updates the documentation references to the current `Function_Call_With_Gemini.cs` sample path.

## Related issue number

Closes #6396

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.