### PR TITLE
fix: validate participants type in BaseGroupChat constructor

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -78,8 +78,19 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
     ):
         self._name = name
         self._description = description
+        if participants is None:
+            raise TypeError("participants must be a non-empty sequence of ChatAgent or Team instances, got None")
+        if not isinstance(participants, (list, tuple)):
+            raise TypeError(
+                f"participants must be a non-empty sequence of ChatAgent or Team instances, got {type(participants).__name__}"
+            )
         if len(participants) == 0:
             raise ValueError("At least one participant is required.")
+        for i, participant in enumerate(participants):
+            if not isinstance(participant, (ChatAgent, Team)):
+                raise TypeError(
+                    f"participants[{i}] must be a ChatAgent or Team instance, got {type(participant).__name__}"
+                )
         if len(participants) != len(set(participant.name for participant in participants)):
             raise ValueError("The participant names must be unique.")
         self._participants = participants

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -1944,3 +1944,26 @@ async def test_selector_group_chat_streaming(runtime: AgentRuntime | None) -> No
 
     # Content-based verification instead of index-based
     # Note: The streaming test verifies the streaming behavior, not the final result content
+
+
+@pytest.mark.asyncio
+async def test_round_robin_group_chat_validates_participants_none() -> None:
+    """Test that participants=None raises a clear TypeError."""
+    with pytest.raises(TypeError, match="participants must be a non-empty sequence"):
+        RoundRobinGroupChat(participants=None)  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_round_robin_group_chat_validates_participants_not_sequence() -> None:
+    """Test that non-sequence participants raises a clear TypeError."""
+    with pytest.raises(TypeError, match="participants must be a non-empty sequence"):
+        RoundRobinGroupChat(participants="not a list")  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_round_robin_group_chat_validates_participants_invalid_type() -> None:
+    """Test that participants containing non-agent objects raises a clear TypeError."""
+    from autogen_agentchat.agents import UserProxyAgent
+
+    with pytest.raises(TypeError, match=r"participants\[1\] must be a ChatAgent or Team"):
+        RoundRobinGroupChat(participants=[UserProxyAgent(name="valid"), "invalid"])  # type: ignore


### PR DESCRIPTION
## Summary

Fixes #7580

Previously, passing None, a non-sequence, or non-agent objects as participants would raise internal AttributeError/TypeError. Now raises clear TypeError with descriptive message.

## Changes

- Added type validation in BaseGroupChat.__init__ for participants parameter
- Validates that participants is a list/tuple (not None or other types)
- Validates that each participant is a ChatAgent or Team instance
- Added regression tests for all validation cases

## Test plan

- [x] New tests pass
- [x] Existing tests still pass