### PR TITLE
docs: list Decionis tool policy extension

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -46,6 +46,7 @@ Find community samples and examples of how to use AutoGen
 | [autogen-oaiapi](https://github.com/SongChiYoung/autogen-oaiapi)  | [PyPi](https://pypi.org/project/autogen-oaiapi/) | an OpenAI-style API server built on top of AutoGen |
 | [autogen-contextplus](https://github.com/SongChiYoung/autogen-contextplus)  | [PyPi](https://pypi.org/project/autogen-contextplus/) | Enhanced model_context implementations, with features such as automatic summarization and truncation of model context. |
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
+| [decionis-autogen](https://github.com/decionis/Decionis/tree/master/sdks/python-autogen) | [PyPi](https://pypi.org/project/decionis-autogen/) | Pre-execution policy gate for AutoGen tools with signed decision evidence. |
 
 
 <!-- Example -->


### PR DESCRIPTION
## Summary

Adds `decionis-autogen` to the documented list of community projects. The package wraps AutoGen tools with a pre-execution policy decision and returns signed decision evidence for auditability.

## Package evidence

- PyPI: https://pypi.org/project/decionis-autogen/0.1.0/
- Source: https://github.com/decionis/Decionis/tree/296ce4aa8a3dfd7d1cf532be3d8b5fba3f810902/sdks/python-autogen
- Release workflow: https://github.com/decionis/Decionis/actions/runs/32899890870

## Compatibility

- Current `autogen-core` tool API
- Optional legacy AutoGen 0.2 `UserProxyAgent` pre-execution hook
- Python 3.10+

## Verification

- Installed `decionis-autogen==0.1.0` from PyPI in a clean Python environment.
- Imported `DecionisGuardedTool` successfully.
- Confirmed the wheel and source distribution are public.
- `git diff --check upstream/main...HEAD`

This is a third-party community extension and does not claim endorsement by Microsoft or AutoGen.