### PR TITLE
fix(core): count dropped function call messages in head-and-tail skipped placeholder

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/model_context/_head_and_tail_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_head_and_tail_chat_completion_context.py
@@ -57,12 +57,14 @@ class HeadAndTailChatCompletionContext(ChatCompletionContext, Component[HeadAndT
             # Remove the first message from the tail.
             tail_messages = tail_messages[1:]
 
-        num_skipped = len(self._messages) - self._head_size - self._tail_size
-        if num_skipped <= 0:
+        if len(self._messages) - self._head_size - self._tail_size <= 0:
             # If there are not enough messages to fill the head and tail,
             # return all messages.
             return self._messages
 
+        # Count the messages that are actually left out, so the placeholder also
+        # accounts for any message dropped from the head or the tail above.
+        num_skipped = len(self._messages) - len(head_messages) - len(tail_messages)
         placeholder_messages = [UserMessage(content=f"Skipped {num_skipped} messages.", source="System")]
         return head_messages + placeholder_messages + tail_messages
 

--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import pytest
+from autogen_core import FunctionCall
 from autogen_core.model_context import (
     BufferedChatCompletionContext,
     HeadAndTailChatCompletionContext,
@@ -10,6 +11,7 @@ from autogen_core.model_context import (
 from autogen_core.models import (
     AssistantMessage,
     ChatCompletionClient,
+    FunctionExecutionResult,
     FunctionExecutionResultMessage,
     LLMMessage,
     UserMessage,
@@ -83,6 +85,36 @@ async def test_head_and_tail_model_context() -> None:
     assert len(retrived) == 3
     assert retrived[0] == messages[0]
     assert retrived[2] == messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_head_and_tail_model_context_placeholder_counts_dropped_function_call_messages() -> None:
+    # The head ends on a tool call message and the tail starts on a tool result
+    # message, so both are dropped in addition to the messages in the middle.
+    model_context = HeadAndTailChatCompletionContext(head_size=2, tail_size=2)
+    messages: List[LLMMessage] = [
+        UserMessage(content="Hello!", source="user"),
+        AssistantMessage(content=[FunctionCall(id="1", name="tool", arguments="{}")], source="assistant"),
+        UserMessage(content="Middle 1", source="user"),
+        UserMessage(content="Middle 2", source="user"),
+        FunctionExecutionResultMessage(
+            content=[FunctionExecutionResult(call_id="1", content="ok", is_error=False, name="tool")]
+        ),
+        UserMessage(content="More places?", source="user"),
+    ]
+    for msg in messages:
+        await model_context.add_message(msg)
+
+    retrieved = await model_context.get_messages()
+
+    # 1 head + 1 placeholder + 1 tail.
+    assert len(retrieved) == 3
+    assert retrieved[0] == messages[0]
+    assert retrieved[2] == messages[-1]
+
+    # Four messages are left out, not just the two in the middle.
+    num_kept = len(retrieved) - 1
+    assert retrieved[1] == UserMessage(content=f"Skipped {len(messages) - num_kept} messages.", source="System")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why are these changes needed?

`HeadAndTailChatCompletionContext.get_messages()` deliberately drops two kinds of message so the returned view never contains a dangling half of a function call pair:

- a trailing `AssistantMessage` whose content is a list of `FunctionCall`s, removed from the **head**
- a leading `FunctionExecutionResultMessage`, removed from the **tail**

The `"Skipped N messages."` placeholder that replaces the omitted middle was computed before those drops were taken into account:

```python
num_skipped = len(self._messages) - self._head_size - self._tail_size
```

That expression only counts the messages between the head and tail windows. When either guard fires, one or two additional messages are dropped but never counted, so the placeholder understates how much history was removed — by one if a single guard fires, by two if both do.

The placeholder is a `UserMessage` that goes to the model, so this is wrong information in the prompt: the model is told less context was elided than actually was.

### Repro

6 messages, `head_size=2`, `tail_size=2`, where `messages[1]` is a tool-call `AssistantMessage` (trimmed from the head) and `messages[4]` is a tool-result message (trimmed from the tail):

```
returned messages:
    UserMessage 'm0 user'
    UserMessage 'Skipped 2 messages.'
    UserMessage 'm5 user'

total messages   : 6
kept (non-placeholder): 2
actually omitted : 4
placeholder says : 'Skipped 2 messages.'
```

Two messages are kept out of six, so four were omitted — the placeholder says two.

## What changed

Derive the count from the head and tail lists that are actually returned:

```python
num_skipped = len(self._messages) - len(head_messages) - len(tail_messages)
```

The early return for the "not enough messages to fill head and tail" case still uses the configured `head_size`/`tail_size`, so a context that needs no truncation keeps returning all messages unchanged. Only the placeholder count changes, and only when a truncating call also dropped a function call message.

After the fix the same repro reports `Skipped 4 messages.`

## Checks

- Added `test_head_and_tail_model_context_placeholder_counts_dropped_function_call_messages`, which covers the both-guards-fire path that existing tests did not reach. It fails on `main` and passes with this change.
- `pytest packages/autogen-core/tests` — 227 passed.
- `pytest packages/autogen-agentchat/tests/test_agent.py packages/autogen-agentchat/tests/test_declarative_components.py` (the dependents that construct this context) — 14 passed.
- `ruff format --check`, `ruff check`, and `mypy` clean on both touched files.

## Related issue number

None — found by inspection.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
