### PR TITLE
fix(core): support CRLF line endings in extract_json_from_str codeblock regex

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/utils/_load_json.py
+++ b/python/packages/autogen-core/src/autogen_core/utils/_load_json.py
@@ -5,16 +5,17 @@ from typing import Any, Dict, List
 
 def extract_json_from_str(content: str) -> List[Dict[str, Any]]:
     """Extract JSON objects from a string. Supports backtick enclosed JSON objects"""
-    pattern = re.compile(r"```(?:\s*([\w\+\-]+))?\n([\s\S]*?)```")
+    pattern = re.compile(r"```(?:\s*([\w\+\-]+))?\r?\n([\s\S]*?)```")
     matches = pattern.findall(content)
     ret: List[Dict[str, Any]] = []
     # If no matches found, assume the entire content is a JSON object
     if not matches:
-        ret.append(json.loads(content))
+        ret.append(json.loads(content.strip()))
+        return ret
     for match in matches:
         language = match[0].strip() if match[0] else None
         if language and language.lower() != "json":
             raise ValueError(f"Expected JSON object, but found language: {language}")
-        content = match[1]
-        ret.append(json.loads(content))
+        matched_content = match[1].strip()
+        ret.append(json.loads(matched_content))
     return ret

--- a/python/packages/autogen-core/tests/test_json_extraction.py
+++ b/python/packages/autogen-core/tests/test_json_extraction.py
@@ -83,3 +83,10 @@ def test_extract_json_from_str_codeblock() -> None:
   """
     with pytest.raises(ValueError):
         extract_json_from_str(invalid_lang_code_block_str)
+
+
+def test_extract_json_from_str_crlf() -> None:
+    crlf_json_str = "```json\r\n{\r\n  \"name\": \"Alice\",\r\n  \"age\": 28\r\n}\r\n```"
+    expected = [{"name": "Alice", "age": 28}]
+    assert extract_json_from_str(crlf_json_str) == expected
+


### PR DESCRIPTION
## Summary

Supports CRLF (`\r\n`) line endings in `autogen_core.utils.extract_json_from_str`:
- Updated regex pattern to `r"```(?:\s*([\w\+\-]+))?\r?\n([\s\S]*?)```"` to match code blocks formatted with Windows/network CRLF line endings.
- Strips whitespace around content before JSON decoding.
- Added unit test `test_extract_json_from_str_crlf` in `test_json_extraction.py`.

## Motivation

When JSON code blocks are received over network streams or generated on Windows environments with CRLF line endings, the previous regex pattern required strict LF (`\n`), causing extraction to fail and falling back to unparsed strings.

## Changes

- `python/packages/autogen-core/src/autogen_core/utils/_load_json.py`: Match optional `\r` in codeblock regex.
- `python/packages/autogen-core/tests/test_json_extraction.py`: Added test case with CRLF line endings.

## Tests

- Added `test_extract_json_from_str_crlf`.
