### PR TITLE
docs: document CancellationToken propagation through nested tools

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -299,6 +299,37 @@ The {py:class}`~autogen_core.CancellationToken` can be used to cancel the reques
 when you call `cancellation_token.cancel()`, which will cause the `await`
 on the `on_messages` call to raise a `CancelledError`.
 
+When an agent delegates work to another agent, a workbench, or a tool, pass the
+same token through every asynchronous boundary. In a message handler,
+`ctx.cancellation_token` is the token to forward:
+
+```python
+from typing import Any, Mapping
+
+from autogen_core import CancellationToken, MessageContext
+from autogen_core.tools import Tool, Workbench
+
+
+async def handle_nested_call(
+    ctx: MessageContext,
+    workbench: Workbench,
+    tool: Tool,
+    arguments: Mapping[str, Any],
+) -> None:
+    cancellation_token: CancellationToken = ctx.cancellation_token
+
+    # Workbench calls must receive the token as a keyword argument.
+    await workbench.call_tool("lookup", arguments, cancellation_token=cancellation_token)
+
+    # Direct tool calls require the token as their second argument.
+    await tool.run_json(arguments, cancellation_token)
+```
+
+Do not create a new `CancellationToken` for the nested call. If the outer
+operation is cancelled, forwarding the token lets the nested agent, workbench,
+and tool observe the cancellation and stop their pending work. A cancelled
+`on_messages` or nested operation raises `asyncio.CancelledError` to its caller.
+
 Read more on [Agent Tutorial](./tutorial/agents.ipynb)
 and {py:class}`~autogen_agentchat.agents.AssistantAgent`.
 


### PR DESCRIPTION
## Why are these changes needed?

Closes #8091. AutoGen already accepts a `CancellationToken` at the top-level agent boundary, but the migration guide did not explain how custom agents should forward that token into nested agents, workbenches, and direct tool calls. Without that guidance, applications can accidentally create a new token and leave nested work running after the parent operation is cancelled.

## What changed?

- Added a focused example showing `ctx.cancellation_token` forwarded to `Workbench.call_tool(..., cancellation_token=...)` and `Tool.run_json(..., cancellation_token)`.
- Documented that nested calls should reuse the outer token and that cancellation propagates as `asyncio.CancelledError`.

## Checks

- `uv run python check_md_code_blocks.py docs/src/user-guide/agentchat-user-guide/migration-guide.md` (passed; all code blocks accepted by Pyright)
- `git diff --check` (passed)
- `env LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 uv run poe docs-check` (the build completed, but the repository's `--fail-on-warning` gate reported 14 pre-existing missing optional dependencies: `cv2`, `chromadb`, `ollama`, `semantic_kernel`, `graphrag`, etc.)

## AI assistance

AI assistance was used to research the existing cancellation APIs, draft the documentation example, and run the validation commands. The final diff was reviewed against the current `MessageContext`, `Workbench`, and `Tool` signatures.
