### PR TITLE
fix(autogen-ext): preserve Azure model info in component config

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -1679,6 +1679,7 @@ class AzureOpenAIChatCompletionClient(
 
     def __init__(self, **kwargs: Unpack[AzureOpenAIClientConfiguration]):
         model_capabilities: Optional[ModelCapabilities] = None  # type: ignore
+        self._raw_config: Dict[str, Any] = dict(kwargs).copy()
         copied_args = dict(kwargs).copy()
         if "model_capabilities" in kwargs:
             model_capabilities = kwargs["model_capabilities"]
@@ -1699,7 +1700,6 @@ class AzureOpenAIChatCompletionClient(
 
         client = _azure_openai_client_from_config(copied_args)
         create_args = _create_args_from_config(copied_args)
-        self._raw_config: Dict[str, Any] = copied_args
         super().__init__(
             client=client,
             create_args=create_args,

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -250,6 +250,34 @@ async def test_azure_openai_chat_completion_client() -> None:
     assert client
 
 
+def test_azure_openai_chat_completion_client_serializes_model_info() -> None:
+    model_info: ModelInfo = {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": ModelFamily.UNKNOWN,
+        "structured_output": True,
+    }
+    client = AzureOpenAIChatCompletionClient(
+        model="contoso-chat",
+        azure_endpoint="https://dummy.com",
+        azure_deployment="contoso-chat",
+        api_version="2020-08-04",
+        api_key="api_key",
+        model_info=model_info,
+    )
+
+    config = client.dump_component()
+
+    assert config.config["model_info"] == model_info
+
+    serialized_config = config.model_dump_json()
+    assert '"model_info"' in serialized_config
+
+    reloaded_client = AzureOpenAIChatCompletionClient.load_component(json.loads(serialized_config))
+    assert reloaded_client.model_info == model_info
+
+
 @pytest.mark.asyncio
 async def test_openai_chat_completion_client_create(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
## Why are these changes needed?

Before this change, `AzureOpenAIChatCompletionClient` removed `model_info` and
the deprecated `model_capabilities` from the SDK arguments before saving
`_raw_config`. As a result, `dump_component()` omitted the model capabilities required
to load a custom Azure deployment whose name is not in AutoGen's built-in model
table.

Save the original constructor configuration for component serialization, while
continuing to pass the filtered arguments to the Azure SDK. This mirrors the
existing `OpenAIChatCompletionClient` behavior introduced in #5315.

The regression test uses a fake endpoint and key, serializes an unknown Azure
deployment to JSON, then loads it back and verifies that `model_info` is
preserved. It makes no network model call.

## Related issue number

N/A — this is an Azure parity gap discovered while auditing component
serialization; no matching open issue or PR was found.

## Checks

- [x] No documentation update is needed; this restores the documented component configuration round-trip behavior.
- [x] I've added a regression test corresponding to the fix.
- [ ] GitHub automated checks have not run yet.

### Local validation

- `uv run --no-sync pytest packages/autogen-ext/tests/models/test_openai_model_client.py -k azure_openai_chat_completion_client_serializes_model_info -q` (1 passed)
- `uv run --no-sync pytest packages/autogen-ext/tests/models/test_openai_model_client.py -q` (54 passed, 33 skipped)
- `uv run --no-sync ruff format --check packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py packages/autogen-ext/tests/models/test_openai_model_client.py`
- `uv run --no-sync ruff check packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py packages/autogen-ext/tests/models/test_openai_model_client.py`
- Scoped MyPy and Pyright checks on the changed source and test files (both passed)

I also attempted the full `autogen-ext` MyPy command; this dependency subset reports existing missing-optional-integration type errors in unrelated Semantic Kernel, Ollama, and llama-cpp files, not in the changed files.

### AI assistance

This change and regression test were prepared with AI assistance. The local validation commands above were run against this branch.
