### PR TITLE
fix(docs): repair broken relative links, root-relative URLs and dead anchors

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -41,7 +41,7 @@ pip install autogen-agentchat~=0.2
 
 ### Will AutoGen Studio be supported in 0.4?
 
-Yes, this is on the [roadmap](#roadmap).
+Yes, this is on the [roadmap](CONTRIBUTING.md#roadmap).
 Our current plan is to enable an implementation of AutoGen Studio
 on the AgentChat high level API which implements a set of agent functionalities
 (agents, teams, etc).

--- a/dotnet/samples/Hello/HelloAgent/README.md
+++ b/dotnet/samples/Hello/HelloAgent/README.md
@@ -38,7 +38,7 @@ graph LR;
 
 The heart of an autogen application are the event handlers. Agents select a ```TopicSubscription``` to listen for events on a specific topic. When an event is received, the agent's event handler is called with the event data.
 
-Within that event handler you may optionally *emit* new events, which are then sent to the event bus for other agents to process. The EventTypes are declared gRPC ProtoBuf messages that are used to define the schema of the event.  The default protos are available via the ```Microsoft.AutoGen.Contracts;``` namespace and are defined in [autogen/protos](/autogen/protos). The EventTypes are registered in the agent's constructor using the ```IHandle``` interface.
+Within that event handler you may optionally *emit* new events, which are then sent to the event bus for other agents to process. The EventTypes are declared gRPC ProtoBuf messages that are used to define the schema of the event.  The default protos are available via the ```Microsoft.AutoGen.Contracts;``` namespace and are defined in [autogen/protos](../../../../protos). The EventTypes are registered in the agent's constructor using the ```IHandle``` interface.
 
 ```csharp
 TopicSubscription("HelloAgents")]
@@ -117,4 +117,4 @@ message ReadmeRequested {
   </ItemGroup>
 ```
 
-You can send messages using the [```Microsoft.AutoGen.Agents.AgentWorker``` class](autogen/dotnet/src/Microsoft.AutoGen/Agents/AgentWorker.cs). Messages are wrapped in [the CloudEvents specification](https://cloudevents.io) and sent to the event bus.
+You can send messages using the [```Microsoft.AutoGen.Agents.AgentWorker``` class](../../../src/Microsoft.AutoGen/Agents/). Messages are wrapped in [the CloudEvents specification](https://cloudevents.io) and sent to the event bus.

--- a/dotnet/samples/Hello/HelloAgentState/README.md
+++ b/dotnet/samples/Hello/HelloAgentState/README.md
@@ -38,7 +38,7 @@ graph LR;
 
 The heart of an autogen application are the event handlers. Agents select a ```TopicSubscription``` to listen for events on a specific topic. When an event is received, the agent's event handler is called with the event data.
 
-Within that event handler you may optionally *emit* new events, which are then sent to the event bus for other agents to process. The EventTypes are declared gRPC ProtoBuf messages that are used to define the schema of the event.  The default protos are available via the ```Microsoft.AutoGen.Contracts;``` namespace and are defined in [autogen/protos](/autogen/protos). The EventTypes are registered in the agent's constructor using the ```IHandle``` interface.
+Within that event handler you may optionally *emit* new events, which are then sent to the event bus for other agents to process. The EventTypes are declared gRPC ProtoBuf messages that are used to define the schema of the event.  The default protos are available via the ```Microsoft.AutoGen.Contracts;``` namespace and are defined in [autogen/protos](../../../../protos). The EventTypes are registered in the agent's constructor using the ```IHandle``` interface.
 
 ```csharp
 TopicSubscription("HelloAgents")]
@@ -117,7 +117,7 @@ message ReadmeRequested {
   </ItemGroup>
 ```
 
-You can send messages using the [```Microsoft.AutoGen.Agents.AgentWorker``` class](autogen/dotnet/src/Microsoft.AutoGen/Agents/AgentWorker.cs). Messages are wrapped in [the CloudEvents specification](https://cloudevents.io) and sent to the event bus.
+You can send messages using the [```Microsoft.AutoGen.Agents.AgentWorker``` class](../../../src/Microsoft.AutoGen/Agents/). Messages are wrapped in [the CloudEvents specification](https://cloudevents.io) and sent to the event bus.
 
 ### Managing State
 

--- a/dotnet/samples/Hello/README.md
+++ b/dotnet/samples/Hello/README.md
@@ -7,4 +7,4 @@ cd Hello.AppHost
 dotnet run
 ```
 
-For more info see the HelloAgent [README](../HelloAgent/README.md).
+For more info see the HelloAgent [README](./HelloAgent/README.md).

--- a/dotnet/src/AutoGen.SourceGenerator/README.md
+++ b/dotnet/src/AutoGen.SourceGenerator/README.md
@@ -109,5 +109,5 @@ Add two numbers.
 ```
 
 For more examples, please check out the following project
-- [AutoGen.Basic.Sample](../samples/AgentChat/Autogen.Basic.Sample/)
+- [AutoGen.Basic.Sample](../../samples/AgentChat/AutoGen.Basic.Sample/)
 - [AutoGen.SourceGenerator.Tests](../../test/AutoGen.SourceGenerator.Tests/)

--- a/dotnet/src/Microsoft.AutoGen/readme.md
+++ b/dotnet/src/Microsoft.AutoGen/readme.md
@@ -1,3 +1,3 @@
 # Microsoft.AutoGen
 
-- [Getting started sample](../../samples/getting-started/)
+- [Getting started sample](../../samples/GettingStarted/)

--- a/dotnet/test/Microsoft.AutoGen.Integration.Tests.AppHosts/HelloAgentTests/README.md
+++ b/dotnet/test/Microsoft.AutoGen.Integration.Tests.AppHosts/HelloAgentTests/README.md
@@ -38,7 +38,7 @@ graph LR;
 
 The heart of an autogen application are the event handlers. Agents select a ```TopicSubscription``` to listen for events on a specific topic. When an event is received, the agent's event handler is called with the event data.
 
-Within that event handler you may optionally *emit* new events, which are then sent to the event bus for other agents to process. The EventTypes are declared gRPC ProtoBuf messages that are used to define the schema of the event.  The default protos are available via the ```Microsoft.AutoGen.Contracts;``` namespace and are defined in [autogen/protos](/autogen/protos). The EventTypes are registered in the agent's constructor using the ```IHandle``` interface.
+Within that event handler you may optionally *emit* new events, which are then sent to the event bus for other agents to process. The EventTypes are declared gRPC ProtoBuf messages that are used to define the schema of the event.  The default protos are available via the ```Microsoft.AutoGen.Contracts;``` namespace and are defined in [autogen/protos](../../../../protos). The EventTypes are registered in the agent's constructor using the ```IHandle``` interface.
 
 ```csharp
 TopicSubscription("HelloAgents")]
@@ -117,4 +117,4 @@ message ReadmeRequested {
   </ItemGroup>
 ```
 
-You can send messages using the [```Microsoft.AutoGen.Agents.AgentWorker``` class](autogen/dotnet/src/Microsoft.AutoGen/Agents/AgentWorker.cs). Messages are wrapped in [the CloudEvents specification](https://cloudevents.io) and sent to the event bus.
+You can send messages using the [```Microsoft.AutoGen.Agents.AgentWorker``` class](../../../src/Microsoft.AutoGen/Agents/). Messages are wrapped in [the CloudEvents specification](https://cloudevents.io) and sent to the event bus.

--- a/dotnet/website/articles/Agent-overview.md
+++ b/dotnet/website/articles/Agent-overview.md
@@ -16,16 +16,16 @@ To chat with an agent, typically you can invoke @AutoGen.Core.IAgent.GenerateRep
 > AutoGen provides a list of built-in message types like @AutoGen.Core.TextMessage, @AutoGen.Core.ImageMessage, @AutoGen.Core.MultiModalMessage, @AutoGen.Core.ToolCallMessage, @AutoGen.Core.ToolCallResultMessage, etc. You can use these message types to chat with an agent. For further details, see [built-in messages](./Built-in-messages.md).
 
 - Send a @AutoGen.Core.TextMessage to an agent via @AutoGen.Core.IAgent.GenerateReplyAsync*:
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/AgentCodeSnippet.cs?name=ChatWithAnAgent_GenerateReplyAsync)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/AgentCodeSnippet.cs?name=ChatWithAnAgent_GenerateReplyAsync)]
 
 - Send a message to an agent via @AutoGen.Core.AgentExtension.SendAsync*:
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/AgentCodeSnippet.cs?name=ChatWithAnAgent_SendAsync)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/AgentCodeSnippet.cs?name=ChatWithAnAgent_SendAsync)]
 
 ## Streaming chat
 If an agent implements @AutoGen.Core.IStreamingAgent, you can use @AutoGen.Core.IStreamingAgent.GenerateStreamingReplyAsync* to chat with the agent in a streaming way. You would need to process the streaming updates on your side though.
 
 - Send a @AutoGen.Core.TextMessage to an agent via @AutoGen.Core.IStreamingAgent.GenerateStreamingReplyAsync*, and print the streaming updates to console:
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/AgentCodeSnippet.cs?name=ChatWithAnAgent_GenerateStreamingReplyAsync)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/AgentCodeSnippet.cs?name=ChatWithAnAgent_GenerateStreamingReplyAsync)]
 
 ## Register middleware to an agent
 @AutoGen.Core.IMiddleware and @AutoGen.Core.IStreamingMiddleware are used to extend the behavior of @AutoGen.Core.IAgent.GenerateReplyAsync* and @AutoGen.Core.IStreamingAgent.GenerateStreamingReplyAsync*. You can register middleware to an agent to customize the behavior of the agent on things like function call support, converting message of different types, print message, gather user input, etc.

