### PR TITLE
fix: serialize tool outputs to JSON, remove trailing assistant messages, resolve Bedrock model IDs

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:

--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -171,6 +171,9 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
                 return json.dumps(dumped)
             return str(dumped)
 
+        if isinstance(value, (dict, list)):
+            return json.dumps(value)
+
         return str(value)
 
     @abstractmethod

--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -172,7 +172,10 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
             return str(dumped)
 
         if isinstance(value, (dict, list)):
-            return json.dumps(value)
+            try:
+                return json.dumps(value)
+            except (TypeError, ValueError):
+                pass
 
         return str(value)
 

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -480,6 +480,34 @@ async def test_func_tool_return_list() -> None:
     assert tool.return_value_as_string(result) == "[1, 2]"
 
 
+@pytest.mark.asyncio
+async def test_func_tool_return_dict_serializes_to_json() -> None:
+    """Test that dict return values are serialized to valid JSON, not Python repr."""
+
+    def my_function() -> dict:
+        return {"status": "success", "count": 42}
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    assert isinstance(result, dict)
+    # Should be valid JSON with double quotes, not Python repr with single quotes
+    assert tool.return_value_as_string(result) == '{"status": "success", "count": 42}'
+
+
+@pytest.mark.asyncio
+async def test_func_tool_return_list_serializes_to_json() -> None:
+    """Test that list return values are serialized to valid JSON."""
+
+    def my_function() -> list:
+        return ["a", "b", "c"]
+
+    tool = FunctionTool(my_function, description="Function tool.")
+    result = await tool.run_json({}, CancellationToken())
+    assert isinstance(result, list)
+    # Should be valid JSON
+    assert tool.return_value_as_string(result) == '["a", "b", "c"]'
+
+
 def test_nested_tool_schema_generation() -> None:
     schema: ToolSchema = MyNestedTool().schema
 

--- a/python/packages/autogen-core/tests/test_tools.py
+++ b/python/packages/autogen-core/tests/test_tools.py
@@ -1,7 +1,7 @@
 import inspect
 from dataclasses import dataclass
 from functools import partial
-from typing import Annotated, List
+from typing import Annotated, List, Any
 
 import pytest
 from autogen_core import CancellationToken
@@ -484,7 +484,7 @@ async def test_func_tool_return_list() -> None:
 async def test_func_tool_return_dict_serializes_to_json() -> None:
     """Test that dict return values are serialized to valid JSON, not Python repr."""
 
-    def my_function() -> dict:
+    def my_function() -> dict[str, Any]:
         return {"status": "success", "count": 42}
 
     tool = FunctionTool(my_function, description="Function tool.")
@@ -498,7 +498,7 @@ async def test_func_tool_return_dict_serializes_to_json() -> None:
 async def test_func_tool_return_list_serializes_to_json() -> None:
     """Test that list return values are serialized to valid JSON."""
 
-    def my_function() -> list:
+    def my_function() -> list[str]:
         return ["a", "b", "c"]
 
     tool = FunctionTool(my_function, description="Function tool.")

--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_anthropic_client.py
@@ -540,14 +540,19 @@ class BaseAnthropicChatCompletionClient(ChatCompletionClient):
 
     def _rstrip_last_assistant_message(self, messages: Sequence[LLMMessage]) -> Sequence[LLMMessage]:
         """
-        Remove the last assistant message if it is empty.
+        Remove trailing assistant messages so the conversation ends with a user message.
+        The Anthropic API requires conversations to end with a user message.
         """
-        # When Claude models last message is AssistantMessage, It could not end with whitespace
-        if isinstance(messages[-1], AssistantMessage):
-            if isinstance(messages[-1].content, str):
-                messages[-1].content = messages[-1].content.rstrip()
+        msgs = list(messages)
+        # Strip whitespace from trailing assistant message content first
+        if msgs and isinstance(msgs[-1], AssistantMessage) and isinstance(msgs[-1].content, str):
+            msgs[-1].content = msgs[-1].content.rstrip()
 
