### PR TITLE
docs: fix typos in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ We use GitHub issues and milestones to track our roadmap. You can view the upcom
 
 The set of `autogen-*` packages are generally all versioned together. When a change is made to one package, all packages are updated to the same version. This is to ensure that all packages are in sync with each other.
 
-We will update verion numbers according to the following rules:
+We will update version numbers according to the following rules:
 
 - Increase minor version (0.X.0) upon breaking changes
 - Increase patch version (0.0.X) upon new features or bug fixes
@@ -49,14 +49,14 @@ We will update verion numbers according to the following rules:
 
 1. Create a PR that updates the version numbers across the codebase ([example](https://github.com/microsoft/autogen/pull/4359))
 2. The docs CI will fail for the PR, but this is expected and will be resolved in the next step
-3. After merging the PR, create and push a tag that corresponds to the new verion. For example, for `0.4.0.dev13`:
+3. After merging the PR, create and push a tag that corresponds to the new version. For example, for `0.4.0.dev13`:
     - `git tag v0.4.0.dev13 && git push origin v0.4.0.dev13`
 4. Restart the docs CI by finding the failed [job corresponding to the `push` event](https://github.com/microsoft/autogen/actions/workflows/docs.yml) and restarting all jobs
 5. Run [this](https://github.com/microsoft/autogen/actions/workflows/single-python-package.yml) workflow for each of the packages that need to be released and get an approval for the release for it to run
 
 ## Triage process
 
-To help ensure the health of the project and community the AutoGen committers have a weekly triage process to ensure that all issues and pull requests are reviewed and addressed in a timely manner. The following documents the responsibilites while on triage duty:
+To help ensure the health of the project and community the AutoGen committers have a weekly triage process to ensure that all issues and pull requests are reviewed and addressed in a timely manner. The following documents the responsibilities while on triage duty:
 
 - Issues
   - Review all new issues - these will be tagged with [`needs-triage`](https://github.com/microsoft/autogen/issues?q=is%3Aissue%20state%3Aopen%20label%3Aneeds-triage).
@@ -79,7 +79,7 @@ To help ensure the health of the project and community the AutoGen committers ha
 - Discussions
   - Look for recently updated discussions and reply as needed or find someone on the team to reply.
 - Security
-  - Look through any securty alerts and file issues or dismiss as needed.
+  - Look through any security alerts and file issues or dismiss as needed.
 
 ## Becoming a Reviewer
 


### PR DESCRIPTION
This PR fixes four spelling errors in CONTRIBUTING.md:\n\n- verion -> version\n- responsibilites -> responsibilities\n- securty -> security\n\nThese corrections improve the readability of the contribution and release instructions without changing their meaning.\n\nValidation:\n- git diff --check