### PR TITLE
fix: await async callable termination conditions

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/conditions/_terminations.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 import time
 from typing import Awaitable, Callable, List, Sequence
 
@@ -213,10 +213,9 @@ class FunctionalTermination(TerminationCondition):
     async def __call__(self, messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> StopMessage | None:
         if self._terminated:
             raise TerminatedException("Termination condition has already been reached")
-        if asyncio.iscoroutinefunction(self._func):
-            result = await self._func(messages)
-        else:
-            result = self._func(messages)
+        result = self._func(messages)
+        if inspect.isawaitable(result):
+            result = await result
         if result is True:
             self._terminated = True
             return StopMessage(content="Functional termination condition met", source="FunctionalTermination")

--- a/python/packages/autogen-agentchat/tests/test_termination_condition.py
+++ b/python/packages/autogen-agentchat/tests/test_termination_condition.py
@@ -431,3 +431,15 @@ async def test_functional_termination() -> None:
     assert termination.terminated
     await termination.reset()
     assert await termination([TextMessage(content="Hello", source="user")]) is None
+
+
+@pytest.mark.asyncio
+async def test_functional_termination_awaits_async_callable_instance() -> None:
+    class AsyncCallable:
+        async def __call__(self, messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> bool:
+            return True
+
+    termination = FunctionalTermination(AsyncCallable())
+
+    assert await termination([TextMessage(content="stop", source="user")]) is not None
+    assert termination.terminated


### PR DESCRIPTION
## Why are these changes needed?

`FunctionalTermination` documents support for async callables, but an object with an async `__call__` method is not itself recognized by `asyncio.iscoroutinefunction`. The condition therefore called the object without awaiting its returned coroutine, returned `None`, and emitted an unawaited-coroutine warning instead of terminating.

This change calls the supplied function once and awaits its result whenever the result is awaitable. That preserves synchronous callables and regular async functions while supporting callable instances with async `__call__` methods.

## Related issue number

N/A

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. No documentation change is needed because this fixes the existing documented async-callable behavior.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed. Full GitHub CI has not run yet.

### Validation

- `uv run pytest packages/autogen-agentchat/tests/test_termination_condition.py -k async_callable_instance` (RED before the fix: 1 failed; GREEN after the fix: 1 passed)
- `uv run pytest packages/autogen-agentchat/tests/test_termination_condition.py` (14 passed)
- `uv run poe --directory packages/autogen-agentchat fmt --check`
- `uv run poe --directory packages/autogen-agentchat lint`
- `uv run poe --directory packages/autogen-agentchat pyright`
- `uv run mypy --config-file ../../pyproject.toml src tests` from `python/packages/autogen-agentchat` (64 source files clean)

### AI assistance

This change and regression test were prepared with AI assistance; the validation commands above were run locally.
