### PR TITLE
Add MiniMax image generation tool

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/tools/minimax/__init__.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/minimax/__init__.py
@@ -1,0 +1,13 @@
+from ._image_generation import (
+    MiniMaxImageGenerationArgs,
+    MiniMaxImageGenerationResult,
+    MiniMaxImageGenerationTool,
+    MiniMaxImageGenerationToolConfig,
+)
+
+__all__ = [
+    "MiniMaxImageGenerationArgs",
+    "MiniMaxImageGenerationResult",
+    "MiniMaxImageGenerationTool",
+    "MiniMaxImageGenerationToolConfig",
+]

--- a/python/packages/autogen-ext/src/autogen_ext/tools/minimax/_image_generation.py
+++ b/python/packages/autogen-ext/src/autogen_ext/tools/minimax/_image_generation.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal, Mapping
+
+import httpx
+from autogen_core import CancellationToken, Component
+from autogen_core.tools import BaseTool
+from pydantic import BaseModel, Field, SecretStr, model_validator
+from typing_extensions import Self
+
+MiniMaxImageModel = Literal["image-01", "image-01-live"]
+MiniMaxRegion = Literal["global_en", "cn_zh"]
+ImageResponseFormat = Literal["url", "base64"]
+
+_REGIONAL_ENDPOINTS: Mapping[MiniMaxRegion, str] = {
+    "global_en": "https://api.minimax.io/v1/image_generation",
+    "cn_zh": "https://api.minimaxi.com/v1/image_generation",
+}
+
+
+class MiniMaxImageGenerationArgs(BaseModel):
+    """Arguments accepted by the MiniMax image generation tool."""
+
+    prompt: str = Field(min_length=1, max_length=1500, description="A text description of the image to generate")
+    aspect_ratio: Literal["1:1", "16:9", "4:3", "3:2", "2:3", "3:4", "9:16", "21:9"] | None = Field(
+        default=None, description="The output image aspect ratio"
+    )
+    width: int | None = Field(default=None, ge=512, le=2048, description="The output image width in pixels")
+    height: int | None = Field(default=None, ge=512, le=2048, description="The output image height in pixels")
+    response_format: ImageResponseFormat = Field(default="url", description="Return image URLs or base64 data")
+    seed: int | None = Field(default=None, description="A seed used to make generation reproducible")
+    n: int = Field(default=1, ge=1, le=9, description="The number of images to generate")
+    prompt_optimizer: bool = Field(default=False, description="Whether to optimize the prompt before generation")
+
+    @model_validator(mode="after")
+    def validate_dimensions(self) -> Self:
+        if (self.width is None) != (self.height is None):
+            raise ValueError("width and height must be provided together")
+        if self.width is not None and self.height is not None and (self.width % 8 != 0 or self.height % 8 != 0):
+            raise ValueError("width and height must be divisible by 8")
+        return self
+
+
+class MiniMaxImageGenerationResult(BaseModel):
+    """Images and request metadata returned by the image generation endpoint."""
+
+    images: list[str]
+    response_format: ImageResponseFormat
+    success_count: int
+    failed_count: int
+
+
+class MiniMaxImageGenerationToolConfig(BaseModel):
+    """Serializable configuration for :class:`MiniMaxImageGenerationTool`."""
+
+    api_key: SecretStr
+    model: MiniMaxImageModel = "image-01"
+    region: MiniMaxRegion = "global_en"
+    timeout: float = Field(default=60.0, gt=0)
+
+
+class MiniMaxImageGenerationTool(
+    BaseTool[MiniMaxImageGenerationArgs, MiniMaxImageGenerationResult], Component[MiniMaxImageGenerationToolConfig]
+):
+    """Generate images with MiniMax and return URL or base64 results.
+
+    Args:
+        api_key: API key sent with Bearer authentication.
+        model: Image generation model to use.
+        region: Regional API endpoint to call.
+        timeout: Request timeout in seconds.
+
+    .. note::
+        Install the ``http-tool`` extra before using this tool:
+        ``pip install \"autogen-ext[http-tool]\"``.
+    """
+
+    component_config_schema = MiniMaxImageGenerationToolConfig
+    component_provider_override = "autogen_ext.tools.minimax.MiniMaxImageGenerationTool"
+
+    def __init__(
+        self,
+        api_key: str,
+        model: MiniMaxImageModel = "image-01",
+        region: MiniMaxRegion = "global_en",
+        timeout: float = 60.0,
+    ) -> None:
+        super().__init__(
+            MiniMaxImageGenerationArgs,
+            MiniMaxImageGenerationResult,
+            "minimax_image_generation",
+            "Generate images from a text prompt with MiniMax.",
+        )
+        self._config = MiniMaxImageGenerationToolConfig(
+            api_key=SecretStr(api_key), model=model, region=region, timeout=timeout
+        )
+
+    async def run(
+        self, args: MiniMaxImageGenerationArgs, cancellation_token: CancellationToken
+    ) -> MiniMaxImageGenerationResult:
+        payload: dict[str, Any] = {
+            "model": self._config.model,
+            **args.model_dump(exclude_none=True),
+        }
+        headers = {
+            "Authorization": f"Bearer {self._config.api_key.get_secret_value()}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=self._config.timeout) as client:
+            request = asyncio.ensure_future(
+                client.post(_REGIONAL_ENDPOINTS[self._config.region], headers=headers, json=payload)
+            )
+            response = await cancellation_token.link_future(request)
+
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict):
+            raise ValueError("MiniMax image generation returned an invalid response")
+
+        base_response = body.get("base_resp")
+        if not isinstance(base_response, dict):
+            raise ValueError("MiniMax image generation response is missing base_resp")
+        status_code = base_response.get("status_code")
+        if status_code != 0:
+            status_message = base_response.get("status_msg") or "unknown error"
+            raise RuntimeError(f"MiniMax image generation failed ({status_code}): {status_message}")
+
+        data = body.get("data")
+        if not isinstance(data, dict):
+            raise ValueError("MiniMax image generation response is missing image data")
+        result_key = "image_urls" if args.response_format == "url" else "image_base64"
+        raw_images = data.get(result_key)
+        if not isinstance(raw_images, list) or not all(isinstance(image, str) and image for image in raw_images):
+            raise ValueError(f"MiniMax image generation response is missing {result_key}")
+
+        metadata = body.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+        success_count = metadata.get("success_count", len(raw_images))
+        failed_count = metadata.get("failed_count", 0)
+        try:
+            parsed_success_count = int(success_count)
+            parsed_failed_count = int(failed_count)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("MiniMax image generation response contains invalid metadata") from exc
+
+        return MiniMaxImageGenerationResult(
+            images=raw_images,
+            response_format=args.response_format,
+            success_count=parsed_success_count,
+            failed_count=parsed_failed_count,
+        )
+
+    def _to_config(self) -> MiniMaxImageGenerationToolConfig:
+        return self._config.model_copy()
+
+    @classmethod
+    def _from_config(cls, config: MiniMaxImageGenerationToolConfig) -> Self:
+        return cls(
+            api_key=config.api_key.get_secret_value(),
+            model=config.model,
+            region=config.region,
+            timeout=config.timeout,
+        )

