### PR TITLE
Add async context manager to OpenAI model client

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1142,6 +1142,12 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
     async def close(self) -> None:
         await self._client.close()
 
+    async def __aenter__(self) -> "BaseOpenAIChatCompletionClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        await self.close()
+
     def actual_usage(self) -> RequestUsage:
         return self._actual_usage
 

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -78,6 +78,17 @@ class MyArgs(BaseModel):
     query: str = Field(description="The description.")
 
 
+@pytest.mark.asyncio
+async def test_openai_client_is_async_context_manager() -> None:
+    client = OpenAIChatCompletionClient(model="gpt-4o", api_key="test")
+    client.close = AsyncMock()  # type: ignore[method-assign]
+
+    async with client as entered:
+        assert entered is client
+
+    client.close.assert_awaited_once()
+
+
 class MockChunkDefinition(BaseModel):
     # defining elements for diffentiating mocking chunks
     chunk_choice: ChunkChoice


### PR DESCRIPTION
## Summary

`OpenAIChatCompletionClient` already exposes an asynchronous `close()` method, but callers cannot use the client with `async with`. This change adds the async context manager protocol to the shared OpenAI client base so OpenAI-compatible clients return themselves on entry and close their underlying client on exit.

## Testing

- `ruff format --check` on the changed source and test files
- `ruff check` on the changed source and test files
- `pytest python/packages/autogen-ext/tests/models/test_openai_model_client.py -k async_context_manager --no-cov`

Closes #5108.
