### PR TITLE
fix(dotnet): prevent gRPC agents from receiving their own publishes

### DIFF
--- a/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentRuntime.cs
+++ b/dotnet/src/Microsoft.AutoGen/Core.Grpc/GrpcAgentRuntime.cs
@@ -257,6 +257,11 @@ public sealed class GrpcAgentRuntime : IHostedService, IAgentRuntime, IMessageSi
             if (subscription.Matches(topic))
             {
                 var recipient = subscription.MapToAgent(topic);
+                if (sender.HasValue && sender == recipient)
+                {
+                    continue;
+                }
+
                 var agent = await this._agentsContainer.EnsureAgentAsync(recipient);
 
                 // give the serializer a second chance to have been registered
@@ -488,4 +493,3 @@ public sealed class GrpcAgentRuntime : IHostedService, IAgentRuntime, IMessageSi
         }
     }
 }
-

--- a/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/AgentGrpcTests.cs
+++ b/dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/AgentGrpcTests.cs
@@ -76,6 +76,46 @@ public class AgentGrpcTests : TestBase
     }
 
     [Fact]
+    public async Task AgentShouldNotReceiveItsOwnPublishedMessageTest()
+    {
+        var fixture = new GrpcAgentRuntimeFixture();
+        var runtime = (GrpcAgentRuntime)await fixture.StartAsync();
+
+        Logger<BaseAgent> logger = new(new LoggerFactory());
+        TestProtobufAgent senderAgent = null!;
+        TestProtobufAgent receivingAgent = null!;
+
+        await runtime.RegisterAgentFactoryAsync("SenderAgent", async (id, runtime) =>
+        {
+            senderAgent = new TestProtobufAgent(id, runtime, logger);
+            return await ValueTask.FromResult(senderAgent);
+        });
+
+        await runtime.RegisterAgentFactoryAsync("ReceivingAgent", async (id, runtime) =>
+        {
+            receivingAgent = new TestProtobufAgent(id, runtime, logger);
+            return await ValueTask.FromResult(receivingAgent);
+        });
+
+        var topicType = "TestTopic";
+        AgentId senderId = await runtime.GetAgentAsync("SenderAgent", lazy: false);
+        await runtime.GetAgentAsync("ReceivingAgent", lazy: false);
+        await runtime.AddSubscriptionAsync(new TypeSubscription(topicType, "SenderAgent"));
+        await runtime.AddSubscriptionAsync(new TypeSubscription(topicType, "ReceivingAgent"));
+
+        await runtime.PublishMessageAsync(
+            new TextMessage { Source = topicType, Content = "test" },
+            new TopicId(topicType),
+            sender: senderId).ConfigureAwait(true);
+
+        await Task.Delay(100);
+
+        senderAgent.ReceivedMessages.Any().Should().BeFalse("an agent should not receive its own published message.");
+        receivingAgent.ReceivedMessages.Any().Should().BeTrue("other subscribed agents should still receive the published message.");
+        fixture.Dispose();
+    }
+
+    [Fact]
     public async Task SendMessageAsyncShouldReturnResponseTest()
     {
         // Arrange


### PR DESCRIPTION
## Why are these changes needed?

`GrpcAgentRuntime.HandlePublish` currently invokes every matching local subscription, including the subscription that maps back to the `CloudEvent` sender. This differs from both the .NET in-process runtime and the Python runtime, and forces agents to add their own filtering to avoid processing the messages they just published.

This change compares the mapped recipient with the optional sender before instantiating or dispatching to the recipient. Only the sender is skipped; other agents subscribed to the same topic continue to receive the published message.

The regression test registers a sender and a second subscriber for the same topic, publishes with the sender identity, and verifies both sides of the behavior: the sender receives nothing while the other subscriber still receives the message.

## Related issue number

Closes #4998

## Validation

- `dotnet test dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/Microsoft.AutoGen.Core.Grpc.Tests.csproj --configuration Release --filter FullyQualifiedName~AgentShouldNotReceiveItsOwnPublishedMessageTest --no-restore --verbosity minimal` — passed (1/1).
- Before the runtime change, the same regression test failed with `Expected agent.ReceivedMessages.Any() to be False ... but found True`.
- `dotnet test dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/Microsoft.AutoGen.Core.Grpc.Tests.csproj --configuration Release --filter Category=GRPC --no-restore --verbosity minimal` — five tests passed; the unrelated `GatewayShouldNotReceiveRegistrationsUntilRuntimeStart` fixture-isolation test failed only in the combined parallel run and passed on an isolated rerun (1/1).
- `dotnet format dotnet/test/Microsoft.AutoGen.Core.Grpc.Tests/Microsoft.AutoGen.Core.Grpc.Tests.csproj --verify-no-changes --no-restore --verbosity minimal` — passed.
- `git diff --check` — passed.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. No documentation change is needed because this aligns the gRPC runtime with the already established self-delivery behavior.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed. (Pending the repository CI run.)
