### PR TITLE
feat(agentchat): SelectorGroupChat concurrent speakers

### DIFF
--- a/python/packages/autogen-agentchat/src/autogen_agentchat/state/_states.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/state/_states.py
@@ -51,6 +51,7 @@ class SelectorManagerState(BaseGroupChatManagerState):
     """State for :class:`~autogen_agentchat.teams.SelectorGroupChat` manager."""
 
     previous_speaker: Optional[str] = Field(default=None)
+    previous_speakers: Optional[List[str]] = Field(default=None)
     type: str = Field(default="SelectorManagerState")
 
 

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_base_group_chat_manager.py
@@ -82,6 +82,9 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
         self._message_factory = message_factory
         self._emit_team_events = emit_team_events
         self._active_speakers: List[str] = []
+        # Accumulate responses from concurrent speakers so termination conditions
+        # see the full turn delta, not only the last speaker to finish.
+        self._turn_response_delta: List[BaseAgentEvent | BaseChatMessage] = []
 
     @rpc
     async def handle_start(self, message: GroupChatStart, ctx: MessageContext) -> None:
@@ -148,6 +151,7 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
 
             # Append the messages to the message thread.
             await self.update_message_thread(delta)
+            self._turn_response_delta.extend(delta)
 
             # Remove the agent from the active speakers list.
             self._active_speakers.remove(message.name)
@@ -155,14 +159,18 @@ class BaseGroupChatManager(SequentialRoutedAgent, ABC):
                 # If there are still active speakers, return without doing anything.
                 return
 
-            # Check if the conversation should be terminated.
-            if await self._apply_termination_condition(delta, increment_turn_count=True):
+            # Apply termination to the full concurrent-turn delta (all speakers).
+            turn_delta = self._turn_response_delta
+            self._turn_response_delta = []
+            if await self._apply_termination_condition(turn_delta, increment_turn_count=True):
                 # Stop the group chat.
                 return
 
             # Select speakers to continue the conversation.
             await self._transition_to_next_speakers(ctx.cancellation_token)
         except Exception as e:
+            # Drop any partial concurrent-turn buffer before signaling failure.
+            self._turn_response_delta = []
             # Handle the exception and signal termination with an error.
             error = SerializableException.from_exception(e)
             await self._signal_termination_with_error(error)

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_selector_group_chat.py
@@ -38,8 +38,8 @@ from ._events import GroupChatTermination
 
 trace_logger = logging.getLogger(TRACE_LOGGER_NAME)
 
-SyncSelectorFunc = Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], str | None]
-AsyncSelectorFunc = Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], Awaitable[str | None]]
+SyncSelectorFunc = Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], str | list[str] | None]
+AsyncSelectorFunc = Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], Awaitable[str | list[str] | None]]
 SelectorFuncType = Union[SyncSelectorFunc | AsyncSelectorFunc]
 
 SyncCandidateFunc = Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], List[str]]
@@ -72,6 +72,7 @@ class SelectorGroupChatManager(BaseGroupChatManager):
         emit_team_events: bool,
         model_context: ChatCompletionContext | None,
         model_client_streaming: bool = False,
+        max_concurrent_speakers: int = 1,
     ) -> None:
         super().__init__(
             name,
@@ -86,10 +87,13 @@ class SelectorGroupChatManager(BaseGroupChatManager):
             message_factory,
             emit_team_events,
         )
+        if max_concurrent_speakers < 1:
+            raise ValueError("max_concurrent_speakers must be at least 1.")
         self._model_client = model_client
         self._selector_prompt = selector_prompt
-        self._previous_speaker: str | None = None
+        self._previous_speakers: list[str] = []
         self._allow_repeated_speaker = allow_repeated_speaker
+        self._max_concurrent_speakers = max_concurrent_speakers
         self._selector_func = selector_func
         self._is_selector_func_async = iscoroutinefunction(self._selector_func)
         self._max_selector_attempts = max_selector_attempts
@@ -111,13 +115,14 @@ class SelectorGroupChatManager(BaseGroupChatManager):
         await self._model_context.clear()
         if self._termination_condition is not None:
             await self._termination_condition.reset()
-        self._previous_speaker = None
+        self._previous_speakers = []
 
     async def save_state(self) -> Mapping[str, Any]:
         state = SelectorManagerState(
             message_thread=[msg.dump() for msg in self._message_thread],
             current_turn=self._current_turn,
-            previous_speaker=self._previous_speaker,
+            previous_speaker=self._previous_speakers[0] if self._previous_speakers else None,
+            previous_speakers=self._previous_speakers if self._previous_speakers else None,
         )
         return state.model_dump()
 
