### PR TITLE
fix: TextMentionTermination drops sources in component serialization; docstring and typo fixes

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -1033,7 +1033,7 @@ In `v0.2` group chat, when tools are involved, you need to register the tool fun
 and include the user proxy in the group chat. The tool calls made by other agents
 will be routed to the user proxy to execute.
 
-We have observed numerous issues with this approach, such as the the tool call
+We have observed numerous issues with this approach, such as the tool call
 routing not working as expected, and the tool call request and result cannot be
 accepted by models without support for function calling.
 

--- a/python/docs/src/user-guide/core-user-guide/cookbook/instrumenting.md
+++ b/python/docs/src/user-guide/core-user-guide/cookbook/instrumenting.md
@@ -1,4 +1,4 @@
-# Instrumentating your code locally
+# Instrumenting your code locally
 
 AutoGen supports instrumenting your code using [OpenTelemetry](https://opentelemetry.io). This allows you to collect traces and logs from your code and send them to a backend of your choice.
 

--- a/python/docs/src/user-guide/core-user-guide/faqs.md
+++ b/python/docs/src/user-guide/core-user-guide/faqs.md
@@ -4,11 +4,11 @@
 
 Agents might be distributed across multiple machines, so the underlying agent instance is intentionally discouraged from being accessed. If the agent is definitely running on the same machine, you can access the agent instance by calling {py:meth}`autogen_core.AgentRuntime.try_get_underlying_agent_instance` on the `AgentRuntime`. If the agent is not available this will throw an exception.
 
-## How do I call call a function on an agent?
+## How do I call a function on an agent?
 
 Since the instance itself is not accessible, you can't call a function on an agent directly. Instead, you should create a type to represent the function call and its arguments, and then send that message to the agent. Then in the agent, create a handler for that message type and implement the required logic. This also supports returning a response to the caller.
 
-This allows your agent to work in a distributed environment a well as a local one.
+This allows your agent to work in a distributed environment as well as a local one.
 
 ## Why do I need to use a factory to register an agent?
 
@@ -37,7 +37,7 @@ worker1 = GrpcWorkerAgentRuntime(host_address=host_address, extra_grpc_config=ex
 
 ## What are model capabilities and how do I specify them?
 
-Model capabilites are additional capabilities an LLM may have beyond the standard natural language features. There are currently 3 additional capabilities that can be specified within Autogen
+Model capabilities are additional capabilities an LLM may have beyond the standard natural language features. There are currently 3 additional capabilities that can be specified within Autogen
 
 - vision: The model is capable of processing and interpreting image data.
 - function_calling: The model has the capacity to accept function descriptions; such as the function name, purpose, input parameters, etc; and can respond with an appropriate function to call including any necessary parameters.

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -106,6 +106,7 @@ class MaxMessageTermination(TerminationCondition, Component[MaxMessageTerminatio
 
 class TextMentionTerminationConfig(BaseModel):
     text: str
+    sources: Sequence[str] | None = None
 
 
 class TextMentionTermination(TerminationCondition, Component[TextMentionTerminationConfig]):
@@ -148,11 +149,11 @@ class TextMentionTermination(TerminationCondition, Component[TextMentionTerminat
         self._terminated = False
 
     def _to_config(self) -> TextMentionTerminationConfig:
-        return TextMentionTerminationConfig(text=self._termination_text)
+        return TextMentionTerminationConfig(text=self._termination_text, sources=self._sources)
 
     @classmethod
     def _from_config(cls, config: TextMentionTerminationConfig) -> Self:
-        return cls(text=config.text)
+        return cls(text=config.text, sources=config.sources)
 
 
 class FunctionalTermination(TerminationCondition):

--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -746,7 +746,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
                                 _warn_if_none(temp_message, "on_publish")
                             except BaseException as e:
                                 # TODO: we should raise the intervention exception to the publisher.
-                                logger.error(f"Exception raised in in intervention handler: {e}", exc_info=True)
+                                logger.error(f"Exception raised in intervention handler: {e}", exc_info=True)
                                 return
                             if temp_message is DropMessage or isinstance(temp_message, DropMessage):
                                 event_logger.info(

--- a/python/packages/autogen-core/src/autogen_core/model_context/_head_and_tail_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_head_and_tail_chat_completion_context.py
@@ -39,7 +39,7 @@ class HeadAndTailChatCompletionContext(ChatCompletionContext, Component[HeadAndT
         self._tail_size = tail_size
 
     async def get_messages(self) -> List[LLMMessage]:
-        """Get at most `head_size` recent messages and `tail_size` oldest messages."""
+        """Get at most `head_size` oldest messages and `tail_size` most recent messages."""
         head_messages = self._messages[: self._head_size]
         # Handle the last message is a function call message.
         if (

--- a/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_function_tool.py
@@ -144,7 +144,7 @@ class FunctionTool(BaseTool[BaseModel, BaseModel], Component[FunctionToolConfig]
     def _from_config(cls, config: FunctionToolConfig) -> Self:
         warnings.warn(
             "\n⚠️  SECURITY WARNING ⚠️\n"
-            "Loading a FunctionTool from config will execute code to import the provided global imports and and function code.\n"
+            "Loading a FunctionTool from config will execute code to import the provided global imports and function code.\n"
             "Only load configs from TRUSTED sources to prevent arbitrary code execution.",
             UserWarning,
             stacklevel=2,


### PR DESCRIPTION
## Summary

### Serialization bug
`TextMentionTerminationConfig` had no `sources` field, and `_to_config`/`_from_config` dropped `self._sources` — so a `dump_component()`/`load_component()` round-trip **silently changed behavior**: the reloaded condition matched the text from all sources instead of only the configured ones. `sources` is a documented, tested parameter (`tests/test_termination_condition.py:151`), and `SourceMatchTerminationConfig` already serializes its `sources` the same way. The config model, `_to_config` and `_from_config` now pass it through.

### Docstring / strings
- `HeadAndTailChatCompletionContext.get_messages`: docstring swapped recent/oldest — head is the **first/oldest** messages, tail the most recent (the class docstring already says first n / last m).
- 'and and' in `FunctionTool`'s config-loading **security warning** string; 'in in' in an intervention-handler `logger.error`; 'the the' in the agentchat migration guide; 'call call' / 'a well as' / 'capabilites' in the core FAQ; 'Instrumentating' heading in the instrumenting cookbook (referenced as 'Instrumenting' elsewhere).