### PR TITLE
fix(core): reject nested dataclasses in generic fields

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_serialization.py
+++ b/python/packages/autogen-core/src/autogen_core/_serialization.py
@@ -1,6 +1,19 @@
 import json
 from dataclasses import asdict, dataclass, fields
-from typing import Any, ClassVar, Dict, List, Protocol, Sequence, TypeVar, cast, get_args, get_origin, runtime_checkable
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Protocol,
+    Sequence,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+    runtime_checkable,
+)
 
 from google.protobuf import any_pb2
 from google.protobuf.message import Message
@@ -35,8 +48,18 @@ def is_dataclass(cls: type[Any]) -> bool:
 
 
 def has_nested_dataclass(cls: type[IsDataclass]) -> bool:
-    # iterate fields and check if any of them are dataclasses
-    return any(is_dataclass(f.type) for f in cls.__dataclass_fields__.values())
+    type_hints = get_type_hints(cls)
+    return any(has_nested_dataclass_in_type(type_hints[field.name]) for field in fields(cls))
+
+
+def has_nested_dataclass_in_type(tp: Any) -> bool:
+    """Return whether a type or its generic arguments contain a dataclass."""
+    if isinstance(tp, type) and is_dataclass(tp):
+        return True
+    origin = get_origin(tp)
+    if isinstance(origin, type) and is_dataclass(origin):
+        return True
+    return any(has_nested_dataclass_in_type(arg) for arg in get_args(tp))
 
 
 def contains_a_union(cls: type[IsDataclass]) -> bool:

--- a/python/packages/autogen-core/tests/test_serialization.py
+++ b/python/packages/autogen-core/tests/test_serialization.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union
+from typing import Generic, TypeVar, Union
 
 import pytest
 from autogen_core import Image
@@ -35,6 +35,44 @@ class DataclassMessage:
 class NestingDataclassMessage:
     message: str
     nested: DataclassMessage
+
+
+@dataclass
+class ListNestingDataclassMessage:
+    message: str
+    nested: list[DataclassMessage]
+
+
+@dataclass
+class DictNestingDataclassMessage:
+    message: str
+    nested: dict[str, DataclassMessage]
+
+
+@dataclass
+class NestedListDataclassMessage:
+    message: str
+    nested: list[list[DataclassMessage]]
+
+
+T = TypeVar("T")
+
+
+@dataclass
+class GenericDataclassMessage(Generic[T]):
+    message: T
+
+
+@dataclass
+class GenericNestingDataclassMessage:
+    message: str
+    nested: list[GenericDataclassMessage[str]]
+
+
+@dataclass
+class ForwardReferenceNestingDataclassMessage:
+    message: str
+    nested: "list[DataclassMessage]"
 
 
 @dataclass
@@ -84,6 +122,30 @@ def test_nesting_dataclass_dataclass() -> None:
     serde = SerializationRegistry()
     with pytest.raises(ValueError):
         serde.add_serializer(try_get_known_serializers_for_type(NestingDataclassMessage))
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        ListNestingDataclassMessage,
+        DictNestingDataclassMessage,
+        NestedListDataclassMessage,
+        GenericNestingDataclassMessage,
+        ForwardReferenceNestingDataclassMessage,
+    ],
+)
+def test_nesting_dataclass_in_generic_container(
+    cls: type[
+        ListNestingDataclassMessage
+        | DictNestingDataclassMessage
+        | NestedListDataclassMessage
+        | GenericNestingDataclassMessage
+        | ForwardReferenceNestingDataclassMessage
+    ],
+) -> None:
+    serde = SerializationRegistry()
+    with pytest.raises(ValueError):
+        serde.add_serializer(try_get_known_serializers_for_type(cls))
 
 
 def test_proto() -> None:


### PR DESCRIPTION
## Why are these changes needed?

`DataclassJsonMessageSerializer` rejects directly nested dataclasses, but its previous check missed dataclasses inside containers, parameterized generic aliases, and resolvable forward-reference annotations. The serializer uses `asdict()` and then constructs only the outer dataclass, so an accepted `list[Child]` message deserializes with `dict` children instead of `Child` instances.

Resolve the dataclass field annotations and recursively detect nested dataclasses through generic origins and arguments. This preserves the existing supported-type boundary by rejecting these unsupported message types before they can silently lose type information.

## Related issue number

N/A — no matching issue or PR was found during an all-state duplicate check.

## Checks

- [x] No documentation changes are needed for this internal serializer validation fix.
- [x] I've added regression tests for list, dict, nested-list, parameterized generic, and forward-reference annotations through the `SerializationRegistry` registration path.
- [ ] GitHub auto checks are pending. Local checks run:
  - `uv run --no-sync pytest packages/autogen-core/tests/test_serialization.py -k generic_container -q`
  - `uv run --no-sync pytest packages/autogen-core/tests/test_serialization.py -q`
  - `uv run --no-sync poe --directory packages/autogen-core test`
  - `uv run --no-sync poe --directory packages/autogen-core fmt --check`
  - `uv run --no-sync poe --directory packages/autogen-core lint`
  - `uv run --no-sync poe --directory packages/autogen-core mypy`
  - `uv run --no-sync poe --directory packages/autogen-core pyright`
  - `uv run --no-sync poe fmt --check`
  - `uv run --no-sync poe lint`
  - `uv run --no-sync poe pyright`
  - `uv run --no-sync poe docs-build`
  - `uv run --no-sync poe docs-check`

## AI assistance

AI assistance was used to investigate, implement, and test this fix. The final diff and regression coverage received an independent review.
