### PR TITLE
fix: Failed to call `_from_config()` when `HttpTool` in `StaticStreamWorkbench`

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8")) as f:
         lines = f.readlines()
 
     for line in lines:

--- a/python/fixup_generated_files.py
+++ b/python/fixup_generated_files.py
@@ -24,7 +24,7 @@ substitutions: Dict[str, str] = {
 
 def main():
     for file in files:
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8")) as f:
             content = f.read()
 
         print("Fixing imports in file:", file)

--- a/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/MagenticOne/scenario.py
@@ -20,7 +20,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8")) as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])

--- a/python/packages/agbench/benchmarks/GAIA/Templates/ParallelAgents/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/ParallelAgents/scenario.py
@@ -267,7 +267,7 @@ async def aggregate_final_answer(task: str, client: ChatCompletionClient, team_r
 async def main(num_teams: int, num_answers: int) -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8")) as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])

--- a/python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py
+++ b/python/packages/agbench/benchmarks/GAIA/Templates/SelectorGroupChat/scenario.py
@@ -25,7 +25,7 @@ warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWa
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8")) as f:
         config = yaml.safe_load(f)
 
     orchestrator_client = ChatCompletionClient.load_component(config["orchestrator_client"])

--- a/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py
+++ b/python/packages/agbench/benchmarks/HumanEval/Templates/AgentChat/scenario.py
@@ -15,7 +15,7 @@ from autogen_core.models import ChatCompletionClient
 async def main() -> None:
 
     # Load model configuration and create the model client.
-    with open("config.yaml", "r") as f:
+    with open("config.yaml", "r", encoding="utf-8")) as f:
         config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(config["model_config"])
 

--- a/python/packages/agbench/benchmarks/process_logs.py
+++ b/python/packages/agbench/benchmarks/process_logs.py
@@ -145,7 +145,7 @@ def get_number_of_chat_messages(chat_messages_dir):
     # Count the number of chat messages in the chat_messages_dir
     result = 0
     for file in glob.glob(f"{chat_messages_dir}/*_messages.json"):
-        with open(file, "r") as f:
+        with open(file, "r", encoding="utf-8")) as f:
             content = json.load(f)
             for agent, messages in content.items():
                 result += len(messages)
@@ -158,7 +158,7 @@ def did_agent_stall(instance_dir):
     if not os.path.isfile(log_file_path):
         return None
     # Stalled.... Replanning...
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r", encoding="utf-8")) as f:
         for line in f:
             if "Stalled.... Replanning..." in line:
                 return True
@@ -172,7 +172,7 @@ def get_message_logs(instance_dir):
         return None
     messages = []
     # for each line, convert to dict, check if it has a message and source key, and append to messages
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r", encoding="utf-8")) as f:
         for line in f:
             line_dict = json.loads(line)
             if "message" in line_dict and "source" in line_dict:
@@ -186,13 +186,13 @@ def get_task_information(instance_dir, benchmark_name):
         prompt_file = os.path.join(instance_dir, "prompt.txt")
         if not os.path.isfile(prompt_file):
             return None
-        with open(prompt_file, "r") as f:
+        with open(prompt_file, "r", encoding="utf-8")) as f:
             return f.read().strip()
     elif benchmark_name == "webarena":
         task_prompt_file = os.path.join(instance_dir, "task_prompt.json")
         if not os.path.isfile(task_prompt_file):
             return None
-        with open(task_prompt_file, "r") as f:
+        with open(task_prompt_file, "r", encoding="utf-8")) as f:
             return json.load(f)["intent"]
     else:
         raise ValueError(f"Unsupported benchmark_name: {benchmark_name}")
@@ -204,7 +204,7 @@ def is_progress_not_being_made(instance_dir):
     log_file_path = os.path.join(instance_dir, "log.jsonl")
     if not os.path.isfile(log_file_path):
         return None