@@ -128,7 +133,12 @@ class SelectorGroupChatManager(BaseGroupChatManager):
             self._model_context, [msg for msg in self._message_thread if isinstance(msg, BaseChatMessage)]
         )
         self._current_turn = selector_state.current_turn
-        self._previous_speaker = selector_state.previous_speaker
+        if selector_state.previous_speakers is not None:
+            self._previous_speakers = list(selector_state.previous_speakers)
+        elif selector_state.previous_speaker is not None:
+            self._previous_speakers = [selector_state.previous_speaker]
+        else:
+            self._previous_speakers = []
 
     @staticmethod
     async def _add_messages_to_context(
@@ -150,12 +160,15 @@ class SelectorGroupChatManager(BaseGroupChatManager):
         await self._add_messages_to_context(self._model_context, base_chat_messages)
 
     async def select_speaker(self, thread: Sequence[BaseAgentEvent | BaseChatMessage]) -> List[str] | str:
-        """Selects the next speaker in a group chat using a ChatCompletion client,
-        with the selector function as override if it returns a speaker name.
+        """Selects the next speaker(s) in a group chat using a ChatCompletion client,
+        with the selector function as override if it returns speaker name(s).
 
         .. note::
 
-            This method always returns a single speaker name.
+            When ``max_concurrent_speakers`` is 1 (default), model-based selection
+            returns a single speaker. A custom ``selector_func`` may still return
+            multiple names. When ``max_concurrent_speakers`` > 1, the model may
+            select multiple speakers to respond concurrently.
 
         A key assumption is that the agent type is the same as the topic type, which we use as the agent name.
         """
@@ -168,13 +181,18 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                 sync_selector_func = cast(SyncSelectorFunc, self._selector_func)
                 speaker = sync_selector_func(thread)
             if speaker is not None:
-                if speaker not in self._participant_names:
-                    raise ValueError(
-                        f"Selector function returned an invalid speaker name: {speaker}. "
-                        f"Expected one of: {self._participant_names}."
-                    )
+                speakers = [speaker] if isinstance(speaker, str) else list(speaker)
+                if not speakers:
+                    raise ValueError("Selector function returned an empty speaker list.")
+                for s in speakers:
+                    if s not in self._participant_names:
+                        raise ValueError(
+                            f"Selector function returned an invalid speaker name: {s}. "
+                            f"Expected one of: {self._participant_names}."
+                        )
                 # Skip the model based selection.
-                return [speaker]
+                self._previous_speakers = speakers
+                return speakers
 
         # Use the candidate function to filter participants if provided
         if self._candidate_func is not None:
@@ -192,27 +210,32 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                     f"Expected one of: {self._participant_names}."
                 )
         else:
-            # Construct the candidate agent list to be selected from, skip the previous speaker if not allowed.
-            if self._previous_speaker is not None and not self._allow_repeated_speaker:
-                participants = [p for p in self._participant_names if p != self._previous_speaker]
+            # Construct the candidate agent list to be selected from, skip previous speakers if not allowed.
+            if self._previous_speakers and not self._allow_repeated_speaker:
+                participants = [p for p in self._participant_names if p not in self._previous_speakers]
             else:
                 participants = list(self._participant_names)
 
         assert len(participants) > 0
 
         # Construct agent roles.
-        # Each agent sould appear on a single line.
+        # Each agent should appear on a single line.
         roles = ""
         for topic_type, description in zip(self._participant_names, self._participant_descriptions, strict=True):
             roles += re.sub(r"\s+", " ", f"{topic_type}: {description}").strip() + "\n"
         roles = roles.strip()
 
-        # Select the next speaker.
+        # Select the next speaker(s).
         if len(participants) > 1:
+            if self._max_concurrent_speakers > 1:
+                agent_names = await self._select_multiple_speakers(roles, participants, self._max_selector_attempts)
+                self._previous_speakers = agent_names
+                trace_logger.debug(f"Selected speakers: {agent_names}")
+                return agent_names
             agent_name = await self._select_speaker(roles, participants, self._max_selector_attempts)
         else:
             agent_name = participants[0]
-        self._previous_speaker = agent_name
+        self._previous_speakers = [agent_name]
         trace_logger.debug(f"Selected speaker: {agent_name}")
         return [agent_name]
 
@@ -286,10 +309,10 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                 agent_name = list(mentions.keys())[0]
                 if (
                     not self._allow_repeated_speaker
-                    and self._previous_speaker is not None
-                    and agent_name == self._previous_speaker
+                    and self._previous_speakers
+                    and agent_name in self._previous_speakers
                 ):
-                    trace_logger.debug(f"Model selected the previous speaker: {agent_name} (attempt {num_attempts})")
+                    trace_logger.debug(f"Model selected a previous speaker: {agent_name} (attempt {num_attempts})")
                     feedback = (
                         f"Repeated speaker is not allowed, please select a different name from: {str(participants)}."
                     )
@@ -299,13 +322,108 @@ class SelectorGroupChatManager(BaseGroupChatManager):
                     trace_logger.debug(f"Model selected a valid name: {agent_name} (attempt {num_attempts})")
                     return agent_name
 
-        if self._previous_speaker is not None:
-            trace_logger.warning(f"Model failed to select a speaker after {max_attempts}, using the previous speaker.")
-            return self._previous_speaker
+        if self._previous_speakers:
+            trace_logger.warning(f"Model failed to select a speaker after {max_attempts}, using a previous speaker.")
+            return self._previous_speakers[0]
         trace_logger.warning(
             f"Model failed to select a speaker after {max_attempts} and there was no previous speaker, using the first participant."
         )
         return participants[0]
+
+    async def _select_multiple_speakers(self, roles: str, participants: List[str], max_attempts: int) -> List[str]:
+        """Select multiple speakers concurrently using the model."""
+        model_context_messages = await self._model_context.get_messages()
+        model_context_history = self.construct_message_history(model_context_messages)
+        max_speakers = min(self._max_concurrent_speakers, len(participants))
+
+        concurrent_prompt = (
+            f"You are in a role play game. The following roles are available:\n{roles}.\n"
+            f"Read the following conversation. Then select up to {max_speakers} roles "
+            f"from {str(participants)} to play next. These roles will respond concurrently.\n"
+            f"Return the selected role names separated by commas.\n\n"
+            f"{model_context_history}\n\n"
+            f"Read the above conversation. Then select up to {max_speakers} roles "
+            f"from {str(participants)} to respond concurrently. Return only the role names, separated by commas."
+        )
+
+        select_speaker_messages: List[SystemMessage | UserMessage | AssistantMessage]
+        if ModelFamily.is_openai(self._model_client.model_info["family"]):
+            select_speaker_messages = [SystemMessage(content=concurrent_prompt)]
+        else:
+            select_speaker_messages = [UserMessage(content=concurrent_prompt, source="user")]
+
+        num_attempts = 0
+        while num_attempts < max_attempts:
+            num_attempts += 1
+            if self._model_client_streaming:
+                chunk: CreateResult | str = ""
+                async for _chunk in self._model_client.create_stream(messages=select_speaker_messages):
+                    chunk = _chunk
+                    if self._emit_team_events:
+                        if isinstance(chunk, str):
+                            await self._output_message_queue.put(
+                                ModelClientStreamingChunkEvent(content=cast(str, _chunk), source=self._name)
+                            )
+                        else:
+                            assert isinstance(chunk, CreateResult)
+                            assert isinstance(chunk.content, str)
+                            await self._output_message_queue.put(
+                                SelectorEvent(content=chunk.content, source=self._name)
+                            )
+                assert isinstance(chunk, CreateResult)
+                response = chunk
+            else:
+                response = await self._model_client.create(messages=select_speaker_messages)
+            assert isinstance(response.content, str)
+            select_speaker_messages.append(AssistantMessage(content=response.content, source="selector"))
+            mentions = self._mentioned_agents(response.content, self._participant_names)
+            if len(mentions) == 0:
+                trace_logger.debug(
+                    f"Model failed to select valid names: {response.content} (attempt {num_attempts})"
+                )
+                feedback = f"No valid name was mentioned. Please select from: {str(participants)}."
+                select_speaker_messages.append(UserMessage(content=feedback, source="user"))
+                continue
+
+            # Preserve mention order from the response text where possible by sorting on first appearance.
+            selected = [name for name in mentions if name in participants]
+            if not selected:
+                trace_logger.debug(
+                    f"Model selected non-candidate names: {list(mentions.keys())} (attempt {num_attempts})"
+                )
+                feedback = f"Please select from the candidates: {str(participants)}."
+                select_speaker_messages.append(UserMessage(content=feedback, source="user"))
+                continue
+
+            if (
+                not self._allow_repeated_speaker
+                and self._previous_speakers
+                and any(name in self._previous_speakers for name in selected)
+            ):
+                repeated = [name for name in selected if name in self._previous_speakers]
+                trace_logger.debug(f"Model selected previous speakers: {repeated} (attempt {num_attempts})")
+                feedback = (
+                    f"Repeated speakers are not allowed ({repeated}). "
+                    f"Please select different names from: {str(participants)}."
+                )
+                select_speaker_messages.append(UserMessage(content=feedback, source="user"))
+                continue
+
+            # Cap to max concurrent speakers while preserving order of first mention.
+            ordered = sorted(selected, key=lambda n: response.content.find(n) if n in response.content else 10**9)
+            ordered = ordered[:max_speakers]
+            trace_logger.debug(f"Model selected valid names: {ordered} (attempt {num_attempts})")
+            return ordered
+
+        if self._previous_speakers:
+            trace_logger.warning(
+                f"Model failed to select speakers after {max_attempts}, using previous speakers (capped)."
+            )
+            return self._previous_speakers[:max_speakers]
+        trace_logger.warning(
+            f"Model failed to select speakers after {max_attempts}, using the first {max_speakers} participants."
+        )
+        return participants[:max_speakers]
 
     def _mentioned_agents(self, message_content: str, agent_names: List[str]) -> Dict[str, int]:
         """Counts the number of times each agent is mentioned in the provided message content.
@@ -354,6 +472,7 @@ class SelectorGroupChatConfig(BaseModel):
     allow_repeated_speaker: bool
     # selector_func: ComponentModel | None
     max_selector_attempts: int = 3
+    max_concurrent_speakers: int = 1
     emit_team_events: bool = False
     model_client_streaming: bool = False
     model_context: ComponentModel | None = None
@@ -397,8 +516,12 @@ class SelectorGroupChat(BaseGroupChat, Component[SelectorGroupChatConfig]):
         max_selector_attempts (int, optional): The maximum number of attempts to select a speaker using the model. Defaults to 3.
             If the model fails to select a speaker after the maximum number of attempts, the previous speaker will be used if available,
             otherwise the first participant will be used.
-        selector_func (Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], str | None], Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], Awaitable[str | None]], optional): A custom selector
-            function that takes the conversation history and returns the name of the next speaker.
+        max_concurrent_speakers (int, optional): Maximum number of speakers the model may select to respond concurrently.
+            Defaults to 1 (sequential). Values greater than 1 enable model-based multi-speaker selection.
+            A custom ``selector_func`` may still return multiple names when this is 1.
+        selector_func (Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], str | list[str] | None], Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], Awaitable[str | list[str] | None]], optional): A custom selector
+            function that takes the conversation history and returns the name of the next speaker, or a list of names
+            for concurrent speakers.
             If provided, this function will be used to override the model to select the next speaker.
             If the function returns None, the model will be used to select the next speaker.
             NOTE: `selector_func` is not serializable and will be ignored during serialization and deserialization process.
