### PR TITLE
[RFC #7748] feat(samples): standalone SQLite shared memory provider and concurrency suite

### DIFF
--- a/python/samples/agent_memory_sqlite/README.md
+++ b/python/samples/agent_memory_sqlite/README.md
@@ -1,0 +1,16 @@
+# Standalone SQLite Shared Memory Provider
+
+A standalone, thread-safe SQLite shared memory provider for multi-agent systems, featuring:
+- **Hierarchical Scopes:** Lexical scoping across `{agent, group, global}` tiers with SQL window ranking.
+- **Bi-Temporal Lifecycle:** Soft-invalidation via `valid_from` and `valid_to` timestamps, preserving complete audit provenance.
+- **Atomic Supersede:** Optimistic conditional replacement ensuring only active in-force records are superseded.
+- **Trusted Context Binding:** `BoundSessionMemory` tool wrapper ensuring models cannot forge caller scope or authority tier.
+- **Concurrency Rigor:** WAL mode and bounded barrier synchronization with setup error handling.
+
+## Running Tests
+
+From this directory:
+
+```bash
+pytest -v test_sqlite_shared_memory.py
+```

--- a/python/samples/agent_memory_sqlite/sqlite_shared_memory.py
+++ b/python/samples/agent_memory_sqlite/sqlite_shared_memory.py
@@ -1,0 +1,365 @@
+"""
+SQLiteSharedMemoryStore - Standalone SQLite Shared Memory Provider for Microsoft AutoGen
+Targeting examples/agent_memory/ against pinned commit 027ecf0.
+
+Features:
+- Scoped memory isolation: agent, group, global tiers.
+- Bi-temporal lifecycle: valid_from, valid_to soft invalidation.
+- Atomic conditional supersede: ensures only current in-force facts are superseded.
+- Scoped window ranking: narrowest scope and highest authority tier shadow lower tiers.
+- Trusted context binding: model-facing tool interfaces cannot forge authority tiers.
+"""
+
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from typing import List, Dict, Optional, Tuple, Any
+
+class WorkerSetupError(Exception):
+    """Raised when worker database connection or pragma initialization fails."""
+    pass
+
+class ReplacementConflictError(Exception):
+    """Raised when an atomic conditional supersede fails due to competing concurrent update."""
+    pass
+
+class ScopeAuthorizationError(Exception):
+    """Raised when an unauthorized actor attempts to supersede or delete out-of-scope memory."""
+    pass
+
+
+class SQLiteSharedMemoryStore:
+    def __init__(self, db_path: str, timeout: float = 5.0):
+        self.db_path = db_path
+        self.timeout = timeout
+        self._init_schema()
+
+    def get_connection(self) -> sqlite3.Connection:
+        """Create connection and assert strict PRAGMA invariants."""
+        try:
+            conn = sqlite3.connect(self.db_path, timeout=self.timeout)
+            conn.row_factory = sqlite3.Row
+            
+            # Enforce foreign keys and WAL mode
+            conn.execute("PRAGMA foreign_keys = ON;")
+            conn.execute("PRAGMA journal_mode = WAL;")
+            
+            fk = conn.execute("PRAGMA foreign_keys;").fetchone()[0]
+            wal = conn.execute("PRAGMA journal_mode;").fetchone()[0].lower()
+            
+            assert fk == 1, "PRAGMA foreign_keys must be 1"
+            assert wal == "wal", f"PRAGMA journal_mode must be 'wal', got '{wal}'"
+            return conn
+        except Exception as e:
+            raise WorkerSetupError(f"Failed to initialize SQLite connection to {self.db_path}: {e}") from e
+
+    def _init_schema(self) -> None:
+        conn = self.get_connection()
+        try:
+            with conn:
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS memory_capsules (
+                        capsule_id TEXT PRIMARY KEY,
+                        tenant_id TEXT NOT NULL,
+                        scope_type TEXT NOT NULL,
+                        scope_id TEXT NOT NULL,
+                        subject TEXT NOT NULL,
+                        predicate TEXT NOT NULL,
+                        object TEXT NOT NULL,
+                        authority_tier INTEGER NOT NULL DEFAULT 20,
+                        confidence REAL NOT NULL DEFAULT 1.0,
+                        superseded_by TEXT,
+                        valid_from TEXT NOT NULL,
+                        valid_to TEXT,
+                        FOREIGN KEY (superseded_by) REFERENCES memory_capsules(capsule_id)
+                    );
+                """)
+                conn.execute("""
+                    CREATE INDEX IF NOT EXISTS idx_memory_capsules_active
+                    ON memory_capsules(tenant_id, subject, predicate, valid_to);
+                """)
+                conn.execute("""
+                    CREATE INDEX IF NOT EXISTS idx_memory_capsules_scope
+                    ON memory_capsules(tenant_id, scope_type, scope_id);
+                """)
+        finally:
+            conn.close()
+
+    def create(
+        self,
+        tenant_id: str,
+        scope_type: str,
+        scope_id: str,
+        subject: str,
+        predicate: str,
+        object_: str,
+        authority_tier: int = 20,
+        confidence: float = 1.0
+    ) -> str:
+        """Create an active memory capsule."""
+        capsule_id = str(uuid.uuid4())
+        now_iso = datetime.now(timezone.utc).isoformat()
+        conn = self.get_connection()
+        try:
+            with conn:
+                conn.execute("""
+                    INSERT INTO memory_capsules (
+                        capsule_id, tenant_id, scope_type, scope_id,
+                        subject, predicate, object, authority_tier,
+                        confidence, valid_from, valid_to
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """, (
+                    capsule_id, tenant_id, scope_type, scope_id,
+                    subject.strip(), predicate.strip(), object_.strip(),
+                    authority_tier, confidence, now_iso
+                ))
+            return capsule_id
+        finally:
+            conn.close()
+
+    def recall(
+        self,
+        tenant_id: str,
+        scope_hierarchy: List[Tuple[str, str]],
+        subject: Optional[str] = None,
+        predicate: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Recall active memories matching caller scope hierarchy.
+        Higher authority_tier wins; within same tier, narrower scope (session/agent > group > global) wins.
+        """
+        conn = self.get_connection()
+        try:
+            # Build scope predicate
+            scope_clauses = []
+            params: List[Any] = [tenant_id]
+            for s_type, s_id in scope_hierarchy:
+                scope_clauses.append("(scope_type = ? AND scope_id = ?)")
+                params.extend([s_type, s_id])
+            
+            scope_filter = " OR ".join(scope_clauses) if scope_clauses else "1=0"
+            
+            filter_clauses = [f"tenant_id = ?", f"({scope_filter})", "valid_to IS NULL"]
+            if subject:
+                filter_clauses.append("subject = ?")
+                params.append(subject.strip())
+            if predicate:
+                filter_clauses.append("predicate = ?")
+                params.append(predicate.strip())
+
+            where_sql = " AND ".join(filter_clauses)
+
+            # Window query resolving scope hierarchy
+            sql = f"""
+                WITH active_candidates AS (
+                    SELECT 
+                        capsule_id, tenant_id, scope_type, scope_id,
+                        subject, predicate, object, authority_tier,
+                        confidence, valid_from,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY subject, predicate
+                            ORDER BY 
+                                authority_tier DESC,
+                                CASE scope_type
+                                    WHEN 'agent'  THEN 1
+                                    WHEN 'group'  THEN 2
+                                    WHEN 'global' THEN 3
+                                    ELSE 4
+                                END ASC,
+                                valid_from DESC
+                        ) AS rank
+                    FROM memory_capsules
+                    WHERE {where_sql}
+                )
+                SELECT 
+                    capsule_id, tenant_id, scope_type, scope_id,
+                    subject, predicate, object, authority_tier,
+                    confidence, valid_from
+                FROM active_candidates
+                WHERE rank = 1
+                ORDER BY subject, predicate;
+            """
+            cursor = conn.execute(sql, params)
+            return [dict(row) for row in cursor.fetchall()]
+        finally:
+            conn.close()
+
+    def supersede(
+        self,
+        tenant_id: str,
+        target_id: str,
+        new_subject: str,
+        new_predicate: str,
+        new_object: str,
+        authority_tier: int = 20,
+        confidence: float = 1.0
+    ) -> Tuple[str, str]:
+        """
+        Atomic conditional update: marks predecessor invalid (valid_to = now) 
+        ONLY if currently active (valid_to IS NULL) and authority_tier is sufficient.
+        """
+        now_iso = datetime.now(timezone.utc).isoformat()
+        new_id = str(uuid.uuid4())
+        conn = self.get_connection()
+        try:
+            with conn:
+                cursor = conn.cursor()
+                # Check target exists, belongs to tenant, is active, and authority tier permits
+                cursor.execute("""
+                    SELECT scope_type, scope_id, authority_tier, valid_to
+                    FROM memory_capsules
+                    WHERE capsule_id = ? AND tenant_id = ?
+                """, (target_id, tenant_id))
+                row = cursor.fetchone()
+                if not row:
+                    raise KeyError(f"Memory capsule {target_id} not found for tenant {tenant_id}")
+                
+                target_scope_type = row["scope_type"]
+                target_scope_id = row["scope_id"]
+                target_authority = row["authority_tier"]
+                target_valid_to = row["valid_to"]
+
+                if target_valid_to is not None:
+                    raise ReplacementConflictError(f"Memory capsule {target_id} has already been superseded")
+
+                if authority_tier < target_authority:
+                    raise ScopeAuthorizationError(
+                        f"Authority tier {authority_tier} cannot supersede existing tier {target_authority}"
+                    )
+
+                # 1. Insert successor first
+                cursor.execute("""
+                    INSERT INTO memory_capsules (
+                        capsule_id, tenant_id, scope_type, scope_id,
+                        subject, predicate, object, authority_tier,
+                        confidence, valid_from, valid_to
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """, (
+                    new_id, tenant_id, target_scope_type, target_scope_id,
+                    new_subject.strip(), new_predicate.strip(), new_object.strip(),
+                    authority_tier, confidence, now_iso
+                ))
+
+                # 2. Conditionally update predecessor with optimistic concurrency check
+                cursor.execute("""
+                    UPDATE memory_capsules
+                    SET valid_to = ?, superseded_by = ?
+                    WHERE capsule_id = ? AND valid_to IS NULL
+                """, (now_iso, new_id, target_id))
+
+                if cursor.rowcount == 0:
+                    raise ReplacementConflictError(f"Concurrent update conflict: {target_id} was superseded by peer")
+
+            return new_id, target_id
+        finally:
+            conn.close()
+
+    def forget(self, tenant_id: str, target_id: str, authority_tier: int = 20) -> bool:
+        """Soft-deletes a fact by setting valid_to = now, preserving audit trail."""
+        now_iso = datetime.now(timezone.utc).isoformat()
+        conn = self.get_connection()
+        try:
+            with conn:
+                cursor = conn.cursor()
+                cursor.execute("""
+                    SELECT authority_tier, valid_to
+                    FROM memory_capsules
+                    WHERE capsule_id = ? AND tenant_id = ?
+                """, (target_id, tenant_id))
+                row = cursor.fetchone()
+                if not row:
+                    return False
+                if row["valid_to"] is not None:
+                    return False
+                if authority_tier < row["authority_tier"]:
+                    raise ScopeAuthorizationError("Insufficient authority tier to forget fact")
+
+                cursor.execute("""
+                    UPDATE memory_capsules
+                    SET valid_to = ?
+                    WHERE capsule_id = ? AND valid_to IS NULL
+                """, (now_iso, target_id))
+                return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    def bind(
+        self,
+        tenant_id: str,
+        scope_type: str,
+        scope_id: str,
+        authority_tier: int = 20,
+        allowed_scopes: Optional[List[Tuple[str, str]]] = None
+    ) -> 'BoundSessionMemory':
+        """Bind storage store to a trusted orchestrator session context."""
+        return BoundSessionMemory(
+            store=self,
+            tenant_id=tenant_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            authority_tier=authority_tier,
+            allowed_scopes=allowed_scopes or [(scope_type, scope_id)]
+        )
+
+
+class BoundSessionMemory:
+    """
+    Model-facing memory tool wrapper.
+    Caller scope and authority tier are injected server-side by the host application.
+    The LLM tool surface only accepts (subject, predicate, object).
+    """
+    def __init__(
+        self,
+        store: SQLiteSharedMemoryStore,
+        tenant_id: str,
+        scope_type: str,
+        scope_id: str,
+        authority_tier: int,
+        allowed_scopes: List[Tuple[str, str]]
+    ):
+        self._store = store
+        self._tenant_id = tenant_id
+        self._scope_type = scope_type
+        self._scope_id = scope_id
+        self._authority_tier = authority_tier
+        self._allowed_scopes = allowed_scopes
+
+    def remember(self, subject: str, predicate: str, object_: str) -> str:
+        """Tool interface for memory insertion."""
+        return self._store.create(
+            tenant_id=self._tenant_id,
+            scope_type=self._scope_type,
+            scope_id=self._scope_id,
+            authority_tier=self._authority_tier,
+            subject=subject,
+            predicate=predicate,
+            object_=object_
+        )
+
+    def search(self, subject: Optional[str] = None, predicate: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Tool interface for memory recall."""
+        return self._store.recall(
+            tenant_id=self._tenant_id,
+            scope_hierarchy=self._allowed_scopes,
+            subject=subject,
+            predicate=predicate
+        )
+
+    def supersede(self, target_id: str, new_subject: str, new_predicate: str, new_object: str) -> Tuple[str, str]:
+        """Tool interface for memory update."""
+        return self._store.supersede(
+            tenant_id=self._tenant_id,
+            target_id=target_id,
+            new_subject=new_subject,
+            new_predicate=new_predicate,
+            new_object=new_object,
+            authority_tier=self._authority_tier
+        )
+
+    def forget(self, target_id: str) -> bool:
+        """Tool interface for memory deletion."""
+        return self._store.forget(
+            tenant_id=self._tenant_id,
+            target_id=target_id,
+            authority_tier=self._authority_tier
+        )

--- a/python/samples/agent_memory_sqlite/test_sqlite_shared_memory.py
+++ b/python/samples/agent_memory_sqlite/test_sqlite_shared_memory.py
@@ -1,0 +1,303 @@
+import os
+import sqlite3
+import threading
+import pytest
+from typing import List
+
+from sqlite_shared_memory import (
+    SQLiteSharedMemoryStore,
+    BoundSessionMemory,
+    WorkerSetupError,
+    ReplacementConflictError,
+    ScopeAuthorizationError
+)
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_memory.db")
+
+@pytest.fixture
+def store(db_path):
+    return SQLiteSharedMemoryStore(db_path)
+
+
+def test_sqlite_pragmas(store):
+    """Assert that foreign keys are ON and journal mode is WAL."""
+    conn = store.get_connection()
+    try:
+        fk = conn.execute("PRAGMA foreign_keys;").fetchone()[0]
+        wal = conn.execute("PRAGMA journal_mode;").fetchone()[0].lower()
+        assert fk == 1, "PRAGMA foreign_keys must be 1"
+        assert wal == "wal", "PRAGMA journal_mode must be wal"
+    finally:
+        conn.close()
+
+
+def test_create_and_recall_scoped(store):
+    """Verify lexical scope hierarchy (agent > group > global within equal authority)."""
+    tenant = "tenant_alpha"
+    # Create global rule
+    store.create(tenant, "global", "global_main", "project", "style", "black", authority_tier=20)
+    # Create group rule
+    store.create(tenant, "group", "group_backend", "project", "style", "ruff", authority_tier=20)
+    # Create agent rule
+    store.create(tenant, "agent", "agent_worker1", "project", "style", "flake8", authority_tier=20)
+
+    # Agent recall with full hierarchy [agent, group, global]
+    hierarchy = [("agent", "agent_worker1"), ("group", "group_backend"), ("global", "global_main")]
+    memories = store.recall(tenant, hierarchy, subject="project", predicate="style")
+    assert len(memories) == 1
+    assert memories[0]["object"] == "flake8"
+    assert memories[0]["scope_type"] == "agent"
+
+    # Group recall with hierarchy [group, global]
+    group_hierarchy = [("group", "group_backend"), ("global", "global_main")]
+    group_memories = store.recall(tenant, group_hierarchy, subject="project", predicate="style")
+    assert len(group_memories) == 1
+    assert group_memories[0]["object"] == "ruff"
+    assert group_memories[0]["scope_type"] == "group"
+
+
+def test_authority_tier_override(store):
+    """Assert that higher authority tier (Tier 100) strictly overrides lower tier (Tier 20) regardless of scope."""
+    tenant = "tenant_alpha"
+    # Agent tier 20 note
+    store.create(tenant, "agent", "agent_1", "security", "auth", "allow_insecure", authority_tier=20)
+    # Global tier 100 operator policy
+    store.create(tenant, "global", "global_policy", "security", "auth", "strict_mfa", authority_tier=100)
+
+    hierarchy = [("agent", "agent_1"), ("global", "global_policy")]
+    memories = store.recall(tenant, hierarchy, subject="security", predicate="auth")
+    assert len(memories) == 1
+    assert memories[0]["object"] == "strict_mfa"
+    assert memories[0]["authority_tier"] == 100
+
+
+def test_atomic_supersede_precedence(store):
+    """Verify that supersede marks predecessor invalid and recall returns the successor."""
+    tenant = "tenant_alpha"
+    orig_id = store.create(tenant, "agent", "agent_1", "db", "port", "5432", authority_tier=20)
+
+    new_id, superseded_id = store.supersede(
+        tenant, orig_id, "db", "port", "5433", authority_tier=20
+    )
+    assert superseded_id == orig_id
+    assert new_id != orig_id
+
+    # Check recall: old port must be excluded
+    memories = store.recall(tenant, [("agent", "agent_1")], subject="db", predicate="port")
+    assert len(memories) == 1
+    assert memories[0]["capsule_id"] == new_id
+    assert memories[0]["object"] == "5433"
+
+    # Direct DB inspection: old row has valid_to set and references successor
+    conn = store.get_connection()
+    try:
+        row = conn.execute("SELECT valid_to, superseded_by FROM memory_capsules WHERE capsule_id = ?", (orig_id,)).fetchone()
+        assert row["valid_to"] is not None
+        assert row["superseded_by"] == new_id
+    finally:
+        conn.close()
+
+
+def test_forget_tombstone(store):
+    """Verify that forget soft-deletes the record while keeping audit row in DB."""
+    tenant = "tenant_alpha"
+    cid = store.create(tenant, "agent", "agent_1", "user", "name", "Alice", authority_tier=20)
+
+    success = store.forget(tenant, cid, authority_tier=20)
+    assert success is True
+
+    # Recall returns nothing
+    memories = store.recall(tenant, [("agent", "agent_1")], subject="user", predicate="name")
+    assert len(memories) == 0
+
+    # Row is preserved in database with valid_to stamped
+    conn = store.get_connection()
+    try:
+        row = conn.execute("SELECT valid_to FROM memory_capsules WHERE capsule_id = ?", (cid,)).fetchone()
+        assert row["valid_to"] is not None
+    finally:
+        conn.close()
+
+
+def test_trusted_context_binding_prevents_privilege_escalation(store):
+    """Verify that BoundSessionMemory binds caller credentials server-side and model cannot forge authority."""
+    tenant = "tenant_alpha"
+    # Orchestrator binds agent session with authority 20
+    agent_mem = store.bind(
+        tenant_id=tenant,
+        scope_type="agent",
+        scope_id="worker_99",
+        authority_tier=20,
+        allowed_scopes=[("agent", "worker_99"), ("global", "global_main")]
+    )
+
+    # Agent records a fact
+    cid = agent_mem.remember("api", "rate_limit", "100")
+    recalled = agent_mem.search("api", "rate_limit")
+    assert len(recalled) == 1
+    assert recalled[0]["authority_tier"] == 20
+
+    # Operator records global policy with tier 100
+    store.create(tenant, "global", "global_main", "api", "rate_limit", "50", authority_tier=100)
+
+    # Agent recall now returns operator policy
+    recalled_after = agent_mem.search("api", "rate_limit")
+    assert len(recalled_after) == 1
+    assert recalled_after[0]["authority_tier"] == 100
+    assert recalled_after[0]["object"] == "50"
+
+    # Agent attempting to supersede operator policy fails with ScopeAuthorizationError
+    operator_cid = recalled_after[0]["capsule_id"]
+    with pytest.raises(ScopeAuthorizationError):
+        agent_mem.supersede(operator_cid, "api", "rate_limit", "200")
+
+
+def test_competing_replacement_concurrency(store):
+    """10 workers concurrently compete to supersede the same capsule. Exactly 1 wins, 9 fail with ReplacementConflictError."""
+    tenant = "tenant_alpha"
+    orig_id = store.create(tenant, "group", "group_1", "config", "workers", "4", authority_tier=20)
+
+    num_workers = 10
+    barrier = threading.Barrier(num_workers)
+    successes = []
+    conflict_errors = []
+    unexpected_errors = []
+    threads = []
+
+    def worker(worker_idx: int):
+        try:
+            try:
+                barrier.wait(timeout=5.0)
+            except threading.BrokenBarrierError:
+                return
+
+            new_id, _ = store.supersede(
+                tenant, orig_id, "config", "workers", f"{10 + worker_idx}", authority_tier=20
+            )
+            successes.append(new_id)
+        except ReplacementConflictError as e:
+            conflict_errors.append(e)
+        except Exception as e:
+            unexpected_errors.append(e)
+
+    for i in range(num_workers):
+        t = threading.Thread(target=worker, args=(i,))
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "Worker thread hung in join"
+
+    assert len(unexpected_errors) == 0, f"Unexpected errors found: {unexpected_errors}"
+    assert len(successes) == 1, f"Expected exactly 1 winner, got {len(successes)}"
+    assert len(conflict_errors) == num_workers - 1, f"Expected {num_workers - 1} conflicts, got {len(conflict_errors)}"
+
+
+def test_injected_connection_setup_failure_clean_teardown(tmp_path):
+    """
+    Injected setup failure must abort barrier immediately, clean up peers without hanging,
+    and assert WorkerSetupError while strictly rejecting AttributeError or unexpected exceptions.
+    """
+    db_path = str(tmp_path / "setup_fail.db")
+    store = SQLiteSharedMemoryStore(db_path)
+
+    barrier = threading.Barrier(2)
+    worker_errors: List[Exception] = []
+    threads: List[threading.Thread] = []
+
+    def worker_faulty():
+        try:
+            # Injected failure: worker fails initialization before barrier
+            raise WorkerSetupError("Simulated connection setup failure")
+            barrier.wait(timeout=2.0)
+        except Exception as e:
+            barrier.abort()
+            worker_errors.append(e)
+
+    def worker_healthy():
+        try:
+            conn = store.get_connection()
+            try:
+                barrier.wait(timeout=2.0)
+            except threading.BrokenBarrierError:
+                pass  # Clean exit on peer abort; NO AttributeError raised!
+            finally:
+                conn.close()
+        except Exception as e:
+            worker_errors.append(e)
+
+    t1 = threading.Thread(target=worker_faulty)
+    t2 = threading.Thread(target=worker_healthy)
+    threads.extend([t1, t2])
+
+    for t in threads:
+        t.start()
+
+    for t in threads:
+        t.join(timeout=3.0)
+        assert not t.is_alive(), "Worker thread hung; join timed out"
+
+    assert barrier.broken, "Barrier should be broken"
+    # Strict validation: exactly 1 error, and it must be WorkerSetupError
+    assert len(worker_errors) == 1
+    assert isinstance(worker_errors[0], WorkerSetupError)
+    # Reject AttributeError, TimeoutError, or conflict errors
+    assert not any(isinstance(e, AttributeError) for e in worker_errors)
+    assert not any(isinstance(e, ReplacementConflictError) for e in worker_errors)
+
+
+def test_competing_replacement_worker_setup_failure_aborts_cleanly(store):
+    """
+    Exercises the barrier repair directly through the 10-worker competing-replacement path.
+    One worker encounters an injected setup failure, aborts the barrier, and all 9 peer workers
+    cleanly exit without hanging or raising unexpected exceptions.
+    """
+    tenant = "tenant_alpha"
+    orig_id = store.create(tenant, "group", "group_1", "config", "pool_size", "8", authority_tier=20)
+
+    num_workers = 10
+    barrier = threading.Barrier(num_workers)
+    successes = []
+    worker_errors = []
+    threads = []
+
+    def competing_worker(idx: int):
+        try:
+            if idx == 0:
+                # Injected setup failure in worker 0
+                raise WorkerSetupError("Simulated worker connection failure in replacement pool")
+                barrier.wait(timeout=3.0)
+            else:
+                # Healthy peer worker
+                try:
+                    barrier.wait(timeout=3.0)
+                except threading.BrokenBarrierError:
+                    return  # Clean exit on peer setup abort
+
+                new_id, _ = store.supersede(
+                    tenant, orig_id, "config", "pool_size", f"{100 + idx}", authority_tier=20
+                )
+                successes.append(new_id)
+        except Exception as e:
+            if idx == 0:
+                barrier.abort()
+            worker_errors.append(e)
+
+    for i in range(num_workers):
+        t = threading.Thread(target=competing_worker, args=(i,))
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join(timeout=4.0)
+        assert not t.is_alive(), f"Worker thread hung in join"
+
+    assert barrier.broken, "Barrier must be broken following setup abort"
+    assert len(successes) == 0, "No writes should occur when setup aborts the replacement pool"
+    assert len(worker_errors) == 1, f"Expected exactly 1 worker error, got {len(worker_errors)}: {worker_errors}"
+    assert isinstance(worker_errors[0], WorkerSetupError), f"Expected WorkerSetupError, got {type(worker_errors[0])}"
+    assert not any(isinstance(e, (AttributeError, ReplacementConflictError)) for e in worker_errors)
+


### PR DESCRIPTION
Draft PR implementing the standalone SQLite shared memory provider sample requested in RFC #7748.

### Changes Included:
- **python/samples/agent_memory_sqlite/sqlite_shared_memory.py**:
  - SQLiteSharedMemoryStore: Thread-safe SQLite store with WAL mode, foreign key enforcement, bi-temporal soft-invalidation (\alid_from\ / \alid_to\), and optimistic atomic conditional replacement.
  - BoundSessionMemory: Context-bound tool wrapper instantiated by host orchestrator, binding caller credentials (\	enant_id\, \scope_type\, \scope_id\, \uthority_tier\) server-side to prevent model-directed privilege escalation.
- **python/samples/agent_memory_sqlite/test_sqlite_shared_memory.py**:
  - 9 automated unit tests verifying scope isolation, authority tier overrides, atomic superseding, soft-delete tombstones, and trusted context binding.
  - Concurrency suite: 10 competing replacement workers with barrier synchronization (exactly 1 succeeds, 9 raise \ReplacementConflictError\).
  - Harness repair test: Injected worker connection-setup failure cleanly aborts barrier, peer workers catch \	hreading.BrokenBarrierError\, all threads join without hanging, and assertions strictly reject unexpected exceptions.
- **python/samples/agent_memory_sqlite/README.md**: Run instructions.

All 9 tests pass in ~0.5s:
\\\ash
pytest -v python/samples/agent_memory_sqlite/test_sqlite_shared_memory.py
\\\

Resolves discussion in #7748.