--- a/dotnet/website/articles/AutoGen-Mistral-Overview.md
+++ b/dotnet/website/articles/AutoGen-Mistral-Overview.md
@@ -17,10 +17,10 @@ dotnet add package AutoGen.Mistral
 ### Example
 
 Import the required namespace
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=using_statement)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=using_statement)]
 
 Create a @AutoGen.Mistral.MistralClientAgent and start chatting!
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=create_mistral_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=create_mistral_agent)]
 
 Use @AutoGen.Core.IStreamingAgent.GenerateStreamingReplyAsync* to stream the chat completion.
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=streaming_chat)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=streaming_chat)]

--- a/dotnet/website/articles/AutoGen.Gemini/Chat-with-google-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Chat-with-google-gemini.md
@@ -20,12 +20,12 @@ dotnet add package AutoGen.Gemini
 
 ### Step 2: Add using statement
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs?name=Using)]
 
 ### Step 3: Create a Gemini agent
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs?name=Create_Gemini_Agent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs?name=Create_Gemini_Agent)]
 
 ### Step 4: Chat with Gemini
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs?name=Chat_With_Google_Gemini)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Google_Gemini.cs?name=Chat_With_Google_Gemini)]

--- a/dotnet/website/articles/AutoGen.Gemini/Chat-with-vertex-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Chat-with-vertex-gemini.md
@@ -20,13 +20,13 @@ dotnet add package AutoGen.Gemini
 
 ### Step 2: Add using statement
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Chat_With_Vertex_Gemini.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Vertex_Gemini.cs?name=Using)]
 
 ### Step 3: Create a Gemini agent
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Chat_With_Vertex_Gemini.cs?name=Create_Gemini_Agent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Vertex_Gemini.cs?name=Create_Gemini_Agent)]
 
 
 ### Step 4: Chat with Gemini
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Chat_With_Vertex_Gemini.cs?name=Chat_With_Vertex_Gemini)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Chat_With_Vertex_Gemini.cs?name=Chat_With_Vertex_Gemini)]

--- a/dotnet/website/articles/AutoGen.Gemini/Function-call-with-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Function-call-with-gemini.md
@@ -18,21 +18,21 @@ dotnet add package AutoGen.SourceGenerator
 The AutoGen.SourceGenerator package is required to generate the @AutoGen.Core.FunctionContract. For more information, please refer to [Create-type-safe-function-call](../Create-type-safe-function-call.md)
 
 ### Step 2: Add using statement
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=Using)]
 
 ### Step 3: Create `MovieFunction`
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=MovieFunction)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=MovieFunction)]
 
 ### Step 4: Create a Gemini agent
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=Create_Gemini_Agent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=Create_Gemini_Agent)]
 
 ### Step 5: Single turn function call
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=Single_turn)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=Single_turn)]
 
 ### Step 6: Multi-turn function call
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Function_call_with_gemini.cs?name=Multi_turn)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Function_Call_With_Gemini.cs?name=Multi_turn)]
 