@@ -614,6 +737,7 @@ Read the above conversation. Then select the next role from {participants} to pl
 """,
         allow_repeated_speaker: bool = False,
         max_selector_attempts: int = 3,
+        max_concurrent_speakers: int = 1,
         selector_func: Optional[SelectorFuncType] = None,
         candidate_func: Optional[CandidateFuncType] = None,
         custom_message_types: List[type[BaseAgentEvent | BaseChatMessage]] | None = None,
@@ -636,11 +760,14 @@ Read the above conversation. Then select the next role from {participants} to pl
         # Validate the participants.
         if len(participants) < 2:
             raise ValueError("At least two participants are required for SelectorGroupChat.")
+        if max_concurrent_speakers < 1:
+            raise ValueError("max_concurrent_speakers must be at least 1.")
         self._selector_prompt = selector_prompt
         self._model_client = model_client
         self._allow_repeated_speaker = allow_repeated_speaker
         self._selector_func = selector_func
         self._max_selector_attempts = max_selector_attempts
+        self._max_concurrent_speakers = max_concurrent_speakers
         self._candidate_func = candidate_func
         self._model_client_streaming = model_client_streaming
         self._model_context = model_context
@@ -678,6 +805,7 @@ Read the above conversation. Then select the next role from {participants} to pl
             self._emit_team_events,
             self._model_context,
             self._model_client_streaming,
+            self._max_concurrent_speakers,
         )
 
     def _to_config(self) -> SelectorGroupChatConfig:
@@ -691,6 +819,7 @@ Read the above conversation. Then select the next role from {participants} to pl
             selector_prompt=self._selector_prompt,
             allow_repeated_speaker=self._allow_repeated_speaker,
             max_selector_attempts=self._max_selector_attempts,
+            max_concurrent_speakers=self._max_concurrent_speakers,
             # selector_func=self._selector_func.dump_component() if self._selector_func else None,
             emit_team_events=self._emit_team_events,
             model_client_streaming=self._model_client_streaming,
@@ -721,6 +850,7 @@ Read the above conversation. Then select the next role from {participants} to pl
             selector_prompt=config.selector_prompt,
             allow_repeated_speaker=config.allow_repeated_speaker,
             max_selector_attempts=config.max_selector_attempts,
+            max_concurrent_speakers=config.max_concurrent_speakers,
             # selector_func=ComponentLoader.load_component(config.selector_func, Callable[[Sequence[BaseAgentEvent | BaseChatMessage]], str | None])
             # if config.selector_func
             # else None,

--- a/python/packages/autogen-agentchat/tests/test_group_chat.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat.py
@@ -1199,6 +1199,47 @@ async def test_selector_group_chat_custom_selector(runtime: AgentRuntime | None)
 
 
 @pytest.mark.asyncio
+async def test_selector_group_chat_concurrent_speakers_via_selector_func(runtime: AgentRuntime | None) -> None:
+    """selector_func returning multiple names should request concurrent speakers (#5395)."""
+    model_client = ReplayChatCompletionClient(["agent3"])  # unused when selector_func returns names
+    agent1 = _EchoAgent("agent1", description="echo agent 1")
+    agent2 = _EchoAgent("agent2", description="echo agent 2")
+    agent3 = _EchoAgent("agent3", description="echo agent 3")
+
+    call_count = {"n": 0}
+
+    def _select_concurrent(messages: Sequence[BaseAgentEvent | BaseChatMessage]) -> list[str] | str | None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return ["agent1", "agent2"]
+        return "agent3"
+
+    # After concurrent agent1+agent2 the message count is 3; agent3 brings it to 4 and stops.
+    termination = MaxMessageTermination(4)
+    team = SelectorGroupChat(
+        participants=[agent1, agent2, agent3],
+        model_client=model_client,
+        selector_func=_select_concurrent,
+        termination_condition=termination,
+        runtime=runtime,
+    )
+    result = await team.run(task="task")
+    # task + agent1 + agent2 (concurrent first round) + agent3
+    assert len(result.messages) == 4
+    sources = [m.source for m in result.messages[1:]]
+    assert set(sources[:2]) == {"agent1", "agent2"}
+    assert sources[2] == "agent3"
+    assert agent1.total_messages == 1
+    assert agent2.total_messages == 1
+    assert agent3.total_messages == 1
+    assert call_count["n"] == 2
+    assert (
+        result.stop_reason is not None
+        and result.stop_reason == "Maximum number of messages 4 reached, current message count: 4"
+    )
+
+
+@pytest.mark.asyncio
 async def test_selector_group_chat_custom_candidate_func(runtime: AgentRuntime | None) -> None:
     model_client = ReplayChatCompletionClient(["agent3"])
     agent1 = _EchoAgent("agent1", description="echo agent 1")


### PR DESCRIPTION
## Summary
- Allow `selector_func` (and model selection when `max_concurrent_speakers` > 1) to return multiple speakers for `SelectorGroupChat`, addressing #5395.
- Persist `previous_speakers` in manager state and fix `BaseGroupChatManager` so termination conditions receive the full concurrent-turn delta (not only the last speaker to finish).
- Add a regression test for concurrent speakers via `selector_func`.

## Test plan
- [x] `pytest tests/test_group_chat.py::test_selector_group_chat_concurrent_speakers_via_selector_func`
- [x] `pytest tests/test_group_chat.py::test_selector_group_chat_custom_selector`
- [x] `pytest tests/test_group_chat.py::test_selector_group_chat_two_speakers`

Fixes #5395