### PR TITLE
fix: upgrade LocalCommandLineCodeExecutor warning to DeprecationWarning

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/local/__init__.py
@@ -164,7 +164,7 @@ $functions"""
             "Using LocalCommandLineCodeExecutor may execute code on the local machine which can be unsafe. "
             "For security, it is recommended to use DockerCommandLineCodeExecutor instead. "
             "To install Docker, visit: https://docs.docker.com/get-docker/",
-            UserWarning,
+            DeprecationWarning,
             stacklevel=2,
         )
 


### PR DESCRIPTION
## Summary

Fixes #7462

Changed from UserWarning to DeprecationWarning to make the security warning more visible and harder to silently filter in production.

## Changes

- Changed warning type from UserWarning to DeprecationWarning in LocalCommandLineCodeExecutor

## Test plan

- [x] Existing tests still pass