--- a/dotnet/website/articles/AutoGen.Gemini/Image-chat-with-gemini.md
+++ b/dotnet/website/articles/AutoGen.Gemini/Image-chat-with-gemini.md
@@ -15,11 +15,11 @@ dotnet add package AutoGen.Gemini
 ```
 
 ### Step 2: Add using statement
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Image_Chat_With_Vertex_Gemini.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Image_Chat_With_Vertex_Gemini.cs?name=Using)]
 
 ### Step 3: Create a Gemini agent
 
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Image_Chat_With_Vertex_Gemini.cs?name=Create_Gemini_Agent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Image_Chat_With_Vertex_Gemini.cs?name=Create_Gemini_Agent)]
 
 ### Step 4: Send image to Gemini
-[!code-csharp[](../../../samples/AutoGen.Gemini.Sample/Image_Chat_With_Vertex_Gemini.cs?name=Send_Image_Request)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Gemini.Sample/Image_Chat_With_Vertex_Gemini.cs?name=Send_Image_Request)]

--- a/dotnet/website/articles/AutoGen.Ollama/Chat-with-llama.md
+++ b/dotnet/website/articles/AutoGen.Ollama/Chat-with-llama.md
@@ -17,11 +17,11 @@ For how to install from nightly build, please refer to [Installation](../Install
 
 ### Step 2: Add using statement
 
-[!code-csharp[](../../../samples/AutoGen.Ollama.Sample/Chat_With_LLaMA.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaMA.cs?name=Using)]
 
 ### Step 3: Create and chat @AutoGen.Ollama.OllamaAgent
 
 In this step, we create an @AutoGen.Ollama.OllamaAgent and connect it to the Ollama server.
 
-[!code-csharp[](../../../samples/AutoGen.Ollama.Sample/Chat_With_LLaMA.cs?name=Create_Ollama_Agent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaMA.cs?name=Create_Ollama_Agent)]
 

--- a/dotnet/website/articles/AutoGen.Ollama/Chat-with-llava.md
+++ b/dotnet/website/articles/AutoGen.Ollama/Chat-with-llava.md
@@ -17,13 +17,13 @@ For how to install from nightly build, please refer to [Installation](../Install
 
 ### Step 2: Add using statement
 
-[!code-csharp[](../../../samples/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs?name=Using)]
 
 ### Step 3: Create @AutoGen.Ollama.OllamaAgent
 
-[!code-csharp[](../../../samples/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs?name=Create_Ollama_Agent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs?name=Create_Ollama_Agent)]
 
 ### Step 4: Start MultiModal Chat
 LLaVA is a multimodal model that supports both text and image inputs. In this step, we create an image message along with a question about the image.
 
-[!code-csharp[](../../../samples/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs?name=Send_Message)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Ollama.Sample/Chat_With_LLaVA.cs?name=Send_Message)]

--- a/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelAgent-simple-chat.md
+++ b/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelAgent-simple-chat.md
@@ -2,8 +2,8 @@ You can chat with @AutoGen.SemanticKernel.SemanticKernelAgent using both streami
 
 The following example shows how to create an @AutoGen.SemanticKernel.SemanticKernelAgent and chat with it using non-streaming method:
 
-[!code-csharp[](../../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/SemanticKernelCodeSnippet.cs?name=create_semantic_kernel_agent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/SemanticKernelCodeSnippet.cs?name=create_semantic_kernel_agent)]
 
 @AutoGen.SemanticKernel.SemanticKernelAgent also supports streaming chat via @AutoGen.Core.IStreamingAgent.GenerateStreamingReplyAsync*.
 
-[!code-csharp[](../../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/SemanticKernelCodeSnippet.cs?name=create_semantic_kernel_agent_streaming)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/SemanticKernelCodeSnippet.cs?name=create_semantic_kernel_agent_streaming)]

--- a/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelAgent-support-more-messages.md
+++ b/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelAgent-support-more-messages.md
@@ -7,4 +7,4 @@
 >
 > Function call message type like @AutoGen.Core.ToolCallMessage and @AutoGen.Core.ToolCallResultMessage are not supported yet.
 
-[!code-csharp[](../../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/SemanticKernelCodeSnippet.cs?name=register_semantic_kernel_chat_message_content_connector)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/SemanticKernelCodeSnippet.cs?name=register_semantic_kernel_chat_message_content_connector)]

--- a/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelChatAgent-simple-chat.md
+++ b/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelChatAgent-simple-chat.md
@@ -6,17 +6,17 @@ The following step-by-step example shows how to create an @AutoGen.SemanticKerne
 > You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs).
 
 ### Step 1: add using statement
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Using)]
 
 ### Step 2: create kernel
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Create_Kernel)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Create_Kernel)]
 
 ### Step 3: create ChatCompletionAgent
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Create_ChatCompletionAgent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Create_ChatCompletionAgent)]
 
 ### Step 4: create @AutoGen.SemanticKernel.SemanticKernelChatCompletionAgent
 In this step, we create an @AutoGen.SemanticKernel.SemanticKernelChatCompletionAgent and register it with @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector. The @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector will convert the message from AutoGen built-in message types to `ChatMessageContent` and vice versa.
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Create_SemanticKernelChatCompletionAgent)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Create_SemanticKernelChatCompletionAgent)]
 
 ### Step 5: chat with @AutoGen.SemanticKernel.SemanticKernelChatCompletionAgent
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Send_Message)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Create_Semantic_Kernel_Chat_Agent.cs?name=Send_Message)]

--- a/dotnet/website/articles/AutoGen.SemanticKernel/Use-kernel-plugin-in-other-agents.md
+++ b/dotnet/website/articles/AutoGen.SemanticKernel/Use-kernel-plugin-in-other-agents.md
@@ -6,22 +6,22 @@ In semantic kernel, a kernel plugin is a collection of kernel functions that can
 > You can find the complete sample code [here](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs)
 
 ### Step 1: add using statement
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Using)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Using)]
 
 ### Step 2: create plugin
 
 In this step, we create a simple plugin with a single `GetWeather` function that takes a location as input and returns the weather information for that location.
 
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Create_plugin)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Create_plugin)]
 
 ### Step 3: create OpenAIChatAgent and use the plugin
 
 In this step, we firstly create a @AutoGen.SemanticKernel.KernelPluginMiddleware and register the previous plugin with it. The `KernelPluginMiddleware` will load the plugin and make the functions available for use in other agents. Followed by creating an @AutoGen.OpenAI.OpenAIChatAgent and register it with the `KernelPluginMiddleware`.
 
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Use_plugin)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Use_plugin)]
 
 ### Step 4: chat with OpenAIChatAgent
 
 In this final step, we start the chat with the @AutoGen.OpenAI.OpenAIChatAgent by asking the weather in Seattle. The `OpenAIChatAgent` will use the `GetWeather` function from the plugin to get the weather information for Seattle.
 
-[!code-csharp[](../../../samples/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Send_message)]
+[!code-csharp[](../../../samples/AgentChat/AutoGen.SemanticKernel.Sample/Use_Kernel_Functions_With_Other_Agent.cs?name=Send_message)]

--- a/dotnet/website/articles/Built-in-messages.md
+++ b/dotnet/website/articles/Built-in-messages.md
@@ -30,8 +30,8 @@ AutoGen also introduces @AutoGen.Core.IStreamingMessage and @AutoGen.Core.IStrea
 #### Usage
 
 The below code snippet shows how to print a streaming update to console and update the final result on the caller side.
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/BuildInMessageCodeSnippet.cs?name=StreamingCallCodeSnippet)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/BuildInMessageCodeSnippet.cs?name=StreamingCallCodeSnippet)]
 
 If the agent returns a final result instead of the last update as the last message in the streaming call method, the caller can directly use the final result without assembling the final result from multiple updates.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/BuildInMessageCodeSnippet.cs?name=StreamingCallWithFinalMessage)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/BuildInMessageCodeSnippet.cs?name=StreamingCallWithFinalMessage)]

--- a/dotnet/website/articles/Consume-LLM-server-from-LM-Studio.md
+++ b/dotnet/website/articles/Consume-LLM-server-from-LM-Studio.md
@@ -16,5 +16,5 @@ You can use @AutoGen.LMStudio.LMStudioAgent from `AutoGen.LMStudio` package to c
 ### Usage
 The following code shows how to use `LMStudioAgent` to write a piece of C# code to calculate 100th of fibonacci. Before running the code, make sure you have local server from LM Studio running on `localhost:1234`.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example08_LMStudio.cs?name=lmstudio_using_statements)]
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example08_LMStudio.cs?name=lmstudio_example_1)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example08_LMStudio.cs?name=lmstudio_using_statements)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example08_LMStudio.cs?name=lmstudio_example_1)]

--- a/dotnet/website/articles/Create-a-user-proxy-agent.md
+++ b/dotnet/website/articles/Create-a-user-proxy-agent.md
@@ -10,7 +10,7 @@
 
 ### Create a `UserProxyAgent` with `HumanInputMode` set to `ALWAYS`
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/UserProxyAgentCodeSnippet.cs?name=code_snippet_1)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/UserProxyAgentCodeSnippet.cs?name=code_snippet_1)]
 
 When running the code, the user proxy agent will ask user for input and use the input as response.
 ![code output](../images/articles/CreateUserProxyAgent/image-1.png)

--- a/dotnet/website/articles/Create-an-agent.md
+++ b/dotnet/website/articles/Create-an-agent.md
@@ -4,8 +4,8 @@
 
 ## Create an `AssistantAgent` using OpenAI model.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/CreateAnAgent.cs?name=code_snippet_1)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/CreateAnAgent.cs?name=code_snippet_1)]
 
 ## Create an `AssistantAgent` using Azure OpenAI model.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/CreateAnAgent.cs?name=code_snippet_2)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/CreateAnAgent.cs?name=code_snippet_2)]

--- a/dotnet/website/articles/Create-type-safe-function-call.md
+++ b/dotnet/website/articles/Create-type-safe-function-call.md
@@ -25,11 +25,11 @@ Then, create a `public partial` class to host the methods you want to use in Aut
 
 Firstly, import the required namespaces:
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report_using_statement)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report_using_statement)]
 
 Then, create a `WeatherReport` function and mark it with @AutoGen.Core.FunctionAttribute:
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report)]
 
 The source generator will generate the @AutoGen.Core.FunctionContract and function call wrapper for `WeatherReport` in another partial class based on its signature and structural comments. The @AutoGen.Core.FunctionContract is introduced by [#1736](https://github.com/microsoft/autogen/pull/1736) and contains all the necessary metadata such as function name, parameters, and return type. It is LLM independent and can be used to generate openai function definition or semantic kernel function. The function call wrapper is a helper class that provides a type-safe way to call the function.
 
@@ -38,4 +38,4 @@ The source generator will generate the @AutoGen.Core.FunctionContract and functi
 
 The following code shows how to generate openai function definition from the @AutoGen.Core.FunctionContract and call the function using the function call wrapper.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report_consume)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report_consume)]

--- a/dotnet/website/articles/Function-call-with-ollama-and-litellm.md
+++ b/dotnet/website/articles/Function-call-with-ollama-and-litellm.md
@@ -64,16 +64,16 @@ And in your project file, enable structural xml document support by setting the 
 
 Create a `public partial` class to host the methods you want to use in AutoGen agents. The method has to be a `public` instance method and its return type must be `Task<string>`. After the methods are defined, mark them with `AutoGen.Core.FunctionAttribute` attribute.
 
-[!code-csharp[Define WeatherReport function](../../samples/AutoGen.OpenAI.Sample/Tool_Call_With_Ollama_And_LiteLLM.cs?name=Function)]
+[!code-csharp[Define WeatherReport function](../../samples/AgentChat/AutoGen.OpenAI.Sample/Tool_Call_With_Ollama_And_LiteLLM.cs?name=Function)]
 
 Then create a @AutoGen.Core.FunctionCallMiddleware and add the `WeatherReport` function to the middleware. The middleware will pass the `FunctionContract` to the agent when generating a response, and process the tool call response when receiving a `ToolCallMessage`.
-[!code-csharp[Define WeatherReport function](../../samples/AutoGen.OpenAI.Sample/Tool_Call_With_Ollama_And_LiteLLM.cs?name=Create_tools)]
+[!code-csharp[Define WeatherReport function](../../samples/AgentChat/AutoGen.OpenAI.Sample/Tool_Call_With_Ollama_And_LiteLLM.cs?name=Create_tools)]
 
 ## Create @AutoGen.OpenAI.OpenAIChatAgent with `GetWeatherReport` tool and chat with it
 
 Because LiteLLM proxy server is openai-api compatible, we can use @AutoGen.OpenAI.OpenAIChatAgent to connect to it as a third-party openai-api provider. The agent is also registered with a @AutoGen.Core.FunctionCallMiddleware which contains the `WeatherReport` tool. Therefore, the agent can call the `WeatherReport` tool when generating a response.
 
-[!code-csharp[Create an agent with tools](../../samples/AutoGen.OpenAI.Sample/Tool_Call_With_Ollama_And_LiteLLM.cs?name=Create_Agent)]
+[!code-csharp[Create an agent with tools](../../samples/AgentChat/AutoGen.OpenAI.Sample/Tool_Call_With_Ollama_And_LiteLLM.cs?name=Create_Agent)]
 
 The reply from the agent will similar to the following:
 ```bash

