### PR TITLE
fix: use explicit UTF-8 encoding in redirect generation script

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:


### PR DESCRIPTION
Add explicit encoding='utf-8' to all file read/write operations in redirects.py to prevent UnicodeDecodeError on Windows systems with non-UTF-8 default encoding.

Fixes #7749

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
