### PR TITLE
fix: include extra_body in OpenAI client config model

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -74,6 +74,8 @@ class BaseOpenAIClientConfiguration(CreateArguments, total=False):
     include_name_in_message: bool
     """Whether to include the 'name' field in user message parameters. Defaults to True. Set to False for providers that don't support the 'name' field."""
     default_headers: Dict[str, str] | None
+    extra_body: Dict[str, object] | None
+    """Additional parameters to pass to the OpenAI API. This is passed directly to the underlying OpenAI client."""
 
 
 # See OpenAI docs for explanation of these parameters
@@ -120,6 +122,7 @@ class BaseOpenAIClientConfigurationConfigModel(CreateArgumentsConfigModel):
     add_name_prefixes: bool | None = None
     include_name_in_message: bool | None = None
     default_headers: Dict[str, str] | None = None
+    extra_body: Dict[str, object] | None = None
 
 
 # See OpenAI docs for explanation of these parameters

--- a/python/packages/autogen-ext/tests/models/test_openai_model_client.py
+++ b/python/packages/autogen-ext/tests/models/test_openai_model_client.py
@@ -3378,3 +3378,30 @@ async def test_reasoning_effort_validation() -> None:
         }
 
         ChatCompletionClient.load_component(config)
+
+
+def test_openai_client_config_includes_extra_body() -> None:
+    """Test that extra_body is included in config serialization/deserialization."""
+    from autogen_ext.models.openai import OpenAIChatCompletionClient
+    from autogen_ext.models.openai.config import OpenAIClientConfigurationConfigModel
+
+    config = OpenAIClientConfigurationConfigModel(
+        model="gpt-4",
+        api_key="test-key",
+        extra_body={"enable_thinking": False},
+        model_info={
+            "vision": False,
+            "function_calling": True,
+            "json_output": True,
+            "family": "unknown",
+            "structured_output": True,
+        },
+    )
+
+    # Verify extra_body is in the config
+    assert config.extra_body == {"enable_thinking": False}
+
+    # Verify it serializes correctly
+    dumped = config.model_dump(exclude_none=True)
+    assert "extra_body" in dumped
+    assert dumped["extra_body"] == {"enable_thinking": False}


### PR DESCRIPTION
## Summary

Fixes #7418

Previously, extra_body was not included in the config model, causing it to be silently dropped when loaded via AutoGen Studio JSON config.

## Changes

- Added extra_body field to BaseOpenAIClientConfiguration and BaseOpenAIClientConfigurationConfigModel
- Added test to verify extra_body is serialized/deserialized correctly

## Test plan

- [x] New test passes
- [x] Existing tests still pass