--- a/dotnet/website/articles/Group-chat.md
+++ b/dotnet/website/articles/Group-chat.md
@@ -33,7 +33,7 @@ flowchart LR
 
 The code below shows how to create a dynamic group chat with @AutoGen.Core.GroupChat. In this example, we will create a dynamic group chat with 4 agents: `admin`, `coder`, `reviewer` and `runner`. In this case we don't pass a workflow to the group chat, so the group chat will use driven by the admin agent.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_group_chat)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_group_chat)]
 
 > [!TIP]
 > You can set up initial context for the group chat using @AutoGen.Core.GroupChatExtension.SendIntroduction*. The initial context can help group admin orchestrates the conversation flow.
@@ -48,26 +48,26 @@ Output:
 
 The code below shows how to create `admin` agent. `admin` agent will create a task for group to work on and terminate the conversation when task is completed.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_admin)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_admin)]
 
 - Create coder agent
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_coder)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_coder)]
 
 - Create reviewer agent
 
 The code below shows how to create `reviewer` agent. `reviewer` agent is a dotnet code reviewer who can review code written by `coder`. In this example, a `function` is used to examine if the code written by `coder` follows the condition.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=reviewer_function)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=reviewer_function)]
 
 > [!TIP]
 > You can use @AutoGen.Core.FunctionAttribute to generate type-safe function definition and function call wrapper for the function. For more information, please check out [Create type safe function call](./Create-type-safe-function-call.md).
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_reviewer)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_reviewer)]
 
 - Create runner agent
 
 > [!TIP]
 > `AutoGen` provides a built-in support for running code snippet. For more information, please check out [Execute code snippet](./Run-dotnet-code.md).
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_runner)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_runner)]

--- a/dotnet/website/articles/Middleware-overview.md
+++ b/dotnet/website/articles/Middleware-overview.md
@@ -8,15 +8,15 @@ Here are a few examples of how middleware is used in AutoGen.Net:
 To use middleware in an existing agent, you can either create a @AutoGen.Core.MiddlewareAgent on top of the original agent or register middleware functions to the original agent.
 
 ### Create @AutoGen.Core.MiddlewareAgent on top of the original agent
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MiddlewareAgentCodeSnippet.cs?name=create_middleware_agent_with_original_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MiddlewareAgentCodeSnippet.cs?name=create_middleware_agent_with_original_agent)]
 
 ### Register middleware functions to the original agent
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MiddlewareAgentCodeSnippet.cs?name=register_middleware_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MiddlewareAgentCodeSnippet.cs?name=register_middleware_agent)]
 
 ## Short-circuit the next agent
 The example below shows how to short-circuit the inner agent
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MiddlewareAgentCodeSnippet.cs?name=short_circuit_middleware_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MiddlewareAgentCodeSnippet.cs?name=short_circuit_middleware_agent)]
 
 > [!Note]
 > When multiple middleware functions are registered, the order of middleware functions is first registered, last invoked.
@@ -24,4 +24,4 @@ The example below shows how to short-circuit the inner agent
 ## Streaming middleware
 You can also modify the behavior of @AutoGen.Core.IStreamingAgent.GenerateStreamingReplyAsync* by registering streaming middleware to it. One example is @AutoGen.OpenAI.OpenAIChatRequestMessageConnector which converts `StreamingChatCompletionsUpdate` to one of `AutoGen.Core.TextMessageUpdate` or `AutoGen.Core.ToolCallMessageUpdate`.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MiddlewareAgentCodeSnippet.cs?name=register_streaming_middleware)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MiddlewareAgentCodeSnippet.cs?name=register_streaming_middleware)]

--- a/dotnet/website/articles/MistralChatAgent-count-token-usage.md
+++ b/dotnet/website/articles/MistralChatAgent-count-token-usage.md
@@ -4,22 +4,22 @@ The following example shows how to create a `MistralAITokenCounterMiddleware` @A
 To collect the token usage for the entire chat session, one easy solution is simply collect all the responses from agent and sum up the token usage for each response. To collect all the agent responses, we can create a middleware which simply saves all responses to a list and register it with the agent. To get the token usage information for each response, because in the example we are using @AutoGen.Mistral.MistralClientAgent, we can simply get the token usage from the response object.
 
 > [!NOTE]
-> You can find the complete example in the [Example13_OpenAIAgent_JsonMode](https://github.com/microsoft/autogen/tree/main/dotnet/samples/AgentChat/Autogen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs).
+> You can find the complete example in the [Example13_OpenAIAgent_JsonMode](https://github.com/microsoft/autogen/tree/main/dotnet/samples/AgentChat/AutoGen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs).
 
 - Step 1: Adding using statement
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=using_statements)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=using_statements)]
 
 - Step 2: Create a `MistralAITokenCounterMiddleware` class which implements @AutoGen.Core.IMiddleware. This middleware will collect all the responses from the agent and sum up the token usage for each response.
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=token_counter_middleware)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=token_counter_middleware)]
 
 - Step 3: Create a `MistralClientAgent`
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=create_mistral_client_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=create_mistral_client_agent)]
 
 - Step 4: Register the `MistralAITokenCounterMiddleware` with the `MistralClientAgent`. Note that the order of each middlewares matters. The token counter middleware needs to be registered before `mistralMessageConnector` because it collects response only when the responding message type is `IMessage<ChatCompletionResponse>` while the `mistralMessageConnector` will convert `IMessage<ChatCompletionResponse>` to one of @AutoGen.Core.TextMessage, @AutoGen.Core.ToolCallMessage or @AutoGen.Core.ToolCallResultMessage.
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=register_middleware)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=register_middleware)]
 
 - Step 5: Chat with the `MistralClientAgent` and get the token usage information from the response object.
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=chat_with_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example14_MistralClientAgent_TokenCount.cs?name=chat_with_agent)]
 
 ### Output
 When running the example, the completion token count will be printed to the console.

