### PR TITLE
fix(video-surfer): apply extract_audio path guards to save_screenshot

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/_path_guards.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/_path_guards.py
@@ -1,0 +1,26 @@
+"""Shared path checks for VideoSurfer tools.
+
+extract_audio already refused URLs and writes outside the working
+directory. save_screenshot did not. Keep the rules in one place.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+_URL_SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://")
+
+
+def reject_url_path(path: str, *, field_name: str) -> None:
+    """Reject a path that looks like a URL (SSRF via ffmpeg/OpenCV)."""
+    if _URL_SCHEME.match(path):
+        raise ValueError(f"{field_name} must be a local file path, not a URL.")
+
+
+def ensure_output_within_cwd(output_path: str, *, field_name: str) -> None:
+    """Reject an output path that resolves outside the current working directory."""
+    cwd = os.path.realpath(os.getcwd())
+    output_real = os.path.realpath(output_path)
+    if not output_real.startswith(cwd + os.sep) and output_real != cwd:
+        raise ValueError(f"{field_name} must be within the current working directory.")

--- a/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/tools.py
+++ b/python/packages/autogen-ext/src/autogen_ext/agents/video_surfer/tools.py
@@ -11,6 +11,8 @@ from autogen_core.models import (
     UserMessage,
 )
 
+from ._path_guards import ensure_output_within_cwd, reject_url_path
+
 
 def extract_audio(video_path: str, audio_output_path: str) -> str:
     """
@@ -20,22 +22,15 @@ def extract_audio(video_path: str, audio_output_path: str) -> str:
     :param audio_output_path: Path to save the extracted audio file (must end with .mp3).
     :return: Confirmation message with the path to the saved audio file.
     """
-    import os
-    import re
-
     # Reject URLs to prevent SSRF via ffmpeg
-    if re.match(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://", video_path):
-        raise ValueError("video_path must be a local file path, not a URL.")
+    reject_url_path(video_path, field_name="video_path")
 
     # Enforce .mp3 extension to prevent writing arbitrary file types
     if not audio_output_path.lower().endswith(".mp3"):
         raise ValueError("audio_output_path must end with .mp3.")
 
-    # Prevent path traversal — output must stay within the current working directory
-    cwd = os.path.realpath(os.getcwd())
-    output_real = os.path.realpath(audio_output_path)
-    if not output_real.startswith(cwd + os.sep) and output_real != cwd:
-        raise ValueError("audio_output_path must be within the current working directory.")
+    # Prevent path traversal - output must stay within the current working directory
+    ensure_output_within_cwd(audio_output_path, field_name="audio_output_path")
 
     (ffmpeg.input(video_path).output(audio_output_path, format="mp3").run(quiet=True, overwrite_output=True))  # type: ignore
     return f"Audio extracted and saved to {audio_output_path}."
@@ -85,10 +80,13 @@ def save_screenshot(video_path: str, timestamp: float, output_path: str) -> None
     """
     Captures a screenshot at the specified timestamp and saves it to the output path.
 
-    :param video_path: Path to the video file.
+    :param video_path: Path to the video file (must be a local file path, not a URL).
     :param timestamp: Timestamp in seconds.
-    :param output_path: Path to save the screenshot. The file format is determined by the extension in the path.
+    :param output_path: Path to save the screenshot. Must stay within the current working directory. The file format is determined by the extension in the path.
     """
+    reject_url_path(video_path, field_name="video_path")
+    ensure_output_within_cwd(output_path, field_name="output_path")
+
     cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         raise IOError(f"Cannot open video file {video_path}")

--- a/python/packages/autogen-ext/tests/agents/test_video_surfer_path_guards.py
+++ b/python/packages/autogen-ext/tests/agents/test_video_surfer_path_guards.py
@@ -1,0 +1,54 @@
+"""VideoSurfer extract_audio already refused URLs and writes outside cwd.
+
+save_screenshot did not. These tests mock the video-surfer extra so they
+run without opencv/ffmpeg/whisper.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+for _name in ("cv2", "ffmpeg", "whisper"):
+    sys.modules.setdefault(_name, MagicMock())
+
+try:
+    import numpy  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("numpy", MagicMock())
+
+from autogen_ext.agents.video_surfer.tools import extract_audio, save_screenshot
+
+
+def test_extract_audio_rejects_url_video_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="local file path"):
+        extract_audio("https://example.com/video.mp4", "out.mp3")
+
+
+def test_extract_audio_rejects_output_outside_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="current working directory"):
+        extract_audio("video.mp4", "../escaped.mp3")
+
+
+def test_save_screenshot_rejects_url_video_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="local file path"):
+        save_screenshot("https://example.com/video.mp4", 0.0, "frame.png")
+
+
+def test_save_screenshot_rejects_output_outside_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="current working directory"):
+        save_screenshot("video.mp4", 0.0, "../escaped.png")
+
+
+def test_save_screenshot_rejects_absolute_output_outside_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    outside = tmp_path.parent / "escaped.png"
+    with pytest.raises(ValueError, match="current working directory"):
+        save_screenshot("video.mp4", 0.0, str(outside))


### PR DESCRIPTION
## What

VideoSurfer's `extract_audio` already refuses a URL `video_path` and an `audio_output_path` that resolves outside the current working directory. `save_screenshot` takes the same kinds of paths and did not run those checks. An agent-chosen `output_path` such as `../escaped.png` (or an absolute path outside cwd) is passed straight to `cv2.imwrite`. A URL `video_path` is passed straight to `cv2.VideoCapture`.

On `main` at `027ecf0`:

```python
# extract_audio
if re.match(r"^[a-zA-Z][a-zA-Z0-9+\-.]*://", video_path):
    raise ValueError("video_path must be a local file path, not a URL.")
# ...
if not output_real.startswith(cwd + os.sep) and output_real != cwd:
    raise ValueError("audio_output_path must be within the current working directory.")

# save_screenshot
cap = cv2.VideoCapture(video_path)
# ...
cv2.imwrite(output_path, frame)
```

Default `VideoSurfer` includes `save_screenshot` in its tool list. After this change, `save_screenshot` uses the same two helpers as `extract_audio`.

## Why

I was reading VideoSurfer's tools because `extract_audio` already documents an SSRF and path-traversal guard. I expected `save_screenshot` to share that jail. It does not. I confirmed the three new `save_screenshot` tests fail on `027ecf0` (they never raise the cwd/URL `ValueError`) and pass with this patch.

## How

Move the URL and cwd checks into `video_surfer/_path_guards.py`. Call them from `extract_audio` (same behaviour, same error strings) and from `save_screenshot` before OpenCV runs.

## Testing

```bash
python3 -m pytest python/packages/autogen-ext/tests/agents/test_video_surfer_path_guards.py -q
```

5 passed. The three `save_screenshot` cases fail on `027ecf0` and pass with the patch. The two `extract_audio` cases already passed on `027ecf0`.

The test file stubs `cv2`, `ffmpeg`, and `whisper` so it runs without the `video-surfer` extra.