### PR TITLE
docs(python): fix migration guide link

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@ This directory works as a single `uv` workspace containing all project packages,
 
 ## Migrating from 0.2.x?
 
-Please refer to the [migration guide](./migration_guide.md) for how to migrate your code from 0.2.x to 0.4.x.
+Please refer to the [migration guide](./docs/src/user-guide/agentchat-user-guide/migration-guide.md) for how to migrate your code from 0.2.x to 0.4.x.
 
 ## Quick Start
 


### PR DESCRIPTION
## Why are these changes needed?

The Python README linked to `./migration_guide.md`, which no longer exists. This updates the link to the current AgentChat migration guide so readers can reach the documented 0.2.x to 0.4.x migration path.

## Related issue number

N/A — documentation-only broken link fix.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. (Not applicable: link-only change.)
- [x] I've made sure all auto checks have passed. (Verified the target file exists on `main`.)