--- a/dotnet/website/articles/MistralChatAgent-use-function-call.md
+++ b/dotnet/website/articles/MistralChatAgent-use-function-call.md
@@ -18,24 +18,24 @@ dotnet add package AutoGen.SourceGenerator
 > If you are using VSCode as your editor, you may need to restart the editor to see the generated code.
 
 Import the required namespace
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=using_statement)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=using_statement)]
 
 Then define a public partial `MistralAgentFunction` class and `GetWeather` method. The `GetWeather` method is a simple function that returns the weather of a given location that marked with @AutoGen.Core.FunctionAttribute. Marking the class as `public partial` together with the @AutoGen.Core.FunctionAttribute attribute allows the source generator to generate the @AutoGen.Core.FunctionContract for the `GetWeather` method.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=weather_function)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=weather_function)]
 
 Then create an @AutoGen.Mistral.MistralClientAgent and register it with @AutoGen.Mistral.Extension.MistralAgentExtension.RegisterMessageConnector* so it can support @AutoGen.Core.ToolCallMessage and @AutoGen.Core.ToolCallResultMessage. These message types are necessary to use @AutoGen.Core.FunctionCallMiddleware, which provides support for processing and invoking function calls.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=create_mistral_function_call_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=create_mistral_function_call_agent)]
 
 Then create an @AutoGen.Core.FunctionCallMiddleware with `GetWeather` function When creating the middleware, we also pass a `functionMap` object which means the function will be automatically invoked when the agent replies a `GetWeather` function call.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=create_get_weather_function_call_middleware)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=create_get_weather_function_call_middleware)]
 
 After the function call middleware is created, register it with the agent so the `GetWeather` function will be passed to agent during chat completion.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=register_function_call_middleware)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=register_function_call_middleware)]
 
 Finally, you can chat with the @AutoGen.Mistral.MistralClientAgent about weather! The agent will automatically invoke the `GetWeather` function to "get" the weather information and return the result.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=send_message_with_function_call)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/MistralAICodeSnippet.cs?name=send_message_with_function_call)]

--- a/dotnet/website/articles/OpenAIChatAgent-connect-to-third-party-api.md
+++ b/dotnet/website/articles/OpenAIChatAgent-connect-to-third-party-api.md
@@ -24,24 +24,24 @@ ollama serve
 
 ## Steps
 - Import the required namespaces:
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=using_statement)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=using_statement)]
 
 - Create a `CustomHttpClientHandler` class.
 
 The `CustomHttpClientHandler` class is used to customize the HttpClientHandler. In this example, we override the `SendAsync` method to redirect the request to local Ollama server, which is running on `http://localhost:11434`.
 
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=CustomHttpClientHandler)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=CustomHttpClientHandler)]
 
 - Create an `OpenAIChatAgent` instance and connect to the third-party API.
 
 Then create an @AutoGen.OpenAI.OpenAIChatAgent instance and connect to the OpenAI API from Ollama. You can customize the transport behavior of `OpenAIClient` by passing a customized `HttpClientTransport` instance. In the customized `HttpClientTransport` instance, we pass the `CustomHttpClientHandler` we just created which redirects all openai chat requests to the local Ollama server.
 
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=create_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=create_agent)]
 
 - Chat with the `OpenAIChatAgent`.
 Finally, you can start chatting with the agent. In this example, we send a coding question to the agent and get the response.
 
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=send_message)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Connect_To_Ollama.cs?name=send_message)]
 
 ## Sample Output
 The following is the sample output of the code snippet above:

--- a/dotnet/website/articles/OpenAIChatAgent-simple-chat.md
+++ b/dotnet/website/articles/OpenAIChatAgent-simple-chat.md
@@ -1,11 +1,11 @@
 The following example shows how to create an @AutoGen.OpenAI.OpenAIChatAgent and chat with it.
 
 Firsly, import the required namespaces:
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
 
 Then, create an @AutoGen.OpenAI.OpenAIChatAgent and chat with it:
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=create_openai_chat_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=create_openai_chat_agent)]
 
 @AutoGen.OpenAI.OpenAIChatAgent also supports streaming chat via @AutoGen.Core.IAgent.GenerateStreamingReplyAsync*.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=create_openai_chat_agent_streaming)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=create_openai_chat_agent_streaming)]

--- a/dotnet/website/articles/OpenAIChatAgent-support-more-messages.md
+++ b/dotnet/website/articles/OpenAIChatAgent-support-more-messages.md
@@ -1,6 +1,6 @@
 By default, @AutoGen.OpenAI.OpenAIChatAgent only supports the @AutoGen.Core.IMessage<T> type where `T` is original request or response message from `Azure.AI.OpenAI`. To support more AutoGen built-in message types like @AutoGen.Core.TextMessage, @AutoGen.Core.ImageMessage, @AutoGen.Core.MultiModalMessage and so on, you can register the agent with @AutoGen.OpenAI.OpenAIChatRequestMessageConnector. The @AutoGen.OpenAI.OpenAIChatRequestMessageConnector will convert the message from AutoGen built-in message types to `Azure.AI.OpenAI.ChatRequestMessage` and vice versa.
 
 import the required namespaces:
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=register_openai_chat_message_connector)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=register_openai_chat_message_connector)]

--- a/dotnet/website/articles/OpenAIChatAgent-use-function-call.md
+++ b/dotnet/website/articles/OpenAIChatAgent-use-function-call.md
@@ -15,19 +15,19 @@ Firstly, you need to install the following packages:
 > If you are using VSCode as your editor, you may need to restart the editor to see the generated code.
 
 Firstly, import the required namespaces:
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=using_statement)]
 
 Then, define a public partial class: `Function` with `GetWeather` method
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=weather_function)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=weather_function)]
 
 Then, create an @AutoGen.OpenAI.OpenAIChatAgent and register it with @AutoGen.OpenAI.OpenAIChatRequestMessageConnector so it can support @AutoGen.Core.ToolCallMessage and @AutoGen.Core.ToolCallResultMessage. These message types are necessary to use @AutoGen.Core.FunctionCallMiddleware, which provides support for processing and invoking function calls.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=openai_chat_agent_get_weather_function_call)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=openai_chat_agent_get_weather_function_call)]
 
 Then, create an @AutoGen.Core.FunctionCallMiddleware with `GetWeather` function and register it with the agent above. When creating the middleware, we also pass a `functionMap` to @AutoGen.Core.FunctionCallMiddleware, which means the function will be automatically invoked when the agent replies a `GetWeather` function call.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=create_function_call_middleware)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=create_function_call_middleware)]
 
 Finally, you can chat with the @AutoGen.OpenAI.OpenAIChatAgent and invoke the `GetWeather` function.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=chat_agent_send_function_call)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/OpenAICodeSnippet.cs?name=chat_agent_send_function_call)]

--- a/dotnet/website/articles/OpenAIChatAgent-use-json-mode.md
+++ b/dotnet/website/articles/OpenAIChatAgent-use-json-mode.md
@@ -12,15 +12,15 @@ JSON mode is a new feature in OpenAI which allows you to instruct model to alway
 
 To enable JSON mode for @AutoGen.OpenAI.OpenAIChatAgent, set `responseFormat` to `ChatCompletionsResponseFormat.JsonObject` when creating the agent. Note that when enabling JSON mode, you also need to instruct the agent to output JSON format in its system message.
 
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Use_Json_Mode.cs?name=create_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Use_Json_Mode.cs?name=create_agent)]
 
 After enabling JSON mode, the `openAIClientAgent` will always respond in JSON format when it receives a message.
 
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Use_Json_Mode.cs?name=chat_with_agent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Use_Json_Mode.cs?name=chat_with_agent)]
 
 When running the example, the output from `openAIClientAgent` will be a valid JSON object which can be parsed as `Person` class defined below. Note that in the output, the `address` field is missing because the address information is not provided in user input.
 
