### PR TITLE
fix(docs): underline sidebar nav links on keyboard focus

### DIFF
--- a/python/docs/src/_static/custom.css
+++ b/python/docs/src/_static/custom.css
@@ -145,3 +145,15 @@ html[data-theme="light"] .bd-header {
 .prev-next-title {
   word-break: break-word;
 }
+
+/* A11y: visible underline for left sidebar nav on keyboard focus (issue #6090 item 15) */
+nav.bd-links .navbar-nav a:focus-visible {
+  text-decoration: underline !important;
+  text-underline-offset: 0.2em;
+}
+
+/* A11y: underline for On This Page links on keyboard focus (issue #6090 item 21) */
+.bd-sidebar-secondary .sidebar-secondary-items .nav-item > a:focus-visible {
+  text-decoration: underline !important;
+  text-underline-offset: 0.2em;
+}


### PR DESCRIPTION
## Summary
- Add visible `text-decoration: underline` for left sidebar (`nav.bd-links`) links on `:focus-visible`.
- Same treatment for On This Page secondary sidebar links.

Addresses items **(15)** and **(21)** in #6090.

## Testing plan
- [ ] Open AutoGen docs, Tab to a left-nav link, confirm underline appears on keyboard focus.
- [ ] Tab to an On This Page link, confirm underline appears.
- [ ] Mouse hover behavior remains unchanged aside from focus-visible styles.