### PR TITLE
docs: clarify AutoGen Studio dependency isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ pip install -U "autogen-agentchat" "autogen-ext[openai]"
 
 The current stable version can be found in the [releases](https://github.com/microsoft/autogen/releases). If you are upgrading from AutoGen v0.2, please refer to the [Migration Guide](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/migration-guide.html) for detailed instructions on how to update your code and configurations.
 
+Install AutoGen Studio for its no-code GUI in a separate virtual environment.
+Its published dependency constraints may not be compatible with the latest
+AgentChat and Core packages:
+
 ```bash
-# Install AutoGen Studio for no-code GUI
 pip install -U "autogenstudio"
 ```
 


### PR DESCRIPTION
## Why are these changes needed?

The root README presents the latest AgentChat/Core and AutoGen Studio installation commands together without warning that the published packages may use incompatible dependency lines. `autogenstudio==0.4.2.2` requires `autogen-agentchat>=0.4.9.2,<0.6`, while `autogen-agentchat==0.7.5` is outside that range.

This update clarifies that AutoGen Studio should be installed in a separate virtual environment and that its published dependency constraints may differ from the latest AgentChat and Core packages.

## Related issue number

Related to #7173.

## Checks

- [x] I've included any doc changes needed for https://microsoft.github.io/autogen/.
- [x] Tests are not applicable because this is a documentation-only change.
- [ ] I've made sure all auto checks have passed. Pending CI.

Local verification:

- `git diff --check`
- Dependency conflict reproduced with `uv pip install --dry-run`
- Markdown rendered successfully with `markdown-it-py`
- `markdownlint-cli2 README.md` reports no new issues compared with `origin/main`
- `poe format`
- `poe lint`
- `poe docs-build` — succeeded with 14 warnings
- `poe mypy` — AgentChat passed; Extensions could not complete because optional integration dependencies were not installed