### PR TITLE
fix(autogen-ext): serialize Redis memory components

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/memory/redis/_redis_memory.py
+++ b/python/packages/autogen-ext/src/autogen_ext/memory/redis/_redis_memory.py
@@ -6,6 +6,7 @@ from autogen_core.memory import Memory, MemoryContent, MemoryMimeType, MemoryQue
 from autogen_core.model_context import ChatCompletionContext
 from autogen_core.models import SystemMessage
 from pydantic import BaseModel, Field
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +171,7 @@ class RedisMemory(Memory, Component[RedisMemoryConfig]):
     """
 
     component_config_schema = RedisMemoryConfig
-    component_provider_override = "autogen_ext.memory.redis_memory.RedisMemory"
+    component_provider_override = "autogen_ext.memory.redis.RedisMemory"
 
     def __init__(self, config: RedisMemoryConfig | None = None) -> None:
         """Initialize RedisMemory."""
@@ -190,6 +191,17 @@ class RedisMemory(Memory, Component[RedisMemoryConfig]):
                 distance_threshold=self.config.distance_threshold,
                 redis_client=client,
             )
+
+    def _to_config(self) -> RedisMemoryConfig:
+        """Serialize the memory configuration."""
+
+        return self.config
+
+    @classmethod
+    def _from_config(cls, config: RedisMemoryConfig) -> Self:
+        """Deserialize the memory configuration."""
+
+        return cls(config=config)
 
     async def update_context(
         self,

--- a/python/packages/autogen-ext/tests/memory/test_redis_memory.py
+++ b/python/packages/autogen-ext/tests/memory/test_redis_memory.py
@@ -176,6 +176,32 @@ def test_memory_config() -> None:
         _ = RedisMemoryConfig(algorithm="pythagoras")  # type: ignore[arg-type]
 
 
+def test_redis_memory_component_serialization() -> None:
+    config = RedisMemoryConfig(
+        redis_url="redis://example:6379/2",
+        index_name="component-test",
+        prefix="component",
+        sequential=True,
+        top_k=3,
+    )
+
+    with (
+        patch("autogen_ext.memory.redis._redis_memory.Redis.from_url"),
+        patch("autogen_ext.memory.redis._redis_memory.MessageHistory"),
+    ):
+        memory = RedisMemory(config)
+        dumped = memory.dump_component()
+
+        assert dumped.provider == "autogen_ext.memory.redis.RedisMemory"
+        assert dumped.config["redis_url"] == config.redis_url
+        assert dumped.config["index_name"] == config.index_name
+
+        loaded = RedisMemory.load_component(dumped)
+
+    assert isinstance(loaded, RedisMemory)
+    assert loaded.config == config
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(not redis_available(), reason="Redis instance not available locally")
 @pytest.mark.parametrize("sequential", [True, False])


### PR DESCRIPTION
## Why are these changes needed?

`RedisMemory` declares `RedisMemoryConfig` as its component schema, but it inherits configuration methods that raise `NotImplementedError`. This makes configuration export fail for production callers such as an `AssistantAgent` serializing its memory list. Its provider string also names a module that does not exist, so loading a dumped component would fail even after serialization was implemented.

This PR returns the existing configuration from `_to_config`, reconstructs the memory in `_from_config`, and uses the public `autogen_ext.memory.redis.RedisMemory` provider path. The regression test round-trips a configured sequential memory through the component loader without requiring Redis or an embedding model.

## Related issue number

N/A — no matching open issue or PR for RedisMemory component serialization was found. Open PR #7497 changes only the unrelated Redis import-error text in the same source file.

## Checks

- [x] No documentation changes are needed for this focused bug fix.
- [x] I've added tests corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

Local validation run:

- `uv run --no-sync pytest packages/autogen-ext/tests/memory/test_redis_memory.py -k component_serialization -q` (RED before the production change: `NotImplementedError`; GREEN after: 1 passed)
- `uv run --no-sync pytest packages/autogen-ext/tests/memory/test_redis_memory.py -k 'component_serialization or memory_config' -q` (2 passed)
- `uv run --no-sync ruff format --check packages/autogen-ext/src/autogen_ext/memory/redis/_redis_memory.py packages/autogen-ext/tests/memory/test_redis_memory.py`
- `uv run --no-sync ruff check packages/autogen-ext/src/autogen_ext/memory/redis/_redis_memory.py packages/autogen-ext/tests/memory/test_redis_memory.py`
- `uv run --no-sync mypy --config-file ../../pyproject.toml --ignore-missing-imports src/autogen_ext/memory/redis/_redis_memory.py tests/memory/test_redis_memory.py`
- `uv run --no-sync pyright src/autogen_ext/memory/redis/_redis_memory.py tests/memory/test_redis_memory.py`
- `uv run --no-sync poe fmt --check` and `uv run --no-sync poe lint` from `packages/autogen-ext`

The full RedisMemory test file was also attempted, but its existing semantic-memory tests require `sentence-transformers`, which is not installed by the selected locked Redis extras. Package-wide mypy/pyright were attempted and report unrelated missing optional integrations outside this change; the changed files pass scoped checks.

## AI assistance

AI assistance was used to prepare this focused fix and regression test. The validation commands above were executed in the repository.
