### PR TITLE
fix: MessageFilterAgent preserves strict chronological order

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_message_filter_agent.py
@@ -152,19 +152,27 @@ class MessageFilterAgent(BaseChatAgent, Component[MessageFilterAgentConfig]):
         return self._wrapped_agent.produced_message_types
 
     def _apply_filter(self, messages: Sequence[BaseChatMessage]) -> Sequence[BaseChatMessage]:
-        result: List[BaseChatMessage] = []
+        # 1. Map each source to its matching message indices in the original sequence
+        source_indices: dict[str, list[int]] = {}
+        for idx, msg in enumerate(messages):
+            source_indices.setdefault(msg.source, []).append(idx)
 
+        # 2. Identify which indices are selected according to per_source criteria
+        selected_indices: set[int] = set()
         for source_filter in self._filter.per_source:
-            msgs = [m for m in messages if m.source == source_filter.source]
+            matching = source_indices.get(source_filter.source, [])
+            if not matching:
+                continue
 
             if source_filter.position == "first" and source_filter.count:
-                msgs = msgs[: source_filter.count]
+                selected_indices.update(matching[: source_filter.count])
             elif source_filter.position == "last" and source_filter.count:
-                msgs = msgs[-source_filter.count :]
+                selected_indices.update(matching[-source_filter.count :])
+            else:
+                selected_indices.update(matching)
 
-            result.extend(msgs)
-
-        return result
+        # 3. Emit messages preserving strict chronological order
+        return [m for idx, m in enumerate(messages) if idx in selected_indices]
 
     async def on_messages(
         self,

--- a/python/packages/autogen-agentchat/tests/test_message_filter_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_message_filter_agent.py
@@ -1,0 +1,65 @@
+import pytest
+from typing import List
+from autogen_agentchat.agents import MessageFilterAgent, MessageFilterConfig, PerSourceFilter, BaseChatAgent
+from autogen_agentchat.messages import TextMessage
+from autogen_core import CancellationToken
+from typing import Sequence, Any, AsyncGenerator, Union
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import BaseAgentEvent, BaseChatMessage
+
+class DummyAgent(BaseChatAgent):
+    def __init__(self, name: str):
+        super().__init__(name=name, description="Dummy agent")
+        self.received_messages: List[BaseChatMessage] = []
+
+    @property
+    def produced_message_types(self) -> Sequence[type[BaseChatMessage]]:
+        return (TextMessage,)
+
+    async def on_messages(self, messages: Sequence[BaseChatMessage], cancellation_token: CancellationToken) -> Response:
+        self.received_messages = list(messages)
+        return Response(chat_message=TextMessage(content="dummy", source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_message_filter_agent_chronological_order() -> None:
+    # 5 messages in this exact chronological order
+    messages: List[BaseChatMessage] = [
+        TextMessage(content="please solve X", source="user"),
+        TextMessage(content="A's first attempt", source="A"),
+        TextMessage(content="B's first review", source="B"),
+        TextMessage(content="A's second attempt", source="A"),
+        TextMessage(content="B's second review", source="B"),
+    ]
+
+    inner = DummyAgent("B_inner")
+    
+    # We want to keep the user's first message, A's last message, and B's last 10 messages.
+    # The config list order shouldn't dictate the chronological output order.
+    filtered_agent = MessageFilterAgent(
+        name="B",
+        wrapped_agent=inner,
+        filter=MessageFilterConfig(per_source=[
+            PerSourceFilter(source="user", position="first", count=1),
+            PerSourceFilter(source="A", position="last", count=1),
+            PerSourceFilter(source="B", position="last", count=10),
+        ]),
+    )
+
+    await filtered_agent.on_messages(messages, CancellationToken())
+    
+    # Verify strict chronological preservation: User (t0) -> B's 1st (t2) -> A's 2nd (t3) -> B's 2nd (t4)
+    # A's 1st attempt (t1) is dropped because we only want A's last message.
+    sources = [m.source for m in inner.received_messages]
+    contents = [m.content for m in inner.received_messages]
+    
+    assert sources == ["user", "B", "A", "B"]
+    assert contents == [
+        "please solve X",
+        "B's first review",
+        "A's second attempt",
+        "B's second review"
+    ]


### PR DESCRIPTION
Fixes #7971

This PR changes `MessageFilterAgent._apply_filter` to maintain the original sequence of the `messages` list rather than grouping them by the order in which sources are declared in `per_source`. This prevents the message timeline from becoming inverted and guarantees causal ordering for downstream agents.

Added a test `test_message_filter_agent_chronological_order` to ensure messages are output in chronological order according to their indexes in the initial sequence.