### PR TITLE
fix(runtime): use running loop for futures

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -360,7 +360,7 @@ class SingleThreadedAgentRuntime(AgentRuntime):
             parent=None,
             extraAttributes={"message_type": type(message).__name__},
         ):
-            future = asyncio.get_event_loop().create_future()
+            future = asyncio.get_running_loop().create_future()
             if recipient.type not in self._known_agent_names:
                 future.set_exception(Exception("Recipient not found"))
                 return await future

--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py
@@ -382,7 +382,7 @@ class GrpcWorkerAgentRuntime(AgentRuntime):
             "create", recipient, parent=None, extraAttributes={"message_type": data_type}
         ):
             # create a new future for the result
-            future = asyncio.get_event_loop().create_future()
+            future = asyncio.get_running_loop().create_future()
             request_id = await self._get_new_request_id()
             self._pending_requests[request_id] = future
             serialized_message = self._serialization_registry.serialize(

--- a/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host_servicer.py
+++ b/python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host_servicer.py
@@ -243,7 +243,7 @@ class GrpcWorkerAgentRuntimeHostServicer(agent_worker_pb2_grpc.AgentRpcServicer)
         await target_send_queue.send(agent_worker_pb2.Message(request=request))
 
         # Create a future to wait for the response from the target.
-        future = asyncio.get_event_loop().create_future()
+        future = asyncio.get_running_loop().create_future()
         self._pending_responses.setdefault(target_client_id, {})[request.request_id] = future
 
         # Create a task to wait for the response and send it back to the client.


### PR DESCRIPTION
## Problem
Several runtime `send_message` paths create futures from inside async methods with `asyncio.get_event_loop().create_future()`.

Since these methods are already executing in a running event loop, `asyncio.get_running_loop()` is the more direct API and avoids relying on event-loop policy fallback behavior.

## Before / after
Before, the single-threaded runtime and gRPC runtime paths asked the event-loop policy for a loop before creating response futures.

After, they create those futures from the currently running loop. The surrounding request tracking, cancellation linking, and background task behavior are unchanged.

## Verification
- `python -m py_compile python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime_host_servicer.py python/packages/autogen-ext/src/autogen_ext/runtimes/grpc/_worker_runtime.py`
- `git diff --check`