### PR TITLE
fix(autogen-ext): correct claude-3-haiku context window in OpenAI-compatible model table

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_model_info.py
@@ -479,7 +479,7 @@ _MODEL_TOKEN_LIMITS: Dict[str, int] = {
     "gemini-2.0-flash-lite-preview-02-05": 1048576,
     "gemini-2.5-pro-preview-03-25": 2097152,
     "gemini-2.5-flash": 1048576,
-    "claude-3-haiku-20240307": 50000,
+    "claude-3-haiku-20240307": 200000,
     "claude-3-sonnet-20240229": 200000,
     "claude-3-opus-20240229": 200000,
     "claude-3-5-haiku-20241022": 200000,


### PR DESCRIPTION
### What

`claude-3-haiku-20240307` was listed with a 50,000-token context window in the OpenAI-compatible model info table (`autogen_ext.models.openai._model_info`). This PR corrects it to 200,000.

### Why

The same repository's Anthropic table (`autogen_ext.models.anthropic._model_info`) and Anthropic's docs both list claude-3-haiku's context window as 200k tokens. When claude-3-haiku is used through `OpenAIChatCompletionClient` (e.g. via an OpenAI-compatible endpoint), `remaining_tokens()` — and therefore `TokenLimitedChatCompletionContext` — under-counts the available budget by 150k tokens and silently drops conversation history far earlier than necessary.

### How I checked

- `get_token_limit("claude-3-haiku-20240307")` returns 200000 after the change (50000 before)
- `pytest python/packages/autogen-ext/tests/models/test_openai_model_client.py -k "model_info or token"` — 6 passed
- `ruff check` / `ruff format --check` on the changed file — clean

One-line change, no API surface change; fits the maintenance-mode policy (bug fixes only).
