### PR TITLE
fix(autogenstudio): preserve DB password in alembic.ini (Fixes #7341)

### DIFF
--- a/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
+++ b/python/packages/autogen-studio/autogenstudio/database/schema_manager.py
@@ -194,7 +194,11 @@ else:
         """
         Generates content for alembic.ini file.
         """
-        engine_url = str(self.engine.url).replace("%", "%%")
+        # render_as_string(hide_password=False) is required because str(URL) masks the
+        # password as "***" in SQLAlchemy 2.x, which would make Alembic authenticate
+        # with the literal "***" and fail (see issue #7341). "%" must still be escaped
+        # for ConfigParser interpolation.
+        engine_url = self.engine.url.render_as_string(hide_password=False).replace("%", "%%")
         return f"""
 [alembic]
 script_location = {self.alembic_dir}

--- a/python/packages/autogen-studio/tests/test_schema_manager.py
+++ b/python/packages/autogen-studio/tests/test_schema_manager.py
@@ -1,0 +1,40 @@
+import configparser
+from pathlib import Path
+from types import SimpleNamespace
+
+from sqlalchemy.engine import make_url
+
+from autogenstudio.database.schema_manager import SchemaManager
+
+
+def _alembic_ini_url(engine_uri: str) -> str:
+    """Generate the alembic.ini content for a URI and return the parsed sqlalchemy.url."""
+    # _generate_alembic_ini_content() only reads engine.url, so a lightweight stub
+    # keeps this pure URL-rendering test free of DBAPI driver imports (psycopg/libpq).
+    engine = SimpleNamespace(url=make_url(engine_uri))
+    schema_manager = SchemaManager(engine=engine, base_dir=Path("/tmp/schema_manager_test"))  # type: ignore[arg-type]
+    content = schema_manager._generate_alembic_ini_content()
+    parser = configparser.ConfigParser()
+    parser.read_string(content)
+    return parser.get("alembic", "sqlalchemy.url")
+
+
+def test_alembic_ini_preserves_database_password():
+    """Regression test for #7341: the URL written to alembic.ini must keep the real
+    password. SQLAlchemy 2.x masks passwords in ``str(URL)`` as ``***``, so writing
+    that form into alembic.ini made Alembic authenticate with the literal ``***`` and
+    fail with "password authentication failed" on first-time database initialization
+    even though the application engine itself connected successfully."""
+    ini_url = _alembic_ini_url("postgresql+psycopg://autogen:autogen@postgres:5432/autogen")
+    assert make_url(ini_url).password == "autogen"
+    assert "***" not in ini_url
+
+
+def test_alembic_ini_roundtrips_password_with_special_characters():
+    """Passwords with URL-reserved characters must survive the alembic.ini round trip
+    (URL encoding on render + ConfigParser ``%%`` escaping)."""
+    ini_url = _alembic_ini_url("postgresql+psycopg://alice:p%40ssw0rd@db.example.com:5432/app")
+    parsed = make_url(ini_url)
+    assert parsed.username == "alice"
+    assert parsed.password == "p@ssw0rd"
+    assert parsed.host == "db.example.com"


### PR DESCRIPTION
## Why are these changes needed?

Fixes #7341 — on first-time startup against PostgreSQL, AutoGen Studio's
Alembic migration step (`SchemaManager.generate_revision`) fails with
`password authentication failed` even though the app's own engine connects
successfully with the same `DATABASE_URI` (verified via psql).

**Root cause:** `_generate_alembic_ini_content()` serialized the engine URL
with `str(self.engine.url)`. In SQLAlchemy 2.x, `str(URL)` masks the password
as `***` (`URL.__str__` renders with `hide_password=True`). The URL written to
`alembic.ini` therefore became:

```
postgresql+psycopg://autogen:***@postgres:5432/autogen
```

Alembic's `autogenerate` then opened a fresh connection using the literal
password `***`, which PostgreSQL rejects. This only surfaces on first boot
because `generate_revision()` runs only when the database is empty; on later
restarts the tables already exist and the migration path is skipped, which is
why the UI "works" while the startup log still shows the error.

**Fix:** render the URL with `URL.render_as_string(hide_password=False)` so the
real password is preserved in `alembic.ini`, keeping the existing `%` → `%%`
escaping so passwords containing `%` still survive ConfigParser interpolation.

## Related issue number

Closes #7341

## Test plan / evidence

- New regression tests in `tests/test_schema_manager.py` (RED first — both
  failed on `main` with `assert '***' == 'autogen'`, then passed after the fix):
  - `test_alembic_ini_preserves_database_password` — the ini URL must contain
    the real password, never `***`.
  - `test_alembic_ini_roundtrips_password_with_special_characters` — a password
    with URL-reserved characters (`p@ssw0rd`) round-trips correctly through
    URL rendering + ConfigParser `%%` escaping.
- Local run: `pytest tests/test_schema_manager.py tests/test_db_manager.py -q`
  → 5 passed; the 3 remaining errors in `test_db_manager.py` are pre-existing
  on clean `main` (OpenAIChatCompletionClient fixture fails to construct with
  the released autogen-ext on this host — unrelated to this change, verified
  by running the same tests with the fix stashed).
- `ruff check` and `ruff format --check` pass on the changed files.
- Second-agent review: `hermes chat -Q` fresh-context review of the exact diff
  returned CLEAN / findings handled (see below).
- Note: this is a re-proposal of the same root-cause fix as closed PR #7349
  (closed unmerged after ~2 months with no maintainer review). This PR adds
  regression tests and an updated explanation; happy to adjust to maintainer
  preference.

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
