### PR TITLE
docs: correct typos in design documentation

### DIFF
--- a/docs/design/01 - Programming Model.md
+++ b/docs/design/01 - Programming Model.md
@@ -2,7 +2,7 @@
 
 Understanding your workflow and mapping it to agents is the key to building an agent system in AutoGen.
 
-The programming model is basically publish-subscribe. Agents subscribe to events they care about and also can publish events that other agents may care about. Agents may also have additonal assets such as Memory, prompts, data sources, and skills (external APIs).
+The programming model is basically publish-subscribe. Agents subscribe to events they care about and also can publish events that other agents may care about. Agents may also have additional assets such as Memory, prompts, data sources, and skills (external APIs).
 
 ## Events Delivered as CloudEvents
 

--- a/docs/design/04 - Agent and Topic ID Specs.md
+++ b/docs/design/04 - Agent and Topic ID Specs.md
@@ -9,7 +9,7 @@ This document describes the structure, constraints, and behavior of Agent IDs an
 #### type
 
 - Type: `string`
-- Description: The agent type is not an agent class. It associates an agent with a specific factory function, which produces instances of agents of the same agent `type`. For example, different factory functions can produce the same agent class but with different constructor perameters.
+- Description: The agent type is not an agent class. It associates an agent with a specific factory function, which produces instances of agents of the same agent `type`. For example, different factory functions can produce the same agent class but with different constructor parameters.
 - Constraints: UTF8 and only contain alphanumeric letters (a-z) and (0-9), or underscores (\_). A valid identifier cannot start with a number, or contain any spaces.
 - Examples:
   - `code_reviewer`

--- a/docs/design/05 - Services.md
+++ b/docs/design/05 - Services.md
@@ -6,7 +6,7 @@ Each AutoGen agent system has one or more Agent Workers and a set of services fo
 
 - In-Memory: the Agent Workers and Services are all hosted in the same process and communicate over in-memory channels. Available for python and .NET.
 - Python only: Agent workers communicate with a python hosted service that implements an in-memory message bus and agent registry.
-- Micrososft Orleans: a distributed actor system that can host the services and workers, enables distributed state with persistent storage, can leverage multiple event bus types, and cross-language agent communication.
+- Microsoft Orleans: a distributed actor system that can host the services and workers, enables distributed state with persistent storage, can leverage multiple event bus types, and cross-language agent communication.
 - *Roadmap: support for other languages distributed systems such as dapr or Akka.*
 
 The Services in the system include:


### PR DESCRIPTION
## Summary
Correct three spelling errors in the AutoGen design documentation.

## Validation
- Ran `git diff --check`
- Confirmed the corrected words are no longer reported by the targeted spell check