### PR TITLE
fix(autogen-ext): preserve Docker GPU requests in config

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
@@ -80,6 +80,7 @@ class DockerCommandLineCodeExecutorConfig(BaseModel):
     extra_hosts: Dict[str, str] = {}
     init_command: Optional[str] = None
     delete_tmp_files: bool = False
+    device_requests: Optional[List[Dict[str, Any]]] = None
 
 
 class DockerCommandLineCodeExecutor(CodeExecutor, Component[DockerCommandLineCodeExecutorConfig]):
@@ -588,6 +589,9 @@ $functions"""
             extra_hosts=self._extra_hosts,
             init_command=self._init_command,
             delete_tmp_files=self._delete_tmp_files,
+            device_requests=[dict(device_request) for device_request in self._device_requests]
+            if self._device_requests is not None
+            else None,
         )
 
     @classmethod
@@ -608,4 +612,7 @@ $functions"""
             extra_hosts=config.extra_hosts,
             init_command=config.init_command,
             delete_tmp_files=config.delete_tmp_files,
+            device_requests=[DeviceRequest(**device_request) for device_request in config.device_requests]
+            if config.device_requests is not None
+            else None,
         )

--- a/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
+++ b/python/packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py
@@ -13,6 +13,7 @@ from aiofiles import open
 from autogen_core import CancellationToken
 from autogen_core.code_executor import CodeBlock
 from autogen_ext.code_executors.docker import DockerCommandLineCodeExecutor
+from docker.types import DeviceRequest
 
 
 def docker_tests_enabled() -> bool:
@@ -258,13 +259,16 @@ async def test_docker_commandline_code_executor_extra_args() -> None:
 @pytest.mark.asyncio
 async def test_docker_commandline_code_executor_serialization() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
-        executor = DockerCommandLineCodeExecutor(work_dir=temp_dir)
+        device_request = DeviceRequest(count=-1, capabilities=[["gpu"]])
+        executor = DockerCommandLineCodeExecutor(work_dir=temp_dir, device_requests=[device_request])
 
         executor_config = executor.dump_component()
         loaded_executor = DockerCommandLineCodeExecutor.load_component(executor_config)
 
         assert executor.bind_dir == loaded_executor.bind_dir
         assert executor.timeout == loaded_executor.timeout
+        assert executor_config.config["device_requests"] == [dict(device_request)]
+        assert loaded_executor._device_requests == [device_request]  # type: ignore[reportPrivateUsage]
 
 
 def test_invalid_timeout() -> None:


### PR DESCRIPTION
## Why are these changes needed?

`DockerCommandLineCodeExecutor` supports Docker `device_requests` at runtime and passes them to `containers.create`, but its component configuration omitted the field. Restoring an executor from component configuration therefore silently drops GPU device requests.

This adds a JSON-compatible optional config field, serializes each Docker `DeviceRequest` to its API mapping, and reconstructs it when loading the component. The regression test covers the supported `dump_component()`/`load_component()` path for a GPU request.

## Related issue number

N/A — there is no matching open issue or pull request. #6339 added runtime GPU support but did not serialize the existing option.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. Existing documentation for the option remains accurate; no documentation change is needed.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed. GitHub checks are pending.

Local validation:

- `uv run --no-sync pytest packages/autogen-ext/tests/code_executors/test_docker_commandline_code_executor.py -q` — 16 passed
- `uv run --no-sync ruff format --check` and `uv run --no-sync ruff check` on both changed files
- scoped `mypy` and `pyright` on both changed files
- `uv run --no-sync poe fmt --check` and `uv run --no-sync poe lint` in `packages/autogen-ext`

Package-wide `poe mypy` and `poe pyright` were also attempted. In the focused Docker test environment they report existing failures from unrelated optional integrations that are not installed; neither reported a finding in the two changed files.

## AI assistance

AI assistance was used to investigate the defect and prepare the patch and regression test. The submitted diff, production path, duplicate check, and local test results were independently reviewed.
