### PR TITLE
docs: use explicit UTF-8 encoding in redirect generation script

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:


### PR DESCRIPTION
Closes #7749

## Why this fix is correct
`redirects.py` uses default system encoding for three `open()` calls (read template, read URL list, write generated pages). On Windows locales where the default codepage is not UTF-8 (e.g. cp936), any non-ASCII character in `redirect_template.html` or `redirect_urls.txt` would raise `UnicodeDecodeError`/`UnicodeEncodeError`. The docs tooling already lives in a UTF-8 world (Markdown + HTML are UTF-8), so pinning `encoding="utf-8"` makes behavior identical across all platforms.

## Alternatives I considered
- Wrapping reads in `errors="replace"` — silently corrupts content instead of failing, hides real problems. Rejected.
- Only fixing the write side — the read side (template + URL list) is equally exposed, so it must be fixed too.

## Suggested for maintainers
This is safe and non-behavioral for everyone on UTF-8 systems (the common case). If you want extra belt-and-suspenders, you could add a `Path.read_text(encoding="utf-8")` helper, but the inline change is minimal and sufficient for this issue.