### PR TITLE
fix(file-surfer): preserve base path in components

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py
@@ -39,6 +39,7 @@ class FileSurferConfig(BaseModel):
     name: str
     model_client: ComponentModel
     description: str | None = None
+    base_path: str | None = None
 
 
 class FileSurfer(BaseChatAgent, Component[FileSurferConfig]):
@@ -197,12 +198,23 @@ class FileSurfer(BaseChatAgent, Component[FileSurferConfig]):
             name=self.name,
             model_client=self._model_client.dump_component(),
             description=self.description,
+            base_path=self._browser._base_path,  # pyright: ignore[reportPrivateUsage]
         )
 
     @classmethod
     def _from_config(cls, config: FileSurferConfig) -> Self:
+        model_client = ChatCompletionClient.load_component(config.model_client)
+        if config.base_path is None:
+            # Configs saved before ``base_path`` was introduced keep their legacy
+            # constructor behavior when deserialized.
+            return cls(
+                name=config.name,
+                model_client=model_client,
+                description=config.description or cls.DEFAULT_DESCRIPTION,
+            )
         return cls(
             name=config.name,
-            model_client=ChatCompletionClient.load_component(config.model_client),
+            model_client=model_client,
             description=config.description or cls.DEFAULT_DESCRIPTION,
+            base_path=config.base_path,
         )

--- a/python/packages/autogen-ext/tests/test_filesurfer_agent.py
+++ b/python/packages/autogen-ext/tests/test_filesurfer_agent.py
@@ -10,6 +10,7 @@ import pytest
 from autogen_agentchat import EVENT_LOGGER_NAME
 from autogen_agentchat.messages import TextMessage
 from autogen_ext.agents.file_surfer import FileSurfer
+from autogen_ext.agents.file_surfer._file_surfer import FileSurferConfig
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 from openai.resources.chat.completions import AsyncCompletions
 from openai.types.chat.chat_completion import ChatCompletion, Choice
@@ -166,4 +167,29 @@ async def test_file_surfer_serialization() -> None:
     deserialized_agent = FileSurfer.load_component(serialized_agent)
 
     # Check that the deserialized agent has the same attributes as the original agent
+    assert isinstance(deserialized_agent, FileSurfer)
+
+
+def test_file_surfer_serialization_preserves_explicit_base_path(tmp_path: Any) -> None:
+    """An explicit FileSurfer root must survive component serialization."""
+    agent = FileSurfer(
+        "FileSurfer",
+        model_client=OpenAIChatCompletionClient(model="gpt-4.1-nano-2025-04-14", api_key=""),
+        base_path=str(tmp_path),
+    )
+
+    deserialized_agent = FileSurfer.load_component(agent.dump_component())
+
+    assert deserialized_agent._browser._base_path == os.path.realpath(str(tmp_path))  # pyright: ignore[reportPrivateUsage]
+
+
+def test_file_surfer_loads_legacy_config_without_base_path() -> None:
+    """Configs written before base-path persistence remain loadable."""
+    config = FileSurferConfig(
+        name="FileSurfer",
+        model_client=OpenAIChatCompletionClient(model="gpt-4.1-nano-2025-04-14", api_key="").dump_component(),
+    )
+
+    deserialized_agent = FileSurfer._from_config(config)  # pyright: ignore[reportPrivateUsage]
+
     assert isinstance(deserialized_agent, FileSurfer)


### PR DESCRIPTION
## Why are these changes needed?

`FileSurfer` accepts an explicit `base_path`, but its component configuration did not store that value. Reconstructing a serialized component therefore created a browser rooted at the process default instead of its originally configured directory. This loses the caller's intended filesystem scope in persisted teams and Studio configurations.

This change persists the browser's resolved base path in `FileSurferConfig` and restores it when loading the component. Configurations written before this field existed continue to use the legacy constructor behavior.

## Related issue number

None.

## Checks

- [x] No documentation change is needed: the existing public `base_path` documentation remains accurate.
- [x] Added regression coverage for an explicit base path and legacy configuration loading.
- [x] `uv run --directory python --no-sync pytest packages/autogen-ext/tests/test_filesurfer_agent.py -vv`
- [x] `uv run --directory python --no-sync ruff check packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py packages/autogen-ext/tests/test_filesurfer_agent.py`
- [x] `uv run --directory python --no-sync ruff format --check packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py packages/autogen-ext/tests/test_filesurfer_agent.py`
- [x] `uv run --directory python --no-sync pyright packages/autogen-ext/src/autogen_ext/agents/file_surfer/_file_surfer.py packages/autogen-ext/tests/test_filesurfer_agent.py`

## AI assistance

AI assistance was used to investigate, draft, and test this change. The regression was reproduced before the implementation: serializing a `FileSurfer` with an explicit temporary directory reloaded it with the process working directory instead.
