### PR TITLE
fix(openai): handle None chunks in streaming

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -906,6 +906,9 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         # Process the stream of chunks.
         async for chunk in chunks:
+            if chunk is None:  # pyright: ignore[reportUnnecessaryComparison]
+                continue
+
             if first_chunk:
                 first_chunk = False
                 # Emit the start event.
@@ -949,6 +952,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             maybe_model = chunk.model
 
             reasoning_content: str | None = None
+
             if choice.delta.model_extra is not None and "reasoning_content" in choice.delta.model_extra:
                 # If there is a reasoning_content field, then we populate the thought field. This is for models such as R1.
                 reasoning_content = choice.delta.model_extra.get("reasoning_content")

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -3378,3 +3378,52 @@ async def test_reasoning_effort_validation() -> None:
         }
 
         ChatCompletionClient.load_component(config)
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_completion_client_streaming_none_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that streaming handles None chunks without throwing AttributeError."""
+
+    async def _none_chunk_stream() -> AsyncGenerator[Any, None]:
+        # Yield None first (reproducing issue #7130)
+        yield None
+        # Followed by a valid ChatCompletionChunk
+        yield ChatCompletionChunk(
+            id="chunk-1",
+            choices=[
+                ChunkChoice(
+                    finish_reason=None,
+                    index=0,
+                    delta=ChoiceDelta(content="Hello world", role="assistant"),
+                )
+            ],
+            created=0,
+            model="gpt-4o",
+            object="chat.completion.chunk",
+        )
+        # Final stop chunk
+        yield ChatCompletionChunk(
+            id="chunk-2",
+            choices=[
+                ChunkChoice(
+                    finish_reason="stop",
+                    index=0,
+                    delta=ChoiceDelta(content=None, role="assistant"),
+                )
+            ],
+            created=0,
+            model="gpt-4o",
+            object="chat.completion.chunk",
+        )
+
+    async def _mock_stream_with_none_chunk(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:
+        return _none_chunk_stream()
+
+    monkeypatch.setattr(AsyncCompletions, "create", _mock_stream_with_none_chunk)
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="fake_key")
+
+    results: List[Any] = []
+    async for response in client.create_stream(messages=[UserMessage(content="Hello", source="user")]):
+        results.append(response)
+
+    assert "Hello world" in results


### PR DESCRIPTION
## Summary

Handles `None` items in the OpenAI streaming response so they are skipped instead of causing an `AttributeError`.

## Changes

- Skip `None` chunks before accessing chunk fields during streaming.
- Add a regression test that yields a `None` chunk followed by valid content.

## Validation

- Targeted regression test: passed.
- Full `test_openai_model_client.py`: 87 passed.
- Ruff: passed.
- Pyright: 0 errors, 0 warnings, 0 informations.
- `git diff --check`: passed.

Fixes #7130