### PR TITLE
feat: add Cross-Chain Intent Tool supporting ERC-7683 standard

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/cross_chain/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/cross_chain/__init__.py
@@ -1,0 +1,3 @@
+from ._intent_tool import CrossChainIntentTool, CrossChainOrder
+
+__all__ = ["CrossChainIntentTool", "CrossChainOrder"]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/cross_chain/_intent_tool.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/cross_chain/_intent_tool.py
@@ -1,0 +1,82 @@
+
+from typing import Any, Dict, List, Optional, Union
+from pydantic import BaseModel, Field, ConfigDict
+import httpx
+from autogen_core import CancellationToken, Component
+from autogen_core.tools import BaseTool
+
+class CrossChainOrder(BaseModel):
+    swapper: str = Field(..., description="The address of the swapper")
+    nonce: int = Field(..., description="A unique nonce for the order")
+    originChainId: int = Field(..., description="The ID of the origin chain")
+    expiry: int = Field(..., description="The expiration timestamp of the order")
+    staticOutput: str = Field(..., description="The address of the static output")
+    fillDeadline: int = Field(..., description="The deadline for filling the order")
+    orderData: str = Field(..., description="Additional order data (hex string or encoded bytes)")
+
+class CrossChainIntentResponse(BaseModel):
+    intent_id: Optional[str] = None
+    status: Optional[str] = None
+    error: Optional[str] = None
+    status_code: Optional[int] = None
+
+class CrossChainIntentToolConfig(BaseModel):
+    solver_url: str
+    name: str = "cross_chain_intent"
+    description: str = "Submit a cross-chain intent to a solver following ERC-7683 standard."
+
+class CrossChainIntentTool(BaseTool[CrossChainOrder, CrossChainIntentResponse], Component[CrossChainIntentToolConfig]):
+    """A tool for submitting cross-chain intents following ERC-7683 standards.
+
+    This tool allows agents to formulate and submit cross-chain swap or bridge intents
+    to a solver or an intent engine.
+    """
+
+    component_type = "tool"
+    component_provider_override = "autogen_ext.tools.cross_chain.CrossChainIntentTool"
+    component_config_schema = CrossChainIntentToolConfig
+
+    def __init__(
+        self,
+        solver_url: str,
+        name: str = "cross_chain_intent",
+        description: str = "Submit a cross-chain intent to a solver following ERC-7683 standard.",
+    ) -> None:
+        super().__init__(CrossChainOrder, CrossChainIntentResponse, name, description)
+        self._solver_url = solver_url
+
+    async def run(self, args: CrossChainOrder, cancellation_token: CancellationToken) -> CrossChainIntentResponse:
+        """Submit the cross-chain order to the solver."""
+        order_dict = args.model_dump()
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    self._solver_url,
+                    json=order_dict,
+                    timeout=10.0
+                )
+                response.raise_for_status()
+                data = response.json()
+                # Handle potential camelCase from API
+                intent_id = data.get("intentId") or data.get("intent_id")
+                return CrossChainIntentResponse(intent_id=intent_id, status=data.get("status"))
+            except httpx.HTTPStatusError as e:
+                return CrossChainIntentResponse(error=f"HTTP error occurred: {e}", status_code=e.response.status_code)
+            except Exception as e:
+                return CrossChainIntentResponse(error=f"An error occurred: {str(e)}")
+
+    def _to_config(self) -> CrossChainIntentToolConfig:
+        return CrossChainIntentToolConfig(
+            solver_url=self._solver_url,
+            name=self.name,
+            description=self.description
+        )
+
+    @classmethod
+    def _from_config(cls, config: CrossChainIntentToolConfig) -> "CrossChainIntentTool":
+        return cls(
+            solver_url=config.solver_url,
+            name=config.name,
+            description=config.description
+        )

--- a/python/packages/autogen-ext/tests/tools/test_cross_chain_intent_tool.py
+++ b/python/packages/autogen-ext/tests/tools/test_cross_chain_intent_tool.py
@@ -1,0 +1,41 @@
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from autogen_ext.tools.cross_chain import CrossChainIntentTool, CrossChainOrder
+from autogen_core import CancellationToken
+import httpx
+
+@pytest.mark.asyncio
+async def test_cross_chain_intent_tool_run():
+    solver_url = "https://api.solver.xyz/v1/intents"
+    tool = CrossChainIntentTool(solver_url=solver_url)
+    
+    order = CrossChainOrder(
+        swapper="0x123",
+        nonce=1,
+        originChainId=1,
+        expiry=1700000000,
+        staticOutput="0x456",
+        fillDeadline=1700000100,
+        orderData="0x"
+    )
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"intentId": "0xabc", "status": "submitted"}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_response
+        
+        result = await tool.run(order, CancellationToken())
+        
+        assert result.intent_id == "0xabc"
+        assert result.status == "submitted"
+        mock_post.assert_called_once()
+
+def test_tool_schema():
+    tool = CrossChainIntentTool(solver_url="http://localhost")
+    schema = tool.schema
+    assert schema["name"] == "cross_chain_intent"
+    assert "swapper" in schema["parameters"]["properties"]


### PR DESCRIPTION
## Why are these changes needed?\n\nThis PR introduces a `CrossChainIntentTool` to AutoGen, enabling agents to participate in cross-chain intent protocols as discussed in #7888. The tool follows the ERC-7683 standard for cross-chain intents, allowing agents to:\n- Formulate cross-chain orders (swaps, bridges, etc.)\n- Submit intents to solver engines via HTTP\n- Support multi-chain coordination in agentic workflows\n\nThis implementation provides a foundational bridge for Web3-enabled autonomous agents in the AutoGen ecosystem.\n\n## Related issue number\n\nCloses #7888\n\n## Checks\n\n- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.\n- [x] I've made sure all auto checks have passed.