### PR TITLE
docs: add security extension points guidance

### DIFF
--- a/python/docs/src/user-guide/extensions-user-guide/index.md
+++ b/python/docs/src/user-guide/extensions-user-guide/index.md
@@ -14,6 +14,7 @@ myst:
 installation
 discover
 create-your-own
+security-extension-points
 ```
 
 ```{toctree}
@@ -54,5 +55,12 @@ Discover community extensions and samples
 :link-alt: Create your own: Create your own extension
 
 Create your own extension
+:::
+
+:::{grid-item-card} {fas}`shield-halved;pst-color-primary` Security extension points
+:link: ./security-extension-points.html
+:link-alt: Security extension points: Add external policy and threat scanners
+
+Add external policy and threat scanners
 :::
 ::::

--- a/python/docs/src/user-guide/extensions-user-guide/security-extension-points.md
+++ b/python/docs/src/user-guide/extensions-user-guide/security-extension-points.md
@@ -1,0 +1,96 @@
+# Security extension points
+
+AutoGen does not ship a built-in content threat rules wrapper. If you need prompt injection, credential leakage, exfiltration, or dangerous-command detection, build it as an external extension and compose it at the boundary where the untrusted content enters your application.
+
+This keeps AutoGen's maintenance-mode surface small while still giving existing users a clear path for policy engines such as Agent Threat Rules, allowlist validators, or organization-specific scanners.
+
+## Choose the boundary to inspect
+
+| Boundary | Use when | Existing API |
+|---|---|---|
+| Incoming chat messages | You need to filter or tag messages before an agent receives them. | Wrap a {py:class}`~autogen_agentchat.agents.BaseChatAgent`, following the same wrapper shape as {py:class}`~autogen_agentchat.agents.MessageFilterAgent`. |
+| Tool arguments and return values | You need to inspect the operation an agent is about to run, or the content returned by that operation. | Wrap an {py:class}`~autogen_core.tools.Tool` and delegate to the original tool after your policy check. |
+| Workbench tool calls | You need one policy layer across dynamic tools from an MCP server or another shared resource. | Wrap a {py:class}`~autogen_core.tools.Workbench` and inspect {py:meth}`~autogen_core.tools.Workbench.call_tool` arguments and {py:class}`~autogen_core.tools.ToolResult` values. |
+
+For tool-calling agents, prefer the tool or workbench boundary over only scanning chat messages. Tool outputs from web pages, files, MCP servers, and other external systems are often where prompt injection and data exfiltration instructions first enter the run.
+
+## Recommended behavior for a scanner extension
+
+A scanner extension should be deterministic and explicit:
+
+- Do not call another model from the scanner by default. Regex rules, allowlists, and static policy checks are easier to audit and cheaper to run.
+- Return or raise a clear denial result when blocking. Silent drops can leave multi-agent workflows waiting for a response that will never arrive.
+- Include the tool name, call ID, matched rule, and severity in the denial metadata so the application can log or route the event.
+- Default to tagging or returning structured errors for medium-confidence findings, then let the application decide whether to block.
+- Keep the rule pack outside AutoGen when rules change frequently. A separate package can release rule updates without tying them to AutoGen's release cadence.
+
+## Minimal tool wrapper pattern
+
+The {py:class}`~autogen_core.tools.Tool` protocol is enough to adapt an existing tool without changing AutoGen itself:
+
+```python
+from collections.abc import Mapping
+from typing import Any
+
+from autogen_core import CancellationToken
+from autogen_core.tools import Tool, ToolSchema
+
+
+class ScannedTool:
+    def __init__(self, wrapped: Tool, scanner: Any) -> None:
+        self._wrapped = wrapped
+        self._scanner = scanner
+
+    @property
+    def name(self) -> str:
+        return self._wrapped.name
+
+    @property
+    def description(self) -> str:
+        return self._wrapped.description
+
+    @property
+    def schema(self) -> ToolSchema:
+        return self._wrapped.schema
+
+    def args_type(self) -> type[Any]:
+        return self._wrapped.args_type()
+
+    def return_type(self) -> type[Any]:
+        return self._wrapped.return_type()
+
+    def state_type(self) -> type[Any] | None:
+        return self._wrapped.state_type()
+
+    def return_value_as_string(self, value: Any) -> str:
+        return self._wrapped.return_value_as_string(value)
+
+    async def run_json(
+        self,
+        args: Mapping[str, Any],
+        cancellation_token: CancellationToken,
+        call_id: str | None = None,
+    ) -> Any:
+        self._scanner.raise_if_blocked(tool_name=self.name, arguments=args, call_id=call_id)
+        result = await self._wrapped.run_json(args, cancellation_token, call_id=call_id)
+        self._scanner.raise_if_blocked(tool_name=self.name, result=self.return_value_as_string(result), call_id=call_id)
+        return result
+
+    async def save_state_json(self) -> Mapping[str, Any]:
+        return await self._wrapped.save_state_json()
+
+    async def load_state_json(self, state: Mapping[str, Any]) -> None:
+        await self._wrapped.load_state_json(state)
+```
+
+This pattern is intentionally external. It lets security packages depend on `autogen-core`, pin their own rule sets, and decide whether matches should tag, block, redact, or escalate.
+
+## Notes for MCP and browser tools
+
+When a workbench exposes tools from an MCP server, scan both directions:
+
+1. Inspect `call_tool()` arguments before they leave the agent process.
+2. Inspect the returned `ToolResult` text before the model receives it.
+3. Keep a hostname or command allowlist in the application when the tool can browse, fetch URLs, read files, or execute shell commands.
+
+Only connect AutoGen to MCP servers and browser tools that you trust. A scanner can reduce risk, but it is not a sandbox and does not replace container isolation, least-privilege credentials, or human approval for high-impact actions.


### PR DESCRIPTION
## Why are these changes needed?

AutoGen is in maintenance mode, but issue #7669 asks where Agent Threat Rules-style content scanning should fit for existing AutoGen users.

This PR adds a docs-only security extension points page that explains the maintainer-shaped path: keep fast-changing threat rule packs outside AutoGen, and compose external scanners at existing message, tool, or workbench boundaries. It specifically calls out that tool and workbench boundaries are better fits than chat-message-only scanning for prompt injection and exfiltration entering through web pages, files, MCP servers, or other tool outputs.

## Related issue number

Related to #7669

## Verification

- Characterization check before docs change failed as expected: no `security-extension-points.md` page and no extensions-guide toctree entry.
- `python3` characterization check after docs change: `PASS: docs coverage for #7669 exists`
- `uv run python check_md_code_blocks.py docs/src/user-guide/extensions-user-guide/security-extension-points.md` passed.
- `git diff --check FETCH_HEAD...HEAD` passed.
- `uv run sphinx-build -b html -W --keep-going docs/src docs/build` reached and rendered `user-guide/extensions-user-guide/security-extension-points`; it still exits non-zero on pre-existing optional dependency autodoc warnings for `cv2`, `chromadb`, `mem0`, `redisvl`, `llama_cpp`, `ollama`, `semantic_kernel`, `graphrag`, and `json_schema_to_pydantic`.

## Second-agent review

Preferred reviewer `claude -p` was available but failed authentication with `OAuth access token has been revoked`.

Fallback reviewer `hermes chat -Q` reviewed `/tmp/oss-pr-second-agent-review.diff` and returned `CLEAN`: no blocking correctness, regression, test, security, duplicate/superseded, or maintainer-fit issues found.

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

Created with: Hermes Agent
