### PR TITLE
docs: fix typo in group chat comment

### DIFF
--- a/dotnet/src/AutoGen.Core/Extension/GroupChatExtension.cs
+++ b/dotnet/src/AutoGen.Core/Extension/GroupChatExtension.cs
@@ -58,7 +58,7 @@ public static class GroupChatExtension
                 yield break;
             }
 
-            // messages will contain the complete chat history, include initalize messages
+            // messages will contain the complete chat history, including initial messages
             // but we only need to add the last message to the chat history
             // fix #3268
             chatHistory = chatHistory.Append(lastMessage);


### PR DESCRIPTION
## Why are these changes needed?

The comment in `GroupChatExtension.cs` contains a typo and uses an incorrect word form. This updates it to describe the initial messages included in the chat history.

No runtime behavior changes.

## Related issue number

N/A

## Checks

- [x] Documentation/comment change only; no tests are needed.
- [x] `git diff --check`
- [ ] Auto checks have passed.