### PR TITLE
fix(core): preserve initial messages when loading buffered contexts

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/model_context/_buffered_chat_completion_context.py
+++ b/python/packages/autogen-core/src/autogen_core/model_context/_buffered_chat_completion_context.py
@@ -47,4 +47,4 @@ class BufferedChatCompletionContext(ChatCompletionContext, Component[BufferedCha
 
     @classmethod
     def _from_config(cls, config: BufferedChatCompletionContextConfig) -> Self:
-        return cls(**config.model_dump())
+        return cls(buffer_size=config.buffer_size, initial_messages=config.initial_messages)

--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -1,6 +1,8 @@
+import json
 from typing import List
 
 import pytest
+from autogen_core import FunctionCall
 from autogen_core.model_context import (
     BufferedChatCompletionContext,
     HeadAndTailChatCompletionContext,
@@ -10,6 +12,7 @@ from autogen_core.model_context import (
 from autogen_core.models import (
     AssistantMessage,
     ChatCompletionClient,
+    FunctionExecutionResult,
     FunctionExecutionResultMessage,
     LLMMessage,
     UserMessage,
@@ -49,6 +52,39 @@ async def test_buffered_model_context() -> None:
     assert len(retrieved) == 2
     assert retrieved[0] == messages[0]
     assert retrieved[1] == messages[1]
+
+
+@pytest.mark.asyncio
+async def test_buffered_model_context_component_round_trip() -> None:
+    messages: List[LLMMessage] = [
+        UserMessage(content="Hello!", source="user"),
+        AssistantMessage(content="How can I help?", source="assistant"),
+        UserMessage(content="Tell me about Seattle.", source="user"),
+    ]
+    model_context = BufferedChatCompletionContext(buffer_size=2, initial_messages=messages)
+
+    config = json.loads(model_context.dump_component().model_dump_json())
+    restored = BufferedChatCompletionContext.load_component(config)
+
+    assert await restored.get_messages() == messages[-2:]
+    assert await restored.save_state() == await model_context.save_state()
+
+
+@pytest.mark.asyncio
+async def test_buffered_model_context_component_round_trip_filters_function_result() -> None:
+    messages: List[LLMMessage] = [
+        AssistantMessage(content=[FunctionCall(id="call_1", arguments="{}", name="search")], source="assistant"),
+        FunctionExecutionResultMessage(
+            content=[FunctionExecutionResult(content="Seattle", call_id="call_1", name="search")]
+        ),
+        AssistantMessage(content="Done.", source="assistant"),
+    ]
+    model_context = BufferedChatCompletionContext(buffer_size=2, initial_messages=messages)
+
+    config = json.loads(model_context.dump_component().model_dump_json())
+    restored = BufferedChatCompletionContext.load_component(config)
+
+    assert await restored.get_messages() == [messages[-1]]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why are these changes needed?

Reloading a `BufferedChatCompletionContext` component with `initial_messages` turns its messages into dictionaries because `_from_config()` unpacks `config.model_dump()`. This breaks the `LLMMessage` return contract and prevents `get_messages()` from removing a leading function result after truncation.

Pass the validated message objects directly to the constructor, as the other context implementations do. Add JSON component round-trip regressions for ordinary messages and a truncated tool-call exchange.

## Related issue number

No existing issue; reproduced through a JSON component round trip.

## Validation

- Both new regression tests fail against the unchanged implementation.
- `pytest tests/test_model_context.py -q`: 11 passed.
- Ruff formatting and lint checks passed for both changed files.
- Mypy passed for both changed files.

## Checks

- [x] I've included any doc changes needed (no public API or documentation changes).
- [x] I've added tests corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed (upstream CI pending).

This change and its regression tests were prepared with Codex.
