### PR TITLE
docs: fix typos across documentation (16 files)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ We use GitHub issues and milestones to track our roadmap. You can view the upcom
 
 The set of `autogen-*` packages are generally all versioned together. When a change is made to one package, all packages are updated to the same version. This is to ensure that all packages are in sync with each other.
 
-We will update verion numbers according to the following rules:
+We will update version numbers according to the following rules:
 
 - Increase minor version (0.X.0) upon breaking changes
 - Increase patch version (0.0.X) upon new features or bug fixes
@@ -49,14 +49,14 @@ We will update verion numbers according to the following rules:
 
 1. Create a PR that updates the version numbers across the codebase ([example](https://github.com/microsoft/autogen/pull/4359))
 2. The docs CI will fail for the PR, but this is expected and will be resolved in the next step
-3. After merging the PR, create and push a tag that corresponds to the new verion. For example, for `0.4.0.dev13`:
+3. After merging the PR, create and push a tag that corresponds to the new version. For example, for `0.4.0.dev13`:
     - `git tag v0.4.0.dev13 && git push origin v0.4.0.dev13`
 4. Restart the docs CI by finding the failed [job corresponding to the `push` event](https://github.com/microsoft/autogen/actions/workflows/docs.yml) and restarting all jobs
 5. Run [this](https://github.com/microsoft/autogen/actions/workflows/single-python-package.yml) workflow for each of the packages that need to be released and get an approval for the release for it to run
 
 ## Triage process
 
-To help ensure the health of the project and community the AutoGen committers have a weekly triage process to ensure that all issues and pull requests are reviewed and addressed in a timely manner. The following documents the responsibilites while on triage duty:
+To help ensure the health of the project and community the AutoGen committers have a weekly triage process to ensure that all issues and pull requests are reviewed and addressed in a timely manner. The following documents the responsibilities while on triage duty:
 
 - Issues
   - Review all new issues - these will be tagged with [`needs-triage`](https://github.com/microsoft/autogen/issues?q=is%3Aissue%20state%3Aopen%20label%3Aneeds-triage).
@@ -72,14 +72,14 @@ To help ensure the health of the project and community the AutoGen committers ha
   - Bonus: there is a backlog of old issues that need to be reviewed - if you have time, review these as well and close or refresh as many as you can.
 - PRs
   - The UX on GH flags all recently updated PRs. Draft PRs can be ignored, otherwise review all recently updated PRs.
-  - If a PR is ready for review and you can provide one please go ahead. If you cant, please assign someone. You can quickly spin up a codespace with the PR to test it out.
+  - If a PR is ready for review and you can provide one please go ahead. If you can't, please assign someone. You can quickly spin up a codespace with the PR to test it out.
   - If a PR is needing a reply from the op, please tag it `awaiting-op-response`.
   - If a PR is approved and passes CI, its ready to merge, please do so.
   - If it looks like there is a possibly transient CI failure, re-run failed jobs.
 - Discussions
   - Look for recently updated discussions and reply as needed or find someone on the team to reply.
 - Security
-  - Look through any securty alerts and file issues or dismiss as needed.
+  - Look through any security alerts and file issues or dismiss as needed.
 
 ## Becoming a Reviewer
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,6 +1,6 @@
 # AutoGen for .NET
 
-Thre are two sets of packages here:
+There are two sets of packages here:
 AutoGen.\* the older packages derived from AutoGen 0.2 for .NET - these will gradually be deprecated and ported into the new packages
 Microsoft.AutoGen.* the new packages for .NET that use the event-driven model - These APIs are not yet stable and are subject to change.
 

--- a/dotnet/nuget/NUGET.md
+++ b/dotnet/nuget/NUGET.md
@@ -1,7 +1,7 @@
 ### About AutoGen for .NET
 `AutoGen for .NET` is the official .NET SDK for [AutoGen](https://github.com/microsoft/autogen). It enables you to create LLM agents and construct multi-agent workflows with ease. It also provides integration with popular platforms like OpenAI, Semantic Kernel, and LM Studio.
 
-### Gettings started
+### Getting started
 - Find documents and examples on our [document site](https://microsoft.github.io/autogen-for-net/)
 - Report a bug or request a feature by creating a new issue in our [github repo](https://github.com/microsoft/autogen)
 - Consume the nightly build package from one of the [nightly build feeds](https://microsoft.github.io/autogen-for-net/articles/Installation.html#nighly-build)

--- a/dotnet/samples/dev-team/README.md
+++ b/dotnet/samples/dev-team/README.md
@@ -26,13 +26,13 @@ https://github.com/microsoft/azure-openai-dev-skills-orchestrator/assets/1072810
 * User begins with creating an issue and then stateing what they want to accomplish, natural language, as simple or as detailed as needed.
 * Product manager agent will respond with a Readme, which can be iterated upon.
   * User approves the readme or gives feedback via issue comments.
-  * Once the readme is approved, the user closes the issue and the Readme is commited to a PR.
+  * Once the readme is approved, the user closes the issue and the Readme is committed to a PR.
 * Developer lead agent responds with a decomposed plan for development, which also can be iterated upon.
   * User approves the plan or gives feedback via issue comments.
   * Once the readme is approved, the user closes the issue and the plan is used to break down the task to different developer agents.
 * Developer agents respond with code, which can be iterated upon.
   * User approves the code or gives feedback via issue comments.
-  * Once the code is approved, the user closes the issue and the code is commited to a PR.
+  * Once the code is approved, the user closes the issue and the code is committed to a PR.
 
 ```mermaid
 graph TD;
@@ -46,7 +46,7 @@ graph TD;
     RCC -->|ProductManager| RCR([ReadmeCreated event]);
     RCR --> |AzureGenie| RES[Store Readme in blob storage];
     RES --> RES2([ReadmeStored event]);
-    RES2 --> |Hubber| REC[Readme commited to branch and create new PR];
+    RES2 --> |Hubber| REC[Readme committed to branch and create new PR];
 
     DPR([DevPlanRequested event]) -->|DeveloperLead| DPG[Generation of new development plan];
     NEA1 --> DPR;
@@ -65,5 +65,5 @@ graph TD;
     CS --> SRC([SandboxRunCreated event]);
     SRC --> |Sandbox| SRM[Check every minute if the run finished];
     SRM --> SRF([SandboxRunFinished event]);
-    SRF --> |Hubber| SRCC[Code files commited to branch];
+    SRF --> |Hubber| SRCC[Code files committed to branch];
 ```

--- a/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelAgent-support-more-messages.md
+++ b/dotnet/website/articles/AutoGen.SemanticKernel/SemanticKernelAgent-support-more-messages.md
@@ -1,6 +1,6 @@
 @AutoGen.SemanticKernel.SemanticKernelAgent only supports the original `ChatMessageContent` type via `IMessage<ChatMessageContent>`. To support more AutoGen built-in message types like @AutoGen.Core.TextMessage, @AutoGen.Core.ImageMessage, @AutoGen.Core.MultiModalMessage, you can register the agent with @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector. The @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector will convert the message from AutoGen built-in message types to `ChatMessageContent` and vice versa.
 > [!NOTE]
-> At the current stage, @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector only supports conversation for the followng built-in @AutoGen.Core.IMessage
+> At the current stage, @AutoGen.SemanticKernel.SemanticKernelChatMessageContentConnector only supports conversation for the following built-in @AutoGen.Core.IMessage
 > - @AutoGen.Core.TextMessage
 > - @AutoGen.Core.ImageMessage
 > - @AutoGen.Core.MultiModalMessage

--- a/dotnet/website/articles/Built-in-messages.md
+++ b/dotnet/website/articles/Built-in-messages.md
@@ -2,7 +2,7 @@
 
 Start from 0.0.9, AutoGen introduces the @AutoGen.Core.IMessage and @AutoGen.Core.IMessage`1 types to provide a unified message interface for different agents. The @AutoGen.Core.IMessage is a non-generic interface that represents a message. The @AutoGen.Core.IMessage`1 is a generic interface that represents a message with a specific `T` where `T` can be any type.
 
-Besides, AutoGen also provides a set of built-in message types that implement the @AutoGen.Core.IMessage and @AutoGen.Core.IMessage`1 interfaces. These built-in message types are designed to cover different types of messages as much as possilbe. The built-in message types include:
+Besides, AutoGen also provides a set of built-in message types that implement the @AutoGen.Core.IMessage and @AutoGen.Core.IMessage`1 interfaces. These built-in message types are designed to cover different types of messages as much as possible. The built-in message types include:
 
 > [!NOTE]
 > The minimal requirement for an agent to be used as admin in @AutoGen.Core.GroupChat is to support @AutoGen.Core.TextMessage.

--- a/dotnet/website/articles/Group-chat-overview.md
+++ b/dotnet/website/articles/Group-chat-overview.md
@@ -2,7 +2,7 @@
 
 In AutoGen, there are two types of group chat:
 - @AutoGen.Core.RoundRobinGroupChat : This group chat runs agents in a round-robin sequence. The chat history plus the most recent reply from the previous agent will be passed to the next agent.
-- @AutoGen.Core.GroupChat : This group chat provides a more dynamic yet controlable way to determine the next speaker agent. You can either use a llm agent as group admin, or use a @AutoGen.Core.Graph, which is introduced by [this PR](https://github.com/microsoft/autogen/pull/1761), or both to determine the next speaker agent.
+- @AutoGen.Core.GroupChat : This group chat provides a more dynamic yet controllable way to determine the next speaker agent. You can either use a llm agent as group admin, or use a @AutoGen.Core.Graph, which is introduced by [this PR](https://github.com/microsoft/autogen/pull/1761), or both to determine the next speaker agent.
 
 > [!NOTE]
-> In @AutoGen.Core.GroupChat, when only the group admin is used to determine the next speaker agent, it's recommented to use a more powerful llm model, such as `gpt-4` to ensure the best experience.
+> In @AutoGen.Core.GroupChat, when only the group admin is used to determine the next speaker agent, it's recommended to use a more powerful llm model, such as `gpt-4` to ensure the best experience.

--- a/dotnet/website/articles/Group-chat.md
+++ b/dotnet/website/articles/Group-chat.md
@@ -1,7 +1,7 @@
-@AutoGen.Core.GroupChat invokes agents in a dynamic way. On one hand, It relies on its admin agent to intellegently determines the next speaker based on conversation context, and on the other hand, it also allows you to control the conversation flow by using a @AutoGen.Core.Graph. This makes it a more dynamic yet controlable way to determine the next speaker agent. You can use @AutoGen.Core.GroupChat to create a dynamic group chat with multiple agents working together to resolve a given task.
+@AutoGen.Core.GroupChat invokes agents in a dynamic way. On one hand, It relies on its admin agent to intellegently determines the next speaker based on conversation context, and on the other hand, it also allows you to control the conversation flow by using a @AutoGen.Core.Graph. This makes it a more dynamic yet controllable way to determine the next speaker agent. You can use @AutoGen.Core.GroupChat to create a dynamic group chat with multiple agents working together to resolve a given task.
 
 > [!NOTE]
-> In @AutoGen.Core.GroupChat, when only the group admin is used to determine the next speaker agent, it's recommented to use a more powerful llm model, such as `gpt-4` to ensure the best experience.
+> In @AutoGen.Core.GroupChat, when only the group admin is used to determine the next speaker agent, it's recommended to use a more powerful llm model, such as `gpt-4` to ensure the best experience.
 
 ## Use @AutoGen.Core.GroupChat to implement a code interpreter chat flow
 The following example shows how to create a dynamic group chat with @AutoGen.Core.GroupChat. In this example, we will create a dynamic group chat with 4 agents: `admin`, `coder`, `reviewer` and `runner`. Each agent has its own role in the group chat:

--- a/dotnet/website/release_note/update.md
+++ b/dotnet/website/release_note/update.md
@@ -14,7 +14,7 @@
 - [Issue 2649](https://github.com/microsoft/autogen/issues/2649) Deprecate `Workflow` type.
 ###### Bug Fixes
 - [Issue 2735](https://github.com/microsoft/autogen/issues/2735) Fix tool call issue in AutoGen.Mistral package.
-- [Issue 2722](https://github.com/microsoft/autogen/issues/2722) Fix parallel funciton call in function call middleware.
+- [Issue 2722](https://github.com/microsoft/autogen/issues/2722) Fix parallel function call in function call middleware.
 - [Issue 2633](https://github.com/microsoft/autogen/issues/2633) Set up `name` field in `OpenAIChatMessageConnector`
 - [Issue 2660](https://github.com/microsoft/autogen/issues/2660) Fix dotnet interactive restoring issue when system language is Chinese
 - [Issue 2687](https://github.com/microsoft/autogen/issues/2687) Add `global::` prefix to generated code to avoid conflict with user-defined types. 
@@ -55,7 +55,7 @@
 - Graph chat support with conditional transition workflow [#1761](https://github.com/microsoft/autogen/pull/1761)
 - AutoGen.SourceGenerator: Generate `FunctionContract` from `FunctionAttribute` [#1736](https://github.com/microsoft/autogen/pull/1736)
 ##### Update on 0.0.7 (2024-02-11)
-- Add `AutoGen.LMStudio` to support comsume openai-like API from LMStudio local server
+- Add `AutoGen.LMStudio` to support consume openai-like API from LMStudio local server
 ##### Update on 0.0.6 (2024-01-23)
 - Add `MiddlewareAgent`
 - Use `MiddlewareAgent` to implement existing agent hooks (RegisterPreProcess, RegisterPostProcess, RegisterReply)

--- a/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
+++ b/python/docs/src/user-guide/agentchat-user-guide/migration-guide.md
@@ -88,7 +88,7 @@ config_list = [
 model_client = OpenAIWrapper(config_list=config_list)
 ```
 
-> **Note**: In AutoGen 0.2, the OpenAI client would try configs in the list until one worked. 0.4 instead expects a specfic model configuration to be chosen.
+> **Note**: In AutoGen 0.2, the OpenAI client would try configs in the list until one worked. 0.4 instead expects a specific model configuration to be chosen.
 
 In `v0.4`, we offer two ways to create a model client.
 
@@ -160,7 +160,7 @@ custom_model_client = OpenAIChatCompletionClient(
 ```
 
 > **Note**: We don't test all the OpenAI-Compatible APIs, and many of them
-> works differently from the OpenAI API even though they may claim to suppor it.
+> works differently from the OpenAI API even though they may claim to support it.
 > Please test them before using them.
 
 Read about [Model Clients](./tutorial/models.ipynb)
@@ -1272,7 +1272,7 @@ for more details.
 Base on the feedback from the community, the `initiate_chats` function
 is too opinionated and not flexible enough to support the diverse set of scenarios that
 users want to implement. We often find users struggling to get the `initiate_chats` function
-to work when they can easily glue the steps together usign basic Python code.
+to work when they can easily glue the steps together using basic Python code.
 Therefore, in `v0.4`, we do not provide a built-in function for sequential chat in the AgentChat API.
 
 Instead, you can create an event-driven sequential workflow using the Core API,
@@ -1295,7 +1295,7 @@ See {py:class}`~autogen_ext.agents.openai.OpenAIAssistantAgent` for more details
 
 In `v0.2`, long context that overflows the model's context window can be handled
 by using the `transforms` capability that is added to an `ConversableAgent`
-after which is contructed.
+after which is constructed.
 
 The feedbacks from our community has led us to believe this feature is essential
 and should be a built-in component of {py:class}`~autogen_agentchat.agents.AssistantAgent`, and can be used for

--- a/python/docs/src/user-guide/autogenstudio-user-guide/faq.md
+++ b/python/docs/src/user-guide/autogenstudio-user-guide/faq.md
@@ -15,7 +15,7 @@ A: You can specify the directory where files are stored by setting the `--appdir
 
 Yes. AutoGen standardizes on the openai model api format, and you can use any api server that offers an openai compliant endpoint.
 
-AutoGen Studio is based on declaritive specifications which applies to models as well. Agents can include a model_client field which specifies the model endpoint details including `model`, `api_key`, `base_url`, `model type`. Note, you can define your [model client](https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/components/model-clients.html) in python and dump it to a json file for use in AutoGen Studio.
+AutoGen Studio is based on declarative specifications which applies to models as well. Agents can include a model_client field which specifies the model endpoint details including `model`, `api_key`, `base_url`, `model type`. Note, you can define your [model client](https://microsoft.github.io/autogen/dev/user-guide/core-user-guide/components/model-clients.html) in python and dump it to a json file for use in AutoGen Studio.
 
 In the following sample, we will define an OpenAI, AzureOpenAI and a local model client in python and dump them to a json file.
 

--- a/python/docs/src/user-guide/core-user-guide/faqs.md
+++ b/python/docs/src/user-guide/core-user-guide/faqs.md
@@ -33,11 +33,11 @@ host = GrpcWorkerAgentRuntimeHost(address=host_address, extra_grpc_config=extra_
 worker1 = GrpcWorkerAgentRuntime(host_address=host_address, extra_grpc_config=extra_grpc_config)
 ```
 
-**Note**: When `GrpcWorkerAgentRuntime` creates a host connection for the clients, it uses `DEFAULT_GRPC_CONFIG` from `HostConnection` class as default set of values which will can be overriden if you pass parameters with the same name using `extra_grpc_config`.
+**Note**: When `GrpcWorkerAgentRuntime` creates a host connection for the clients, it uses `DEFAULT_GRPC_CONFIG` from `HostConnection` class as default set of values which will can be overridden if you pass parameters with the same name using `extra_grpc_config`.
 
 ## What are model capabilities and how do I specify them?
 
-Model capabilites are additional capabilities an LLM may have beyond the standard natural language features. There are currently 3 additional capabilities that can be specified within Autogen
+Model capabilities are additional capabilities an LLM may have beyond the standard natural language features. There are currently 3 additional capabilities that can be specified within Autogen
 
 - vision: The model is capable of processing and interpreting image data.
 - function_calling: The model has the capacity to accept function descriptions; such as the function name, purpose, input parameters, etc; and can respond with an appropriate function to call including any necessary parameters.

--- a/python/packages/agbench/README.md
+++ b/python/packages/agbench/README.md
@@ -14,7 +14,7 @@ AutoGenBench also requires Docker (Desktop or Engine). **It will not run in GitH
 
 If you are working in WSL, you can follow the instructions below to set up your environment:
 
-1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Ressources, WSL Integration, Enable integration with additional distros – Ubuntu
+1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Resources, WSL Integration, Enable integration with additional distros – Ubuntu
 2. Clone autogen and export `AUTOGEN_REPO_BASE`. This environment variable enables the Docker containers to use the correct version agents.
     ```bash
     git clone git@github.com:microsoft/autogen.git

--- a/python/packages/agbench/benchmarks/README.md
+++ b/python/packages/agbench/benchmarks/README.md
@@ -4,7 +4,7 @@ This directory provides ability to benchmarks agents (e.g., built using Autogen)
 
 ## Setup on WSL
 
-1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Ressources, WSL Integration, Enable integration with additional distros – Ubuntu
+1. Install Docker Desktop. After installation, restart is needed, then open Docker Desktop, in Settings, Resources, WSL Integration, Enable integration with additional distros – Ubuntu
 2. Clone autogen and export `AUTOGEN_REPO_BASE`. This environment variable enables the Docker containers to use the correct version agents.
     ```bash
     git clone git@github.com:microsoft/autogen.git

--- a/python/samples/agentchat_chess_game/README.md
+++ b/python/samples/agentchat_chess_game/README.md
@@ -45,7 +45,7 @@ config:
   api_key: replace with your API key or skip it if you have environment variable OPENAI_API_KEY set
 ```
 
-To use a locally hosted DeepSeek-R1:8b model using Ollama throught its compatibility endpoint,
+To use a locally hosted DeepSeek-R1:8b model using Ollama through its compatibility endpoint,
 you can use the following configuration:
 
 ```yaml

--- a/python/samples/core_semantic_router/README.md
+++ b/python/samples/core_semantic_router/README.md
@@ -13,7 +13,7 @@ In this example, we have a simple scenario where we have a set of distributed ag
 
 The way this system is designed, when a user initiates a session, the semantic router agent will identify the intent of the user (currently using the overly simple method of string matching), identify the most relevant agent, and then route the user to that agent. The agent will then manage the conversation with the user, and the user will be able to interact with the agent in a conversational manner.
 
-While the logic of the agents is simple in this example, the goal is to show how the distributed runtime capabilities of autogen supports this scenario independantly of the capabilities of the agents themselves.
+While the logic of the agents is simple in this example, the goal is to show how the distributed runtime capabilities of autogen supports this scenario independently of the capabilities of the agents themselves.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

Fixes 30 spelling mistakes across 16 documentation files (CONTRIBUTING.md, dotnet website articles, python user guides, and sample/package READMEs). Found with `codespell` and each replacement manually verified in context — intentional terms (e.g. the "AGS" AutoGen Studio abbreviation) were left untouched.

Selected fixes: `verion` → `version`, `responsibilites` → `responsibilities`, `securty` → `security`, `commited` → `committed`, `controlable` → `controllable`, `recommented` → `recommended`, `Ressources` → `Resources`, `usign` → `using`, `throught` → `through`, `Thre are` → `There are`, `Gettings started` → `Getting started`, `declaritive` → `declarative`, `independantly` → `independently`, and more.

Docs-only change; no code touched.

## Checklist

- [x] I have read the CONTRIBUTING.md
