### PR TITLE
fix: correct 'funciton' typo in XML doc comments

### DIFF
--- a/dotnet/src/AutoGen.Mistral/Extension/FunctionContractExtension.cs
+++ b/dotnet/src/AutoGen.Mistral/Extension/FunctionContractExtension.cs
@@ -12,7 +12,7 @@ namespace AutoGen.Mistral.Extension;
 public static class FunctionContractExtension
 {
     /// <summary>
-    /// Convert a <see cref="FunctionContract"/> to a <see cref="FunctionDefinition"/> that can be used in funciton call.
+    /// Convert a <see cref="FunctionContract"/> to a <see cref="FunctionDefinition"/> that can be used in function call.
     /// </summary>
     /// <param name="functionContract">function contract</param>
     /// <returns><see cref="FunctionDefinition"/></returns>

--- a/dotnet/src/AutoGen.OpenAI/Extension/FunctionContractExtension.cs
+++ b/dotnet/src/AutoGen.OpenAI/Extension/FunctionContractExtension.cs
@@ -12,7 +12,7 @@ namespace AutoGen.OpenAI.Extension;
 public static class FunctionContractExtension
 {
     /// <summary>
-    /// Convert a <see cref="FunctionContract"/> to a <see cref="ChatTool"/> that can be used in gpt funciton call.
+    /// Convert a <see cref="FunctionContract"/> to a <see cref="ChatTool"/> that can be used in gpt function call.
     /// </summary>
     /// <param name="functionContract">function contract</param>
     /// <returns><see cref="ChatTool"/></returns>
@@ -60,7 +60,7 @@ public static class FunctionContractExtension
     }
 
     /// <summary>
-    /// Convert a <see cref="FunctionContract"/> to a <see cref="ChatTool"/> that can be used in gpt funciton call.
+    /// Convert a <see cref="FunctionContract"/> to a <see cref="ChatTool"/> that can be used in gpt function call.
     /// </summary>
     /// <param name="functionContract">function contract</param>
     /// <returns><see cref="ChatTool"/></returns>


### PR DESCRIPTION
Fix the misspelling of \unciton\ in the XML doc comments of two extension classes:

- \dotnet/src/AutoGen.OpenAI/Extension/FunctionContractExtension.cs\ (2 occurrences)
- \dotnet/src/AutoGen.Mistral/Extension/FunctionContractExtension.cs\ (1 occurrence)

Comment-only change; no behavior impact.