### PR TITLE
fix(ext): reject stale hunks in TextCanvas.apply_patch with context validation

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/memory/canvas/_text_canvas.py
+++ b/python/packages/autogen-ext/src/autogen_ext/memory/canvas/_text_canvas.py
@@ -139,6 +139,9 @@ class TextCanvas(BaseCanvas):
         """Apply *patch_text* (unified diff) to the latest revision and save a new revision.
 
         Uses the *unidiff* library to accurately apply hunks and validate context lines.
+        Hunks whose removed or context lines do not match the latest revision (e.g. a
+        patch prepared against an older revision) are rejected with a ``ValueError``
+        and no new revision is created.
         """
         if isinstance(patch_data, bytes):
             patch_data = patch_data.decode("utf-8")
@@ -162,14 +165,38 @@ class TextCanvas(BaseCanvas):
         line_offset = 0
         for hunk in patched_file:
             # Calculate the slice boundaries in the *current* working copy.
-            start = hunk.source_start - 1 + line_offset
+            # A hunk with no source lines (source_length == 0) inserts after
+            # original line *source_start*, so the 0-based insertion index is
+            # *source_start* itself rather than *source_start* - 1.
+            if hunk.source_length > 0:
+                start = hunk.source_start - 1 + line_offset
+            else:
+                start = hunk.source_start + line_offset
             end = start + hunk.source_length
-            # Build the replacement block for this hunk.
+            # Build the replacement block for this hunk and the source block
+            # (removed + context lines) it expects to replace.
             replacement: List[str] = []
+            expected_source: List[str] = []
             for line in hunk:
-                if line.is_added or line.is_context:
+                if line.is_added:
                     replacement.append(line.value)
+                else:
+                    # context and removed lines make up the hunk's source block.
+                    expected_source.append(line.value)
+                    if line.is_context:
+                        replacement.append(line.value)
                 # removed lines (line.is_removed) are *not* added.
+            # Reject hunks whose removed/context lines do not match the current
+            # content (e.g. a patch prepared against an older revision), as well
+            # as hunks that fall outside the current content.
+            if start < 0 or end > len(working_lines) or working_lines[start:end] != expected_source:
+                raise ValueError(
+                    f"Patch for '{filename}' does not match the latest revision "
+                    f"(revision {self._files[filename][-1].revision}): hunk at source "
+                    f"line {hunk.source_start} expects source/context lines that differ "
+                    "from the current content. Regenerate the patch from the latest "
+                    "content and reapply."
+                )
             # Replace the slice with the hunk‑result.
             working_lines[start:end] = replacement
             line_offset += len(replacement) - (end - start)

--- a/python/packages/autogen-ext/tests/memory/test_text_canvas_memory.py
+++ b/python/packages/autogen-ext/tests/memory/test_text_canvas_memory.py
@@ -3,6 +3,7 @@ import difflib
 import pytest
 from autogen_core import CancellationToken
 from autogen_core.model_context import UnboundedChatCompletionContext
