### PR TITLE
Document message delivery behavior differences

### DIFF
--- a/docs/dotnet/core/differences-from-python.md
+++ b/docs/dotnet/core/differences-from-python.md
@@ -6,3 +6,19 @@
 > TLDR; Default behavior is identical.
 
 When an agent publishes a message to a topic to which it also listens, the message will not be received by the agent that sent it. This is also the behavior in the Python runtime. However to support previous usage, in @Microsoft.AutoGen.Core.InProcessRuntime, you can set the @Microsoft.AutoGen.Core.InProcessRuntime.DeliverToSelf property to true in the TopicSubscription attribute to allow an agent to receive messages it sends.
+
+| Behavior                                         | Python Agent                 | .NET Agent                              |
+| ------------------------------------------------ | ---------------------------- | --------------------------------------- |
+| Agent publishes to a topic it also subscribes to | Own message **not received** | Own message **not received by default** |
+| Enable self-receiving                            | —                            | `DeliverToSelf = true` can enable it    |
+| Runtime mentioned                                | Python runtime               | `InProcessRuntime`                      |
+
+
+## Python vs .NET
+
+The default topic delivery behavior is the same in both runtimes: an agent
+does not receive a message that it publishes to a topic it is subscribed to.
+
+The .NET `InProcessRuntime` additionally supports opting into self-delivery
+by setting `DeliverToSelf` to `true` in the `TopicSubscription` attribute.
+


### PR DESCRIPTION
Add comparison table for agent message delivery behavior between Python and .NET.

<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