-    with open(log_file_path, "r") as f:
+    with open(log_file_path, "r", encoding="utf-8")) as f:
         for line in f:
             line_dict = json.loads(line)
             if (

--- a/python/packages/agbench/src/agbench/linter/cli.py
+++ b/python/packages/agbench/src/agbench/linter/cli.py
@@ -19,7 +19,7 @@ def prepend_line_numbers(lines: List[str]) -> List[str]:
 
 
 def load_log_file(path: str, prepend_numbers: bool = False) -> Document:
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8")) as f:
         lines = f.readlines()
     if prepend_numbers:
         lines = prepend_line_numbers(lines)

--- a/python/packages/agbench/src/agbench/linter/coders/oai_coder.py
+++ b/python/packages/agbench/src/agbench/linter/coders/oai_coder.py
@@ -41,7 +41,7 @@ class OAIQualitativeCoder(BaseQualitativeCoder):
             if not os.path.exists(self.cache_dir):
                 os.makedirs(self.cache_dir)
             if cache_file and os.path.exists(cache_file):
-                with open(cache_file, "r") as f:
+                with open(cache_file, "r", encoding="utf-8")) as f:
                     cached_coded_doc_json = f.read()
                     return CodedDocument.from_json(cached_coded_doc_json)
 

--- a/python/packages/agbench/src/agbench/run_cmd.py
+++ b/python/packages/agbench/src/agbench/run_cmd.py
@@ -295,7 +295,7 @@ def get_scenario_env(token_provider: Optional[Callable[[], str]] = None, env_fil
     if env_file is None:
         # Env file was not specified, so read the default, or warn if the default file is missing.
         if os.path.isfile(DEFAULT_ENV_FILE_YAML):
-            with open(DEFAULT_ENV_FILE_YAML, "r") as fh:
+            with open(DEFAULT_ENV_FILE_YAML, "r", encoding="utf-8")) as fh:
                 env_file_contents = yaml.safe_load(fh)
         elif os.path.isfile(DEFAULT_ENV_FILE_JSON):
             with open(DEFAULT_ENV_FILE_JSON, "rt") as fh:
@@ -737,7 +737,7 @@ def split_jsonl(file_path: str, num_parts: int) -> List[List[Dict[str, Any]]]:
     """
     Split a JSONL file into num_parts approximately equal parts.
     """
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8")) as f:
         data = [json.loads(line) for line in f]
 
     random.shuffle(data)  # Shuffle the data for better distribution
@@ -942,7 +942,7 @@ def run_cli(args: Sequence[str]) -> None:
 
     if parsed_args.config is not None:
         # Make sure the config file is readable, so that we fail early
-        with open(parsed_args.config, "r"):
+        with open(parsed_args.config, "r", encoding="utf-8")):
             pass
 
     # don't support parallel and subsample together

--- a/python/packages/autogen-ext/examples/mcp_session_host_example.py
+++ b/python/packages/autogen-ext/examples/mcp_session_host_example.py
@@ -63,10 +63,10 @@ def load_model_client_from_config(config_path: str) -> ChatCompletionClient:
 
     # Load config based on file extension
     if config_file.suffix.lower() == ".json":
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8")) as f:
             config_data = json.load(f)
     elif config_file.suffix.lower() in [".yml", ".yaml"]:
-        with open(config_file, "r") as f:
+        with open(config_file, "r", encoding="utf-8")) as f:
             config_data = yaml.safe_load(f)
     else:
         raise ValueError(f"Unsupported config file type: {config_file.suffix}. Use .json, .yml, or .yaml")

--- a/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
+++ b/python/packages/autogen-ext/src/autogen_ext/experimental/task_centric_memory/utils/chat_completion_client_recorder.py
@@ -73,7 +73,7 @@ class ChatCompletionClientRecorder(ChatCompletionClient):
             # Load the previously recorded messages and responses from disk.
             self.logger.info("Replay mode enabled.\nRetrieving session from: " + self.session_file_path)
             try:
-                with open(self.session_file_path, "r") as f:
+                with open(self.session_file_path, "r", encoding="utf-8")) as f:
                     self.records = json.load(f)
             except Exception as e:
                 error_str = f"\nFailed to load recorded session: '{self.session_file_path}': {e}"

