### PR TITLE
fix(autogen-ext): include tool_choice in ChatCompletionCache hash key

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
@@ -179,6 +179,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         tools: Sequence[Tool | ToolSchema],
         json_output: Optional[bool | type[BaseModel]],
         extra_create_args: Mapping[str, Any],
+        tool_choice: Tool | Literal["auto", "required", "none"] = "auto",
     ) -> tuple[Optional[Union[CreateResult, List[Union[str, CreateResult]]]], str]:
         """
         Helper function to check the cache for a result.
@@ -192,11 +193,14 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         elif isinstance(json_output, bool):
             json_output_data = json_output
 
+        tool_choice_data = tool_choice.schema if isinstance(tool_choice, Tool) else tool_choice  # type: ignore[union-attr]
+
         data = {
             "messages": [message.model_dump() for message in messages],
             "tools": [(tool.schema if isinstance(tool, Tool) else tool) for tool in tools],
             "json_output": json_output_data,
             "extra_create_args": extra_create_args,
+            "tool_choice": tool_choice_data,
         }
         serialized_data = json.dumps(data, sort_keys=True)
         cache_key = hashlib.sha256(serialized_data.encode()).hexdigest()
@@ -270,7 +274,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
 
         NOTE: cancellation_token is ignored for cached results.
         """
-        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args)
+        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args, tool_choice)
         if cached_result is not None:
             if isinstance(cached_result, CreateResult):
                 # Cache hit from previous non-streaming call
@@ -319,6 +323,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
                 tools,
                 json_output,
                 extra_create_args,
+                tool_choice,
             )
             if cached_result is not None:
                 if isinstance(cached_result, list):

--- a/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
+++ b/python/packages/autogen-ext/tests/models/test_chat_completion_cache.py
@@ -921,6 +921,34 @@ async def test_create_stream_with_cached_non_streaming_result_empty_content() ->
 
 
 @pytest.mark.asyncio
+async def test_cache_different_tool_choice_is_cache_miss() -> None:
+    """Test that calls with different tool_choice values produce distinct cache keys.
+
+    Regression test for: two back-to-back calls that differ only in tool_choice
+    previously hashed to the same key, causing the second call to be served the
+    wrong (first) cached result silently.
+    """
+    responses, prompts, system_prompt, replay_client, cached_client = get_test_data(num_messages=2)
+
+    messages = [system_prompt, UserMessage(content=prompts[0], source="user")]
+
+    # First call with tool_choice="auto"
+    result_auto = await cached_client.create(messages, tool_choice="auto")
+    assert not result_auto.cached
+    assert result_auto.content == responses[0]
+
+    # Second call, same messages but different tool_choice — must be a cache miss
+    result_none = await cached_client.create(messages, tool_choice="none")
+    assert not result_none.cached, "Different tool_choice must not hit the cache from tool_choice='auto'"
+    assert result_none.content == responses[1]
+
+    # Third call with tool_choice="auto" again — should now be a cache hit
+    result_auto_again = await cached_client.create(messages, tool_choice="auto")
+    assert result_auto_again.cached
+    assert result_auto_again.content == responses[0]
+
+
+@pytest.mark.asyncio
 async def test_create_stream_with_cached_non_streaming_result_non_string_content() -> None:
     """
     Test that when create_stream() finds a cached non-streaming result with non-string content,


### PR DESCRIPTION
## Summary

`ChatCompletionCache._check_cache()` builds a SHA-256 key from `messages`, `tools`, `json_output`, and `extra_create_args`, but **never includes `tool_choice`**. Two successive `create()` / `create_stream()` calls that differ _only_ in `tool_choice` (e.g. `"auto"` vs `"none"`) hash to the same key, so the second call is silently served the first call's cached result.

Fixes #7968.

## Changes

- `_check_cache()` gains a `tool_choice` parameter (default `"auto"` to preserve existing behaviour).
- `tool_choice` is serialised into the hash dict: `tool.schema` for `Tool` instances, the string literal otherwise.
- Both `create()` and `create_stream()` pass `tool_choice` through to `_check_cache()`.
- New regression test `test_cache_different_tool_choice_is_cache_miss` verifies that `auto` → `none` → `auto` produces two misses then a hit.

## Test plan

- [x] All 26 existing tests pass unchanged (`pytest tests/models/test_chat_completion_cache.py`)
- [x] New regression test (`test_cache_different_tool_choice_is_cache_miss`) passes

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.