### PR TITLE
feat(ext): add Mistral AI model support to OpenAIChatCompletionClient

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -46,6 +46,14 @@ _MODEL_POINTERS = {
     "llama-3.3-70b": "Llama-3.3-70B-Instruct",
     "llama-4-scout": "Llama-4-Scout-17B-16E-Instruct-FP8",
     "llama-4-maverick": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+    # Mistral models
+    "mistral-large-latest": "mistral-large-2411",
+    "mistral-small-latest": "mistral-small-2503",
+    "codestral-latest": "codestral-2501",
+    "ministral-8b-latest": "ministral-8b-2410",
+    "ministral-3b-latest": "ministral-3b-2410",
+    "pixtral-large-latest": "pixtral-large-2411",
+    "pixtral-12b-latest": "pixtral-12b-2409",
 }
 
 _MODEL_INFO: Dict[str, ModelInfo] = {
@@ -441,6 +449,94 @@ _MODEL_INFO: Dict[str, ModelInfo] = {
         "structured_output": True,
         "multiple_system_messages": True,
     },
+    "mistral-large-2411": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "mistral-small-2503": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "codestral-2501": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.CODESRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "ministral-8b-2410": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MINISTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "ministral-3b-2410": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MINISTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "pixtral-large-2411": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.PIXTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "pixtral-12b-2409": {
+        "vision": True,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.PIXTRAL,
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "open-mistral-7b": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
+    "open-mixtral-8x7b": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
+    "open-mixtral-8x22b": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.MISTRAL,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
+    "open-codestral-mamba": {
+        "vision": False,
+        "function_calling": False,
+        "json_output": True,
+        "family": ModelFamily.OPEN_CODESRAL_MAMBA,
+        "structured_output": False,
+        "multiple_system_messages": False,
+    },
 }
 
 _MODEL_TOKEN_LIMITS: Dict[str, int] = {
@@ -491,11 +587,23 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
     "Llama-3.3-70B-Instruct": 128000,
     "Llama-4-Scout-17B-16E-Instruct-FP8": 128000,
     "Llama-4-Maverick-17B-128E-Instruct-FP8": 128000,
+    "mistral-large-2411": 131072,
+    "mistral-small-2503": 131072,
+    "codestral-2501": 262144,
+    "ministral-8b-2410": 131072,
+    "ministral-3b-2410": 131072,
+    "pixtral-large-2411": 131072,
+    "pixtral-12b-2409": 131072,
+    "open-mistral-7b": 32768,
+    "open-mixtral-8x7b": 32768,
+    "open-mixtral-8x22b": 65536,
+    "open-codestral-mamba": 262144,
 }
 
 GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 ANTHROPIC_OPENAI_BASE_URL = "https://api.anthropic.com/v1/"
 LLAMA_API_BASE_URL = "https://api.llama.com/compat/v1/"
+MISTRAL_API_BASE_URL = "https://api.mistral.ai/v1/"
 
 
 def resolve_model(model: str) -> str:

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1480,6 +1480,13 @@ class OpenAIChatCompletionClient(BaseOpenAIChatCompletionClient, Component[OpenA
                 copied_args["base_url"] = _model_info.LLAMA_API_BASE_URL
             if "api_key" not in copied_args and "LLAMA_API_KEY" in os.environ:
                 copied_args["api_key"] = os.environ["LLAMA_API_KEY"]
+        if copied_args["model"].startswith(
+            ("mistral-", "codestral-", "ministral-", "pixtral-", "open-mistral-", "open-codestral-", "open-mixtral-")
+        ):
+            if "base_url" not in copied_args:
+                copied_args["base_url"] = _model_info.MISTRAL_API_BASE_URL
+            if "api_key" not in copied_args and "MISTRAL_API_KEY" in os.environ:
+                copied_args["api_key"] = os.environ["MISTRAL_API_KEY"]
 
         client = _openai_client_from_config(copied_args)
         create_args = _create_args_from_config(copied_args)

--- a/python/packages/autogen-ext/tests/models/test_utils.py
+++ b/python/packages/autogen-ext/tests/models/test_utils.py
@@ -1,5 +1,11 @@
 import pytest
+from autogen_core.models import ModelFamily
 from autogen_ext.models._utils.parse_r1_content import parse_r1_content
+from autogen_ext.models.openai._model_info import (
+    MISTRAL_API_BASE_URL,
+    get_info,
+    resolve_model,
+)
 
 
 def test_parse_r1_content() -> None:
@@ -41,3 +47,21 @@ def test_parse_r1_content() -> None:
         thought, content = parse_r1_content(content)
         assert thought is None
         assert content == "</think>Hello, <think>world"
+
+
+def test_mistral_model_info() -> None:
+    assert resolve_model("mistral-large-latest") == "mistral-large-2411"
+    assert resolve_model("codestral-latest") == "codestral-2501"
+    assert resolve_model("pixtral-large-latest") == "pixtral-large-2411"
+
+    info = get_info("mistral-large-latest")
+    assert info["family"] == ModelFamily.MISTRAL
+    assert info["function_calling"] is True
+    assert info["json_output"] is True
+    assert info["structured_output"] is True
+    assert info["multiple_system_messages"] is False
+
+    assert get_info("pixtral-large-latest")["vision"] is True
+    assert get_info("open-codestral-mamba")["function_calling"] is False
+
+    assert MISTRAL_API_BASE_URL == "https://api.mistral.ai/v1/"


### PR DESCRIPTION
## Summary

Fixes #6151

Adds Mistral AI model support to `OpenAIChatCompletionClient`, mirroring the existing Gemini/Claude/Llama pattern.

**Changes in `_model_info.py`:**
- Added 7 model pointer aliases (`mistral-large-latest`, `mistral-small-latest`, `codestral-latest`, `ministral-8b-latest`, `ministral-3b-latest`, `pixtral-large-latest`, `pixtral-12b-latest`)
- Added capability entries for 11 canonical Mistral models (`mistral-large-2411`, `mistral-small-2503`, `codestral-2501`, `ministral-8b-2410`, `ministral-3b-2410`, `pixtral-large-2411`, `pixtral-12b-2409`, `open-mistral-7b`, `open-mixtral-8x7b`, `open-mixtral-8x22b`, `open-codestral-mamba`)
- Added context window sizes for all 11 models
- Added `MISTRAL_API_BASE_URL = "https://api.mistral.ai/v1/"`

**Changes in `_openai_client.py`:**
- Auto-sets `base_url` to `MISTRAL_API_BASE_URL` when model name starts with a Mistral prefix (`mistral-`, `codestral-`, `ministral-`, `pixtral-`, `open-mistral-`, `open-codestral-`, `open-mixtral-`)
- Auto-reads `MISTRAL_API_KEY` from environment when no `api_key` is provided

**Usage after this change:**
```python
from autogen_ext.models.openai import OpenAIChatCompletionClient

# Works with just the model name + env var MISTRAL_API_KEY set
client = OpenAIChatCompletionClient(model="mistral-large-latest")
```

## Test plan

- [x] `test_mistral_model_info`: verifies model pointer resolution, capability flags, and `MISTRAL_API_BASE_URL` constant
- [x] `test_parse_r1_content` (existing) still passes
- [x] Full `packages/autogen-ext/tests/models/` suite: 64 passed, 11 skipped, 0 new failures (pre-existing failure in `test_anthropic_model_client[bedrock]` due to deprecated AWS Bedrock model, unrelated to this change)