### PR TITLE
test(agentchat): cover streaming cancellation cleanup

### DIFF
--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -2685,6 +2685,51 @@ class TestAssistantAgentCancellationToken:
         assert chunk_events[1].content == "chunk2"
 
     @pytest.mark.asyncio
+    async def test_stream_cleanup_after_cancellation(self) -> None:
+        """Test that cancelling a blocked stream cleans up its pending task."""
+        model_client = MagicMock()
+        model_client.model_info = {"function_calling": False, "vision": False, "family": ModelFamily.GPT_4O}
+        started = asyncio.Event()
+        released = asyncio.Event()
+        closed = asyncio.Event()
+        blocked_task: asyncio.Task[bool] | None = None
+
+        async def mock_create_stream(*args: Any, **kwargs: Any) -> Any:
+            nonlocal blocked_task
+            blocked_task = asyncio.create_task(released.wait())
+            kwargs["cancellation_token"].link_future(blocked_task)
+            started.set()
+            try:
+                await blocked_task
+                yield "late chunk"
+            finally:
+                closed.set()
+
+        model_client.create_stream = mock_create_stream
+        agent = AssistantAgent(name="test_agent", model_client=model_client, model_client_stream=True)
+        cancellation_token = CancellationToken()
+        messages: List[Any] = []
+
+        async def consume_stream() -> None:
+            async for message in agent.on_messages_stream(
+                [TextMessage(content="Test", source="user")], cancellation_token
+            ):
+                messages.append(message)
+
+        consumer = asyncio.create_task(consume_stream())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        cancellation_token.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+        await asyncio.wait_for(closed.wait(), timeout=1)
+        released.set()
+        await asyncio.sleep(0)
+
+        assert messages == []
+        assert blocked_task is not None and blocked_task.cancelled()
+
+    @pytest.mark.asyncio
     async def test_cancellation_during_tool_execution(self) -> None:
         """Test cancellation token during tool execution."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

AssistantAgent streaming cancellation did not have deterministic coverage for a model stream blocked on pending work. This adds a regression test that cancels the stream, verifies the consumer terminates before any late chunk is emitted, and confirms the linked pending task and async generator are cleaned up.

## Related issue number

Closes #8092

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally. (No documentation changes are needed for this test-only change.)
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.

Local validation:

- `pytest packages/autogen-agentchat/tests/test_assistant_agent.py -q` (89 passed, 3 skipped)
- `ruff check` and `ruff format --check`
- `mypy` on the changed test module
- Repository `poe pyright` task (0 errors)