-[!code-csharp[](../../samples/AutoGen.OpenAI.Sample/Use_Json_Mode.cs?name=person_class)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.OpenAI.Sample/Use_Json_Mode.cs?name=person_class)]
 
 The output will be:
 ```bash

--- a/dotnet/website/articles/Print-message-middleware.md
+++ b/dotnet/website/articles/Print-message-middleware.md
@@ -13,7 +13,7 @@
 ## Use @AutoGen.Core.PrintMessageMiddleware in an agent
 You can use @AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintMessage* to register the @AutoGen.Core.PrintMessageMiddleware to an agent.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs?name=PrintMessageMiddleware)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs?name=PrintMessageMiddleware)]
 
 @AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintMessage* will format the message and print it to console
 ![image](../images/articles/PrintMessageMiddleware/printMessage.png)
@@ -22,6 +22,6 @@ You can use @AutoGen.Core.PrintMessageMiddlewareExtension.RegisterPrintMessage* 
 
 @AutoGen.Core.PrintMessageMiddleware also supports streaming message types like @AutoGen.Core.TextMessageUpdate and @AutoGen.Core.ToolCallMessageUpdate. If you register @AutoGen.Core.PrintMessageMiddleware to a @AutoGen.Core.IStreamingAgent, it will format the streaming message and print it to console if the message is of supported type.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs?name=print_message_streaming)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/PrintMessageMiddlewareCodeSnippet.cs?name=print_message_streaming)]
 
 ![image](../images/articles/PrintMessageMiddleware/streamingoutput.gif)

--- a/dotnet/website/articles/Roundrobin-chat.md
+++ b/dotnet/website/articles/Roundrobin-chat.md
@@ -14,19 +14,19 @@ flowchart LR
 
 Step 1: Add required using statements
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example11_Sequential_GroupChat_Example.cs?name=using_statement)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example11_Sequential_GroupChat_Example.cs?name=using_statement)]
 
 Step 2: Create a `bingSearch` agent using @AutoGen.SemanticKernel.SemanticKernelAgent
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example11_Sequential_GroupChat_Example.cs?name=CreateBingSearchAgent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example11_Sequential_GroupChat_Example.cs?name=CreateBingSearchAgent)]
 
 Step 3: Create a `summarization` agent using @AutoGen.SemanticKernel.SemanticKernelAgent
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example11_Sequential_GroupChat_Example.cs?name=CreateSummarizerAgent)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example11_Sequential_GroupChat_Example.cs?name=CreateSummarizerAgent)]
 
 Step 4: Create a @AutoGen.Core.RoundRobinGroupChat and add `bingSearch` and `summarization` agents to it
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example11_Sequential_GroupChat_Example.cs?name=Sequential_GroupChat_Example)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example11_Sequential_GroupChat_Example.cs?name=Sequential_GroupChat_Example)]
 
 Output:
 

--- a/dotnet/website/articles/Run-dotnet-code.md
+++ b/dotnet/website/articles/Run-dotnet-code.md
@@ -6,7 +6,7 @@ More languages will be supported in the future.
 ## What is a code snippet?
 A code snippet in agent response is a code block with a language identifier. For example:
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/RunCodeSnippetCodeSnippet.cs?name=code_snippet_1_3)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/RunCodeSnippetCodeSnippet.cs?name=code_snippet_1_3)]
 
 ## Why running code snippet is useful?
 The ability of running code snippet can greatly extend the ability of an agent. Because it enables agent to resolve tasks by writing code and run it, which is much more powerful than just returning a text response.
@@ -24,10 +24,10 @@ The built-in feature of running dotnet code snippet is provided by [dotnet-inter
 ```
 
 Then you can use @AutoGen.DotnetInteractive.DotnetInteractiveKernelBuilder* to create a in-process dotnet-interactive composite kernel with C# and F# kernels.
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/RunCodeSnippetCodeSnippet.cs?name=code_snippet_1_1)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/RunCodeSnippetCodeSnippet.cs?name=code_snippet_1_1)]
 
 After that, use @AutoGen.DotnetInteractive.Extension.RunSubmitCodeCommandAsync* method to run code snippet. The method will return the result of the code snippet.
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/RunCodeSnippetCodeSnippet.cs?name=code_snippet_1_2)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/RunCodeSnippetCodeSnippet.cs?name=code_snippet_1_2)]
 
 ## Run python code snippet
 To run python code, firstly you need to have python installed on your machine, then you need to set up ipykernel and jupyter in your environment.
@@ -53,7 +53,7 @@ Available kernels:
 
 Then you can add the python kernel to the dotnet-interactive composite kernel by calling `AddPythonKernel` method.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/RunCodeSnippetCodeSnippet.cs?name=code_snippet_1_4)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/RunCodeSnippetCodeSnippet.cs?name=code_snippet_1_4)]
 
 ## Further reading
 You can refer to the following examples for running code snippet in agentic workflow:

--- a/dotnet/website/articles/Two-agent-chat.md
+++ b/dotnet/website/articles/Two-agent-chat.md
@@ -16,4 +16,4 @@ The following example shows how to start a conversation between the teacher agen
 > [!NOTE]
 > The teacher agent uses @AutoGen.Core.MiddlewareExtension.RegisterPostProcess* to register a post process function which returns a hard-coded termination message when a certain condition is met. Comparing with putting the @AutoGen.Core.GroupChatExtension.TERMINATE keyword in the prompt, this approach is more robust especially when a weaker LLM model is used.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example02_TwoAgent_MathChat.cs?name=code_snippet_1)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example02_TwoAgent_MathChat.cs?name=code_snippet_1)]

--- a/dotnet/website/articles/Use-function-call.md
+++ b/dotnet/website/articles/Use-function-call.md
@@ -12,32 +12,32 @@ Typically, there are three ways to pass a function definition to an agent to ena
 In some agents like @AutoGen.AssistantAgent or @AutoGen.OpenAI.GPTAgent, you can pass function definitions when creating the agent
 
 Suppose the `TypeSafeFunctionCall` is defined in the following code snippet:
-[!code-csharp[TypeSafeFunctionCall](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report)]
+[!code-csharp[TypeSafeFunctionCall](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/TypeSafeFunctionCallCodeSnippet.cs?name=weather_report)]
 
 You can then pass the `WeatherReport` to the agent when creating it:
-[!code-csharp[assistant agent](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=code_snippet_4)]
+[!code-csharp[assistant agent](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=code_snippet_4)]
 
 ## Passing function definitions in @AutoGen.Core.GenerateReplyOptions when invoking an agent
 You can also pass function definitions in @AutoGen.Core.GenerateReplyOptions when invoking an agent. This is useful when you want to override the function definitions passed to the agent when creating it.
 
-[!code-csharp[assistant agent](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=overrider_function_contract)]
+[!code-csharp[assistant agent](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=overrider_function_contract)]
 
 ## Register an agent with @AutoGen.Core.FunctionCallMiddleware to process and invoke function calls
 You can also register an agent with @AutoGen.Core.FunctionCallMiddleware to process and invoke function calls. This is useful when you want to process and invoke function calls in a more flexible way.
 
-[!code-csharp[assistant agent](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=register_function_call_middleware)]
+[!code-csharp[assistant agent](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=register_function_call_middleware)]
 
 ## Invoke function call inside an agent
 To invoke a function instead of returning the function call object, you can pass its function call wrapper to the agent via `functionMap`.
 
 You can then pass the `WeatherReportWrapper` to the agent via `functionMap`:
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=code_snippet_6)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=code_snippet_6)]
 
 When a function call object is returned, the agent will invoke the function and uses the return value as response rather than returning the function call object.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=code_snippet_6_1)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=code_snippet_6_1)]
 
 ## Invoke function call by another agent
 You can also use another agent to invoke the function call from one agent. This is a useful pattern in two-agent chat, where one agent is used as a function proxy to invoke the function call from another agent. Once the function call is invoked, the result can be returned to the original agent for further processing.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=two_agent_weather_chat)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/FunctionCallCodeSnippet.cs?name=two_agent_weather_chat)]

