### PR TITLE
fix(docs): use utf-8 for redirect generation

### DIFF
--- a/python/docs/redirects/redirects.py
+++ b/python/docs/redirects/redirects.py
@@ -7,8 +7,11 @@ THIS_FILE_DIR = Path(__file__).parent
 
 # Contains single text template $to_url
 HTML_PAGE_TEMPLATE_FILE = THIS_FILE_DIR / "redirect_template.html"
-HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open("r").read()
+HTML_REDIRECT_TEMPLATE = HTML_PAGE_TEMPLATE_FILE.open(
+    "r", encoding="utf-8"
+).read()
 REDIRECT_URLS_FILE = THIS_FILE_DIR / "redirect_urls.txt"
+
 
 def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     # Create a new redirect page
@@ -30,7 +33,7 @@ def generate_redirect(file_to_write: str, new_url: str, base_dir: Path):
     redirect_page_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write the redirect page
-    with open(redirect_page_path, "w") as f:
+    with open(redirect_page_path, "w", encoding="utf-8") as f:
         f.write(redirect_page)
 
 
@@ -42,7 +45,7 @@ def main():
     base_dir = Path(sys.argv[1])
 
     # Read file
-    with open(REDIRECT_URLS_FILE, "r") as f:
+    with open(REDIRECT_URLS_FILE, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     for line in lines:
@@ -52,5 +55,5 @@ def main():
         file_to_write = old_url.replace("/autogen/", "/")
         generate_redirect(file_to_write, new_url, base_dir)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Read the redirect template and URL list with explicit UTF-8 encoding.
- Write generated redirect pages with explicit UTF-8 encoding.

## Problem
The redirect generation utility currently depends on Python's locale default encoding for text file I/O. That can be inconsistent on Windows and other environments where the locale is not UTF-8.

## Before / after
Before, redirect generation used the platform default encoding. After, the same files are read and written as UTF-8 explicitly, making generated docs redirects more reproducible across environments.

## Verification
- `python -m py_compile python\\docs\\redirects\\redirects.py`
- `python python\\docs\\redirects\\redirects.py $env:TEMP\\autogen_redirect_smoke`
- Checked generated `index.html` and `docs\\Getting-Started\\index.html` existed in the temp output folder.
- `git diff --check`

Thank you for maintaining AutoGen.