### PR TITLE
docs: add btp-guard AST security gating cookbook recipe

### DIFF
--- a/docs/btp_security_gating.ipynb
+++ b/docs/btp_security_gating.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6f30d3db",
+   "metadata": {},
+   "source": [
+    "# Pre-Flight Invariant AST Security Gating for AutoGen Code Execution\n",
+    "\n",
+    "This cookbook demonstrates how to integrate `btp-guard` (Bartholomew Trust Protocol) into AutoGen's `LocalCommandLineCodeExecutor` to provide deterministic, in-memory pre-flight AST gating for code blocks before dispatch.\n",
+    "\n",
+    "### Key Features\n",
+    "* **Sub-50µs Overhead:** In-memory inspection for Python, Bash, and SQL code.\n",
+    "* **Proactive Interception:** Pre-emptively traps high-risk operations (e.g., `rm -rf`, `DROP TABLE`, credential exposures) before host execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64d4860e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet autogen btp-guard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33a938ad",
+   "metadata": {},
+   "source": [
+    "## Step 1: Extend `LocalCommandLineCodeExecutor`\n",
+    "Intercept incoming code blocks and evaluate them against BTP security invariants prior to execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40aa9d5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogen.coding import LocalCommandLineCodeExecutor\n",
+    "from btp_guard import guard\n",
+    "\n",
+    "class SecureCodeExecutor(LocalCommandLineCodeExecutor):\n",
+    "    def execute_code_blocks(self, code_blocks):\n",
+    "        for block in code_blocks:\n",
+    "            # Sub-50µs in-memory evaluation\n",
+    "            is_safe, reason = guard.evaluate(block.language, block.code)\n",
+    "            if not is_safe:\n",
+    "                return 1, f\"[BTP Security Veto] Execution aborted: {reason}\", None\n",
+    "                \n",
+    "        return super().execute_code_blocks(code_blocks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8722d4eb",
+   "metadata": {},
+   "source": [
+    "## Step 2: Validating Allowed Execution\n",
+    "Standard operations execute without noticeable overhead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "871c0952",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class CodeBlock:\n",
+    "    def __init__(self, language, code):\n",
+    "        self.language = language\n",
+    "        self.code = code\n",
+    "\n",
+    "executor = SecureCodeExecutor(work_dir=\"coding\")\n",
+    "\n",
+    "safe_block = CodeBlock(\"python\", \"print('AutoGen execution secure.')\")\n",
+    "exit_code, logs, _ = executor.execute_code_blocks([safe_block])\n",
+    "\n",
+    "print(f\"Exit Code: {exit_code}\")\n",
+    "print(f\"Logs: {logs}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae208876",
+   "metadata": {},
+   "source": [
+    "## Step 3: Intercepting Security Violations\n",
+    "Destructive commands (such as `rm -rf /` or DDL purges) trigger an immediate BTP veto before hitting the host/shell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e078451",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unsafe_block = CodeBlock(\"bash\", \"rm -rf /\")\n",
+    "exit_code, logs, _ = executor.execute_code_blocks([unsafe_block])\n",
+    "\n",
+    "print(f\"Exit Code: {exit_code}\")\n",
+    "print(f\"Logs: {logs}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f34d8175",
+   "metadata": {},
+   "source": [
+    "## Security Considerations & Limitations\n",
+    "\n",
+    "> **Important:** Static AST inspection serves as a zero-latency heuristic pre-filter for obvious high-risk patterns. It does not replace container or OS isolation (e.g., Docker or sandboxes). Dynamic constructs like `eval()` or dynamic string concatenation sit outside static syntax tree boundaries. Always pair pre-flight gating with robust runtime sandboxing for defense-in-depth."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #8162

Adds a cookbook recipe notebook demonstrating sub-50µs pre-flight AST invariant gating for AutoGen code execution using `btp-guard`. Includes both allowed execution and intercepted violation examples, as well as clear safety boundaries regarding static inspection limitations.