--- a/dotnet/website/articles/Use-graph-in-group-chat.md
+++ b/dotnet/website/articles/Use-graph-in-group-chat.md
@@ -18,8 +18,8 @@ The following code shows how to create a graph that represents the diagram above
 > [!TIP]
 > @AutoGen.Core.Graph supports conditional transitions. To create a conditional transition, you can pass a lambda function to `canTransitionAsync` when creating a @AutoGen.Core.Transition. The lambda function should return a boolean value indicating if the transition can be taken.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_workflow)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_workflow)]
 
 Once the graph is created, you can pass it to the group chat. The group chat will then use the graph along with admin agent to orchestrate the conversation flow.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_group_chat_with_workflow)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/Example07_Dynamic_GroupChat_Calculate_Fibonacci.cs?name=create_group_chat_with_workflow)]

--- a/dotnet/website/articles/getting-start.md
+++ b/dotnet/website/articles/getting-start.md
@@ -13,8 +13,8 @@ dotnet add package AutoGen
 
 Then you can start with the following code snippet to create a conversable agent and chat with it.
 
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/GetStartCodeSnippet.cs?name=snippet_GetStartCodeSnippet)]
-[!code-csharp[](../../samples/AgentChat/Autogen.Basic.Sample/CodeSnippet/GetStartCodeSnippet.cs?name=code_snippet_1)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/GetStartCodeSnippet.cs?name=snippet_GetStartCodeSnippet)]
+[!code-csharp[](../../samples/AgentChat/AutoGen.Basic.Sample/CodeSnippet/GetStartCodeSnippet.cs?name=code_snippet_1)]
 
 ### Tutorial
 Getting started with AutoGen.Net by following the [tutorial](../tutorial/Chat-with-an-agent.md) series.

--- a/dotnet/website/tutorial/Chat-with-an-agent.md
+++ b/dotnet/website/tutorial/Chat-with-an-agent.md
@@ -11,7 +11,7 @@ This tutorial shows how to generate response using an @AutoGen.Core.IAgent by ta
 > - @AutoGen.Gemini.GeminiChatAgent
 
 > [!NOTE]
-> The complete code example can be found in [Chat_With_Agent.cs](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/Autogen.Basic.Sample/GettingStart/Chat_With_Agent.cs)
+> The complete code example can be found in [Chat_With_Agent.cs](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Chat_With_Agent.cs)
 
 ## Step 1: Install AutoGen
 
@@ -23,7 +23,7 @@ dotnet add package AutoGen
 
 ## Step 2: add Using Statements
 
-[!code-csharp[Using Statements](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Using)]
+[!code-csharp[Using Statements](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Using)]
 
 ## Step 3: Create an @AutoGen.OpenAI.OpenAIChatAgent
 
@@ -31,20 +31,20 @@ dotnet add package AutoGen
 > The @AutoGen.OpenAI.Extension.OpenAIAgentExtension.RegisterMessageConnector* method registers an @AutoGen.OpenAI.OpenAIChatRequestMessageConnector middleware which converts OpenAI message types to AutoGen message types. This step is necessary when you want to use AutoGen built-in message types like @AutoGen.Core.TextMessage, @AutoGen.Core.ImageMessage, etc.
 > For more information, see [Built-in-messages](../articles/Built-in-messages.md)
 
-[!code-csharp[Create an OpenAIChatAgent](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Create_Agent)]
+[!code-csharp[Create an OpenAIChatAgent](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Create_Agent)]
 
 ## Step 4: Generate Response
 To generate response, you can use one of the overloaded method of @AutoGen.Core.AgentExtension.SendAsync* method. The following code shows how to generate response with text message:
 
-[!code-csharp[Generate Response](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Chat_With_Agent)]
+[!code-csharp[Generate Response](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Chat_With_Agent)]
 
 To generate response with chat history, you can pass the chat history to the @AutoGen.Core.AgentExtension.SendAsync* method:
 
-[!code-csharp[Generate Response with Chat History](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Chat_With_History)]
+[!code-csharp[Generate Response with Chat History](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Chat_With_History)]
 
 To streamingly generate response, use @AutoGen.Core.IStreamingAgent.GenerateStreamingReplyAsync*
 
-[!code-csharp[Generate Streaming Response](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Streaming_Chat)]
+[!code-csharp[Generate Streaming Response](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Chat_With_Agent.cs?name=Streaming_Chat)]
 
 ## Further Reading
 - [Chat with google gemini](../articles/AutoGen.Gemini/Chat-with-google-gemini.md)

--- a/dotnet/website/tutorial/Create-agent-with-tools.md
+++ b/dotnet/website/tutorial/Create-agent-with-tools.md
@@ -14,7 +14,7 @@ Tools are pre-defined functions in user's project that agent can invoke. Agent c
 > This tutorial uses the latest `GPT-3.5-turbo` as example.
 
 > [!NOTE]
-> The complete code example can be found in [Use_Tools_With_Agent.cs](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs)
+> The complete code example can be found in [Use_Tools_With_Agent.cs](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs)
 
 ## Key Concepts
 - @AutoGen.Core.FunctionContract: The contract of a function that agent can invoke. It contains the function name, description, parameters schema, and return type.
