### PR TITLE
fix: preserve MessageFilterAgent chronological order

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
@@ -152,10 +152,12 @@ class MessageFilterAgent(BaseChatAgent, Component[MessageFilterAgentConfig]):
         return self._wrapped_agent.produced_message_types
 
     def _apply_filter(self, messages: Sequence[BaseChatMessage]) -> Sequence[BaseChatMessage]:
-        result: List[BaseChatMessage] = []
+        result: List[tuple[int, BaseChatMessage]] = []
 
         for source_filter in self._filter.per_source:
-            msgs = [m for m in messages if m.source == source_filter.source]
+            msgs = [
+                (index, message) for index, message in enumerate(messages) if message.source == source_filter.source
+            ]
 
             if source_filter.position == "first" and source_filter.count:
                 msgs = msgs[: source_filter.count]
@@ -164,7 +166,7 @@ class MessageFilterAgent(BaseChatAgent, Component[MessageFilterAgentConfig]):
 
             result.extend(msgs)
 
-        return result
+        return [message for _, message in sorted(result, key=lambda item: item[0])]
 
     async def on_messages(
         self,

--- a/python/packages/autogen-agentchat/tests/test_group_chat_graph.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat_graph.py
@@ -1143,6 +1143,32 @@ async def test_message_filter_agent_with_position_none_gets_all() -> None:
 
 
 @pytest.mark.asyncio
+async def test_message_filter_agent_preserves_chronological_order() -> None:
+    inner_agent = _TestMessageFilterAgent("inner")
+    wrapper = MessageFilterAgent(
+        name="wrapper",
+        wrapped_agent=inner_agent,
+        filter=MessageFilterConfig(
+            per_source=[
+                PerSourceFilter(source="user", position="first", count=1),
+                PerSourceFilter(source="A", position="last", count=1),
+                PerSourceFilter(source="B", position="last", count=10),
+            ]
+        ),
+    )
+    messages = [
+        TextMessage(source="user", content="task"),
+        TextMessage(source="A", content="first attempt"),
+        TextMessage(source="B", content="review"),
+        TextMessage(source="A", content="revised attempt"),
+    ]
+
+    await wrapper.on_messages(messages, CancellationToken())
+
+    assert inner_agent.received_messages == [messages[0], messages[2], messages[3]]
+
+
+@pytest.mark.asyncio
 async def test_digraph_group_chat() -> None:
     inner_agent = _TestMessageFilterAgent("agent")
     wrapper = MessageFilterAgent(


### PR DESCRIPTION
## Why are these changes needed?

`MessageFilterAgent` selected the correct messages for each source, but concatenated those selections in `per_source` configuration order. When source messages were interleaved, the wrapped agent therefore received a scrambled conversation timeline.

This change retains each selected message's original index and restores chronological order after all per-source filters have been applied. The existing first/last/count selection behavior remains unchanged.

A regression test reproduces the documented looping-agent case where a prior response from B must remain before A's newer revision.

## Related issue number

Closes #7971

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. No documentation change is required because this restores the behavior described by the existing example.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

## Test plan

- `poe --directory packages/autogen-agentchat fmt` (65 files unchanged)
- `poe --directory packages/autogen-agentchat lint`
- `poe --directory packages/autogen-agentchat mypy` (64 source files checked)
- `poe --directory packages/autogen-agentchat pyright` (0 errors)
- `poe --directory packages/autogen-agentchat test` (377 passed, 5 skipped)
