### PR TITLE
Docs: add a download link to notebook pages

### DIFF
--- a/python/docs/src/_templates/sourcelink.html
+++ b/python/docs/src/_templates/sourcelink.html
@@ -1,0 +1,17 @@
+{# Offer the original notebook on notebook-backed pages; preserve the source link elsewhere. #}
+{% if show_source and has_source and sourcename %}
+  <div class="tocsection sourcelink">
+    {% if sourcename.endswith(".ipynb.txt") %}
+      <a
+        href="{{ pathto('_sources/' + sourcename, true)|e }}"
+        download="{{ pagename.split('/')[-1] }}.ipynb"
+      >
+        <i class="fa-solid fa-download" aria-hidden="true"></i> {{ _("Download Notebook") }}
+      </a>
+    {% else %}
+      <a href="{{ pathto('_sources/' + sourcename, true)|e }}">
+        <i class="fa-solid fa-file-lines" aria-hidden="true"></i> {{ _("Show Source") }}
+      </a>
+    {% endif %}
+  </div>
+{% endif %}


### PR DESCRIPTION
## Why are these changes needed?

Notebook-backed documentation pages currently expose the standard PyData theme **Show Source** link. For these pages the link points to a copied source such as `_sources/user-guide/core-user-guide/quickstart.ipynb.txt`, so readers see raw notebook JSON in the browser and the `.txt` suffix obscures the fact that the page can be downloaded and opened as a notebook. That is the usability problem described in #3761.

This PR adds a focused override of PyData Sphinx Theme 0.16's `sourcelink.html` component:

- when Sphinx reports a source name ending in `.ipynb.txt`, the entry is presented as **Download Notebook** with a download icon;
- the link still targets Sphinx's copied `_sources/...ipynb.txt` asset, but the HTML `download` filename uses the page basename with an `.ipynb` extension, so the saved file is immediately usable;
- Markdown, reStructuredText, and other non-notebook pages retain the existing **Show Source** label, file-lines icon, and source URL behavior.

The override uses the existing `show_source`, `has_source`, and `sourcename` guards from the pinned theme template, so pages that do not expose source continue to omit the entry.

## Related issue number

Closes #3761

## Validation

I rendered an isolated two-page Sphinx fixture with the same documentation dependencies pinned by this repository (`myst-nb==1.1.2` and `pydata-sphinx-theme==0.16.0`) and the proposed template copied byte-for-byte:

- `sphinx-build -W --keep-going -E -a . build-3` — passed without warnings.
- The notebook page rendered `href="_sources/notebook.ipynb.txt"`, `download="notebook.ipynb"`, the download icon, and the **Download Notebook** label.
- The Markdown page retained `href="_sources/page.md.txt"`, the file-lines icon, and the **Show Source** label, with no notebook-download label.
- `python -m json.tool build-3/_sources/notebook.ipynb.txt` — passed, confirming that the downloaded source remains valid notebook JSON.
- `git diff --check` — passed.

No notebook was executed and no model credentials or external API calls were required.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. The change is the documentation-theme override itself.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. The exact pinned-theme fixture covers both the notebook path and the unchanged non-notebook path.
- [ ] I've made sure all auto checks have passed. (Pending the repository CI run.)
