### PR TITLE
fix: TextCanvas.apply_patch validates context lines

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/memory/canvas/_text_canvas.py
+++ b/python/packages/autogen-ext/src/autogen_ext/memory/canvas/_text_canvas.py
@@ -164,14 +164,21 @@ class TextCanvas(BaseCanvas):
             # Calculate the slice boundaries in the *current* working copy.
             start = hunk.source_start - 1 + line_offset
             end = start + hunk.source_length
-            # Build the replacement block for this hunk.
+            expected_source: List[str] = []
             replacement: List[str] = []
             for line in hunk:
+                if line.is_removed or line.is_context:
+                    expected_source.append(line.value)
                 if line.is_added or line.is_context:
                     replacement.append(line.value)
                 # removed lines (line.is_removed) are *not* added.
+                
+            if working_lines[start:end] != expected_source:
+                raise ValueError("Patch rejected: Hunk source context does not match the target file.")
+                
             # Replace the slice with the hunk‑result.
             working_lines[start:end] = replacement
+
             line_offset += len(replacement) - (end - start)
         new_content = "".join(working_lines)
 

--- a/python/packages/autogen-ext/tests/memory/test_text_canvas_memory.py
+++ b/python/packages/autogen-ext/tests/memory/test_text_canvas_memory.py
@@ -119,3 +119,41 @@ async def test_update_context_injects_snapshot(
     assert result.memories.results
     assert isinstance(result.memories.results[0].content, str)
     assert story_v2.strip() in result.memories.results[0].content
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_rejects_stale_hunks() -> None:
+    """Test that patch application rejects hunks if their source context doesn't match."""
+    import difflib
+    from autogen_ext.memory.canvas import TextCanvasMemory
+    from autogen_core import CancellationToken
+    
+    BASE = "service=payments\nregion=Singapore\nstatus=active\n"
+    EDIT_A = "service=payments\nregion=Tokyo\nstatus=active\n"
+    EDIT_B = "service=payments\nregion=London\nstatus=active\n"
+    
+    memory = TextCanvasMemory()
+    update = memory.get_update_file_tool()
+    apply_patch = memory.get_apply_patch_tool()
+    token = CancellationToken()
+    
+    await update.run_json({"filename": "state.txt", "new_content": BASE}, token)
+    
+    # Generate patch from BASE -> EDIT_A
+    stale_patch = "".join(
+        difflib.unified_diff(
+            BASE.splitlines(keepends=True),
+            EDIT_A.splitlines(keepends=True),
+            fromfile="state.txt",
+            tofile="state.txt"
+        )
+    )
+    
+    # Fast-forward canvas to EDIT_B
+    await update.run_json({"filename": "state.txt", "new_content": EDIT_B}, token)
+    
+    # The stale patch should be rejected because its context (Singapore) doesn't match (London)
+    with pytest.raises(ValueError, match="Patch rejected: Hunk source context does not match"):
+        await apply_patch.run_json({"filename": "state.txt", "patch_text": stale_patch}, token)
+        
+    assert memory.canvas.get_latest_content("state.txt") == EDIT_B


### PR DESCRIPTION
Fixes #8193

This PR modifies `TextCanvas.apply_patch` to construct the expected source lines from the hunk and validate that the lines in the current working copy exactly match the source context before allowing the patch to apply. 
If the context does not match, a `ValueError` is raised, preventing stale patches from silently applying over newer edits.

A regression test is included to ensure patch application rejects hunks if their source context doesn't match.