### PR TITLE
fix: upgrade Docker fallback warning to DeprecationWarning

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/__init__.py
@@ -70,7 +70,7 @@ def create_default_code_executor(work_dir: Optional[str] = None) -> CodeExecutor
         "Docker is not available or not running. Using LocalCommandLineCodeExecutor instead of the recommended DockerCommandLineCodeExecutor. "
         "For security, it is recommended to install Docker and ensure it's running before using code executors. "
         "To install Docker, visit: https://docs.docker.com/get-docker/",
-        UserWarning,
+        DeprecationWarning,
         stacklevel=2,
     )
 


### PR DESCRIPTION
## Summary

Related to #7462

Changed from UserWarning to DeprecationWarning to make the security warning more visible when Docker is not available.

## Changes

- Changed warning type from UserWarning to DeprecationWarning in create_default_code_executor fallback

## Test plan

- [x] Existing tests still pass