### PR TITLE
fix(autogen-ext): add extra_body to OpenAI client config and serialization models

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Dict, List, Literal, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Union
 
 from autogen_core import ComponentModel
 from autogen_core.models import ModelCapabilities, ModelInfo  # type: ignore
@@ -57,6 +57,8 @@ class CreateArguments(TypedDict, total=False):
     - 'low': Faster responses with less reasoning
     - 'medium': Balanced reasoning and speed
     - 'high': More thorough reasoning, may take longer"""
+    extra_body: Optional[Dict[str, Any]]
+    """Additional vendor-specific or custom parameters to pass directly in the request body."""
 
 
 AsyncAzureADTokenProvider = Callable[[], Union[str, Awaitable[str]]]
@@ -108,6 +110,7 @@ class CreateArgumentsConfigModel(BaseModel):
     parallel_tool_calls: bool | None = None
     # Controls the amount of effort the model uses for reasoning (reasoning models only)
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
+    extra_body: Dict[str, Any] | None = None
 
 
 class BaseOpenAIClientConfigurationConfigModel(CreateArgumentsConfigModel):

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -3378,3 +3378,37 @@ async def test_reasoning_effort_validation() -> None:
         }
 
         ChatCompletionClient.load_component(config)
+
+
+@pytest.mark.asyncio
+async def test_extra_body_configuration_and_serialization() -> None:
+    """Test extra_body parameter configuration, serialization, and deserialization."""
+    from autogen_core.models import ChatCompletionClient
+
+    # Test direct client initialization with extra_body
+    client = OpenAIChatCompletionClient(
+        model="gpt-4o",
+        api_key="fake_key",
+        extra_body={"enable_thinking": True, "custom_param": 123},
+    )
+    assert client._create_args["extra_body"] == {"enable_thinking": True, "custom_param": 123}  # pyright: ignore[reportPrivateUsage]
+    assert client._raw_config["extra_body"] == {"enable_thinking": True, "custom_param": 123}  # pyright: ignore[reportPrivateUsage]
+
+    # Test load_component with extra_body
+    config = {
+        "provider": "OpenAIChatCompletionClient",
+        "config": {
+            "model": "gpt-4o",
+            "api_key": "fake_key",
+            "extra_body": {"enable_thinking": True, "vendor_flag": "fast"},
+        },
+    }
+    loaded_client = ChatCompletionClient.load_component(config)
+    assert loaded_client._create_args["extra_body"] == {"enable_thinking": True, "vendor_flag": "fast"}  # type: ignore[attr-defined] # pyright: ignore[reportPrivateUsage]
+    assert loaded_client._raw_config["extra_body"] == {"enable_thinking": True, "vendor_flag": "fast"}  # type: ignore[attr-defined] # pyright: ignore[reportPrivateUsage]
+
+    # Test component dump and reload roundtrip
+    dumped = client.dump_component()
+    reloaded = OpenAIChatCompletionClient.load_component(dumped)
+    assert reloaded._create_args["extra_body"] == {"enable_thinking": True, "custom_param": 123}  # pyright: ignore[reportPrivateUsage]
+

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -3407,8 +3407,34 @@ async def test_extra_body_configuration_and_serialization() -> None:
     assert loaded_client._create_args["extra_body"] == {"enable_thinking": True, "vendor_flag": "fast"}  # type: ignore[attr-defined] # pyright: ignore[reportPrivateUsage]
     assert loaded_client._raw_config["extra_body"] == {"enable_thinking": True, "vendor_flag": "fast"}  # type: ignore[attr-defined] # pyright: ignore[reportPrivateUsage]
 
-    # Test component dump and reload roundtrip
+    # Test component dump payload inspection before reloading
     dumped = client.dump_component()
+    assert dumped.config.extra_body == {"enable_thinking": True, "custom_param": 123}
+
+    # Test component dump and reload roundtrip
     reloaded = OpenAIChatCompletionClient.load_component(dumped)
     assert reloaded._create_args["extra_body"] == {"enable_thinking": True, "custom_param": 123}  # pyright: ignore[reportPrivateUsage]
+    assert reloaded._raw_config["extra_body"] == {"enable_thinking": True, "custom_param": 123}  # pyright: ignore[reportPrivateUsage]
+
+    # Verify the reloaded client's public dump matches original dump payload
+    reloaded_dumped = reloaded.dump_component()
+    assert reloaded_dumped.config.extra_body == {"enable_thinking": True, "custom_param": 123}
+
+    # Test AzureOpenAIChatCompletionClient dump and load roundtrip with extra_body
+    azure_client = AzureOpenAIChatCompletionClient(
+        model="gpt-4o",
+        azure_endpoint="https://fake.openai.azure.com/",
+        azure_deployment="gpt-4o-dep",
+        api_version="2024-06-01",
+        api_key="fake_key",
+        extra_body={"enable_thinking": True, "custom_param": 456},
+    )
+    assert azure_client._create_args["extra_body"] == {"enable_thinking": True, "custom_param": 456}  # pyright: ignore[reportPrivateUsage]
+    azure_dumped = azure_client.dump_component()
+    assert azure_dumped.config.extra_body == {"enable_thinking": True, "custom_param": 456}
+
+    reloaded_azure = AzureOpenAIChatCompletionClient.load_component(azure_dumped)
+    assert reloaded_azure._create_args["extra_body"] == {"enable_thinking": True, "custom_param": 456}  # pyright: ignore[reportPrivateUsage]
+    assert reloaded_azure.dump_component().config.extra_body == {"enable_thinking": True, "custom_param": 456}
+
 


### PR DESCRIPTION
## Description
Fixes #7418

`OpenAIChatCompletionClient` supported `extra_body` in runtime create args, but `extra_body` was missing from `CreateArguments` (TypedDict) and `CreateArgumentsConfigModel` (Pydantic model) in `autogen_ext.models.openai.config`.

As a result, configuring `extra_body` through component configurations (e.g., in AutoGen Studio or `ChatCompletionClient.load_component(...)`) silently dropped the field.

## Changes Made
- Added `extra_body: Optional[Dict[str, Any]]` to `CreateArguments` in `src/autogen_ext/models/openai/config/__init__.py`.
- Added `extra_body: Dict[str, Any] | None = None` to `CreateArgumentsConfigModel`.
- Added unit test `test_extra_body_configuration_and_serialization` in `tests/models/test_openai_model_client.py` verifying client initialization, `load_component`, and `dump_component` roundtrips.

## Checklist
- [x] Linked existing issue #7418.
- [x] Added unit tests for serialization and component loading.
- [x] Followed conventional commits convention.