### PR TITLE
fix(core): raise RecipientNotFoundError instead of generic Exception for unknown recipients

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/__init__.py
@@ -58,6 +58,7 @@ from ._serialization import (
 )
 from ._single_threaded_agent_runtime import SingleThreadedAgentRuntime
 from ._subscription import Subscription
+from .exceptions import RecipientNotFoundError
 from ._subscription_context import SubscriptionInstantiationContext
 from ._telemetry import (
     trace_create_agent_span,
@@ -140,4 +141,5 @@ __all__ = [
     "trace_create_agent_span",
     "trace_invoke_agent_span",
     "trace_tool_span",
+    "RecipientNotFoundError",
 ]

--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -44,7 +44,7 @@ from ._serialization import JSON_DATA_CONTENT_TYPE, MessageSerializer, Serializa
 from ._subscription import Subscription
 from ._telemetry import EnvelopeMetadata, MessageRuntimeTracingConfig, TraceHelper, get_telemetry_envelope_metadata
 from ._topic import TopicId
-from .exceptions import MessageDroppedException
+from .exceptions import MessageDroppedException, RecipientNotFoundError
 
 logger = logging.getLogger("autogen_core")
 event_logger = logging.getLogger("autogen_core.events")
@@ -362,7 +362,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
         ):
             future = asyncio.get_event_loop().create_future()
             if recipient.type not in self._known_agent_names:
-                future.set_exception(Exception("Recipient not found"))
+                future.set_exception(RecipientNotFoundError(f"Recipient '{recipient.type}' not found in the runtime."))
                 return await future
 
             content = message.__dict__ if hasattr(message, "__dict__") else message

--- a/python/packages/autogen-core/src/autogen_core/exceptions.py
+++ b/python/packages/autogen-core/src/autogen_core/exceptions.py
@@ -1,4 +1,10 @@
-__all__ = ["CantHandleException", "UndeliverableException", "MessageDroppedException", "NotAccessibleError"]
+__all__ = [
+    "CantHandleException",
+    "UndeliverableException",
+    "MessageDroppedException",
+    "NotAccessibleError",
+    "RecipientNotFoundError",
+]
 
 
 class CantHandleException(Exception):
@@ -15,3 +21,13 @@ class MessageDroppedException(Exception):
 
 class NotAccessibleError(Exception):
     """Tried to access a value that is not accessible. For example if it is remote cannot be accessed locally."""
+
+
+class RecipientNotFoundError(Exception):
+    """Raised when a message is sent to an agent type that is not registered in the runtime.
+
+    Args:
+        recipient: The :class:`~autogen_core.AgentId` that could not be found.
+
+    .. versionadded:: v0.4.10
+    """

--- a/python/packages/autogen-core/tests/test_runtime.py
+++ b/python/packages/autogen-core/tests/test_runtime.py
@@ -7,6 +7,7 @@ from autogen_core import (
     AgentType,
     DefaultTopicId,
     MessageContext,
+    RecipientNotFoundError,
     RoutedAgent,
     SingleThreadedAgentRuntime,
     TopicId,
@@ -362,5 +363,16 @@ async def test_event_handler_exception_multi_message() -> None:
         await runtime.publish_message(MessageType(), topic_id=DefaultTopicId())
         await runtime.publish_message(MessageType(), topic_id=DefaultTopicId())
         await runtime.stop_when_idle()
+
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_unregistered_agent_raises_recipient_not_found() -> None:
+    runtime = SingleThreadedAgentRuntime()
+    runtime.start()
+    with pytest.raises(RecipientNotFoundError):
+        await runtime.send_message(MessageType(), AgentId("nonexistent_agent", "default"))
+    await runtime.stop_when_idle()
 
     await runtime.close()


### PR DESCRIPTION
## Summary

Fixes #4964

When `send_message` is called with an agent type that is not registered in the runtime, the runtime now raises `RecipientNotFoundError` instead of a bare `Exception("Recipient not found")`. This lets callers catch the specific error class rather than parsing the error message string.

**Changes:**
- Added `RecipientNotFoundError` to `autogen_core/exceptions.py`
- Exported `RecipientNotFoundError` from `autogen_core.__init__` so it is accessible as `from autogen_core import RecipientNotFoundError`
- Updated `_single_threaded_agent_runtime.py` to raise `RecipientNotFoundError` at the point where recipient lookup fails
- Added a test in `test_runtime.py` that verifies `RecipientNotFoundError` is raised for unregistered agent types

## Test plan

- [x] New test `test_send_message_to_unregistered_agent_raises_recipient_not_found` passes
- [x] Full `packages/autogen-core/tests/` suite passes (225 tests, 0 failures)
- [x] `RecipientNotFoundError` is importable directly from `autogen_core`
- [x] `RecipientNotFoundError` is also accessible via `autogen_core.exceptions.RecipientNotFoundError`