### PR TITLE
.NET: modernize the InferenceAgent sample

### DIFF
--- a/dotnet/samples/Hello/HelloAIAgents/HelloAIAgent.cs
+++ b/dotnet/samples/Hello/HelloAIAgents/HelloAIAgent.cs
@@ -1,29 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // HelloAIAgent.cs
 
+using Microsoft.AutoGen.Agents;
 using Microsoft.AutoGen.Contracts;
 using Microsoft.AutoGen.Core;
 using Microsoft.Extensions.AI;
 
 namespace Hello;
-[TopicSubscription("agents")]
-public class HelloAIAgent(
-    [FromKeyedServices("AgentsMetadata")] AgentsMetadata typeRegistry,
+
+[TypeSubscription("HelloAITopic")]
+public sealed class HelloAIAgent(
     IHostApplicationLifetime hostApplicationLifetime,
-    IChatClient client) : HelloAgent(
-        typeRegistry,
-        hostApplicationLifetime),
+    AgentId id,
+    IAgentRuntime runtime,
+    IChatClient client,
+    ILogger<InferenceAgent<NewMessageReceived>>? logger = null)
+    : InferenceAgent<NewMessageReceived>(id, runtime, "Hello AI Agent", logger, client),
         IHandle<NewMessageReceived>
 {
-    // This Handle supercedes the one in the base class
-    public new async Task Handle(NewMessageReceived item, CancellationToken cancellationToken = default)
+    public async ValueTask HandleAsync(NewMessageReceived item, MessageContext messageContext)
     {
-        var prompt = "Please write a limerick greeting someone with the name " + item.Message;
-        var response = await client.CompleteAsync(prompt);
-        var evt = new Output { Message = response.Message.Text };
-        await PublishMessageAsync(evt).ConfigureAwait(false);
+        var prompt = $"Write a short limerick greeting someone named {item.Message}.";
+        var response = await ChatClient.GetResponseAsync(
+            prompt,
+            cancellationToken: messageContext.CancellationToken);
 
-        var goodbye = new ConversationClosed { UserId = this.AgentId.Key, UserMessage = "Goodbye" };
-        await PublishMessageAsync(goodbye).ConfigureAwait(false);
+        Console.WriteLine(response.Text);
+        hostApplicationLifetime.StopApplication();
     }
 }

--- a/dotnet/samples/Hello/HelloAIAgents/HelloAIAgents.csproj
+++ b/dotnet/samples/Hello/HelloAIAgents/HelloAIAgents.csproj
@@ -11,7 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.AutoGen\Agents\Microsoft.AutoGen.Agents.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.AutoGen\Contracts\Microsoft.AutoGen.Contracts.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.AutoGen\Core.Grpc\Microsoft.AutoGen.Core.Grpc.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.AutoGen\Core\Microsoft.AutoGen.Core.csproj" />
     <ProjectReference Include="..\..\..\src\Microsoft.AutoGen\Extensions\MEAI\Microsoft.AutoGen.Extensions.MEAI.csproj" />
   </ItemGroup>

--- a/dotnet/samples/Hello/HelloAIAgents/Program.cs
+++ b/dotnet/samples/Hello/HelloAIAgents/Program.cs
@@ -5,78 +5,34 @@ using Hello;
 using Microsoft.AutoGen.Agents;
 using Microsoft.AutoGen.Contracts;
 using Microsoft.AutoGen.Core;
+using Microsoft.AutoGen.Core.Grpc;
 
-// send a message to the agent
-var builder = new HostApplicationBuilder();
-// put these in your environment or appsettings.json
-builder.Configuration["HelloAIAgents:ModelType"] = "azureopenai";
-builder.Configuration["HelloAIAgents:LlmModelName"] = "gpt-3.5-turbo";
-Environment.SetEnvironmentVariable("AZURE_OPENAI_CONNECTION_STRING", "Endpoint=https://TODO.openai.azure.com/;Key=TODO;Deployment=TODO");
-if (Environment.GetEnvironmentVariable("AZURE_OPENAI_CONNECTION_STRING") == null)
+const string serviceName = "HelloAIAgents";
+var connectionString = Environment.GetEnvironmentVariable("AZURE_OPENAI_CONNECTION_STRING")
+    ?? throw new InvalidOperationException(
+        "AZURE_OPENAI_CONNECTION_STRING is not set. Expected: "
+        + "Endpoint=https://<resource>.openai.azure.com/;Key=<key>;Deployment=<deployment>");
+
+var hostBuilder = new HostApplicationBuilder();
+hostBuilder.Configuration[$"ConnectionStrings:{serviceName}"] = connectionString;
+hostBuilder.AddOpenAIChatClient(serviceName);
+
+var appBuilder = new AgentsAppBuilder(hostBuilder);
+var hostAddress = Environment.GetEnvironmentVariable("AGENT_HOST");
+if (hostAddress is not null)
 {
-    throw new InvalidOperationException("AZURE_OPENAI_CONNECTION_STRING not set, try something like AZURE_OPENAI_CONNECTION_STRING = \"Endpoint=https://TODO.openai.azure.com/;Key=TODO;Deployment=TODO\"");
+    appBuilder.AddGrpcAgentWorker(hostAddress)
+        .AddAgent<HelloAIAgent>("HelloAIAgent");
 }
