### PR TITLE
docs: add autogen-ext-hubris to community projects

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/discover.md
+++ b/python/docs/src/user-guide/extensions-user-guide/discover.md
@@ -46,6 +46,7 @@ Find community samples and examples of how to use AutoGen
 | [autogen-oaiapi](https://github.com/SongChiYoung/autogen-oaiapi)  | [PyPi](https://pypi.org/project/autogen-oaiapi/) | an OpenAI-style API server built on top of AutoGen |
 | [autogen-contextplus](https://github.com/SongChiYoung/autogen-contextplus)  | [PyPi](https://pypi.org/project/autogen-contextplus/) | Enhanced model_context implementations, with features such as automatic summarization and truncation of model context. |
 | [autogen-ext-yepcode](https://github.com/yepcode/autogen-ext-yepcode)  | [PyPi](https://pypi.org/project/autogen-ext-yepcode/) | Enables agents to securely execute code in isolated remote sandboxes using [YepCode](https://yepcode.io)’s serverless runtime. |
+| [autogen-ext-hubris](https://github.com/Aimagine-life/autogen-ext-hubris)  | [PyPi](https://pypi.org/project/autogen-ext-hubris/) | Model client for [Hubris](https://hubris.pw), a ruble-billed, OpenAI-compatible LLM gateway with 400+ models |
 
 
 <!-- Example -->


### PR DESCRIPTION
Adds [autogen-ext-hubris](https://github.com/Aimagine-life/autogen-ext-hubris) ([PyPI](https://pypi.org/project/autogen-ext-hubris/)) to the community projects table, following the same format as `autogen-openaiext-client`.

`HubrisChatCompletionClient` is a thin subclass of `OpenAIChatCompletionClient` preconfigured for Hubris (https://hubris.pw) — a ruble-billed, OpenAI-compatible LLM gateway with 400+ models — presetting `base_url` and resolving `model_info` for known catalog models.

Docs-only change (single table row).