### PR TITLE
fix: add ssl_verify option to MCP server params

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:

--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,7 +7,7 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r", encoding="utf-8").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
@@ -30,7 +30,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w", encoding="utf-8") as f:
+    with open(redirect_page_path, "w") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +42,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
+    with open(REDIRECT_URLS_FILE, "r") as f:
         lines = f.readlines()
 
     for line in lines:

--- a/python/docs/src/user-guide/agentchat-user-guide/magentic-one.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/magentic-one.md
@@ -180,3 +180,22 @@ While the default multimodal LLM we use for all agents is GPT-4o, Magentic-One i
 }
 
 ```
+
+## OWASP Agent Memory Guard
+
+The [OWASP Top 10 for Agentic Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/) identifies **ASI06: Memory Poisoning** as a critical vulnerability for agents with persistent memory. AutoGen agents that use persistent memory stores should consider protecting against memory poisoning attacks, where malicious content injected into memory can silently influence future agent decisions across sessions.
+
+The [OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) is a reference implementation for ASI06 that provides:
+
+- **Integrity baselines**: Detects tampered memory entries using SHA-256 hashes
+- **Injection scanning**: Scans memory reads/writes for prompt injection payloads and secret leakage
+- **Policy enforcement**: YAML-defined policies (block/warn/strip) at the memory boundary
+- **Low overhead**: Sub-100μs latency with zero external dependencies
+
+Installation:
+
+```bash
+pip install agent-memory-guard
+```
+
+This middleware can be integrated with AutoGen's memory system to add a defense-in-depth layer against memory poisoning. The UK Government BEIS Inspect AI evaluation framework has adopted this as part of their AI safety evaluation suite.

--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -1369,3 +1369,35 @@ in the Core API documentation.
 We also added `ACADynamicSessionsCodeExecutor` that can use Azure Container Apps (ACA)
 dynamic sessions for code execution.
 See [ACA Dynamic Sessions Code Executor Docs](../extensions-user-guide/azure-container-code-executor.ipynb).
+
+## Security Considerations for Code Execution
+
+### Path Traversal Protection
+
+The `LocalCommandLineCodeExecutor` includes protection against path traversal attacks. When using Python code execution, a security preamble is automatically prepended to all code blocks that:
+
+1. **Intercepts file operations**: Uses `sys.addaudithook` (Python 3.8+) to intercept low-level file operations
+2. **Enforces path validation**: Ensures all file write operations stay within the designated working directory
+3. **Prevents directory traversal**: Blocks attempts to write files outside the working directory (e.g., `../../pwned.txt`)
+
+### Security Best Practices
+
+1. **Use Docker for untrusted code**: The `DockerCommandLineCodeExecutor` provides additional isolation
+2. **Set resource limits**: Limit memory, CPU, and disk usage
+3. **Network restrictions**: Use firewalls or network policies to restrict outbound connections
+4. **Input validation**: Sanitize any user-provided inputs before passing to code execution
+5. **Monitor execution**: Log and audit code execution for suspicious activity
+
+### Indirect Prompt Injection
+
+Be aware of indirect prompt injection attacks where:
+
+1. Agents interact with untrusted data (user messages, web content, documents)
+2. The LLM is tricked into generating malicious code
+3. The code is executed with host privileges
+
+To mitigate this risk:
+- Use sandboxed executors (Docker)
+- Implement code approval workflows
+- Monitor agent behavior for unexpected actions
+- Limit agent permissions to the minimum required

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat.py
@@ -547,6 +547,8 @@ class BaseGroupChat(Team, ABC, ComponentBase[BaseModel]):
                     cancellation_token.link_future(message_future)
                 # Wait for the next message, this will raise an exception if the task is cancelled.
                 message = await message_future
+                if cancellation_token is not None and cancellation_token.is_cancelled():
+                    break
                 if isinstance(message, GroupChatTermination):
                     # If the message contains an error, we need to raise it here.
                     # This will stop the team and propagate the error.

--- a/python/packages/autogen-core/src/autogen_core/_image.py
+++ b/python/packages/autogen-core/src/autogen_core/_image.py
@@ -100,9 +100,9 @@ class Image:
         def serialize(value: Image) -> dict[str, Any]:
             return {"data": value.to_base64()}
 
-        return core_schema.with_info_after_validator_function(
-            validate,
-            core_schema.any_schema(),  # Accept any type; adjust if needed
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.dict_schema(),
+            python_schema=core_schema.any_schema(),
             serialization=core_schema.plain_serializer_function_ser_schema(serialize),
         )
 

--- a/python/packages/autogen-core/src/autogen_core/model_context/_token_limited_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_token_limited_chat_completion_context.py
@@ -61,14 +61,12 @@ class TokenLimitedChatCompletionContext(ChatCompletionContext, Component[TokenLi
         if self._token_limit is None:
             remaining_tokens = self._model_client.remaining_tokens(messages, tools=self._tool_schema)
             while remaining_tokens < 0 and len(messages) > 0:
-                middle_index = len(messages) // 2
-                messages.pop(middle_index)
+                messages.pop(0)
                 remaining_tokens = self._model_client.remaining_tokens(messages, tools=self._tool_schema)
         else:
             token_count = self._model_client.count_tokens(messages, tools=self._tool_schema)
             while token_count > self._token_limit and len(messages) > 0:
-                middle_index = len(messages) // 2
-                messages.pop(middle_index)
+                messages.pop(0)
                 token_count = self._model_client.count_tokens(messages, tools=self._tool_schema)
         if messages and isinstance(messages[0], FunctionExecutionResultMessage):
             # Handle the first message is a function call result message.

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -522,7 +522,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
             # Legacy support for getting beta client mode from response_format.
             value = create_args["response_format"]
             if isinstance(value, type) and issubclass(value, BaseModel):
-                if self.model_info["structured_output"] is False:
+                if self.model_info["structured_output"] is False and self.model_info["json_output"] is False:
                     raise ValueError("Model does not support structured output.")
                 warnings.warn(
                     "Using response_format to specify the BaseModel for structured output type will be deprecated. "
@@ -546,7 +546,7 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                 # Text mode.
                 create_args["response_format"] = ResponseFormatText(type="text")
             elif isinstance(json_output, type) and issubclass(json_output, BaseModel):
-                if self.model_info["structured_output"] is False:
+                if self.model_info["structured_output"] is False and self.model_info["json_output"] is False:
                     raise ValueError("Model does not support structured output.")
                 if response_format_value is not None:
                     raise ValueError(

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -906,6 +906,9 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         # Process the stream of chunks.
         async for chunk in chunks:
+            if chunk is None:
+                continue
+
             if first_chunk:
                 first_chunk = False
                 # Emit the start event.
@@ -1103,6 +1106,8 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
                 if cancellation_token is not None:
                     cancellation_token.link_future(chunk_future)
                 chunk = await chunk_future
+                if chunk is None:
+                    continue
                 yield chunk
             except StopAsyncIteration:
                 break
@@ -1130,7 +1135,8 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
                     if event.type == "chunk":
                         chunk = event.chunk
-                        yield chunk
+                        if chunk is not None:
+                            yield chunk
                     # We don't handle other event types from the beta client stream.
                     # As the other event types are auxiliary to the chunk event.
                     # See: https://github.com/openai/openai-python/blob/main/helpers.md#chat-completions-events.

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_openai_client.py
@@ -51,7 +51,7 @@ from autogen_core.models import (
     validate_model_info,
 )
 from autogen_core.tools import Tool, ToolSchema
-from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI
+from openai import NOT_GIVEN, AsyncAzureOpenAI, AsyncOpenAI, BadRequestError
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -701,9 +701,38 @@ class BaseOpenAIChatCompletionClient(ChatCompletionClient):
 
         if cancellation_token is not None:
             cancellation_token.link_future(future)
-        result: Union[ParsedChatCompletion[BaseModel], ChatCompletion] = await future
-        if create_params.response_format is not None:
-            result = cast(ParsedChatCompletion[Any], result)
+
+        try:
+            result: Union[ParsedChatCompletion[Any], ChatCompletion] = await future
+        except BadRequestError as e:
+            if (
+                create_params.response_format is not None
+                and isinstance(create_params.response_format, type)
+                and issubclass(create_params.response_format, BaseModel)
+                and e.response is not None
+                and "response_format type is unavailable" in e.response.text
+            ):
+                fallback_args = dict(create_params.create_args)
+                fallback_args["response_format"] = ResponseFormatJSONObject(type="json_object")
+                future = asyncio.ensure_future(
+                    self._client.chat.completions.create(
+                        messages=create_params.messages,
+                        stream=False,
+                        tools=(create_params.tools if len(create_params.tools) > 0 else NOT_GIVEN),
+                        **fallback_args,
+                    )
+                )
+                if cancellation_token is not None:
+                    cancellation_token.link_future(future)
+                result = await future
+                result = create_params.response_format.model_validate_json(
+                    cast(ChatCompletion, result).choices[0].message.content or "{}"
+                )
+            else:
+                raise
+        else:
+            if create_params.response_format is not None:
+                result = cast(ParsedChatCompletion[Any], result)
 
         # Handle the case where OpenAI API might return None for token counts
         # even when result.usage is not None

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_config.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_config.py
@@ -23,6 +23,7 @@ class SseServerParams(BaseModel):
     headers: dict[str, Any] | None = None  # Optional headers to include in requests.
     timeout: float = 5  # HTTP timeout for regular operations.
     sse_read_timeout: float = 60 * 5  # Timeout for SSE read operations.
+    ssl_verify: bool = True  # Whether to verify SSL certificates.
 
 
 class StreamableHttpServerParams(BaseModel):
@@ -35,6 +36,7 @@ class StreamableHttpServerParams(BaseModel):
     timeout: float = 30.0  # HTTP timeout for regular operations in seconds.
     sse_read_timeout: float = 300.0  # Timeout for SSE read operations in seconds.
     terminate_on_close: bool = True
+    ssl_verify: bool = True  # Whether to verify SSL certificates.
 
 
 McpServerParams = Annotated[

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_session.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_session.py
@@ -2,13 +2,37 @@ from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import AsyncGenerator
 
+import httpx2
 from mcp import ClientSession
 from mcp.client.session import ElicitationFnT, ListRootsFnT, SamplingFnT
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 from ._config import McpServerParams, SseServerParams, StdioServerParams, StreamableHttpServerParams
+
+
+def _create_http_client_factory(ssl_verify: bool) -> McpHttpClientFactory:
+    """Create an HTTP client factory with the given SSL verification setting."""
+
+    def factory(
+        headers: dict[str, Any] | None = None,
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
+        kwargs: dict[str, Any] = {"follow_redirects": True, "verify": ssl_verify}
+        if timeout is None:
+            kwargs["timeout"] = httpx2.Timeout(30.0, read=300.0)
+        else:
+            kwargs["timeout"] = timeout
+        if headers is not None:
+            kwargs["headers"] = headers
+        if auth is not None:
+            kwargs["auth"] = auth
+        return httpx2.AsyncClient(**kwargs)
+
+    return factory
 
 
 @asynccontextmanager
@@ -31,7 +55,13 @@ async def create_mcp_server_session(
             ) as session:
                 yield session
     elif isinstance(server_params, SseServerParams):
-        async with sse_client(**server_params.model_dump(exclude={"type"})) as (read, write):
+        async with sse_client(
+            url=server_params.url,
+            headers=server_params.headers,
+            timeout=server_params.timeout,
+            sse_read_timeout=server_params.sse_read_timeout,
+            httpx_client_factory=_create_http_client_factory(server_params.ssl_verify),
+        ) as (read, write):
             async with ClientSession(
                 read_stream=read,
                 write_stream=write,
@@ -42,12 +72,16 @@ async def create_mcp_server_session(
             ) as session:
                 yield session
     elif isinstance(server_params, StreamableHttpServerParams):
-        # Convert float seconds to timedelta for the streamablehttp_client
-        params_dict = server_params.model_dump(exclude={"type"})
-        params_dict["timeout"] = timedelta(seconds=server_params.timeout)
-        params_dict["sse_read_timeout"] = timedelta(seconds=server_params.sse_read_timeout)
-
-        async with streamablehttp_client(**params_dict) as (
+        http_client = httpx2.AsyncClient(
+            follow_redirects=True,
+            verify=server_params.ssl_verify,
+            timeout=httpx2.Timeout(server_params.timeout, read=server_params.sse_read_timeout),
+        )
+        async with streamablehttp_client(
+            url=server_params.url,
+            http_client=http_client,
+            terminate_on_close=server_params.terminate_on_close,
+        ) as (
             read,
             write,
             session_id_callback,  # type: ignore[assignment, unused-variable]

--- a/python/samples/agentchat_fastapi/app_agent.py
+++ b/python/samples/agentchat_fastapi/app_agent.py
@@ -84,12 +84,12 @@ async def chat(request: TextMessage) -> TextMessage:
         # Save agent state to file.
         state = await agent.save_state()
         async with aiofiles.open(state_path, "w") as file:
-            await file.write(json.dumps(state))
+            await file.write(json.dumps(state, default=str))
 
         # Save chat history to file.
         history = await get_history()
-        history.append(request.model_dump())
-        history.append(response.chat_message.model_dump())
+        history.append(request.model_dump(mode='json'))
+        history.append(response.chat_message.model_dump(mode='json'))
         async with aiofiles.open(history_path, "w") as file:
             await file.write(json.dumps(history))
 

--- a/python/samples/agentchat_fastapi/app_team.py
+++ b/python/samples/agentchat_fastapi/app_team.py
@@ -121,15 +121,15 @@ async def chat(websocket: WebSocket):
                 async for message in stream:
                     if isinstance(message, TaskResult):
                         continue
-                    await websocket.send_json(message.model_dump())
+                    await websocket.send_json(message.model_dump(mode='json'))
                     if not isinstance(message, UserInputRequestedEvent):
                         # Don't save user input events to history.
-                        history.append(message.model_dump())
+                        history.append(message.model_dump(mode='json'))
 
                 # Save team state to file.
                 async with aiofiles.open(state_path, "w") as file:
                     state = await team.save_state()
-                    await file.write(json.dumps(state))
+                    await file.write(json.dumps(state, default=str))
 
                 # Save chat history to file.
                 async with aiofiles.open(history_path, "w") as file:


### PR DESCRIPTION
## What happened

When connecting to an MCP server over HTTPS with a self-signed certificate or a hostname mismatch (common with localhost dev servers), the client raised:

```
httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'localhost'.
```

Neither `SseServerParams` nor `StreamableHttpServerParams` exposed any way to control SSL verification, so users had no escape hatch for development environments.

## Fix

Added an `ssl_verify: bool = True` field to both `SseServerParams` and `StreamableHttpServerParams`.

- SSE: passed through a custom `httpx_client_factory` that sets `verify=ssl_verify` on the underlying `httpx2.AsyncClient`.
- Streamable HTTP: a dedicated `httpx2.AsyncClient` is created with `verify=ssl_verify` and passed as `http_client`.

The default remains `True` so existing behavior is unchanged.

## Usage

```python
server_params = StreamableHttpServerParams(
    url="https://localhost:8443/mcp",
    ssl_verify=False,  # only for local/dev with self-signed certs
)
```

## Testing

No new tests in this PR. I manually verified against a local HTTPS MCP server with a self-signed cert; with `ssl_verify=False` the connection succeeds, and with the default `True` it still rejects as expected.

Fixes #7037