-builder.Configuration["ConnectionStrings:HelloAIAgents"] = Environment.GetEnvironmentVariable("AZURE_OPENAI_CONNECTION_STRING");
-builder.AddChatCompletionService("HelloAIAgents");
-var _ = new AgentTypes(new Dictionary<string, Type>
+else
 {
-    { "HelloAIAgents", typeof(HelloAIAgent) }
-});
-var local = true;
-if (Environment.GetEnvironmentVariable("AGENT_HOST") != null) { local = false; }
-var app = await Microsoft.AutoGen.Core.Grpc.AgentsApp.PublishMessageAsync("HelloAgents", new NewMessageReceived
-{
-    Message = "World"
-}, local: local).ConfigureAwait(false);
+    appBuilder.UseInProcessRuntime()
+        .AddAgent<HelloAIAgent>("HelloAIAgent");
+}
+
+var app = await appBuilder.BuildAsync();
+await app.StartAsync();
+await app.PublishMessageAsync(
+    new NewMessageReceived { Message = "World" },
+    new TopicId("HelloAITopic"));
 await app.WaitForShutdownAsync();
-
-namespace Hello
-{
-    [TopicSubscription("HelloAgents")]
-    public class HelloAgent(
-        [FromKeyedServices("AgentsMetadata")] AgentsMetadata typeRegistry,
-        IHostApplicationLifetime hostApplicationLifetime) : ConsoleAgent(
-            typeRegistry),
-            ISayHello,
-            IHandle<NewMessageReceived>,
-            IHandle<ConversationClosed>
-    {
-        public async Task Handle(NewMessageReceived item, CancellationToken cancellationToken = default)
-        {
-            var response = await SayHello(item.Message).ConfigureAwait(false);
-            var evt = new Output
-            {
-                Message = response
-            };
-            await PublishMessageAsync(evt).ConfigureAwait(false);
-            var goodbye = new ConversationClosed
-            {
-                UserId = this.AgentId.Key,
-                UserMessage = "Goodbye"
-            };
-            await PublishMessageAsync(goodbye).ConfigureAwait(false);
-        }
-        public async Task Handle(ConversationClosed item, CancellationToken cancellationToken = default)
-        {
-            var goodbye = $"*********************  {item.UserId} said {item.UserMessage}  ************************";
-            var evt = new Output
-            {
-                Message = goodbye
-            };
-            await PublishMessageAsync(evt).ConfigureAwait(false);
-            //sleep30 seconds
-            await Task.Delay(30000).ConfigureAwait(false);
-            hostApplicationLifetime.StopApplication();
-
-        }
-        public async Task<string> SayHello(string ask)
-        {
-            var response = $"\n\n\n\n***************Hello {ask}**********************\n\n\n\n";
-            return response;
-        }
-    }
-    public interface ISayHello
-    {
-        public Task<string> SayHello(string ask);
-    }
-}


### PR DESCRIPTION
## Why are these changes needed?

The `HelloAIAgents` sample is intended to demonstrate how to build an agent on top of `InferenceAgent<T>`, but it still uses several APIs that have since been removed (`AgentsMetadata`, `ConsoleAgent`, `AgentTypes`, and the old static `PublishMessageAsync` bootstrap path). As a result, the sample no longer builds against the current .NET projects and cannot serve as a working reference for issue #3927.

This change modernizes the existing sample around the current agent application APIs:

- `HelloAIAgent` now derives directly from `InferenceAgent<NewMessageReceived>` and receives the current `AgentId`, `IAgentRuntime`, `IChatClient`, and optional logger dependencies through activation.
- The handler uses the protected `ChatClient` to generate the greeting and passes through the message-context cancellation token.
- `Program.cs` registers the agent with either the in-process runtime or a gRPC worker, publishes the initial message through the built application, and waits for the agent to finish.
- The Azure OpenAI connection string is read from `AZURE_OPENAI_CONNECTION_STRING`; the sample no longer writes a placeholder credential into the process environment.

The change is deliberately limited to the existing sample and its project references. It does not alter the `InferenceAgent<T>` API or runtime behavior.

## Related issue number

Closes #3927

## Validation

- Before the change, `dotnet build dotnet/samples/Hello/HelloAIAgents/HelloAIAgents.csproj --configuration Release` failed with 16 compile errors from the removed APIs.
- `dotnet restore dotnet/samples/Hello/HelloAIAgents/HelloAIAgents.csproj --verbosity minimal` — passed.
- `dotnet format dotnet/samples/Hello/HelloAIAgents/HelloAIAgents.csproj --verify-no-changes --no-restore --verbosity minimal` — passed.
- `dotnet build dotnet/samples/Hello/HelloAIAgents/HelloAIAgents.csproj --configuration Release --no-restore --verbosity minimal` — passed with 0 warnings and 0 errors.
- `git diff --check` for the three changed sample files — passed.

I did not execute a live model request because that would require a contributor-specific Azure OpenAI deployment and credentials; the sample now fails early with a concrete configuration example when the environment variable is absent.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. This PR updates the runnable sample that documents this API; no website page needs to change.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. This is a sample-only modernization, so the focused restore, format, and Release build are the relevant checks.
- [ ] I've made sure all auto checks have passed. (Pending the repository CI run.)
