### PR TITLE
fix: ignore injected LangChain tool parameters

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py
@@ -169,7 +169,8 @@ class LangChainToolAdapter(BaseTool[BaseModel, Any]):
             fields = {
                 k: (v.annotation, Field(...))
                 for k, v in sig.parameters.items()
-                if k != "self" and v.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+                if k not in ("self", "run_manager", "callbacks")
+                and v.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
             }
             args_type = create_model(f"{name}Args", **fields)  # type: ignore
             # Note: type ignore is used due to a LangChain typing limitation

--- a/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
+++ b/python/packages/autogen-ext/tests/tools/test_langchain_tools.py
@@ -42,6 +42,14 @@ class CustomCalculatorTool(LangChainTool):
         return self._run(a, b, run_manager=run_manager.get_sync() if run_manager else None)
 
 
+class ToolWithoutArgsSchema(LangChainTool):
+    name: str = "tool_without_args_schema"
+    description: str = "A tool whose run manager is injected by LangChain."
+
+    def _run(self, value: str, run_manager: Optional[CallbackManagerForToolRun] = None) -> str:
+        return value
+
+
 @pytest.mark.asyncio
 async def test_langchain_tool_adapter(caplog: pytest.LogCaptureFixture) -> None:
     # Create a LangChain tool
@@ -100,3 +108,9 @@ async def test_langchain_tool_adapter(caplog: pytest.LogCaptureFixture) -> None:
     # Test run method for CustomCalculatorTool
     custom_result = await custom_adapter.run_json({"a": 3, "b": 4}, CancellationToken())
     assert custom_result == 12
+
+
+def test_langchain_tool_adapter_filters_injected_parameters() -> None:
+    adapter = LangChainToolAdapter(ToolWithoutArgsSchema())  # type: ignore
+
+    assert set(adapter.schema["parameters"]["properties"]) == {"value"}


### PR DESCRIPTION
## Why are these changes needed?

Closes #6385. `LangChainToolAdapter` infers a Pydantic input model from `_run` when a LangChain tool does not provide `args_schema`. LangChain injects `run_manager` and `callbacks` into these signatures, but those internal parameters must not be exposed as tool inputs. Including them can make Pydantic schema generation fail for types such as `CallbackManagerForToolRun`.

## What changed?

- Filter LangChain-injected `run_manager` and `callbacks` parameters during fallback signature inference.
- Add a regression test using a tool without an explicit `args_schema` and verify only user-facing inputs are included.

## Compatibility

This only affects fallback schema inference for tools without `args_schema`; tools with an explicit schema are unchanged. No public API changes.

## Checks

- `uv run --package autogen-ext --extra langchain --dev pytest packages/autogen-ext/tests/tools/test_langchain_tools.py -q` — passed (2 tests).
- `uv run --package autogen-ext --dev ruff check packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py packages/autogen-ext/tests/tools/test_langchain_tools.py` — passed.
- `uv run --package autogen-ext --dev ruff format --check packages/autogen-ext/src/autogen_ext/tools/langchain/_langchain_adapter.py packages/autogen-ext/tests/tools/test_langchain_tools.py` — passed.