@@ -45,21 +45,21 @@ Also, you might need to enable structural xml document support by setting `Gener
 
 ## Add Using Statements
 
-[!code-csharp[Using Statements](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Using)]
+[!code-csharp[Using Statements](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Using)]
 
 ## Create agent
 
 Create an @AutoGen.OpenAI.OpenAIChatAgent with `GPT-3.5-turbo` as the backend LLM model.
 
-[!code-csharp[Create an agent with tools](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Create_Agent)]
+[!code-csharp[Create an agent with tools](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Create_Agent)]
 
 ## Define `Tool` class and create tools
 Create a `public partial` class to host the tools you want to use in AutoGen agents. The method has to be a `public` instance method and its return type must be `Task<string>`. After the methods is defined, mark them with @AutoGen.Core.FunctionAttribute attribute.
 
 In the following example, we define a `GetWeather` tool that returns the weather information of a city.
 
-[!code-csharp[Define Tool class](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Tools)]
-[!code-csharp[Create tools](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Create_tools)]
+[!code-csharp[Define Tool class](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Tools)]
+[!code-csharp[Create tools](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Create_tools)]
 
 ## Tool call without auto-invoke
 In this case, when receiving a @AutoGen.Core.ToolCallMessage, the agent will not automatically invoke the tool. Instead, the agent will return the original message back to the user. The user can then decide whether to invoke the tool or not.
@@ -68,11 +68,11 @@ In this case, when receiving a @AutoGen.Core.ToolCallMessage, the agent will not
 
 To implement this, you can create the @AutoGen.Core.FunctionCallMiddleware without passing the `functionMap` parameter to the constructor so that the middleware will not automatically invoke the tool once it receives a @AutoGen.Core.ToolCallMessage from its inner agent.
 
-[!code-csharp[Single-turn tool call without auto-invoke](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Create_no_invoke_middleware)]
+[!code-csharp[Single-turn tool call without auto-invoke](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Create_no_invoke_middleware)]
 
 After creating the function call middleware, you can register it to the agent using `RegisterMiddleware` method, which will return a new agent which can use the methods defined in the `Tool` class.
 
-[!code-csharp[Generate Response](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Single_Turn_No_Invoke)]
+[!code-csharp[Generate Response](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Single_Turn_No_Invoke)]
 
 ## Tool call with auto-invoke
 In this case, the agent will automatically invoke the tool when receiving a @AutoGen.Core.ToolCallMessage and return the @AutoGen.Core.ToolCallAggregateMessage which contains both the tool call request and the tool call result.
@@ -81,21 +81,21 @@ In this case, the agent will automatically invoke the tool when receiving a @Aut
 
 To implement this, you can create the @AutoGen.Core.FunctionCallMiddleware with the `functionMap` parameter so that the middleware will automatically invoke the tool once it receives a @AutoGen.Core.ToolCallMessage from its inner agent.
 
-[!code-csharp[Single-turn tool call with auto-invoke](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Create_auto_invoke_middleware)]
+[!code-csharp[Single-turn tool call with auto-invoke](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Create_auto_invoke_middleware)]
 
 After creating the function call middleware, you can register it to the agent using `RegisterMiddleware` method, which will return a new agent which can use the methods defined in the `Tool` class.
 
-[!code-csharp[Generate Response](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Single_Turn_Auto_Invoke)]
+[!code-csharp[Generate Response](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Single_Turn_Auto_Invoke)]
 
 ## Send the tool call result back to LLM to generate further response
 In some cases, you may want to send the tool call result back to the LLM to generate further response. To do this, you can send the tool call response from agent back to the LLM by calling the `SendAsync` method of the agent.
 
-[!code-csharp[Generate Response](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Multi_Turn_Tool_Call)]
+[!code-csharp[Generate Response](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=Multi_Turn_Tool_Call)]
 
 ## Parallel tool call
 Some LLM models support parallel tool call, which returns multiple tool calls in one single message. Note that @AutoGen.Core.FunctionCallMiddleware has already handled the parallel tool call for you. When it receives a @AutoGen.Core.ToolCallMessage that contains multiple tool calls, it will automatically invoke all the tools in the sequantial order and return the @AutoGen.Core.ToolCallAggregateMessage which contains all the tool call requests and results.
 
-[!code-csharp[Generate Response](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=parallel_tool_call)]
+[!code-csharp[Generate Response](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Use_Tools_With_Agent.cs?name=parallel_tool_call)]
 
 ## Further Reading
 - [Function call with openai](../articles/OpenAIChatAgent-use-function-call.md)

--- a/dotnet/website/tutorial/Image-chat-with-agent.md
+++ b/dotnet/website/tutorial/Image-chat-with-agent.md
@@ -11,7 +11,7 @@ This tutorial shows how to perform image chat with an agent using the @AutoGen.O
 > In this example, we are using the gpt-4o model as the backend model for the agent.
 
 > [!NOTE]
-> The complete code example can be found in [Image_Chat_With_Agent.cs](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/Autogen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs)
+> The complete code example can be found in [Image_Chat_With_Agent.cs](https://github.com/microsoft/autogen/blob/main/dotnet/samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs)
 
 ## Step 1: Install AutoGen
 
@@ -23,27 +23,27 @@ dotnet add package AutoGen
 
 ## Step 2: Add Using Statements
 
-[!code-csharp[Using Statements](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Using)]
+[!code-csharp[Using Statements](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Using)]
 
 ## Step 3: Create an @AutoGen.OpenAI.OpenAIChatAgent
 
-[!code-csharp[Create an OpenAIChatAgent](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Create_Agent)]
+[!code-csharp[Create an OpenAIChatAgent](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Create_Agent)]
 
 ## Step 4: Prepare Image Message
 
 In AutoGen, you can create an image message using either @AutoGen.Core.ImageMessage or @AutoGen.Core.MultiModalMessage. The @AutoGen.Core.ImageMessage takes a single image as input, whereas the @AutoGen.Core.MultiModalMessage allows you to pass multiple modalities like text or image.
 
 Here is how to create an image message using @AutoGen.Core.ImageMessage:
-[!code-csharp[Create Image Message](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Prepare_Image_Input)]
+[!code-csharp[Create Image Message](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Prepare_Image_Input)]
 
 Here is how to create a multimodal message using @AutoGen.Core.MultiModalMessage:
-[!code-csharp[Create MultiModal Message](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Prepare_Multimodal_Input)]
+[!code-csharp[Create MultiModal Message](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Prepare_Multimodal_Input)]
 
 ## Step 5: Generate Response
 
 To generate response, you can use one of the overloaded methods of @AutoGen.Core.AgentExtension.SendAsync* method. The following code shows how to generate response with an image message:
 
-[!code-csharp[Generate Response](../../samples/AgentChat/Autogen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Chat_With_Agent)]
+[!code-csharp[Generate Response](../../samples/AgentChat/AutoGen.Basic.Sample/GettingStart/Image_Chat_With_Agent.cs?name=Chat_With_Agent)]
 
 ## Further Reading
 - [Image chat with gemini](../articles/AutoGen.Gemini/Image-chat-with-gemini.md)

--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@ This directory works as a single `uv` workspace containing all project packages,
 
 ## Migrating from 0.2.x?
 
-Please refer to the [migration guide](./migration_guide.md) for how to migrate your code from 0.2.x to 0.4.x.
+Please refer to the [migration guide](docs/src/user-guide/agentchat-user-guide/migration-guide.md) for how to migrate your code from 0.2.x to 0.4.x.
 
 ## Quick Start
 

--- a/python/packages/agbench/README.md
+++ b/python/packages/agbench/README.md
@@ -61,7 +61,7 @@ Navigate to HumanEval
 ```bash
 cd autogen/python/packages/agbench/benchmarks/HumanEval
 ```
-**Note:** The following instructions are specific to the HumanEval benchmark. For other benchmarks, please refer to the README in the respective benchmark folder, e.g.,: [AssistantBench](benchmarks/AssistantBench/README.md).
+**Note:** The following instructions are specific to the HumanEval benchmark. For other benchmarks, please refer to the README in the respective benchmark folder, e.g.,: [AssistantBench](benchmarks/README.md).
 
 
 Create a file called ENV.json with the following (required) contents (If you're using MagenticOne), if using Azure:

--- a/python/samples/core_distributed-group-chat/README.md
+++ b/python/samples/core_distributed-group-chat/README.md
@@ -1,6 +1,6 @@
 # Distributed Group Chat
 
-This example runs a gRPC server using [GrpcWorkerAgentRuntimeHost](../../src/autogen_core/application/_worker_runtime_host.py) and instantiates three distributed runtimes using [GrpcWorkerAgentRuntime](../../src/autogen_core/application/_worker_runtime.py). These runtimes connect to the gRPC server as hosts and facilitate a round-robin distributed group chat. This example leverages the [Azure OpenAI Service](https://azure.microsoft.com/en-us/products/ai-services/openai-service) to implement writer and editor LLM agents. Agents are instructed to provide concise answers, as the primary goal of this example is to showcase the distributed runtime rather than the quality of agent responses.
+This example runs a gRPC server using [GrpcWorkerAgentRuntimeHost](../../packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host.py) and instantiates three distributed runtimes using [GrpcWorkerAgentRuntime](../../packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py). These runtimes connect to the gRPC server as hosts and facilitate a round-robin distributed group chat. This example leverages the [Azure OpenAI Service](https://azure.microsoft.com/en-us/products/ai-services/openai-service) to implement writer and editor LLM agents. Agents are instructed to provide concise answers, as the primary goal of this example is to showcase the distributed runtime rather than the quality of agent responses.
 
 ## Setup
 


### PR DESCRIPTION
Aggregated doc-audit repairs, all verified against the current tree:

- The dotnet sample projects moved from `dotnet/samples/AutoGen.*.Sample` to `dotnet/samples/AgentChat/`, breaking 38 docfx article links/includes plus the `AutoGen.SourceGenerator` README link.
- The sample directory is `AutoGen.Basic.Sample` (capital G); many relative links used lowercase and missed it.
- Root-relative URLs in markdown resolved against github.com and 404'd; dead same-file anchors repaired.

Docs-only; no code changes (47 files).