### PR TITLE
fix: _rstrip_last_assistant_message only strips trailing whitespace from the content — it does not remove the assistant message.

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -542,10 +542,10 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
         """
         Remove the last assistant message if it is empty.
         """
-        # When Claude models last message is AssistantMessage, It could not end with whitespace
-        if isinstance(messages[-1], AssistantMessage):
-            if isinstance(messages[-1].content, str):
-                messages[-1].content = messages[-1].content.rstrip()
+        # When Claude models last message is AssistantMessage, it must be removed
+        # (Anthropic API requires conversation to end with a user message)
+        while messages and isinstance(messages[-1], AssistantMessage):
+            messages = messages[:-1]
 
         return messages
 


### PR DESCRIPTION
Auto-generated fix for #7768\n\n### What happened?

**Describe the bug**
_rstrip_last_assistant_message only strips trailing whitespace from the content — it does not remove the assistant message. So when the message history genuinely ends with a non-empty assistant message, it passes through unchanged and Anthropic rejects it.

**Claude Recommend Fix**
```python
        from autogen_ext.models.anthropic import AnthropicChatCompletionClient

        class _AnthropicClient(AnthropicChatCompletionClient):
            # autogen-ext 0.7.x only whitespace-strips trailing assistant messages;
            # Anthropic API requires the conversation to end with a user message.
            def _rstrip_last_assistant_message(self, messages: Sequence[_LLMMessage]) -> Sequence[_LLMMessage]:
                msgs = list(messages)
       