### PR TITLE
fix(ci): check-proto-changes-python can never fail

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -353,6 +353,9 @@ jobs:
       - name: Check if there are uncommited changes
         id: changes
         uses: UnicornGlobal/has-changes-action@v1.0.11
-      - name: Process changes
+      - name: Fail if proto files are not up to date
         if: steps.changes.outputs.changed == 1
-        run: echo "There are changes in the proto files. Please commit them."
+        run: |
+          echo "There are changes in the proto files. Please run 'poe gen-proto' and 'poe gen-test-proto' and commit the result."
+          git --no-pager diff
+          exit 1


### PR DESCRIPTION
## Why are these changes needed?

The `check-proto-changes-python` job in `.github/workflows/checks.yml` is supposed to fail CI when the generated proto files (`poe gen-proto` / `poe gen-test-proto`) are out of sync with what's committed. It currently cannot fail, regardless of the actual diff.

**Root cause**

```yaml
- name: Check if there are uncommited changes
  id: changes
  uses: UnicornGlobal/has-changes-action@v1.0.11
- name: Process changes
  if: steps.changes.outputs.changed == 1
  run: echo "There are changes in the proto files. Please commit them."
```

- `UnicornGlobal/has-changes-action` only *sets an output* (`changed`); by design (see [its README](https://github.com/UnicornGlobal/has-changes-action#how)) it never fails the step itself - it exists purely so a caller can branch on the result.
- The `Process changes` step only runs `echo ...`. There is no `exit 1` (or any other failing command), so the step - and therefore the job - always reports success, even when `changed == 1`.

I verified the has-changes-action's `action.yml` (docker action, only produces an output) and its README (the linked example is literally `run: echo "Changes exist"`, i.e. a demo of the output variable, not a working check) to confirm there is no other path that could fail the job.

**How it got here**

Original check (added in #451, refined in a follow-up commit) worked correctly:

```yaml
- name: Evaluate if there are changes
  run: |
    if [[ `git status --porcelain` ]]; then
      echo "There are changes that need to be generated and commit for the proto files"
      git --no-pager diff
      exit 1
    fi
  shell: bash
```

Commit 5be7ac7b12 ("Move reset from a message to a command", #4073 - an unrelated PR) swapped this for the has-changes-action README's demo snippet verbatim, dropping the `exit 1`. Net effect: this job has shown green on every run since 2024-11-06, independent of whether the generated protos actually match what's committed.

I confirmed on a recent successful run on `main` (workflow run [24054593367](https://github.com/microsoft/autogen/actions/runs/24054593367), job `check-proto-changes-python`) that the job exists and passes today; the logic above shows *why* a "success" here carries no information.

## Fix

Restore a real failure path while keeping the current step structure (minimal diff, no third-party-action swap):

```yaml
- name: Fail if proto files are not up to date
  if: steps.changes.outputs.changed == 1
  run: |
    echo "There are changes in the proto files. Please run 'poe gen-proto' and 'poe gen-test-proto' and commit the result."
    git --no-pager diff
    exit 1
```

**Verified the fix locally** by extracting the exact step body before/after as a shell script and running both with the guard condition true (i.e. simulating "proto files are stale"):

- Before: `echo ...` -> exit code `0` (bug: job stays green)
- After: `echo ...; git --no-pager diff; exit 1` -> exit code `1` (job correctly fails)

The `if:` guard itself is untouched, so the happy path (no diff -> `changed == 0` -> step skipped -> job green) is unaffected.

## Related issue number

None filed - this is a small, self-contained CI fix with git-history evidence for the regression; happy to open an issue first if preferred.

## Checks

- [ ] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR. (Workflow-only change; verified via the before/after shell simulation described above rather than a unit test, since this is a `.github/workflows` step body.)
- [ ] I've made sure all auto checks have passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)