### PR TITLE
docs: fix RedisCacheStore → RedisStore in example comments

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -214,7 +214,7 @@ async def main():
         # from autogen_ext.cache_store.redis import RedisStore
         # import redis
         # redis_instance = redis.Redis()
-        # cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
+        # cache_store = RedisStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
         cache_store = DiskCacheStore[CHAT_CACHE_VALUE_TYPE](Cache(tmpdirname))
         cache_client = ChatCompletionCache(openai_model_client, cache_store)
 

--- a/python/docs/src/user-guide/core-user-guide/components/model-clients.ipynb
+++ b/python/docs/src/user-guide/core-user-guide/components/model-clients.ipynb
@@ -306,7 +306,7 @@
     "        # from autogen_ext.cache_store.redis import RedisStore\n",
     "        # import redis\n",
     "        # redis_instance = redis.Redis()\n",
-    "        # cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)\n",
+    "        # cache_store = RedisStore[CHAT_CACHE_VALUE_TYPE](redis_instance)\n",
     "        cache_store = DiskCacheStore[CHAT_CACHE_VALUE_TYPE](Cache(tmpdirname))\n",
     "        cache_client = ChatCompletionCache(openai_model_client, cache_store)\n",
     "\n",

--- a/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
@@ -65,7 +65,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
                 # from autogen_ext.cache_store.redis import RedisStore
                 # import redis
                 # redis_instance = redis.Redis()
-                # cache_store = RedisCacheStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
+                # cache_store = RedisStore[CHAT_CACHE_VALUE_TYPE](redis_instance)
                 cache_store = DiskCacheStore[CHAT_CACHE_VALUE_TYPE](Cache(tmpdirname))
                 cache_client = ChatCompletionCache(openai_model_client, cache_store)
 


### PR DESCRIPTION
## Summary

Fixes #7084

`RedisCacheStore` is not a real class — the correct name is `RedisStore` (from `autogen_ext.cache_store.redis`). The wrong name appeared as a comment in three example code blocks.

**Files changed:**
- `python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py` — docstring example
- `python/docs/src/user-guide/agentchat-user-guide/migration-guide.md` — migration guide example
- `python/docs/src/user-guide/core-user-guide/components/model-clients.ipynb` — model clients notebook

All three were comments showing Redis as an alternative to DiskCache, so no runtime behavior changes.

## Test plan

- [x] `grep -rn "RedisCacheStore"` returns nothing after the fix
- [x] `RedisStore` is the actual class in `autogen_ext/cache_store/redis.py`