-        return messages
+        # Remove trailing assistant messages (and their associated function execution results)
+        while msgs and isinstance(msgs[-1], AssistantMessage):
+            msgs.pop()
+
+        return msgs
 
     async def create(
         self,

--- a/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/anthropic/_model_info.py
@@ -2,6 +2,35 @@ from typing import Dict
 
 from autogen_core.models import ModelFamily, ModelInfo
 
+# Bedrock provider/region prefixes that can appear before the model name
+_BEDROCK_PREFIXES = (
+    "us.anthropic.",
+    "us-east-1.anthropic.",
+    "us-west-2.anthropic.",
+    "eu.anthropic.",
+    "eu-west-1.anthropic.",
+    "apac.anthropic.",
+    "ap-southeast-1.anthropic.",
+    "global.anthropic.",
+    "anthropic.",
+)
+
+
+def _normalize_model_id(model: str) -> str:
+    """Strip Bedrock provider/region prefixes and version suffixes to get the base model ID."""
+    # Strip Bedrock prefixes
+    for prefix in _BEDROCK_PREFIXES:
+        if model.startswith(prefix):
+            model = model[len(prefix) :]
+            break
+    # Strip version suffix like -v1:0, -v2:1
+    if "-v" in model:
+        model = model.split("-v")[0]
+    return model
+
+
+# Mapping of model names to their capabilities
+
 # Mapping of model names to their capabilities
 # For Anthropic's Claude models based on:
 # https://docs.anthropic.com/claude/docs/models-overview
@@ -140,13 +169,16 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
 
 def get_info(model: str) -> ModelInfo:
     """Get the model information for a specific model."""
+    # Normalize Bedrock-style model IDs
+    normalized = _normalize_model_id(model)
+
     # Check for exact match first
-    if model in _MODEL_INFO:
-        return _MODEL_INFO[model]
+    if normalized in _MODEL_INFO:
+        return _MODEL_INFO[normalized]
 
     # Check for partial match (for handling model variants)
     for model_id in _MODEL_INFO:
-        if model.startswith(model_id.split("-2")[0]):  # Match base name
+        if normalized.startswith(model_id.split("-2")[0]):  # Match base name
             return _MODEL_INFO[model_id]
 
     raise KeyError(f"Model '{model}' not found in model info")
@@ -154,13 +186,16 @@ def get_info(model: str) -> ModelInfo:
 
 def get_token_limit(model: str) -> int:
     """Get the token limit for a specific model."""
+    # Normalize Bedrock-style model IDs
+    normalized = _normalize_model_id(model)
+
     # Check for exact match first
-    if model in _MODEL_TOKEN_LIMITS:
-        return _MODEL_TOKEN_LIMITS[model]
+    if normalized in _MODEL_TOKEN_LIMITS:
+        return _MODEL_TOKEN_LIMITS[normalized]
 
     # Check for partial match (for handling model variants)
     for model_id in _MODEL_TOKEN_LIMITS:
-        if model.startswith(model_id.split("-2")[0]):  # Match base name
+        if normalized.startswith(model_id.split("-2")[0]):  # Match base name
             return _MODEL_TOKEN_LIMITS[model_id]
 
     # Default to a reasonable limit if model not found

--- a/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
@@ -1271,3 +1271,28 @@ async def test_anthropic_thinking_mode_with_tools() -> None:
     # Should have thinking content even with tool calls
     assert result.thought is not None
     assert len(result.thought) > 10
+
+
+def test_get_info_bedrock_model_id() -> None:
+    """Bedrock model IDs should resolve to the same info as the base model."""
+    from autogen_ext.models.anthropic._model_info import get_info
+
+    info = get_info("us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+    assert info["function_calling"] is True
+    assert info["vision"] is True
+
+
+def test_get_token_limit_bedrock_model_id() -> None:
+    """Bedrock model IDs should resolve to the correct token limit."""
+    from autogen_ext.models.anthropic._model_info import get_token_limit
+
+    limit = get_token_limit("us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+    assert limit == 200000
+
+
+def test_get_info_eu_bedrock_model_id() -> None:
+    """EU Bedrock model IDs should also resolve correctly."""
+    from autogen_ext.models.anthropic._model_info import get_info
+
+    info = get_info("eu.anthropic.claude-3-7-sonnet-20250219-v1:0")
+    assert info["function_calling"] is True

--- a/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
@@ -828,12 +828,29 @@ def test_mock_rstrip_trailing_whitespace_at_last_assistant_content() -> None:
         AssistantMessage(content="foobar ", source="assistant"),
     ]
 
-    # This will crash if _rstrip_railing_whitespace_at_last_assistant_content is not applied to "content"
     dummy_client = AnthropicChatCompletionClient(model="claude-3-5-haiku-20241022", api_key="dummy-key")
     result = dummy_client._rstrip_last_assistant_message(messages)  # pyright: ignore[reportPrivateUsage]
 
-    assert isinstance(result[-1].content, str)
-    assert result[-1].content == "foobar"
+    # Trailing assistant message should be removed entirely
+    assert len(result) == 2
+    assert isinstance(result[-1], UserMessage)
+
+
+def test_rstrip_removes_multiple_trailing_assistant_messages() -> None:
+    """Test that multiple trailing assistant messages are removed."""
+    messages: list[LLMMessage] = [
+        UserMessage(content="foo", source="user"),
+        AssistantMessage(content="response 1", source="assistant"),
+        AssistantMessage(content="response 2", source="assistant"),
+    ]
+
+    dummy_client = AnthropicChatCompletionClient(model="claude-3-5-haiku-20241022", api_key="dummy-key")
+    result = dummy_client._rstrip_last_assistant_message(messages)  # pyright: ignore[reportPrivateUsage]
+
+    # All trailing assistant messages should be removed
+    assert len(result) == 1
+    assert isinstance(result[-1], UserMessage)
+    assert result[-1].content == "foo"
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_anthropic_model_client.py
@@ -1277,7 +1277,7 @@ def test_get_info_bedrock_model_id() -> None:
     """Bedrock model IDs should resolve to the same info as the base model."""
     from autogen_ext.models.anthropic._model_info import get_info
 
-    info = get_info("us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+    info = get_info("us.anthropic.claude-3-5-sonnet-20240620-v1:0")  # ggignore
     assert info["function_calling"] is True
     assert info["vision"] is True
 
@@ -1286,7 +1286,7 @@ def test_get_token_limit_bedrock_model_id() -> None:
     """Bedrock model IDs should resolve to the correct token limit."""
     from autogen_ext.models.anthropic._model_info import get_token_limit
 
-    limit = get_token_limit("us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+    limit = get_token_limit("us.anthropic.claude-3-5-sonnet-20240620-v1:0")  # ggignore
     assert limit == 200000
 
 
@@ -1294,5 +1294,5 @@ def test_get_info_eu_bedrock_model_id() -> None:
     """EU Bedrock model IDs should also resolve correctly."""
     from autogen_ext.models.anthropic._model_info import get_info
 
-    info = get_info("eu.anthropic.claude-3-7-sonnet-20250219-v1:0")
+    info = get_info("eu.anthropic.claude-3-7-sonnet-20250219-v1:0")  # ggignore
     assert info["function_calling"] is True


### PR DESCRIPTION
## Summary

Fixes #7867, #7768, and #7833

### #7867: Tool output serialization
BaseTool.return_value_as_string used str() for dicts/lists, producing Python repr instead of valid JSON.

### #7768: Anthropic trailing assistant messages
_rstrip_last_assistant_message only stripped whitespace but didn't remove trailing assistant messages.

### #7833: Bedrock model ID resolution
get_info/get_token_limit could not resolve Bedrock model IDs with provider prefixes.

## Changes

- Updated BaseTool.return_value_as_string to use json.dumps for dict/list values
- Updated Anthropic _rstrip_last_assistant_message to remove trailing assistant messages
- Added _normalize_model_id helper for Bedrock model ID resolution
- Added regression tests for all fixes

## Test plan

- [x] New tests pass
- [x] Existing tests still pass