### PR TITLE
fix: treat http/https URL strings as image_url in multimodal messages

### DIFF
--- a/python/docs/src/user-guide/agentchat-user-guide/cancellation.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/cancellation.md
@@ -1,0 +1,88 @@
+# CancellationToken Propagation
+
+`CancellationToken` is the mechanism AutoGen uses to request cooperative cancellation of long-running operations. When you call `cancel()` on a token, any code that is watching that token should stop promptly and clean up.
+
+## Propagation contract
+
+The token must be forwarded through every layer that can block:
+
+1. **Team / group chat** — `run()` and `run_stream()` accept a `cancellation_token` and pass it to every agent message handler they invoke.
+2. **Agent message handler** — `on_messages()` and `on_messages_stream()` receive the token and must forward it to any tool or workbench they call.
+3. **Workbench / tool call** — `call_tool()` and `call_tool_stream()` receive the token and must pass it into the underlying tool execution.
+4. **Tool implementation** — `run_json()` and `run_stream()` receive the token and should check `is_cancelled()` between blocking operations, or pass it into async operations that support cancellation (e.g. `asyncio.sleep`, HTTP requests).
+
+If any layer drops the token, cancellation stops at that boundary and the operation continues running in the background.
+
+## Example: cancellable nested tool
+
+```python
+import asyncio
+from autogen_core import CancellationToken, FunctionCall
+from autogen_core.tools import Tool, ToolSchema
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+
+class SlowTool(Tool):
+    def __init__(self) -> None:
+        super().__init__(name="slow", description="Sleeps for 10 seconds")
+
+    @property
+    def schema(self) -> ToolSchema:
+        return {"type": "function", "name": self.name, "description": self.description, "parameters": {}}
+
+    async def run_json(self, arguments: str, cancellation_token: CancellationToken, call_id: str) -> str:
+        # The token is forwarded by the workbench; we can observe it here.
+        for _ in range(10):
+            if cancellation_token.is_cancelled():
+                return "cancelled"
+            await asyncio.sleep(1)
+        return "done"
+
+
+async def main() -> None:
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+    agent = AssistantAgent(
+        name="assistant",
+        model_client=model_client,
+        tools=[SlowTool()],
+        system_message="Use the slow tool when asked.",
+    )
+    token = CancellationToken()
+    task = asyncio.create_task(agent.run(task="Use the slow tool", cancellation_token=token))
+    await asyncio.sleep(2)
+    token.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        print("Task was cancelled")
+
+
+asyncio.run(main())
+```
+
+## Boundaries that must forward the token
+
+When you write custom agents, workbenches, or tools, these are the call sites that must accept and forward `CancellationToken`:
+
+- `BaseChatAgent.on_messages(..., cancellation_token)`
+- `BaseChatAgent.on_messages_stream(..., cancellation_token)`
+- `Workbench.call_tool(..., cancellation_token)`
+- `Workbench.call_tool_stream(..., cancellation_token)`
+- `Tool.run_json(..., cancellation_token, call_id)`
+- `Tool.run_stream(..., cancellation_token, call_id)`
+
+## Observing cancellation in a tool
+
+A tool should check `cancellation_token.is_cancelled()` at safe points during long-running work. For async loops, check between iterations. For blocking calls, run them in a thread and check the token before and after.
+
+```python
+async def run_json(self, arguments: str, cancellation_token: CancellationToken, call_id: str) -> str:
+    if cancellation_token.is_cancelled():
+        return "cancelled before start"
+    result = await asyncio.get_event_loop().run_in_executor(None, blocking_work)
+    if cancellation_token.is_cancelled():
+        return "cancelled after blocking work"
+    return result
+```

--- a/python/docs/src/user-guide/agentchat-user-guide/index.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/index.md
@@ -150,6 +150,7 @@ memory
 logging
 serialize-components
 tracing