--- a/python/packages/autogen-ext/tests/task_centric_memory/utils.py
+++ b/python/packages/autogen-ext/tests/task_centric_memory/utils.py
@@ -27,5 +27,5 @@ def load_yaml_file(file_path: str) -> Any:
     """
     Opens a file and returns its contents.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8")) as file:
         return yaml.safe_load(file)

--- a/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
+++ b/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
@@ -239,7 +239,7 @@ datefmt = %H:%M:%S
         """Update the Alembic script template to include SQLModel."""
         template_path = self.alembic_dir / "script.py.mako"
         try:
-            with open(template_path, "r") as f:
+            with open(template_path, "r", encoding="utf-8")) as f:
                 content = f.read()
 
             # Add sqlmodel import to imports section
@@ -265,7 +265,7 @@ datefmt = %H:%M:%S
             self._create_minimal_env_py(env_path)
             return
         try:
-            with open(env_path, "r") as f:
+            with open(env_path, "r", encoding="utf-8")) as f:
                 content = f.read()
 
             # Add SQLModel import if not present

--- a/python/packages/autogen-studio/autogenstudio/web/auth/manager.py
+++ b/python/packages/autogen-studio/autogenstudio/web/auth/manager.py
@@ -117,7 +117,7 @@ class AuthManager:
     def from_yaml(cls, yaml_path: str) -> Self:
         """Create AuthManager from YAML config file."""
         try:
-            with open(yaml_path, "r") as f:
+            with open(yaml_path, "r", encoding="utf-8")) as f:
                 config_data = yaml.safe_load(f)
             config = AuthConfig(**config_data)
             return cls(config)

--- a/python/packages/autogen-studio/tests/test_lite_studio.py
+++ b/python/packages/autogen-studio/tests/test_lite_studio.py
@@ -35,7 +35,7 @@ def sample_team_object() -> Dict[str, Union[str, List[Any]]]:
 
 def load_team_from_file(file_path: str) -> Dict[str, Any]:
     """Helper function to load team data from file"""
-    with open(file_path, 'r') as f:
+    with open(file_path, "r", encoding="utf-8")) as f:
         return json.load(f)
 
 
@@ -101,7 +101,7 @@ def test_setup_environment(sample_team_file: str) -> None:
     
     # Read the environment file to verify contents
     env_vars = {}
-    with open(env_file_path, 'r') as f:
+    with open(env_file_path, "r", encoding="utf-8")) as f:
         for line in f:
             if '=' in line:
                 key, value = line.strip().split('=', 1)

--- a/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
+++ b/python/packages/magentic-one-cli/src/magentic_one_cli/_m1.py
@@ -97,12 +97,12 @@ def main() -> None:
 
     if args.config is None:
         if os.path.isfile(DEFAULT_CONFIG_FILE):
-            with open(DEFAULT_CONFIG_FILE, "r") as f:
+            with open(DEFAULT_CONFIG_FILE, "r", encoding="utf-8")) as f:
                 config = yaml.safe_load(f)
         else:
             config = yaml.safe_load(DEFAULT_CONFIG_CONTENTS)
     else:
-        with open(args.config if isinstance(args.config, str) else args.config[0], "r") as f:
+        with open(args.config if isinstance(args.config, str) else args.config[0], "r", encoding="utf-8")) as f:
             config = yaml.safe_load(f)
 
     # Run the task

--- a/python/samples/agentchat_chainlit/app_agent.py
+++ b/python/samples/agentchat_chainlit/app_agent.py
@@ -31,7 +31,7 @@ async def get_weather(city: str) -> str:
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8")) as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chainlit/app_team.py
+++ b/python/samples/agentchat_chainlit/app_team.py
@@ -14,7 +14,7 @@ from autogen_core.models import ChatCompletionClient
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8")) as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chainlit/app_team_user_proxy.py
+++ b/python/samples/agentchat_chainlit/app_team_user_proxy.py
@@ -47,7 +47,7 @@ async def user_action_func(prompt: str, cancellation_token: CancellationToken | 
 @cl.on_chat_start  # type: ignore
 async def start_chat() -> None:
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8")) as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/agentchat_chess_game/main.py
+++ b/python/samples/agentchat_chess_game/main.py
@@ -101,7 +101,7 @@ async def get_ai_move(board: chess.Board, player: AssistantAgent, max_tries: int
 async def main(human_player: bool, max_tries: int) -> None:
     board = chess.Board()
     # Load the model client from config.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8")) as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
     player = create_ai_player(model_client)

--- a/python/samples/agentchat_fastapi/app_agent.py
+++ b/python/samples/agentchat_fastapi/app_agent.py
@@ -40,7 +40,7 @@ history_path = "agent_history.json"
 async def get_agent() -> AssistantAgent:
     """Get the assistant agent, load state from file."""
     # Get model client from config.
-    async with aiofiles.open(model_config_path, "r") as file:
+    async with aiofiles.open(model_config_path, "r", encoding="utf-8")) as file:
         model_config = yaml.safe_load(await file.read())
     model_client = ChatCompletionClient.load_component(model_config)
     # Create the assistant agent.
@@ -52,7 +52,7 @@ async def get_agent() -> AssistantAgent:
     # Load state from file.
     if not os.path.exists(state_path):
         return agent  # Return agent without loading state.
-    async with aiofiles.open(state_path, "r") as file:
+    async with aiofiles.open(state_path, "r", encoding="utf-8")) as file:
         state = json.loads(await file.read())
     await agent.load_state(state)
     return agent
@@ -62,7 +62,7 @@ async def get_history() -> list[dict[str, Any]]:
     """Get chat history from file."""
     if not os.path.exists(history_path):
         return []
-    async with aiofiles.open(history_path, "r") as file:
+    async with aiofiles.open(history_path, "r", encoding="utf-8")) as file:
         return json.loads(await file.read())
 
 

--- a/python/samples/agentchat_fastapi/app_team.py
+++ b/python/samples/agentchat_fastapi/app_team.py
@@ -46,7 +46,7 @@ async def get_team(
     user_input_func: Callable[[str, Optional[CancellationToken]], Awaitable[str]],
 ) -> RoundRobinGroupChat:
     # Get model client from config.
-    async with aiofiles.open(model_config_path, "r") as file:
+    async with aiofiles.open(model_config_path, "r", encoding="utf-8")) as file:
         model_config = yaml.safe_load(await file.read())
     model_client = ChatCompletionClient.load_component(model_config)
     # Create the team.
@@ -70,7 +70,7 @@ async def get_team(
     # Load state from file.
     if not os.path.exists(state_path):
         return team
-    async with aiofiles.open(state_path, "r") as file:
+    async with aiofiles.open(state_path, "r", encoding="utf-8")) as file:
         state = json.loads(await file.read())
     await team.load_state(state)
     return team
@@ -80,7 +80,7 @@ async def get_history() -> list[dict[str, Any]]:
     """Get chat history from file."""
     if not os.path.exists(history_path):
         return []
-    async with aiofiles.open(history_path, "r") as file:
+    async with aiofiles.open(history_path, "r", encoding="utf-8")) as file:
         return json.loads(await file.read())
 
 

--- a/python/samples/agentchat_streamlit/agent.py
+++ b/python/samples/agentchat_streamlit/agent.py
@@ -8,7 +8,7 @@ from autogen_core.models import ChatCompletionClient
 class Agent:
     def __init__(self) -> None:
         # Load the model client from config.
-        with open("model_config.yml", "r") as f:
+        with open("model_config.yml", "r", encoding="utf-8")) as f:
             model_config = yaml.safe_load(f)
         model_client = ChatCompletionClient.load_component(model_config)
         self.agent = AssistantAgent(

--- a/python/samples/core_chainlit/app_agent.py
+++ b/python/samples/core_chainlit/app_agent.py
@@ -55,7 +55,7 @@ async def get_weather(city: str) -> str:
 async def start_chat() -> None:
 
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8")) as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
     #context = BufferedChatCompletionContext(buffer_size=10)

--- a/python/samples/core_chainlit/app_team.py
+++ b/python/samples/core_chainlit/app_team.py
@@ -83,7 +83,7 @@ async def output_result(_agent: ClosureContext, message: StreamResult, ctx: Mess
 async def start_chat() -> None:
 
     # Load model configuration and create the model client.
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8")) as f:
         model_config = yaml.safe_load(f)
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/core_chess_game/main.py
+++ b/python/samples/core_chess_game/main.py
@@ -275,6 +275,6 @@ if __name__ == "__main__":
         handler = logging.FileHandler("chess_game.log")
         logging.getLogger("autogen_core").addHandler(handler)
 
-    with open(args.model_config, "r") as f:
+    with open(args.model_config, "r", encoding="utf-8")) as f:
         model_config = yaml.safe_load(f)
     asyncio.run(main(model_config))

--- a/python/samples/core_distributed-group-chat/_utils.py
+++ b/python/samples/core_distributed-group-chat/_utils.py
@@ -11,7 +11,7 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 def load_config(file_path: str = os.path.join(os.path.dirname(__file__), "config.yaml")) -> AppConfig:
     model_client = {}
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8")) as file:
         config_data = yaml.safe_load(file)
         model_client = config_data["client_config"]
         del config_data["client_config"]

--- a/python/samples/core_streaming_handoffs_fastapi/app.py
+++ b/python/samples/core_streaming_handoffs_fastapi/app.py
@@ -66,7 +66,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         os.makedirs(chat_history_dir)
 
     # Get model client from config.
-    async with aiofiles.open("model_config.yaml", "r") as file:
+    async with aiofiles.open("model_config.yaml", "r", encoding="utf-8")) as file:
         model_config = yaml.safe_load(await file.read())
     model_client = ChatCompletionClient.load_component(model_config)
 
@@ -224,7 +224,7 @@ async def chat_completions_stream(request: Request):
     if os.path.exists(chat_history_file):
         context = BufferedChatCompletionContext(buffer_size=15)
         try:
-            async with aiofiles.open(chat_history_file, "r") as f:
+            async with aiofiles.open(chat_history_file, "r", encoding="utf-8")) as f:
                 content = await f.read()
                 if content: # Check if file is not empty
                     chat_history = json.loads(content)

--- a/python/samples/core_streaming_response_fastapi/app.py
+++ b/python/samples/core_streaming_response_fastapi/app.py
@@ -84,7 +84,7 @@ class MyAgent(RoutedAgent):
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Get model client from config.
-    async with aiofiles.open("model_config.yaml", "r") as file:
+    async with aiofiles.open("model_config.yaml", "r", encoding="utf-8")) as file:
         model_config = yaml.safe_load(await file.read())
     model_client = ChatCompletionClient.load_component(model_config)
 

--- a/python/samples/gitty/src/gitty/_gitty.py
+++ b/python/samples/gitty/src/gitty/_gitty.py
@@ -66,7 +66,7 @@ async def run_gitty(owner: str, repo: str, command: str, number: int) -> None:
     try:
         global_config_path = os.path.expanduser("~/.gitty/config")
         if os.path.exists(global_config_path):
-            with open(global_config_path, "r") as f:
+            with open(global_config_path, "r", encoding="utf-8")) as f:
                 global_instructions = f.read().strip()
     except Exception as e:
         print("Warning: Could not load global config:", e)
@@ -77,7 +77,7 @@ async def run_gitty(owner: str, repo: str, command: str, number: int) -> None:
         local_config_path = os.path.join(gitty_dir, "config")
         print(f"Local config path: {local_config_path}")
         if os.path.exists(local_config_path):
-            with open(local_config_path, "r") as f:
+            with open(local_config_path, "r", encoding="utf-8")) as f:
                 local_instructions = f.read().strip()
     except Exception as e:
         print("Warning: Could not load local config:", e)

--- a/python/samples/task_centric_memory/utils.py
+++ b/python/samples/task_centric_memory/utils.py
@@ -27,6 +27,6 @@ def load_yaml_file(file_path: str) -> Any:
     """
     Opens a file and returns its contents.
     """
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8")) as file:
         return yaml.safe_load(file)
 


### PR DESCRIPTION
Auto-generated fix for #7172

### What happened?

**Describe the bug**
I created a tool using HttpTool and used it in StaticStreamWorkbench. It worked fine.
However, when I created a new instance of StaticStreamWorkbench by calling _from_config(), I got an error:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for HttpToolConfig
headers
  Field required [type=missing, input_value={'name': 'base64_decode',... 'text', 'timeout': 5.0}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
```

Maybe `HttpTool` has some problems to cause the failure of `_from_config()`.

env version:
- autogen-core: 0.7.5
- autogen-ext: 0.7.5
- Python 3.13.9

**To Reproduce**
Here is the code:
```python
from autogen_core.tools import StaticStreamWorkbench
from autogen_ext.tools.h