--- a/python/packages/autogen-ext/tests/tools/minimax/test_image_generation.py
+++ b/python/packages/autogen-ext/tests/tools/minimax/test_image_generation.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from autogen_core import CancellationToken
+from pydantic import ValidationError
+
+from autogen_ext.tools.minimax import MiniMaxImageGenerationTool
+
+
+def _mock_client(monkeypatch: pytest.MonkeyPatch, response_body: dict[str, Any]) -> list[httpx.Request]:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=response_body)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(
+        "autogen_ext.tools.minimax._image_generation.httpx.AsyncClient",
+        lambda **kwargs: client,
+    )
+    return requests
+
+
+@pytest.mark.asyncio
+async def test_generates_url_results_for_global_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests = _mock_client(
+        monkeypatch,
+        {
+            "data": {"image_urls": ["https://example.test/generated.png"]},
+            "metadata": {"success_count": 1, "failed_count": 0},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        },
+    )
+    tool = MiniMaxImageGenerationTool(api_key="test-key")
+
+    result = await tool.run_json({"prompt": "A paper kite"}, CancellationToken())
+
+    assert result.images == ["https://example.test/generated.png"]
+    assert result.response_format == "url"
+    assert result.success_count == 1
+    assert requests[0].url == "https://api.minimax.io/v1/image_generation"
+    assert requests[0].headers["Authorization"] == "Bearer test-key"
+    assert json.loads(requests[0].read()) == {
+        "model": "image-01",
+        "prompt": "A paper kite",
+        "response_format": "url",
+        "n": 1,
+        "prompt_optimizer": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_parses_base64_results_for_china_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests = _mock_client(
+        monkeypatch,
+        {
+            "data": {"image_base64": ["aW1hZ2UtYnl0ZXM="]},
+            "metadata": {"success_count": "1", "failed_count": "0"},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        },
+    )
+    tool = MiniMaxImageGenerationTool(api_key="test-key", model="image-01-live", region="cn_zh")
+
+    result = await tool.run_json(
+        {"prompt": "An ink landscape", "response_format": "base64", "width": 1024, "height": 768},
+        CancellationToken(),
+    )
+
+    assert result.images == ["aW1hZ2UtYnl0ZXM="]
+    assert result.response_format == "base64"
+    assert requests[0].url == "https://api.minimaxi.com/v1/image_generation"
+    assert b'"model":"image-01-live"' in requests[0].read()
+
+
+@pytest.mark.asyncio
+async def test_raises_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_client(
+        monkeypatch,
+        {
+            "data": {"image_urls": []},
+            "base_resp": {"status_code": 1002, "status_msg": "rate limit"},
+        },
+    )
+    tool = MiniMaxImageGenerationTool(api_key="test-key")
+
+    with pytest.raises(RuntimeError, match="1002"):
+        await tool.run_json({"prompt": "A paper kite"}, CancellationToken())
+
+
+def test_validates_dimensions_and_component_round_trip() -> None:
+    tool = MiniMaxImageGenerationTool(api_key="test-key", region="cn_zh")
+
+    with pytest.raises(ValidationError, match="provided together"):
+        tool.args_type().model_validate({"prompt": "A paper kite", "width": 1024})
+    with pytest.raises(ValidationError, match="divisible by 8"):
+        tool.args_type().model_validate({"prompt": "A paper kite", "width": 1025, "height": 1024})
+
+    restored = MiniMaxImageGenerationTool.load_component(tool.dump_component(), MiniMaxImageGenerationTool)
+    assert restored.dump_component().config["region"] == "cn_zh"
+    assert restored.schema["name"] == "minimax_image_generation"


### PR DESCRIPTION
Reason: Add a MiniMax image-generation tool for regional endpoints and URL or base64 responses.

This adds a component-serializable image generation tool with validated text-to-image arguments, selectable global and China endpoints, Bearer authentication, and typed response metadata. The client handles both URL and base64 image payloads and surfaces API-level failures.

Tests cover each regional endpoint, both response formats, API errors, argument validation, and component round trips.

Checks:

- `ruff format --check packages/autogen-ext/src/autogen_ext/tools/minimax packages/autogen-ext/tests/tools/minimax`
- `ruff check packages/autogen-ext/src/autogen_ext/tools/minimax packages/autogen-ext/tests/tools/minimax`
- `pytest -q packages/autogen-ext/tests/tools/minimax/test_image_generation.py`
