### PR TITLE
fix: preserve CodeExecutorAgent retry settings

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_code_executor_agent.py
@@ -57,6 +57,7 @@ class CodeExecutorAgentConfig(BaseModel):
     sources: List[str] | None = None
     system_message: str | None = None
     model_client_stream: bool = False
+    max_retries_on_error: int = 0
     model_context: ComponentModel | None = None
     supported_languages: List[str] | None = None
 
@@ -758,6 +759,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
                 else None
             ),
             model_client_stream=self._model_client_stream,
+            max_retries_on_error=self._max_retries_on_error,
             model_context=self._model_context.dump_component(),
             supported_languages=self._supported_languages,
         )
@@ -774,6 +776,7 @@ class CodeExecutorAgent(BaseChatAgent, Component[CodeExecutorAgentConfig]):
             sources=config.sources,
             system_message=config.system_message,
             model_client_stream=config.model_client_stream,
+            max_retries_on_error=config.max_retries_on_error,
             model_context=ChatCompletionContext.load_component(config.model_context) if config.model_context else None,
             supported_languages=config.supported_languages,
             approval_func=None,  # approval_func cannot be serialized, so it's always None when loading from config

--- a/python/packages/autogen-agentchat/tests/test_code_executor_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_code_executor_agent.py
@@ -418,6 +418,33 @@ async def test_code_execution_agent_serialization() -> None:
     assert deserialized_agent.name == "code_executor"
 
 
+def test_code_executor_agent_serialization_preserves_max_retries_on_error() -> None:
+    """Configured code-execution retries survive a component round-trip."""
+
+    model_client = ReplayChatCompletionClient(
+        [],
+        model_info=ModelInfo(
+            vision=False,
+            function_calling=False,
+            json_output=True,
+            family=ModelFamily.UNKNOWN,
+            structured_output=True,
+        ),
+    )
+    agent = CodeExecutorAgent(
+        name="code_executor",
+        code_executor=LocalCommandLineCodeExecutor(),
+        model_client=model_client,
+        max_retries_on_error=2,
+    )
+
+    serialized_agent = agent.dump_component()
+    assert serialized_agent.config["max_retries_on_error"] == 2
+
+    deserialized_agent = CodeExecutorAgent.load_component(serialized_agent)
+    assert deserialized_agent._max_retries_on_error == 2  # type: ignore[attr-defined]
+
+
 @pytest.mark.asyncio
 async def test_code_execution_agent_serialization_with_model_client() -> None:
     """Test agent config serialization"""


### PR DESCRIPTION
## Why are these changes needed?

`CodeExecutorAgent` exposes `max_retries_on_error`, but its component configuration did not serialize that setting. Reloading a saved agent, team, or Studio configuration therefore silently reset the retry count to `0`. This change preserves the configured value across component serialization and adds a regression test for the round-trip.

## Related issue number

N/A — no matching open issue or implementation PR was found during the submission audit.

## Checks

- [x] No documentation changes are needed; this restores the existing configuration contract.
- [x] I've added tests corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Focused local validation completed:

- `test_code_executor_agent.py`: 27 passed
- Changed-file format and lint checks
- Focused mypy and pyright checks