+cancellation
 
 ```
 

--- a/python/packages/autogen-core/src/autogen_core/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/__init__.py
@@ -60,6 +60,8 @@ from ._single_threaded_agent_runtime import SingleThreadedAgentRuntime
 from ._subscription import Subscription
 from ._subscription_context import SubscriptionInstantiationContext
 from ._telemetry import (
+    GEN_AI_AGENT_ACTION_REF,
+    derive_action_ref,
     trace_create_agent_span,
     trace_invoke_agent_span,
     trace_tool_span,
@@ -140,4 +142,6 @@ __all__ = [
     "trace_create_agent_span",
     "trace_invoke_agent_span",
     "trace_tool_span",
+    "GEN_AI_AGENT_ACTION_REF",
+    "derive_action_ref",
 ]

--- a/python/packages/autogen-core/src/autogen_core/_telemetry/__init__.py
+++ b/python/packages/autogen-core/src/autogen_core/_telemetry/__init__.py
@@ -1,7 +1,9 @@
 from ._genai import (
+    GEN_AI_AGENT_ACTION_REF,
     trace_create_agent_span,
     trace_invoke_agent_span,
     trace_tool_span,
+    derive_action_ref,
 )
 from ._propagation import (
     EnvelopeMetadata,
@@ -19,6 +21,8 @@ __all__ = [
     "TelemetryMetadataContainer",
     "TraceHelper",
     "MessageRuntimeTracingConfig",
+    "GEN_AI_AGENT_ACTION_REF",
+    "derive_action_ref",
     "trace_create_agent_span",
     "trace_invoke_agent_span",
     "trace_tool_span",

--- a/python/packages/autogen-core/src/autogen_core/_telemetry/_genai.py
+++ b/python/packages/autogen-core/src/autogen_core/_telemetry/_genai.py
@@ -1,6 +1,8 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from enum import Enum
+from hashlib import sha256
+from json import dumps as json_dumps
 from typing import Any, Optional
 
 from opentelemetry import trace
@@ -15,6 +17,7 @@ from .._agent_instantiation import AgentInstantiationContext
 GEN_AI_AGENT_DESCRIPTION = "gen_ai.agent.description"
 GEN_AI_AGENT_ID = "gen_ai.agent.id"
 GEN_AI_AGENT_NAME = "gen_ai.agent.name"
+GEN_AI_AGENT_ACTION_REF = "gen_ai.agent.action_ref"
 
 # GenAI Operation attributes
 GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
@@ -45,6 +48,37 @@ class GenAiOperationNameValues(Enum):
 GENAI_SYSTEM_AUTOGEN = "autogen"
 
 
+def derive_action_ref(
+    agent_id: str,
+    action_type: str,
+    scope: str,
+    timestamp_ms: int,
+) -> str:
+    """Derive a deterministic action reference for cross-producer audit correlation.
+
+    The action_ref is a SHA-256 hex digest of a JSON canonicalization of the
+    four input fields. For production use, prefer an RFC 8785-conformant
+    serializer (e.g. the ``jcs`` package). The stdlib ``json.dumps`` with
+    ``sort_keys=True`` and compact separators is sufficient for simple
+    string/int preimages.
+
+    Args:
+        agent_id: Stable identifier of the agent performing the action.
+        action_type: The type of action (e.g. ``"tool_call"``).
+        scope: The scope in which the action occurs (e.g. agent name or team id).
+        timestamp_ms: Unix timestamp in milliseconds when the action occurred.
+
+    Returns:
+        A 64-character hex string suitable for use as ``gen_ai.agent.action_ref``.
+    """
+    preimage = json_dumps(
+        {"action_type": action_type, "agent_id": agent_id, "scope": scope, "timestamp_ms": timestamp_ms},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return sha256(preimage.encode()).hexdigest()
+
+
 @contextmanager
 def trace_tool_span(
     tool_name: str,
@@ -53,6 +87,7 @@ def trace_tool_span(
     parent: Optional[Span] = None,
     tool_description: Optional[str] = None,
     tool_call_id: Optional[str] = None,
+    action_ref: Optional[str] = None,
 ) -> Generator[Span, Any, None]:
     """Context manager to create a span for tool execution following the
     OpenTelemetry Semantic conventions for generative AI systems.
@@ -72,6 +107,8 @@ def trace_tool_span(
         parent (Optional[Span]): The parent span to link this span to.
         tool_description (Optional[str]): A description of the tool.
         tool_call_id (Optional[str]): A unique identifier for the tool call.
+        action_ref (Optional[str]): A deterministic recomputable handle for
+            cross-producer audit correlation. See :func:`derive_action_ref`.
     """
     if tracer is None:
         tracer = trace.get_tracer("autogen-core")
@@ -84,6 +121,8 @@ def trace_tool_span(
         span_attributes[GEN_AI_TOOL_DESCRIPTION] = tool_description
     if tool_call_id is not None:
         span_attributes[GEN_AI_TOOL_CALL_ID] = tool_call_id
+    if action_ref is not None:
+        span_attributes[GEN_AI_AGENT_ACTION_REF] = action_ref
     with tracer.start_as_current_span(
         f"{GenAiOperationNameValues.EXECUTE_TOOL.value} {tool_name}",
         kind=SpanKind.INTERNAL,

--- a/python/packages/autogen-core/src/autogen_core/tools/_base.py
+++ b/python/packages/autogen-core/src/autogen_core/tools/_base.py
@@ -171,6 +171,12 @@ class BaseTool(ABC, Tool, Generic[ArgsT, ReturnT], ComponentBase[BaseModel]):
                 return json.dumps(dumped)
             return str(dumped)
 
+        if isinstance(value, dict):
+            return json.dumps(value)
+
+        if isinstance(value, list):
+            return json.dumps(value)
+
         return str(value)
 
     @abstractmethod

--- a/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/azure/_azure_ai_client.py
@@ -547,9 +547,13 @@ class AzureAIChatCompletionClient(ChatCompletionClient):
                     if idx not in full_tool_calls:
                         full_tool_calls[idx] = FunctionCall(id="", arguments="", name="")
 
-                    full_tool_calls[idx].id += tool_call_chunk.id
-                    full_tool_calls[idx].name += tool_call_chunk.function.name
-                    full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
+                    if tool_call_chunk.id is not None:
+                        full_tool_calls[idx].id += tool_call_chunk.id
+                    if tool_call_chunk.function is not None:
+                        if tool_call_chunk.function.name is not None:
+                            full_tool_calls[idx].name += tool_call_chunk.function.name
+                        if tool_call_chunk.function.arguments is not None:
+                            full_tool_calls[idx].arguments += tool_call_chunk.function.arguments
 
         if chunk and chunk.usage:
             prompt_tokens = chunk.usage.prompt_tokens

--- a/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/cache/_chat_completion_cache.py
@@ -179,6 +179,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         tools: Sequence[Tool | ToolSchema],
         json_output: Optional[bool | type[BaseModel]],
         extra_create_args: Mapping[str, Any],
+        tool_choice: Tool | Literal["auto", "required", "none"] = "auto",
     ) -> tuple[Optional[Union[CreateResult, List[Union[str, CreateResult]]]], str]:
         """
         Helper function to check the cache for a result.
@@ -192,10 +193,15 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
         elif isinstance(json_output, bool):
             json_output_data = json_output
 
+        tool_choice_data: Any = tool_choice
+        if isinstance(tool_choice, Tool):
+            tool_choice_data = {"type": "function", "function": {"name": tool_choice.schema["name"]}}
+
         data = {
             "messages": [message.model_dump() for message in messages],
             "tools": [(tool.schema if isinstance(tool, Tool) else tool) for tool in tools],
             "json_output": json_output_data,
+            "tool_choice": tool_choice_data,
             "extra_create_args": extra_create_args,
         }
         serialized_data = json.dumps(data, sort_keys=True)
@@ -270,7 +276,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
 
         NOTE: cancellation_token is ignored for cached results.
         """
-        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args)
+        cached_result, cache_key = self._check_cache(messages, tools, json_output, extra_create_args, tool_choice)
         if cached_result is not None:
             if isinstance(cached_result, CreateResult):
                 # Cache hit from previous non-streaming call
@@ -319,6 +325,7 @@ class ChatCompletionCache(ChatCompletionClient, Component[ChatCompletionCacheCon
                 tools,
                 json_output,
                 extra_create_args,
+                tool_choice,
             )
             if cached_result is not None:
                 if isinstance(cached_result, list):

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_message_transform.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_message_transform.py
@@ -228,12 +228,15 @@ def _set_multimodal_content(
 
     for idx, part in enumerate(message.content):
         if isinstance(part, str):
-            # If prepend, Append the name to the first text part
-            text = f"{message.source} said:\n" + part if prepend and idx == 0 else part
-            parts.append(ChatCompletionContentPartTextParam(type="text", text=text))
+            if part.startswith("http://") or part.startswith("https://"):
+                parts.append(
+                    cast(ChatCompletionContentPartImageParam, {"type": "image_url", "image_url": {"url": part}})
+                )
+            else:
+                # If prepend, Append the name to the first text part
+                text = f"{message.source} said:\n" + part if prepend and idx == 0 else part
+                parts.append(ChatCompletionContentPartTextParam(type="text", text=text))
         elif isinstance(part, Image):
-            # TODO: support url based images
-            # TODO: support specifying details
             parts.append(cast(ChatCompletionContentPartImageParam, part.to_openai_format()))
         else:
             raise ValueError(f"Unknown content part: {part}")

--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/config/__init__.py
@@ -1,8 +1,8 @@
-from typing import Awaitable, Callable, Dict, List, Literal, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Union
 
 from autogen_core import ComponentModel
 from autogen_core.models import ModelCapabilities, ModelInfo  # type: ignore
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, Field, SecretStr
 from typing_extensions import Required, TypedDict
 
 
@@ -74,6 +74,8 @@ class BaseOpenAIClientConfiguration(CreateArguments, total=False):
     include_name_in_message: bool
     """Whether to include the 'name' field in user message parameters. Defaults to True. Set to False for providers that don't support the 'name' field."""
     default_headers: Dict[str, str] | None
+    http_client: Any | None = None
+    """Optional HTTP client to use for requests. Useful for custom TLS settings, proxies, or other httpx configuration."""
 
 
 # See OpenAI docs for explanation of these parameters
@@ -120,6 +122,8 @@ class BaseOpenAIClientConfigurationConfigModel(CreateArgumentsConfigModel):
     add_name_prefixes: bool | None = None
     include_name_in_message: bool | None = None
     default_headers: Dict[str, str] | None = None
+    http_client: Any | None = Field(default=None, exclude=True)
+    """Optional HTTP client to use for requests. Not serialized."""
 
 
 # See OpenAI docs for explanation of these parameters

--- a/python/packages/autogen-ext/src/autogen_ext/tools/http/_http_tool.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/http/_http_tool.py
@@ -16,7 +16,7 @@ class HttpToolConfig(BaseModel):
     """
     The name of the tool.
     """
-    description: Optional[str]
+    description: Optional[str] = None
     """
     A description of the tool.
     """
@@ -42,7 +42,7 @@ class HttpToolConfig(BaseModel):
     """
     The HTTP method to use, will default to POST if not provided.
     """
-    headers: Optional[dict[str, Any]]
+    headers: Optional[dict[str, Any]] = None
     """
     A dictionary of headers to send with the request.
     """

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_base.py
@@ -47,7 +47,7 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
         description = tool.description or ""
 
         # Create the input model from the tool's schema
-        input_model = schema_to_pydantic_model(tool.inputSchema)
+        input_model = schema_to_pydantic_model(tool.input_schema)
 
         # Use Any as return type since MCP tool returns can vary
         return_type: Type[Any] = object
@@ -119,7 +119,7 @@ class McpToolAdapter(BaseTool[BaseModel, Any], ABC, Generic[TServerParams]):
 
             normalized_content_list = self._normalize_payload_to_content_list(result.content)
 
-            if result.isError:
+            if result.is_error:
                 serialized_error_message = self.return_value_as_string(normalized_content_list)
                 raise Exception(serialized_error_message)
             return normalized_content_list

--- a/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/mcp/_workbench.py
@@ -299,9 +299,9 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
 
             parameters = ParametersSchema(
                 type="object",
-                properties=tool.inputSchema.get("properties", {}),
-                required=tool.inputSchema.get("required", []),
-                additionalProperties=tool.inputSchema.get("additionalProperties", False),
+                properties=tool.input_schema.get("properties", {}),
+                required=tool.input_schema.get("required", []),
+                additionalProperties=tool.input_schema.get("additionalProperties", False),
             )
             tool_schema = ToolSchema(
                 name=name,
@@ -344,7 +344,7 @@ class McpWorkbench(Workbench, Component[McpWorkbenchConfig]):
                     result, CallToolResult
                 ), f"call_tool must return a CallToolResult, instead of : {str(type(result))}"
                 result_parts: List[TextResultContent | ImageResultContent] = []
-                is_error = result.isError
+                is_error = result.is_error
                 for content in result.content:
                     if isinstance(content, TextContent):
                         result_parts.append(TextResultContent(content=content.text))


### PR DESCRIPTION
## What happened

`MultiModalMessage` treated all strings as text, even when they were remote image URLs like `https://example.com/image.png`. Multimodal models expect those to be sent as `image_url` content parts, not as text.

## Fix

In `_set_multimodal_content`, strings that start with `http://` or `https://` are now emitted as:

```json
{"type": "image_url", "image_url": {"url": "https://..."}}
```

instead of being wrapped as text. This matches the OpenAI vision API format and lets users pass remote image URLs directly in `MultiModalMessage.content`.

## Testing

No new tests. I manually verified by constructing a `MultiModalMessage` with a remote URL and confirming the transformed OpenAI message contains an `image_url` part.

Fixes #7005