+
 from autogen_ext.memory.canvas import TextCanvasMemory
 from autogen_ext.memory.canvas._canvas_writer import (
     ApplyPatchArgs,
@@ -34,6 +35,36 @@ def story_v2(story_v1: str) -> str:
 @pytest.fixture()
 def memory() -> TextCanvasMemory:
     return TextCanvasMemory()
+
+
+@pytest.fixture()
+def config_v1() -> str:
+    # Baseline content used by the stale-patch regression tests
+    return "service=payments\nregion=Singapore\nstatus=active\n"
+
+
+@pytest.fixture()
+def config_v2() -> str:
+    # A competing edit that changes the same line the stale patch targets
+    return "service=payments\nregion=London\nstatus=active\n"
+
+
+@pytest.fixture()
+def config_v3() -> str:
+    # A follow-up edit prepared against config_v2 (not against config_v1)
+    return "service=payments\nregion=London\nstatus=retired\n"
+
+
+def make_patch(old: str, new: str, filename: str = "state.txt") -> str:
+    """Helper: build a unified diff between two contents (as the issue repro does)."""
+    return "".join(
+        difflib.unified_diff(
+            old.splitlines(keepends=True),
+            new.splitlines(keepends=True),
+            fromfile=filename,
+            tofile=filename,
+        )
+    )
 
 
 # ── Tests ────────────────────────────────────────────────────────────────────────
@@ -93,6 +124,75 @@ async def test_apply_patch_increments_revision(
     assert memory.canvas.list_files()["story.md"] == 2
     # And the diff history should contain exactly one patch
     assert len(memory.canvas.get_revision_diffs("story.md")) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_rejects_stale_hunks(
+    memory: TextCanvasMemory,
+    config_v1: str,
+    config_v2: str,
+    config_v3: str,
+) -> None:
+    # Regression test for the stale-patch bug: a patch prepared against an
+    # older revision must not be applied to the latest revision.
+    # Revision 1: the baseline content.
+    await memory.get_update_file_tool().run(
+        UpdateFileArgs(filename="state.txt", new_content=config_v1),
+        CancellationToken(),
+    )
+    # A patch prepared against revision 1 (removes "region=Singapore").
+    edit_from_v1 = "service=payments\nregion=Tokyo\nstatus=active\n"
+    stale_patch = make_patch(config_v1, edit_from_v1)
+    # Revision 2: a competing edit changes the same line to "region=London".
+    await memory.get_update_file_tool().run(
+        UpdateFileArgs(filename="state.txt", new_content=config_v2),
+        CancellationToken(),
+    )
+
+    # Applying the stale patch must fail loudly ...
+    with pytest.raises(ValueError, match="does not match the latest revision"):
+        await memory.get_apply_patch_tool().run(
+            ApplyPatchArgs(filename="state.txt", patch_text=stale_patch),
+            CancellationToken(),
+        )
+
+    # ... and leave revision 2 as the latest, untouched content.
+    assert memory.canvas.get_latest_content("state.txt") == config_v2
+    assert memory.canvas.list_files()["state.txt"] == 2
+
+    # Control: a patch prepared from the actual revision-2 content applies.
+    result = await memory.get_apply_patch_tool().run(
+        ApplyPatchArgs(filename="state.txt", patch_text=make_patch(config_v2, config_v3)),
+        CancellationToken(),
+    )
+    assert result.status == "PATCH APPLIED"
+    assert memory.canvas.get_latest_content("state.txt") == config_v3
+    assert memory.canvas.list_files()["state.txt"] == 3
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_rejects_near_miss_context(
+    memory: TextCanvasMemory,
+    config_v1: str,
+) -> None:
+    # A context line that differs from the current content by a single
+    # character must still be rejected (no fuzzy matching).
+    await memory.get_update_file_tool().run(
+        UpdateFileArgs(filename="state.txt", new_content=config_v1),
+        CancellationToken(),
+    )
+    # Patch prepared against content whose context differs slightly from the canvas.
+    drifted = config_v1.replace("payments", "paymentz")
+    near_miss_patch = make_patch(drifted, drifted.replace("active", "retired"))
+
+    with pytest.raises(ValueError, match="does not match the latest revision"):
+        await memory.get_apply_patch_tool().run(
+            ApplyPatchArgs(filename="state.txt", patch_text=near_miss_patch),
+            CancellationToken(),
+        )
+
+    assert memory.canvas.get_latest_content("state.txt") == config_v1
+    assert memory.canvas.list_files()["state.txt"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #8193

## Summary

`TextCanvas.apply_patch()` documented context-line validation, but the hunk loop performed a blind `working_lines[start:end] = replacement` slice assignment — so a unified diff prepared against an older revision was silently applied to the latest revision, returning `PATCH APPLIED` and making stale content the newest revision (reproduced exactly as in the issue: stale edit landed, `region=Tokyo`).

## Changes

- Each hunk's expected source block (removed + context lines, in order) is now built alongside the replacement and compared exactly against the current content slice. Mismatch or out-of-bounds hunks raise `ValueError`, matching the class's existing error convention and propagating through `ApplyPatchTool` like its other validation errors. The check runs before `add_or_update_file()`, so rejected patches leave the canvas untouched.
- Related correctness fix required by the above: the insertion index for zero-length source hunks is now `source_start` (not `source_start - 1`), which fixes silent one-line misplacement of `n=0` difflib patches while keeping file-creation patches working.

## Tests

`python/packages/autogen-ext/tests/memory/test_text_canvas_memory.py` (+100):

- `test_apply_patch_rejects_stale_hunks` — the issue's repro now raises `ValueError`, revision 2 stays latest, and a control patch built from the real revision-2 content then applies cleanly (revision 3)
- `test_apply_patch_rejects_near_miss_context` — one-char context drift is rejected (no fuzzy matching)
- valid-patch coverage via the pre-existing `test_apply_patch_increments_revision`

`pytest tests/memory/test_text_canvas_memory.py` → 6/6 passed; `ruff check` + `ruff format --check` clean on both files. Multi-hunk, deletions, EOF appends, prepends, create-empty, zero-context insert, and chained applies manually verified unaffected.
